### PR TITLE
Added to IO.agda

### DIFF
--- a/src/IO/Primitive.agda
+++ b/src/IO/Primitive.agda
@@ -48,6 +48,9 @@ postulate
   appendFile  : String → Costring → IO Unit
   putStr      : Costring → IO Unit
   putStrLn    : Costring → IO Unit
+  putChar     : Char -> IO Unit
+  getLine     : IO String
+  getChar     : IO Char
 
   -- Reads a finite file. Raises an exception if the file path refers
   -- to a non-physical file (like "/dev/zero").
@@ -60,4 +63,7 @@ postulate
 {-# COMPILED appendFile     appendFile            #-}
 {-# COMPILED putStr         putStr                #-}
 {-# COMPILED putStrLn       putStrLn              #-}
+{-# COMPILED putChar        putChar               #-}
+{-# COMPILED getLine        getLine               #-}
+{-# COMPILED getChar        getChar               #-}
 {-# COMPILED readFiniteFile IO.FFI.readFiniteFile #-}


### PR DESCRIPTION
I added a few more IO functions (namely `putChar`, `readChar`, and `readLine`) to `IO.Primitive` and `IO`. These are pretty self-explanatory.

I also added the utility functions `_>>♯_` and `_>>=♯_` to `IO`. These allow ∞ IO objects to be "chained" together. Basically, they are like `_>>_` and `_>>=_` respectively, but they evaluate to values of type `∀ {a} {A : set a} -> ∞ (IO A)`.

Together, these additions allow one to write the program:

```
open import Coinduction
open import Data.Char
open import Data.String
open import Data.Unit
open import IO

agdaMain : ∞ (IO ⊤)
agdaMain =
  ♯ putStrLn "Enter a string..." >>♯
  ♯ getLine >>=♯ λ str →
  ♯ putStrLn ("You entered " ++ str) >>♯
  ♯ putStrLn "Enter a character..." >>♯
  ♯ getChar >>=♯ λ c →
  ♯ putStr "You entered " >>♯
  ♯ putChar c >>♯
  ♯ putChar '\n'

main = run (♭ agdaMain)
```

All without having to go through IO.Primitive or the ffi.
