### PR TITLE
Support for UHC Backend

### DIFF
--- a/notes/future-version.txt
+++ b/notes/future-version.txt
@@ -16,3 +16,5 @@ future release. Don't remove this message please!
   Data.Fin.Properties.fromℕ≤≡fromℕ≤″.
 
 * The functions in Data.Nat.DivMod have been optimised.
+
+* Support for the UHC backend has been added.

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -29,6 +29,8 @@ data Bool : Set where
 {-# COMPILED_JS true  true  #-}
 {-# COMPILED_JS false false #-}
 
+{-# COMPILED_DATA_UHC Bool __BOOL__ __TRUE__ __FALSE__ #-}
+
 ------------------------------------------------------------------------
 -- Some operations
 

--- a/src/Data/Colist.agda
+++ b/src/Data/Colist.agda
@@ -45,6 +45,7 @@ data Colist {a} (A : Set a) : Set a where
 
 {-# IMPORT Data.FFI #-}
 {-# COMPILED_DATA Colist Data.FFI.AgdaList [] (:) #-}
+{-# COMPILED_DATA_UHC Colist __LIST__ __NIL__ __CONS__ #-}
 
 data Any {a p} {A : Set a} (P : A → Set p) :
          Colist A → Set (a ⊔ p) where

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -28,7 +28,7 @@ data List {a} (A : Set a) : Set a where
 
 {-# IMPORT Data.FFI #-}
 {-# COMPILED_DATA List Data.FFI.AgdaList [] (:) #-}
-
+{-# COMPILED_DATA_UHC List __LIST__ __NIL__ __CONS__ #-}
 ------------------------------------------------------------------------
 -- Some operations
 

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -25,6 +25,7 @@ data _≤_ : Rel ℕ Level.zero where
   s≤s : ∀ {m n} (m≤n : m ≤ n) → suc m ≤ suc n
 
 {-# BUILTIN NATURAL ℕ #-}
+{-# COMPILED_DATA_UHC ℕ __NAT__ __ZERO__ __SUC__ #-}
 
 infixl 6 _+_ _∸_
 infixl 7 _*_

--- a/src/Data/Vec/N-ary.agda
+++ b/src/Data/Vec/N-ary.agda
@@ -48,6 +48,8 @@ f $ⁿ (x ∷ xs) = f x $ⁿ xs
      N-ary n A (Set ℓ) → Set (N-ary-level a ℓ n)
 ∀ⁿ zero    P = P
 ∀ⁿ (suc n) P = ∀ x → ∀ⁿ n (P x)
+{- Normalising is very slow for this function for some reason... -}
+{-# NO_SMASHING ∀ⁿ #-}
 
 -- Universal quantifier with implicit (hidden) arguments.
 

--- a/src/Foreign/Haskell.agda
+++ b/src/Foreign/Haskell.agda
@@ -12,3 +12,4 @@ data Unit : Set where
   unit : Unit
 
 {-# COMPILED_DATA Unit () () #-}
+{-# COMPILED_DATA_UHC Unit __UNIT__ __UNIT__ #-}

--- a/src/IO/Primitive.agda
+++ b/src/IO/Primitive.agda
@@ -28,6 +28,8 @@ postulate
 
 {-# COMPILED return (\_ _ -> return)    #-}
 {-# COMPILED _>>=_  (\_ _ _ _ -> (>>=)) #-}
+{-# COMPILED_UHC return (\_ _ x -> UHC.Agda.Builtins.primReturn x) #-}
+{-# COMPILED_UHC _>>=_ (\_ _ _ _ x y -> UHC.Agda.Builtins.primBind x y) #-}
 
 ------------------------------------------------------------------------
 -- Simple lazy IO
@@ -61,3 +63,10 @@ postulate
 {-# COMPILED putStr         putStr                #-}
 {-# COMPILED putStrLn       putStrLn              #-}
 {-# COMPILED readFiniteFile IO.FFI.readFiniteFile #-}
+{-# COMPILED_UHC getContents    (UHC.Agda.Builtins.primGetContents) #-}
+{-# COMPILED_UHC readFile       (UHC.Agda.Builtins.primReadFile) #-}
+{-# COMPILED_UHC writeFile      (UHC.Agda.Builtins.primWriteFile) #-}
+{-# COMPILED_UHC appendFile     (UHC.Agda.Builtins.primAppendFile) #-}
+{-# COMPILED_UHC putStr         (UHC.Agda.Builtins.primPutStr) #-}
+{-# COMPILED_UHC putStrLn       (UHC.Agda.Builtins.primPutStrLn) #-}
+{-# COMPILED_UHC readFiniteFile (UHC.Agda.Builtins.primReadFiniteFile) #-}


### PR DESCRIPTION
Adds all the necessary pragmas to use the stdlib with the UHC backend. Does not break typechecking or compilation with MAlonzo, no matter if the UHC backend is enabled or not.

Any objections to me merging this?