### PR TITLE
Added the Selectivity property to FunctionProperties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ The library has been tested using Agda version TODO.
 
 Important changes since 0.12:
 
+* Added the Selectivity property in Algebra.FunctionProperties
+  as well as proofs of the selectivity of min and max in
+  Data.Nat.Properties
+	
 ------------------------------------------------------------------------
 -- Release notes for Agda standard library version 0.12
 ------------------------------------------------------------------------

--- a/src/Algebra/FunctionProperties.agda
+++ b/src/Algebra/FunctionProperties.agda
@@ -9,6 +9,7 @@
 
 open import Level
 open import Relation.Binary
+open import Data.Sum
 
 -- The properties are specified using the following relation as
 -- "equality".
@@ -78,6 +79,9 @@ Idempotent ∙ = ∀ x → ∙ IdempotentOn x
 
 IdempotentFun : Op₁ A → Set _
 IdempotentFun f = ∀ x → f (f x) ≈ f x
+
+Selective : Op₂ A → Set _
+Selective _∙_ = ∀ x y → (x ∙ y) ≈ x ⊎ (x ∙ y) ≈ y
 
 _Absorbs_ : Op₂ A → Op₂ A → Set _
 _∙_ Absorbs _∘_ = ∀ x y → (x ∙ (x ∘ y)) ≈ x

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -309,6 +309,20 @@ n≤m+n∸m m       zero    = z≤n
 n≤m+n∸m zero    (suc n) = ≤-refl
 n≤m+n∸m (suc m) (suc n) = s≤s (n≤m+n∸m m n)
 
+⊓-sel : Selective _⊓_
+⊓-sel zero _ = inj₁ refl
+⊓-sel (suc m) zero = inj₂ refl
+⊓-sel (suc m) (suc n) with ⊓-sel m n
+... | inj₁ m⊓n≡m = inj₁ (cong suc m⊓n≡m)
+... | inj₂ m⊓n≡n = inj₂ (cong suc m⊓n≡n)
+
+⊔-sel : Selective _⊔_
+⊔-sel zero    _    = inj₂ refl
+⊔-sel (suc m) zero = inj₁ refl
+⊔-sel (suc m) (suc n) with ⊔-sel m n
+... | inj₁ m⊔n≡m = inj₁ (cong suc m⊔n≡m)
+... | inj₂ m⊔n≡n = inj₂ (cong suc m⊔n≡n)
+
 m⊓n≤m : ∀ m n → m ⊓ n ≤ m
 m⊓n≤m zero    _       = z≤n
 m⊓n≤m (suc m) zero    = z≤n

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -228,6 +228,22 @@ distributiveLattice = record
   ; isDistributiveLattice = isDistributiveLattice
   }
 
+-- Selectivity of ⊓ and ⊔
+
+⊓-sel : Selective _⊓_
+⊓-sel zero    _    = inj₁ refl
+⊓-sel (suc m) zero = inj₂ refl
+⊓-sel (suc m) (suc n) with ⊓-sel m n
+... | inj₁ m⊓n≡m = inj₁ (cong suc m⊓n≡m)
+... | inj₂ m⊓n≡n = inj₂ (cong suc m⊓n≡n)
+
+⊔-sel : Selective _⊔_
+⊔-sel zero    _    = inj₂ refl
+⊔-sel (suc m) zero = inj₁ refl
+⊔-sel (suc m) (suc n) with ⊔-sel m n
+... | inj₁ m⊔n≡m = inj₁ (cong suc m⊔n≡m)
+... | inj₂ m⊔n≡n = inj₂ (cong suc m⊔n≡n)
+
 ------------------------------------------------------------------------
 -- Converting between ≤ and ≤′
 
@@ -308,20 +324,6 @@ n≤m+n∸m : ∀ m n → n ≤ m + (n ∸ m)
 n≤m+n∸m m       zero    = z≤n
 n≤m+n∸m zero    (suc n) = ≤-refl
 n≤m+n∸m (suc m) (suc n) = s≤s (n≤m+n∸m m n)
-
-⊓-sel : Selective _⊓_
-⊓-sel zero _ = inj₁ refl
-⊓-sel (suc m) zero = inj₂ refl
-⊓-sel (suc m) (suc n) with ⊓-sel m n
-... | inj₁ m⊓n≡m = inj₁ (cong suc m⊓n≡m)
-... | inj₂ m⊓n≡n = inj₂ (cong suc m⊓n≡n)
-
-⊔-sel : Selective _⊔_
-⊔-sel zero    _    = inj₂ refl
-⊔-sel (suc m) zero = inj₁ refl
-⊔-sel (suc m) (suc n) with ⊔-sel m n
-... | inj₁ m⊔n≡m = inj₁ (cong suc m⊔n≡m)
-... | inj₂ m⊔n≡n = inj₂ (cong suc m⊔n≡n)
 
 m⊓n≤m : ∀ m n → m ⊓ n ≤ m
 m⊓n≤m zero    _       = z≤n


### PR DESCRIPTION
Added the Selectivity property for operators. Useful when working with "choice" operators such as "min" or "max".

Obviously being selective implies the operator is idempotent as well. As this is my first contribution I'm a bit hesitant about adding this proof to FunctionProperties.agda as there are no other "properties of properties" proofs so to speak. However looking around I don't think there's any other suitable places... I'm happy to listen to advice!