### PR TITLE
Adding drop-length and take-length.

### DIFF
--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -236,7 +236,7 @@ drop-length (x ∷ xs) = drop-length xs
 
 take-length : ∀ {a} {A : Set a} (xs : List A) → take (length xs) xs ≡ xs
 take-length [] = refl
-take-length (x ∷ xs) = cong (_∷_ x) (take-length xs)
+take-length (x ∷ xs) = P.cong (_∷_ x) (take-length xs)
 
 -- TakeWhile, dropWhile, and span.
 


### PR DESCRIPTION
Added two simple but useful properties stating that dropping or taking with the length results in the empty/input list, respectively.
