### PR TITLE
Adding `DecStrictPartialOrder` to Relation.Binary

### DIFF
--- a/src/Relation/Binary.agda
+++ b/src/Relation/Binary.agda
@@ -257,7 +257,7 @@ record DecStrictPartialOrder c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂
     module DSPO = IsDecStrictPartialOrder isDecStrictPartialOrder
     open DSPO public hiding (module Eq)
 
-  strictPartialOrder : Poset c ℓ₁ ℓ₂
+  strictPartialOrder : StrictPartialOrder c ℓ₁ ℓ₂
   strictPartialOrder = record { isStrictPartialOrder = isStrictPartialOrder }
 
   module Eq where


### PR DESCRIPTION
Most orderings in Relation.Binary have a decidable variation. Three notable exceptions are Preorder, StrictPartialOrder and StrictTotalOrder (though the last of these is decidable in itself, by virtue of the `compare` function).

My commit adds implementations of DecStrictPartialOrder and IsDecStrictPartialOrder, and was tested against the HEAD version of Agda.
