### PR TITLE
The great deprivatisation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,17 @@ The library has been tested using Agda version TODO.
 
 Important changes since 0.12:
 
+* Useful lemmas and properties that were previously in private scope,
+  either explicitly or within records, have been made public in several
+  Properties.agda files. These include:
+
+  Data.List.Properties
+  Data.Nat.Properties
+  Data.Vec.Properties
+  Data.Integer.Multiplication.Properties
+  Data.Integer.Addition.Properties
+  Data.Integer.Properties
+
 ------------------------------------------------------------------------
 -- Release notes for Agda standard library version 0.12
 ------------------------------------------------------------------------

--- a/src/Algebra/FunctionProperties.agda
+++ b/src/Algebra/FunctionProperties.agda
@@ -9,6 +9,7 @@
 
 open import Level
 open import Relation.Binary
+open import Data.Sum
 
 -- The properties are specified using the following relation as
 -- "equality".
@@ -78,6 +79,9 @@ Idempotent ∙ = ∀ x → ∙ IdempotentOn x
 
 IdempotentFun : Op₁ A → Set _
 IdempotentFun f = ∀ x → f (f x) ≈ f x
+
+Selective : Op₂ A → Set _
+Selective _∙_ = ∀ x y → (x ∙ y) ≈ x ⊎ (x ∙ y) ≈ y
 
 _Absorbs_ : Op₂ A → Op₂ A → Set _
 _∙_ Absorbs _∘_ = ∀ x y → (x ∙ (x ∘ y)) ≈ x

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -31,46 +31,44 @@ open import Data.Empty
 ------------------------------------------------------------------------
 -- (Bool, ∨, ∧, false, true) forms a commutative semiring
 
-private
+∨-assoc : Associative _∨_
+∨-assoc true  y z = refl
+∨-assoc false y z = refl
 
-  ∨-assoc : Associative _∨_
-  ∨-assoc true  y z = refl
-  ∨-assoc false y z = refl
+∧-assoc : Associative _∧_
+∧-assoc true  y z = refl
+∧-assoc false y z = refl
 
-  ∧-assoc : Associative _∧_
-  ∧-assoc true  y z = refl
-  ∧-assoc false y z = refl
+∨-comm : Commutative _∨_
+∨-comm true  true  = refl
+∨-comm true  false = refl
+∨-comm false true  = refl
+∨-comm false false = refl
 
-  ∨-comm : Commutative _∨_
-  ∨-comm true  true  = refl
-  ∨-comm true  false = refl
-  ∨-comm false true  = refl
-  ∨-comm false false = refl
+∧-comm : Commutative _∧_
+∧-comm true  true  = refl
+∧-comm true  false = refl
+∧-comm false true  = refl
+∧-comm false false = refl
 
-  ∧-comm : Commutative _∧_
-  ∧-comm true  true  = refl
-  ∧-comm true  false = refl
-  ∧-comm false true  = refl
-  ∧-comm false false = refl
+∧-∨-distˡ : _∧_ DistributesOverˡ _∨_
+∧-∨-distˡ true  y z = refl
+∧-∨-distˡ false y z = refl
 
-  distrib-∧-∨ : _∧_ DistributesOver _∨_
-  distrib-∧-∨ = distˡ , distʳ
-    where
-    distˡ : _∧_ DistributesOverˡ _∨_
-    distˡ true  y z = refl
-    distˡ false y z = refl
+∧-∨-distʳ : _∧_ DistributesOverʳ _∨_
+∧-∨-distʳ x y z =
+  begin
+    (y ∨ z) ∧ x
+  ≡⟨ ∧-comm (y ∨ z) x ⟩
+    x ∧ (y ∨ z)
+  ≡⟨ ∧-∨-distˡ x y z ⟩
+    x ∧ y ∨ x ∧ z
+  ≡⟨ P.cong₂ _∨_ (∧-comm x y) (∧-comm x z) ⟩
+    y ∧ x ∨ z ∧ x
+  ∎
 
-    distʳ : _∧_ DistributesOverʳ _∨_
-    distʳ x y z =
-                      begin
-       (y ∨ z) ∧ x
-                      ≡⟨ ∧-comm (y ∨ z) x ⟩
-       x ∧ (y ∨ z)
-                      ≡⟨ distˡ x y z ⟩
-       x ∧ y ∨ x ∧ z
-                      ≡⟨ P.cong₂ _∨_ (∧-comm x y) (∧-comm x z) ⟩
-       y ∧ x ∨ z ∧ x
-                      ∎
+distrib-∧-∨ : _∧_ DistributesOver _∨_
+distrib-∧-∨ = ∧-∨-distˡ , ∧-∨-distʳ
 
 isCommutativeSemiring-∨-∧
   : IsCommutativeSemiring _≡_ _∨_ _∧_ false true
@@ -112,26 +110,25 @@ module RingSolver =
 ------------------------------------------------------------------------
 -- (Bool, ∧, ∨, true, false) forms a commutative semiring
 
-private
+∨-∧-distˡ : _∨_ DistributesOverˡ _∧_
+∨-∧-distˡ true  y z = refl
+∨-∧-distˡ false y z = refl
 
-  distrib-∨-∧ : _∨_ DistributesOver _∧_
-  distrib-∨-∧ = distˡ , distʳ
-    where
-    distˡ : _∨_ DistributesOverˡ _∧_
-    distˡ true  y z = refl
-    distˡ false y z = refl
+∨-∧-distʳ : _∨_ DistributesOverʳ _∧_
+∨-∧-distʳ x y z =
+  begin
+    (y ∧ z) ∨ x
+  ≡⟨ ∨-comm (y ∧ z) x ⟩
+    x ∨ (y ∧ z)
+  ≡⟨ ∨-∧-distˡ x y z ⟩
+    (x ∨ y) ∧ (x ∨ z)
+  ≡⟨ P.cong₂ _∧_ (∨-comm x y) (∨-comm x z) ⟩
+    (y ∨ x) ∧ (z ∨ x)
+  ∎
 
-    distʳ : _∨_ DistributesOverʳ _∧_
-    distʳ x y z =
-                          begin
-       (y ∧ z) ∨ x
-                          ≡⟨ ∨-comm (y ∧ z) x ⟩
-       x ∨ (y ∧ z)
-                          ≡⟨ distˡ x y z ⟩
-       (x ∨ y) ∧ (x ∨ z)
-                          ≡⟨ P.cong₂ _∧_ (∨-comm x y) (∨-comm x z) ⟩
-       (y ∨ x) ∧ (z ∨ x)
-                          ∎
+distrib-∨-∧ : _∨_ DistributesOver _∧_
+distrib-∨-∧ = ∨-∧-distˡ , ∨-∧-distʳ
+ 
 
 isCommutativeSemiring-∧-∨
   : IsCommutativeSemiring _≡_ _∧_ _∨_ true false
@@ -170,34 +167,32 @@ commutativeSemiring-∧-∨ = record
 ------------------------------------------------------------------------
 -- (Bool, ∨, ∧, not, true, false) is a boolean algebra
 
-private
+abs-∨-∧ : _∨_ Absorbs _∧_
+abs-∨-∧ true  y = refl
+abs-∨-∧ false y = refl
 
-  absorptive : Absorptive _∨_ _∧_
-  absorptive = abs-∨-∧ , abs-∧-∨
-    where
-    abs-∨-∧ : _∨_ Absorbs _∧_
-    abs-∨-∧ true  y = refl
-    abs-∨-∧ false y = refl
+abs-∧-∨ : _∧_ Absorbs _∨_
+abs-∧-∨ true  y = refl
+abs-∧-∨ false y = refl
 
-    abs-∧-∨ : _∧_ Absorbs _∨_
-    abs-∧-∨ true  y = refl
-    abs-∧-∨ false y = refl
+absorptive : Absorptive _∨_ _∧_
+absorptive = abs-∨-∧ , abs-∧-∨ 
 
-  not-∧-inverse : Inverse false not _∧_
-  not-∧-inverse =
-    ¬x∧x≡⊥ , (λ x → ∧-comm x (not x) ⟨ P.trans ⟩ ¬x∧x≡⊥ x)
-    where
-    ¬x∧x≡⊥ : LeftInverse false not _∧_
-    ¬x∧x≡⊥ false = refl
-    ¬x∧x≡⊥ true  = refl
+not-∧-inverse : Inverse false not _∧_
+not-∧-inverse =
+  ¬x∧x≡⊥ , (λ x → ∧-comm x (not x) ⟨ P.trans ⟩ ¬x∧x≡⊥ x)
+  where
+  ¬x∧x≡⊥ : LeftInverse false not _∧_
+  ¬x∧x≡⊥ false = refl
+  ¬x∧x≡⊥ true  = refl
 
-  not-∨-inverse : Inverse true not _∨_
-  not-∨-inverse =
-    ¬x∨x≡⊤ , (λ x → ∨-comm x (not x) ⟨ P.trans ⟩ ¬x∨x≡⊤ x)
-    where
-    ¬x∨x≡⊤ : LeftInverse true not _∨_
-    ¬x∨x≡⊤ false = refl
-    ¬x∨x≡⊤ true  = refl
+not-∨-inverse : Inverse true not _∨_
+not-∨-inverse =
+  ¬x∨x≡⊤ , (λ x → ∨-comm x (not x) ⟨ P.trans ⟩ ¬x∨x≡⊤ x)
+  where
+  ¬x∨x≡⊤ : LeftInverse true not _∨_
+  ¬x∨x≡⊤ false = refl
+  ¬x∨x≡⊤ true  = refl
 
 isBooleanAlgebra : IsBooleanAlgebra _≡_ _∨_ _∧_ not true false
 isBooleanAlgebra = record

--- a/src/Data/Integer/Addition/Properties.agda
+++ b/src/Data/Integer/Addition/Properties.agda
@@ -21,91 +21,89 @@ open CommutativeSemiring ℕ.commutativeSemiring
 ------------------------------------------------------------------------
 -- Addition and zero form a commutative monoid
 
-private
+comm : Commutative _+_
+comm -[1+ a ] -[1+ b ] rewrite +-comm a b = refl
+comm (+   a ) (+   b ) rewrite +-comm a b = refl
+comm -[1+ _ ] (+   _ ) = refl
+comm (+   _ ) -[1+ _ ] = refl
 
-  comm : Commutative _+_
-  comm -[1+ a ] -[1+ b ] rewrite +-comm a b = refl
-  comm (+   a ) (+   b ) rewrite +-comm a b = refl
-  comm -[1+ _ ] (+   _ ) = refl
-  comm (+   _ ) -[1+ _ ] = refl
+identityˡ : LeftIdentity (+ 0) _+_
+identityˡ -[1+ _ ] = refl
+identityˡ (+   _ ) = refl
 
-  identityˡ : LeftIdentity (+ 0) _+_
-  identityˡ -[1+ _ ] = refl
-  identityˡ (+   _ ) = refl
+identityʳ : RightIdentity (+ 0) _+_
+identityʳ x rewrite comm x (+ 0) = identityˡ x
 
-  identityʳ : RightIdentity (+ 0) _+_
-  identityʳ x rewrite comm x (+ 0) = identityˡ x
+distribˡ-⊖-+-neg : ∀ a b c → b ⊖ c + -[1+ a ] ≡ b ⊖ (suc c ℕ+ a)
+distribˡ-⊖-+-neg _ zero    zero    = refl
+distribˡ-⊖-+-neg _ zero    (suc _) = refl
+distribˡ-⊖-+-neg _ (suc _) zero    = refl
+distribˡ-⊖-+-neg a (suc b) (suc c) = distribˡ-⊖-+-neg a b c
 
-  distribˡ-⊖-+-neg : ∀ a b c → b ⊖ c + -[1+ a ] ≡ b ⊖ (suc c ℕ+ a)
-  distribˡ-⊖-+-neg _ zero    zero    = refl
-  distribˡ-⊖-+-neg _ zero    (suc _) = refl
-  distribˡ-⊖-+-neg _ (suc _) zero    = refl
-  distribˡ-⊖-+-neg a (suc b) (suc c) = distribˡ-⊖-+-neg a b c
+distribʳ-⊖-+-neg : ∀ a b c → -[1+ a ] + (b ⊖ c) ≡ b ⊖ (suc a ℕ+ c)
+distribʳ-⊖-+-neg a b c
+  rewrite comm -[1+ a ] (b ⊖ c)
+        | distribˡ-⊖-+-neg a b c
+        | +-comm a c
+        = refl
 
-  distribʳ-⊖-+-neg : ∀ a b c → -[1+ a ] + (b ⊖ c) ≡ b ⊖ (suc a ℕ+ c)
-  distribʳ-⊖-+-neg a b c
-    rewrite comm -[1+ a ] (b ⊖ c)
-          | distribˡ-⊖-+-neg a b c
-          | +-comm a c
-          = refl
+distribˡ-⊖-+-pos : ∀ a b c → b ⊖ c + + a ≡ b ℕ+ a ⊖ c
+distribˡ-⊖-+-pos _ zero    zero    = refl
+distribˡ-⊖-+-pos _ zero    (suc _) = refl
+distribˡ-⊖-+-pos _ (suc _) zero    = refl
+distribˡ-⊖-+-pos a (suc b) (suc c) = distribˡ-⊖-+-pos a b c
 
-  distribˡ-⊖-+-pos : ∀ a b c → b ⊖ c + + a ≡ b ℕ+ a ⊖ c
-  distribˡ-⊖-+-pos _ zero    zero    = refl
-  distribˡ-⊖-+-pos _ zero    (suc _) = refl
-  distribˡ-⊖-+-pos _ (suc _) zero    = refl
-  distribˡ-⊖-+-pos a (suc b) (suc c) = distribˡ-⊖-+-pos a b c
+distribʳ-⊖-+-pos : ∀ a b c → + a + (b ⊖ c) ≡ a ℕ+ b ⊖ c
+distribʳ-⊖-+-pos a b c
+  rewrite comm (+ a) (b ⊖ c)
+        | distribˡ-⊖-+-pos a b c
+        | +-comm a b
+        = refl
 
-  distribʳ-⊖-+-pos : ∀ a b c → + a + (b ⊖ c) ≡ a ℕ+ b ⊖ c
-  distribʳ-⊖-+-pos a b c
-    rewrite comm (+ a) (b ⊖ c)
-          | distribˡ-⊖-+-pos a b c
-          | +-comm a b
-          = refl
+assoc : Associative _+_
+assoc (+ zero) y z rewrite identityˡ      y  | identityˡ (y + z) = refl
+assoc x (+ zero) z rewrite identityʳ  x      | identityˡ      z  = refl
+assoc x y (+ zero) rewrite identityʳ (x + y) | identityʳ  y      = refl
+assoc -[1+ a ]  -[1+ b ]  (+ suc c) = sym (distribʳ-⊖-+-neg a c b)
+assoc -[1+ a ]  (+ suc b) (+ suc c) = distribˡ-⊖-+-pos (suc c) b a
+assoc (+ suc a) -[1+ b ]  -[1+ c ]  = distribˡ-⊖-+-neg c a b
+assoc (+ suc a) -[1+ b ] (+ suc c)
+  rewrite distribˡ-⊖-+-pos (suc c) a b
+        | distribʳ-⊖-+-pos (suc a) c b
+        | sym (+-assoc a 1 c)
+        | +-comm a 1
+        = refl
+assoc (+ suc a) (+ suc b) -[1+ c ]
+  rewrite distribʳ-⊖-+-pos (suc a) b c
+        | sym (+-assoc a 1 b)
+        | +-comm a 1
+        = refl
+assoc -[1+ a ] -[1+ b ] -[1+ c ]
+  rewrite sym (+-assoc a 1 (b ℕ+ c))
+        | +-comm a 1
+        | +-assoc a b c
+        = refl
+assoc -[1+ a ] (+ suc b) -[1+ c ]
+  rewrite distribʳ-⊖-+-neg a b c
+        | distribˡ-⊖-+-neg c b a
+        = refl
+assoc (+ suc a) (+ suc b) (+ suc c)
+  rewrite +-assoc (suc a) (suc b) (suc c)
+        = refl
 
-  assoc : Associative _+_
-  assoc (+ zero) y z rewrite identityˡ      y  | identityˡ (y + z) = refl
-  assoc x (+ zero) z rewrite identityʳ  x      | identityˡ      z  = refl
-  assoc x y (+ zero) rewrite identityʳ (x + y) | identityʳ  y      = refl
-  assoc -[1+ a ]  -[1+ b ]  (+ suc c) = sym (distribʳ-⊖-+-neg a c b)
-  assoc -[1+ a ]  (+ suc b) (+ suc c) = distribˡ-⊖-+-pos (suc c) b a
-  assoc (+ suc a) -[1+ b ]  -[1+ c ]  = distribˡ-⊖-+-neg c a b
-  assoc (+ suc a) -[1+ b ] (+ suc c)
-    rewrite distribˡ-⊖-+-pos (suc c) a b
-          | distribʳ-⊖-+-pos (suc a) c b
-          | sym (+-assoc a 1 c)
-          | +-comm a 1
-          = refl
-  assoc (+ suc a) (+ suc b) -[1+ c ]
-    rewrite distribʳ-⊖-+-pos (suc a) b c
-          | sym (+-assoc a 1 b)
-          | +-comm a 1
-          = refl
-  assoc -[1+ a ] -[1+ b ] -[1+ c ]
-    rewrite sym (+-assoc a 1 (b ℕ+ c))
-          | +-comm a 1
-          | +-assoc a b c
-          = refl
-  assoc -[1+ a ] (+ suc b) -[1+ c ]
-    rewrite distribʳ-⊖-+-neg a b c
-          | distribˡ-⊖-+-neg c b a
-          = refl
-  assoc (+ suc a) (+ suc b) (+ suc c)
-    rewrite +-assoc (suc a) (suc b) (suc c)
-          = refl
+isSemigroup : IsSemigroup _≡_ _+_
+isSemigroup = record
+  { isEquivalence = isEquivalence
+  ; assoc         = assoc
+  ; ∙-cong        = cong₂ _+_
+  }
 
-  isSemigroup : IsSemigroup _≡_ _+_
-  isSemigroup = record
-    { isEquivalence = isEquivalence
-    ; assoc         = assoc
-    ; ∙-cong        = cong₂ _+_
-    }
-
-  isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ (+ 0)
-  isCommutativeMonoid = record
-    { isSemigroup = isSemigroup
-    ; identityˡ   = identityˡ
-    ; comm        = comm
-    }
+isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ (+ 0)
+isCommutativeMonoid = record
+  { isSemigroup = isSemigroup
+  ; identityˡ   = identityˡ
+  ; comm        = comm
+  }
 
 commutativeMonoid : CommutativeMonoid _ _
 commutativeMonoid = record

--- a/src/Data/Integer/Multiplication/Properties.agda
+++ b/src/Data/Integer/Multiplication/Properties.agda
@@ -28,19 +28,18 @@ open CommutativeSemiring ℕ.commutativeSemiring
 ------------------------------------------------------------------------
 -- Multiplication and one form a commutative monoid
 
-private
+identityˡ : LeftIdentity (+ 1) ℤ*
+identityˡ (+ zero ) = refl
+identityˡ -[1+  n ] rewrite proj₂ +-identity n = refl
+identityˡ (+ suc n) rewrite proj₂ +-identity n = refl
 
-  identityˡ : LeftIdentity (+ 1) ℤ*
-  identityˡ (+ zero ) = refl
-  identityˡ -[1+  n ] rewrite proj₂ +-identity n = refl
-  identityˡ (+ suc n) rewrite proj₂ +-identity n = refl
+comm : Commutative ℤ*
+comm -[1+ a ] -[1+ b ] rewrite *-comm (suc a) (suc b) = refl
+comm -[1+ a ] (+   b ) rewrite *-comm (suc a) b       = refl
+comm (+   a ) -[1+ b ] rewrite *-comm a       (suc b) = refl
+comm (+   a ) (+   b ) rewrite *-comm a       b       = refl
 
-  comm : Commutative ℤ*
-  comm -[1+ a ] -[1+ b ] rewrite *-comm (suc a) (suc b) = refl
-  comm -[1+ a ] (+   b ) rewrite *-comm (suc a) b       = refl
-  comm (+   a ) -[1+ b ] rewrite *-comm a       (suc b) = refl
-  comm (+   a ) (+   b ) rewrite *-comm a       b       = refl
-
+private 
   lemma : ∀ a b c → c ℕ+ (b ℕ+ a ℕ* suc b) ℕ* suc c
                   ≡ c ℕ+ b ℕ* suc c ℕ+ a ℕ* suc (c ℕ+ b ℕ* suc c)
   lemma =
@@ -50,36 +49,36 @@ private
             refl
     where open ℕ.SemiringSolver
 
-  assoc : Associative ℤ*
-  assoc (+ zero) _ _ = refl
-  assoc x (+ zero) _ rewrite proj₂ *-zero ∣ x ∣ = refl
-  assoc x y (+ zero) rewrite
-      proj₂ *-zero ∣ y ∣
-    | proj₂ *-zero ∣ x ∣
-    | proj₂ *-zero ∣ sign x S* sign y ◃ ∣ x ∣ ℕ* ∣ y ∣ ∣
-    = refl
-  assoc -[1+ a  ] -[1+ b  ] (+ suc c) = cong (+_ ∘ suc) (lemma a b c)
-  assoc -[1+ a  ] (+ suc b) -[1+ c  ] = cong (+_ ∘ suc) (lemma a b c)
-  assoc (+ suc a) (+ suc b) (+ suc c) = cong (+_ ∘ suc) (lemma a b c)
-  assoc (+ suc a) -[1+ b  ] -[1+ c  ] = cong (+_ ∘ suc) (lemma a b c)
-  assoc -[1+ a  ] -[1+ b  ] -[1+ c  ] = cong -[1+_]     (lemma a b c)
-  assoc -[1+ a  ] (+ suc b) (+ suc c) = cong -[1+_]     (lemma a b c)
-  assoc (+ suc a) -[1+ b  ] (+ suc c) = cong -[1+_]     (lemma a b c)
-  assoc (+ suc a) (+ suc b) -[1+ c  ] = cong -[1+_]     (lemma a b c)
+assoc : Associative ℤ*
+assoc (+ zero) _ _ = refl
+assoc x (+ zero) _ rewrite proj₂ *-zero ∣ x ∣ = refl
+assoc x y (+ zero) rewrite
+    proj₂ *-zero ∣ y ∣
+  | proj₂ *-zero ∣ x ∣
+  | proj₂ *-zero ∣ sign x S* sign y ◃ ∣ x ∣ ℕ* ∣ y ∣ ∣
+  = refl
+assoc -[1+ a  ] -[1+ b  ] (+ suc c) = cong (+_ ∘ suc) (lemma a b c)
+assoc -[1+ a  ] (+ suc b) -[1+ c  ] = cong (+_ ∘ suc) (lemma a b c)
+assoc (+ suc a) (+ suc b) (+ suc c) = cong (+_ ∘ suc) (lemma a b c)
+assoc (+ suc a) -[1+ b  ] -[1+ c  ] = cong (+_ ∘ suc) (lemma a b c)
+assoc -[1+ a  ] -[1+ b  ] -[1+ c  ] = cong -[1+_]     (lemma a b c)
+assoc -[1+ a  ] (+ suc b) (+ suc c) = cong -[1+_]     (lemma a b c)
+assoc (+ suc a) -[1+ b  ] (+ suc c) = cong -[1+_]     (lemma a b c)
+assoc (+ suc a) (+ suc b) -[1+ c  ] = cong -[1+_]     (lemma a b c)
 
-  isSemigroup : IsSemigroup _ _
-  isSemigroup = record
-    { isEquivalence = isEquivalence
-    ; assoc         = assoc
-    ; ∙-cong        = cong₂ ℤ*
-    }
+isSemigroup : IsSemigroup _ _
+isSemigroup = record
+  { isEquivalence = isEquivalence
+  ; assoc         = assoc
+  ; ∙-cong        = cong₂ ℤ*
+  }
 
-  isCommutativeMonoid : IsCommutativeMonoid _≡_ ℤ* (+ 1)
-  isCommutativeMonoid = record
-    { isSemigroup = isSemigroup
-    ; identityˡ   = identityˡ
-    ; comm        = comm
-    }
+isCommutativeMonoid : IsCommutativeMonoid _≡_ ℤ* (+ 1)
+isCommutativeMonoid = record
+  { isSemigroup = isSemigroup
+  ; identityˡ   = identityˡ
+  ; comm        = comm
+  }
 
 commutativeMonoid : CommutativeMonoid _ _
 commutativeMonoid = record

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -84,83 +84,82 @@ abs-cong {s₁} {s₂} {n₁} {n₂} eq = begin
 abs-*-commute : Homomorphic₂ ∣_∣ _*_ _ℕ*_
 abs-*-commute i j = abs-◃ _ _
 
--- If you subtract a natural from itself, then you get zero.
+-- Subtraction properties
 
 n⊖n≡0 : ∀ n → n ⊖ n ≡ + 0
 n⊖n≡0 zero    = refl
 n⊖n≡0 (suc n) = n⊖n≡0 n
 
+sign-⊖-< : ∀ {m n} → m < n → sign (m ⊖ n) ≡ Sign.-
+sign-⊖-< {zero}  (s≤s z≤n) = refl
+sign-⊖-< {suc n} (s≤s m<n) = sign-⊖-< m<n
+
++-⊖-left-cancel : ∀ a b c → (a ℕ+ b) ⊖ (a ℕ+ c) ≡ b ⊖ c
++-⊖-left-cancel zero    b c = refl
++-⊖-left-cancel (suc a) b c = +-⊖-left-cancel a b c
+
+⊖-swap : ∀ a b → a ⊖ b ≡ - (b ⊖ a)
+⊖-swap zero    zero    = refl
+⊖-swap (suc _) zero    = refl
+⊖-swap zero    (suc _) = refl
+⊖-swap (suc a) (suc b) = ⊖-swap a b
+
+⊖-≥ : ∀ {m n} → m ≥ n → m ⊖ n ≡ + (m ∸ n)
+⊖-≥ z≤n       = refl
+⊖-≥ (s≤s n≤m) = ⊖-≥ n≤m
+
+⊖-< : ∀ {m n} → m < n → m ⊖ n ≡ - + (n ∸ m)
+⊖-< {zero}  (s≤s z≤n) = refl
+⊖-< {suc m} (s≤s m<n) = ⊖-< m<n
+
+∣⊖∣-< : ∀ {m n} → m < n → ∣ m ⊖ n ∣ ≡ n ∸ m
+∣⊖∣-< {zero}  (s≤s z≤n) = refl
+∣⊖∣-< {suc n} (s≤s m<n) = ∣⊖∣-< m<n
+
 ------------------------------------------------------------------------
 -- The integers form a commutative ring
 
+-- Additive abelian group.
+
+inverseˡ : LeftInverse (+ 0) -_ _+_
+inverseˡ -[1+ n ]  = n⊖n≡0 n
+inverseˡ (+ zero)  = refl
+inverseˡ (+ suc n) = n⊖n≡0 n
+
+inverseʳ : RightInverse (+ 0) -_ _+_
+inverseʳ i = begin
+  i + - i  ≡⟨ +-comm i (- i) ⟩
+  - i + i  ≡⟨ inverseˡ i ⟩
+  + 0      ∎
+
++-isAbelianGroup : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
++-isAbelianGroup = record
+  { isGroup = record
+    { isMonoid = +-isMonoid
+    ; inverse  = inverseˡ , inverseʳ
+    ; ⁻¹-cong  = cong (-_)
+    }
+  ; comm = +-comm
+  }
+
+
+-- Distributivity
+
 private
 
-  ----------------------------------------------------------------------
-  -- Additive abelian group.
-
-  inverseˡ : LeftInverse (+ 0) -_ _+_
-  inverseˡ -[1+ n ]  = n⊖n≡0 n
-  inverseˡ (+ zero)  = refl
-  inverseˡ (+ suc n) = n⊖n≡0 n
-
-  inverseʳ : RightInverse (+ 0) -_ _+_
-  inverseʳ i = begin
-    i + - i  ≡⟨ +-comm i (- i) ⟩
-    - i + i  ≡⟨ inverseˡ i ⟩
-    + 0      ∎
-
-  +-isAbelianGroup : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
-  +-isAbelianGroup = record
-    { isGroup = record
-      { isMonoid = +-isMonoid
-      ; inverse  = inverseˡ , inverseʳ
-      ; ⁻¹-cong  = cong (-_)
-      }
-    ; comm = +-comm
-    }
+  -- Various lemmas used to prove distributivity.
 
   open Algebra.Properties.AbelianGroup
          (record { isAbelianGroup = +-isAbelianGroup })
     using () renaming (⁻¹-involutive to -‿involutive)
 
-  ----------------------------------------------------------------------
-  -- Distributivity
-
-  -- Various lemmas used to prove distributivity.
-
-  sign-⊖-< : ∀ {m n} → m < n → sign (m ⊖ n) ≡ Sign.-
-  sign-⊖-< {zero}  (s≤s z≤n) = refl
-  sign-⊖-< {suc n} (s≤s m<n) = sign-⊖-< m<n
-
   sign-⊖-≱ : ∀ {m n} → m ≱ n → sign (m ⊖ n) ≡ Sign.-
   sign-⊖-≱ = sign-⊖-< ∘ ℕ.≰⇒>
 
-  +-⊖-left-cancel : ∀ a b c → (a ℕ+ b) ⊖ (a ℕ+ c) ≡ b ⊖ c
-  +-⊖-left-cancel zero    b c = refl
-  +-⊖-left-cancel (suc a) b c = +-⊖-left-cancel a b c
-
-  ⊖-swap : ∀ a b → a ⊖ b ≡ - (b ⊖ a)
-  ⊖-swap zero    zero    = refl
-  ⊖-swap (suc _) zero    = refl
-  ⊖-swap zero    (suc _) = refl
-  ⊖-swap (suc a) (suc b) = ⊖-swap a b
-
   -- Lemmas relating _⊖_ and _∸_.
-
-  ∣⊖∣-< : ∀ {m n} → m < n → ∣ m ⊖ n ∣ ≡ n ∸ m
-  ∣⊖∣-< {zero}  (s≤s z≤n) = refl
-  ∣⊖∣-< {suc n} (s≤s m<n) = ∣⊖∣-< m<n
 
   ∣⊖∣-≱ : ∀ {m n} → m ≱ n → ∣ m ⊖ n ∣ ≡ n ∸ m
   ∣⊖∣-≱ = ∣⊖∣-< ∘ ℕ.≰⇒>
-
-  ⊖-≥ : ∀ {m n} → m ≥ n → m ⊖ n ≡ + (m ∸ n)
-  ⊖-≥ z≤n       = refl
-  ⊖-≥ (s≤s n≤m) = ⊖-≥ n≤m
-
-  ⊖-< : ∀ {m n} → m < n → m ⊖ n ≡ - + (n ∸ m)
-  ⊖-< {zero}  (s≤s z≤n) = refl
-  ⊖-< {suc m} (s≤s m<n) = ⊖-< m<n
 
   ⊖-≱ : ∀ {m n} → m ≱ n → m ⊖ n ≡ - + (n ∸ m)
   ⊖-≱ = ⊖-< ∘ ℕ.≰⇒>
@@ -175,8 +174,6 @@ private
   -‿◃ : ∀ n → Sign.- ◃ n ≡ - + n
   -‿◃ zero    = refl
   -‿◃ (suc _) = refl
-
-  -- The main distributivity proof.
 
   distrib-lemma :
     ∀ a b c → (c ⊖ b) * -[1+ a ] ≡ a ℕ+ b ℕ* suc a ⊖ (a ℕ+ c ℕ* suc a)
@@ -199,97 +196,99 @@ private
           | ℕ.*-distrib-∸ʳ (suc a) b c
           = refl
 
-  distribʳ : _*_ DistributesOverʳ _+_
+-- The main distributivity proof.
 
-  distribʳ (+ zero) y z
-    rewrite proj₂ *-zero ∣ y ∣
-          | proj₂ *-zero ∣ z ∣
-          | proj₂ *-zero ∣ y + z ∣
-          = refl
+distribʳ : _*_ DistributesOverʳ _+_
 
-  distribʳ x (+ zero) z
-    rewrite proj₁ +-identity z
-          | proj₁ +-identity (sign z S* sign x ◃ ∣ z ∣ ℕ* ∣ x ∣)
-          = refl
+distribʳ (+ zero) y z
+  rewrite proj₂ *-zero ∣ y ∣
+        | proj₂ *-zero ∣ z ∣
+        | proj₂ *-zero ∣ y + z ∣
+        = refl
 
-  distribʳ x y (+ zero)
-    rewrite proj₂ +-identity y
-          | proj₂ +-identity (sign y S* sign x ◃ ∣ y ∣ ℕ* ∣ x ∣)
-          = refl
+distribʳ x (+ zero) z
+  rewrite proj₁ +-identity z
+        | proj₁ +-identity (sign z S* sign x ◃ ∣ z ∣ ℕ* ∣ x ∣)
+        = refl
 
-  distribʳ -[1+ a ] -[1+ b ] -[1+ c ] = cong (+_) $
-    solve 3 (λ a b c → (con 2 :+ b :+ c) :* (con 1 :+ a)
-                    := (con 1 :+ b) :* (con 1 :+ a) :+
-                       (con 1 :+ c) :* (con 1 :+ a))
-            refl a b c
+distribʳ x y (+ zero)
+  rewrite proj₂ +-identity y
+        | proj₂ +-identity (sign y S* sign x ◃ ∣ y ∣ ℕ* ∣ x ∣)
+        = refl
 
-  distribʳ (+ suc a) (+ suc b) (+ suc c) = cong (+_) $
-    solve 3 (λ a b c → (con 1 :+ b :+ (con 1 :+ c)) :* (con 1 :+ a)
-                    := (con 1 :+ b) :* (con 1 :+ a) :+
-                       (con 1 :+ c) :* (con 1 :+ a))
+distribʳ -[1+ a ] -[1+ b ] -[1+ c ] = cong (+_) $
+  solve 3 (λ a b c → (con 2 :+ b :+ c) :* (con 1 :+ a)
+                  := (con 1 :+ b) :* (con 1 :+ a) :+
+                     (con 1 :+ c) :* (con 1 :+ a))
           refl a b c
 
-  distribʳ -[1+ a ] (+ suc b) (+ suc c) = cong -[1+_] $
-    solve 3 (λ a b c → a :+ (b :+ (con 1 :+ c)) :* (con 1 :+ a)
-                     := (con 1 :+ b) :* (con 1 :+ a) :+
-                        (a :+ c :* (con 1 :+ a)))
-           refl a b c
+distribʳ (+ suc a) (+ suc b) (+ suc c) = cong (+_) $
+  solve 3 (λ a b c → (con 1 :+ b :+ (con 1 :+ c)) :* (con 1 :+ a)
+                  := (con 1 :+ b) :* (con 1 :+ a) :+
+                     (con 1 :+ c) :* (con 1 :+ a))
+        refl a b c
 
-  distribʳ (+ suc a) -[1+ b ] -[1+ c ] = cong -[1+_] $
-    solve 3 (λ a b c → a :+ (con 1 :+ a :+ (b :+ c) :* (con 1 :+ a))
-                    := (con 1 :+ b) :* (con 1 :+ a) :+
-                       (a :+ c :* (con 1 :+ a)))
-           refl a b c
+distribʳ -[1+ a ] (+ suc b) (+ suc c) = cong -[1+_] $
+  solve 3 (λ a b c → a :+ (b :+ (con 1 :+ c)) :* (con 1 :+ a)
+                   := (con 1 :+ b) :* (con 1 :+ a) :+
+                      (a :+ c :* (con 1 :+ a)))
+         refl a b c
 
-  distribʳ -[1+ a ] -[1+ b ] (+ suc c) = distrib-lemma a b c
+distribʳ (+ suc a) -[1+ b ] -[1+ c ] = cong -[1+_] $
+  solve 3 (λ a b c → a :+ (con 1 :+ a :+ (b :+ c) :* (con 1 :+ a))
+                  := (con 1 :+ b) :* (con 1 :+ a) :+
+                     (a :+ c :* (con 1 :+ a)))
+         refl a b c
 
-  distribʳ -[1+ a ] (+ suc b) -[1+ c ] = distrib-lemma a c b
+distribʳ -[1+ a ] -[1+ b ] (+ suc c) = distrib-lemma a b c
 
-  distribʳ (+ suc a) -[1+ b ] (+ suc c)
-    rewrite +-⊖-left-cancel a (c ℕ* suc a) (b ℕ* suc a)
-    with b ≤? c
-  ... | yes b≤c
-    rewrite ⊖-≥ b≤c
-          | +-comm (- (+ (a ℕ+ b ℕ* suc a))) (+ (a ℕ+ c ℕ* suc a))
-          | ⊖-≥ (b≤c *-mono ≤-refl {x = suc a})
-          | ℕ.*-distrib-∸ʳ (suc a) c b
-          | +‿◃ (c ℕ* suc a ∸ b ℕ* suc a)
-          = refl
-  ... | no b≰c
-    rewrite sign-⊖-≱ b≰c
-          | ∣⊖∣-≱ b≰c
-          | -‿◃ ((b ∸ c) ℕ* suc a)
-          | ⊖-≱ (b≰c ∘ ℕ.cancel-*-right-≤ b c a)
-          | ℕ.*-distrib-∸ʳ (suc a) b c
-          = refl
+distribʳ -[1+ a ] (+ suc b) -[1+ c ] = distrib-lemma a c b
 
-  distribʳ (+ suc c) (+ suc a) -[1+ b ]
-    rewrite +-⊖-left-cancel c (a ℕ* suc c) (b ℕ* suc c)
-    with b ≤? a
-  ... | yes b≤a
-    rewrite ⊖-≥ b≤a
-          | ⊖-≥ (b≤a *-mono ≤-refl {x = suc c})
-          | +‿◃ ((a ∸ b) ℕ* suc c)
-          | ℕ.*-distrib-∸ʳ (suc c) a b
-          = refl
-  ... | no b≰a
-    rewrite sign-⊖-≱ b≰a
-          | ∣⊖∣-≱ b≰a
-          | ⊖-≱ (b≰a ∘ ℕ.cancel-*-right-≤ b a c)
-          | -‿◃ ((b ∸ a) ℕ* suc c)
-          | ℕ.*-distrib-∸ʳ (suc c) b a
-          = refl
+distribʳ (+ suc a) -[1+ b ] (+ suc c)
+  rewrite +-⊖-left-cancel a (c ℕ* suc a) (b ℕ* suc a)
+  with b ≤? c
+... | yes b≤c
+  rewrite ⊖-≥ b≤c
+        | +-comm (- (+ (a ℕ+ b ℕ* suc a))) (+ (a ℕ+ c ℕ* suc a))
+        | ⊖-≥ (b≤c *-mono ≤-refl {x = suc a})
+        | ℕ.*-distrib-∸ʳ (suc a) c b
+        | +‿◃ (c ℕ* suc a ∸ b ℕ* suc a)
+        = refl
+... | no b≰c
+  rewrite sign-⊖-≱ b≰c
+        | ∣⊖∣-≱ b≰c
+        | -‿◃ ((b ∸ c) ℕ* suc a)
+        | ⊖-≱ (b≰c ∘ ℕ.cancel-*-right-≤ b c a)
+        | ℕ.*-distrib-∸ʳ (suc a) b c
+        = refl
 
-  -- The IsCommutativeSemiring module contains a proof of
-  -- distributivity which is used below.
+distribʳ (+ suc c) (+ suc a) -[1+ b ]
+  rewrite +-⊖-left-cancel c (a ℕ* suc c) (b ℕ* suc c)
+  with b ≤? a
+... | yes b≤a
+  rewrite ⊖-≥ b≤a
+        | ⊖-≥ (b≤a *-mono ≤-refl {x = suc c})
+        | +‿◃ ((a ∸ b) ℕ* suc c)
+        | ℕ.*-distrib-∸ʳ (suc c) a b
+        = refl
+... | no b≰a
+  rewrite sign-⊖-≱ b≰a
+        | ∣⊖∣-≱ b≰a
+        | ⊖-≱ (b≰a ∘ ℕ.cancel-*-right-≤ b a c)
+        | -‿◃ ((b ∸ a) ℕ* suc c)
+        | ℕ.*-distrib-∸ʳ (suc c) b a
+        = refl
 
-  isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ (+ 0) (+ 1)
-  isCommutativeSemiring = record
-    { +-isCommutativeMonoid = +-isCommutativeMonoid
-    ; *-isCommutativeMonoid = *-isCommutativeMonoid
-    ; distribʳ              = distribʳ
-    ; zeroˡ                 = λ _ → refl
-    }
+-- The IsCommutativeSemiring module contains a proof of
+-- distributivity which is used below.
+
+isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ (+ 0) (+ 1)
+isCommutativeSemiring = record
+  { +-isCommutativeMonoid = +-isCommutativeMonoid
+  ; *-isCommutativeMonoid = *-isCommutativeMonoid
+  ; distribʳ              = distribʳ
+  ; zeroˡ                 = λ _ → refl
+  }
 
 commutativeRing : CommutativeRing _ _
 commutativeRing = record

--- a/src/Data/List/All/Properties.agda
+++ b/src/Data/List/All/Properties.agda
@@ -72,27 +72,25 @@ all-anti-mono p xs⊆ys = All-all p ∘ anti-mono xs⊆ys ∘ all-All p _
 
 -- All P (xs ++ ys) is isomorphic to All P xs and All P ys.
 
-private
+++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {xs ys : List A} →
+      All P xs → All P ys → All P (xs ++ ys)
+++⁺ []         pys = pys
+++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
 
-  ++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {xs ys : List A} →
-        All P xs → All P ys → All P (xs ++ ys)
-  ++⁺ []         pys = pys
-  ++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
+++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} (xs : List A) {ys} →
+      All P (xs ++ ys) → All P xs × All P ys
+++⁻ []       p          = [] , p
+++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (_∷_ px) id $ ++⁻ _ pxs
 
-  ++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} (xs : List A) {ys} →
-        All P (xs ++ ys) → All P xs × All P ys
-  ++⁻ []       p          = [] , p
-  ++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (_∷_ px) id $ ++⁻ _ pxs
+++⁺∘++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} xs {ys}
+          (p : All P (xs ++ ys)) → uncurry′ ++⁺ (++⁻ xs p) ≡ p
+++⁺∘++⁻ []       p          = P.refl
+++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = P.cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
 
-  ++⁺∘++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} xs {ys}
-            (p : All P (xs ++ ys)) → uncurry′ ++⁺ (++⁻ xs p) ≡ p
-  ++⁺∘++⁻ []       p          = P.refl
-  ++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = P.cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
-
-  ++⁻∘++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {xs ys}
+++⁻∘++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {xs ys}
             (p : All P xs × All P ys) → ++⁻ xs (uncurry ++⁺ p) ≡ p
-  ++⁻∘++⁺ ([]       , pys) = P.refl
-  ++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = P.refl
+++⁻∘++⁺ ([]       , pys) = P.refl
+++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = P.refl
 
 ++↔ : ∀ {a p} {A : Set a} {P : A → Set p} {xs ys} →
       (All P xs × All P ys) ↔ All P (xs ++ ys)

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -72,81 +72,96 @@ module SemiringSolver =
 ------------------------------------------------------------------------
 -- (ℕ, ⊔, ⊓, 0) is a commutative semiring without one
 
-private
+⊔-assoc : Associative _⊔_
+⊔-assoc zero    _       _       = refl
+⊔-assoc (suc m) zero    _       = refl
+⊔-assoc (suc m) (suc n) zero    = refl
+⊔-assoc (suc m) (suc n) (suc o) = cong suc $ ⊔-assoc m n o
 
-  ⊔-assoc : Associative _⊔_
-  ⊔-assoc zero    _       _       = refl
-  ⊔-assoc (suc m) zero    o       = refl
-  ⊔-assoc (suc m) (suc n) zero    = refl
-  ⊔-assoc (suc m) (suc n) (suc o) = cong suc $ ⊔-assoc m n o
+⊔-identityʳ : RightIdentity 0 _⊔_
+⊔-identityʳ zero    = refl
+⊔-identityʳ (suc n) = refl
 
-  ⊔-identity : Identity 0 _⊔_
-  ⊔-identity = (λ _ → refl) , n⊔0≡n
-    where
-    n⊔0≡n : RightIdentity 0 _⊔_
-    n⊔0≡n zero    = refl
-    n⊔0≡n (suc n) = refl
+⊔-identityˡ : LeftIdentity 0 _⊔_
+⊔-identityˡ _ = refl
 
-  ⊔-comm : Commutative _⊔_
-  ⊔-comm zero    n       = sym $ proj₂ ⊔-identity n
-  ⊔-comm (suc m) zero    = refl
-  ⊔-comm (suc m) (suc n) =
-    begin
-      suc m ⊔ suc n
-    ≡⟨ refl ⟩
-      suc (m ⊔ n)
-    ≡⟨ cong suc (⊔-comm m n) ⟩
-      suc (n ⊔ m)
-    ≡⟨ refl ⟩
-      suc n ⊔ suc m
-    ∎
+⊔-identity : Identity 0 _⊔_
+⊔-identity = ⊔-identityˡ , ⊔-identityʳ  
 
-  ⊓-assoc : Associative _⊓_
-  ⊓-assoc zero    _       _       = refl
-  ⊓-assoc (suc m) zero    o       = refl
-  ⊓-assoc (suc m) (suc n) zero    = refl
-  ⊓-assoc (suc m) (suc n) (suc o) = cong suc $ ⊓-assoc m n o
+⊔-comm : Commutative _⊔_
+⊔-comm zero    n       = sym $ proj₂ ⊔-identity n
+⊔-comm (suc m) zero    = refl
+⊔-comm (suc m) (suc n) =
+  begin
+    suc m ⊔ suc n
+  ≡⟨ refl ⟩
+    suc (m ⊔ n)
+  ≡⟨ cong suc (⊔-comm m n) ⟩
+    suc (n ⊔ m)
+  ≡⟨ refl ⟩
+    suc n ⊔ suc m
+  ∎
 
-  ⊓-zero : Zero 0 _⊓_
-  ⊓-zero = (λ _ → refl) , n⊓0≡0
-    where
-    n⊓0≡0 : RightZero 0 _⊓_
-    n⊓0≡0 zero    = refl
-    n⊓0≡0 (suc n) = refl
+⊓-assoc : Associative _⊓_
+⊓-assoc zero    _       _       = refl
+⊓-assoc (suc m) zero    o       = refl
+⊓-assoc (suc m) (suc n) zero    = refl
+⊓-assoc (suc m) (suc n) (suc o) = cong suc $ ⊓-assoc m n o
 
-  ⊓-comm : Commutative _⊓_
-  ⊓-comm zero    n       = sym $ proj₂ ⊓-zero n
-  ⊓-comm (suc m) zero    = refl
-  ⊓-comm (suc m) (suc n) =
-    begin
-      suc m ⊓ suc n
-    ≡⟨ refl ⟩
-      suc (m ⊓ n)
-    ≡⟨ cong suc (⊓-comm m n) ⟩
-      suc (n ⊓ m)
-    ≡⟨ refl ⟩
-      suc n ⊓ suc m
-    ∎
+⊓-zeroʳ : RightZero 0 _⊓_
+⊓-zeroʳ zero    = refl
+⊓-zeroʳ (suc n) = refl
 
-  distrib-⊓-⊔ : _⊓_ DistributesOver _⊔_
-  distrib-⊓-⊔ = (distribˡ-⊓-⊔ , distribʳ-⊓-⊔)
-    where
-    distribʳ-⊓-⊔ : _⊓_ DistributesOverʳ _⊔_
-    distribʳ-⊓-⊔ (suc m) (suc n) (suc o) = cong suc $ distribʳ-⊓-⊔ m n o
-    distribʳ-⊓-⊔ (suc m) (suc n) zero    = cong suc $ refl
-    distribʳ-⊓-⊔ (suc m) zero    o       = refl
-    distribʳ-⊓-⊔ zero    n       o       = begin
-      (n ⊔ o) ⊓ 0    ≡⟨ ⊓-comm (n ⊔ o) 0 ⟩
-      0 ⊓ (n ⊔ o)    ≡⟨ refl ⟩
-      0 ⊓ n ⊔ 0 ⊓ o  ≡⟨ ⊓-comm 0 n ⟨ cong₂ _⊔_ ⟩ ⊓-comm 0 o ⟩
-      n ⊓ 0 ⊔ o ⊓ 0  ∎
+⊓-zeroˡ : LeftZero 0 _⊓_
+⊓-zeroˡ _ = refl
 
-    distribˡ-⊓-⊔ : _⊓_ DistributesOverˡ _⊔_
-    distribˡ-⊓-⊔ m n o = begin
-      m ⊓ (n ⊔ o)    ≡⟨ ⊓-comm m _ ⟩
-      (n ⊔ o) ⊓ m    ≡⟨ distribʳ-⊓-⊔ m n o ⟩
-      n ⊓ m ⊔ o ⊓ m  ≡⟨ ⊓-comm n m ⟨ cong₂ _⊔_ ⟩ ⊓-comm o m ⟩
-      m ⊓ n ⊔ m ⊓ o  ∎
+⊓-zero : Zero 0 _⊓_
+⊓-zero = ⊓-zeroˡ , ⊓-zeroʳ
+
+⊓-comm : Commutative _⊓_
+⊓-comm zero    n       = sym $ proj₂ ⊓-zero n
+⊓-comm (suc m) zero    = refl
+⊓-comm (suc m) (suc n) =
+  begin
+    suc m ⊓ suc n
+  ≡⟨ refl ⟩
+    suc (m ⊓ n)
+  ≡⟨ cong suc (⊓-comm m n) ⟩
+    suc (n ⊓ m)
+  ≡⟨ refl ⟩
+    suc n ⊓ suc m
+  ∎
+
+distribʳ-⊓-⊔ : _⊓_ DistributesOverʳ _⊔_
+distribʳ-⊓-⊔ (suc m) (suc n) (suc o) = cong suc $ distribʳ-⊓-⊔ m n o
+distribʳ-⊓-⊔ (suc m) (suc n) zero    = cong suc $ refl
+distribʳ-⊓-⊔ (suc m) zero    o       = refl
+distribʳ-⊓-⊔ zero    n       o       = 
+  begin
+    (n ⊔ o) ⊓ 0    
+  ≡⟨ ⊓-comm (n ⊔ o) 0 ⟩
+    0 ⊓ (n ⊔ o)    
+  ≡⟨ refl ⟩
+    0 ⊓ n ⊔ 0 ⊓ o  
+  ≡⟨ ⊓-comm 0 n ⟨ cong₂ _⊔_ ⟩ ⊓-comm 0 o ⟩
+    n ⊓ 0 ⊔ o ⊓ 0  
+  ∎
+
+distribˡ-⊓-⊔ : _⊓_ DistributesOverˡ _⊔_
+distribˡ-⊓-⊔ m n o = 
+  begin
+    m ⊓ (n ⊔ o)    
+  ≡⟨ ⊓-comm m _ ⟩
+    (n ⊔ o) ⊓ m    
+  ≡⟨ distribʳ-⊓-⊔ m n o ⟩
+    n ⊓ m ⊔ o ⊓ m  
+  ≡⟨ ⊓-comm n m ⟨ cong₂ _⊔_ ⟩ ⊓-comm o m ⟩
+    m ⊓ n ⊔ m ⊓ o  
+  ∎
+
+distrib-⊓-⊔ : _⊓_ DistributesOver _⊔_
+distrib-⊓-⊔ = distribˡ-⊓-⊔ , distribʳ-⊓-⊔
+  
 
 ⊔-⊓-0-isCommutativeSemiringWithoutOne
   : IsCommutativeSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
@@ -184,27 +199,25 @@ private
 ------------------------------------------------------------------------
 -- (ℕ, ⊓, ⊔) is a lattice
 
-private
+abs-⊔-⊓ : _⊔_ Absorbs _⊓_
+abs-⊔-⊓ zero    n       = refl
+abs-⊔-⊓ (suc m) zero    = refl
+abs-⊔-⊓ (suc m) (suc n) = cong suc $ abs-⊔-⊓ m n
 
-  absorptive-⊓-⊔ : Absorptive _⊓_ _⊔_
-  absorptive-⊓-⊔ = abs-⊓-⊔ , abs-⊔-⊓
-    where
-    abs-⊔-⊓ : _⊔_ Absorbs _⊓_
-    abs-⊔-⊓ zero    n       = refl
-    abs-⊔-⊓ (suc m) zero    = refl
-    abs-⊔-⊓ (suc m) (suc n) = cong suc $ abs-⊔-⊓ m n
+abs-⊓-⊔ : _⊓_ Absorbs _⊔_
+abs-⊓-⊔ zero    n       = refl
+abs-⊓-⊔ (suc m) (suc n) = cong suc $ abs-⊓-⊔ m n
+abs-⊓-⊔ (suc m) zero    = cong suc $
+  begin
+    m ⊓ m
+  ≡⟨ cong (_⊓_ m) $ sym $ proj₂ ⊔-identity m ⟩
+    m ⊓ (m ⊔ 0)
+  ≡⟨ abs-⊓-⊔ m zero ⟩
+    m
+  ∎
 
-    abs-⊓-⊔ : _⊓_ Absorbs _⊔_
-    abs-⊓-⊔ zero    n       = refl
-    abs-⊓-⊔ (suc m) (suc n) = cong suc $ abs-⊓-⊔ m n
-    abs-⊓-⊔ (suc m) zero    = cong suc $
-                   begin
-      m ⊓ m
-                   ≡⟨ cong (_⊓_ m) $ sym $ proj₂ ⊔-identity m ⟩
-      m ⊓ (m ⊔ 0)
-                   ≡⟨ abs-⊓-⊔ m zero ⟩
-      m
-                   ∎
+absorptive-⊓-⊔ : Absorptive _⊓_ _⊔_
+absorptive-⊓-⊔ = abs-⊓-⊔ , abs-⊔-⊓
 
 isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
 isDistributiveLattice = record

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -55,7 +55,22 @@ open import Relation.Binary.HeterogeneousEquality using (_≅_; refl)
               (x ∷ xs) ≡ (y ∷ ys) → x ≡ y × xs ≡ ys
 ∷-injective refl = refl , refl
 
+
+------------------------------------------------------------------------
+-- Some properties related to lookup
+
 -- lookup is an applicative functor morphism.
+
+lookup-replicate : ∀ {a n} {A : Set a} (i : Fin n) →
+                   lookup i ∘ replicate {A = A} ≗ id {A = A}
+lookup-replicate zero    = λ _ → refl
+lookup-replicate (suc i) = lookup-replicate i
+
+lookup-⊛ : ∀ {a b n} {A : Set a} {B : Set b}
+           i (fs : Vec (A → B) n) (xs : Vec A n) →
+           lookup i (fs ⊛ xs) ≡ (lookup i fs $ lookup i xs)
+lookup-⊛ zero    (f ∷ fs) (x ∷ xs) = refl
+lookup-⊛ (suc i) (f ∷ fs) (x ∷ xs) = lookup-⊛ i fs xs
 
 lookup-morphism :
   ∀ {a n} (i : Fin n) →
@@ -66,17 +81,6 @@ lookup-morphism i = record
   ; op-pure = lookup-replicate i
   ; op-⊛    = lookup-⊛ i
   }
-  where
-  lookup-replicate : ∀ {a n} {A : Set a} (i : Fin n) →
-                     lookup i ∘ replicate {A = A} ≗ id {A = A}
-  lookup-replicate zero    = λ _ → refl
-  lookup-replicate (suc i) = lookup-replicate i
-
-  lookup-⊛ : ∀ {a b n} {A : Set a} {B : Set b}
-             i (fs : Vec (A → B) n) (xs : Vec A n) →
-             lookup i (fs ⊛ xs) ≡ (lookup i fs $ lookup i xs)
-  lookup-⊛ zero    (f ∷ fs) (x ∷ xs) = refl
-  lookup-⊛ (suc i) (f ∷ fs) (x ∷ xs) = lookup-⊛ i fs xs
 
 -- tabulate is an inverse of flip lookup.
 
@@ -143,6 +147,10 @@ lookup∘update′ {i = suc i} {zero}  i≢j (x ∷ xs) y = refl
 lookup∘update′ {i = suc i} {suc j} i≢j (x ∷ xs) y =
   lookup∘update′ (i≢j ∘ P.cong suc) xs y
 
+
+------------------------------------------------------------------------
+-- Some properties related to map
+
 -- map is a congruence.
 
 map-cong : ∀ {a b n} {A : Set a} {B : Set b} {f g : A → B} →
@@ -191,32 +199,9 @@ map-lookup-allFin {n = n} xs = begin
   xs                                 ∎
   where open P.≡-Reasoning
 
--- tabulate f contains f i.
 
-∈-tabulate : ∀ {n a} {A : Set a} (f : Fin n → A) i → f i ∈ tabulate f
-∈-tabulate f zero    = here
-∈-tabulate f (suc i) = there (∈-tabulate (f ∘ suc) i)
-
--- allFin n contains all elements in Fin n.
-
-∈-allFin : ∀ {n} (i : Fin n) → i ∈ allFin n
-∈-allFin = ∈-tabulate id
-
--- sum commutes with _++_.
-
-sum-++-commute : ∀ {m n} (xs : Vec ℕ m) {ys : Vec ℕ n} →
-                 sum (xs ++ ys) ≡ sum xs + sum ys
-sum-++-commute []            = refl
-sum-++-commute (x ∷ xs) {ys} = begin
-  x + sum (xs ++ ys)
-    ≡⟨ P.cong (λ p → x + p) (sum-++-commute xs) ⟩
-  x + (sum xs + sum ys)
-    ≡⟨ P.sym (+-assoc x (sum xs) (sum ys)) ⟩
-  sum (x ∷ xs) + sum ys
-    ∎
-  where
-  open P.≡-Reasoning
-  open CommutativeSemiring Nat.commutativeSemiring hiding (_+_; sym)
+------------------------------------------------------------------------
+-- Some properties related to foldr
 
 -- foldr is a congruence.
 
@@ -284,47 +269,6 @@ foldr-fusion {B = B} {f} e {C} h fuse =
 idIsFold : ∀ {a n} {A : Set a} → id ≗ foldr (Vec A) {n} _∷_ []
 idIsFold = foldr-universal _ _ id refl (λ _ _ → refl)
 
--- The _∈_ predicate is equivalent (in the following sense) to the
--- corresponding predicate for lists.
-
-∈⇒List-∈ : ∀ {a} {A : Set a} {n x} {xs : Vec A n} →
-           x ∈ xs → x List.∈ toList xs
-∈⇒List-∈ here       = here P.refl
-∈⇒List-∈ (there x∈) = there (∈⇒List-∈ x∈)
-
-List-∈⇒∈ : ∀ {a} {A : Set a} {x : A} {xs} →
-           x List.∈ xs → x ∈ fromList xs
-List-∈⇒∈ (here P.refl) = here
-List-∈⇒∈ (there x∈)    = there (List-∈⇒∈ x∈)
-
--- Proof irrelevance for _[_]=_.
-
-proof-irrelevance-[]= : ∀ {a} {A : Set a} {n} {xs : Vec A n} {i x} →
-                        (p q : xs [ i ]= x) → p ≡ q
-proof-irrelevance-[]= here            here             = refl
-proof-irrelevance-[]= (there xs[i]=x) (there xs[i]=x') =
-  P.cong there (proof-irrelevance-[]= xs[i]=x xs[i]=x')
-
--- _[_]=_ can be expressed using lookup and _≡_.
-
-[]=↔lookup : ∀ {a n i} {A : Set a} {x} {xs : Vec A n} →
-             xs [ i ]= x ↔ lookup i xs ≡ x
-[]=↔lookup {i = i} {x = x} {xs} = record
-  { to         = P.→-to-⟶ to
-  ; from       = P.→-to-⟶ (from i xs)
-  ; inverse-of = record
-    { left-inverse-of  = λ _ → proof-irrelevance-[]= _ _
-    ; right-inverse-of = λ _ → P.proof-irrelevance _ _
-    }
-  }
-  where
-  to : ∀ {n xs} {i : Fin n} → xs [ i ]= x → lookup i xs ≡ x
-  to here            = refl
-  to (there xs[i]=x) = to xs[i]=x
-
-  from : ∀ {n} (i : Fin n) xs → lookup i xs ≡ x → xs [ i ]= x
-  from zero    (.x ∷ _)  refl = here
-  from (suc i) (_  ∷ xs) p    = there (from i xs p)
 
 ------------------------------------------------------------------------
 -- Some properties related to _[_]≔_
@@ -382,3 +326,84 @@ map-[]≔ f (x ∷ xs) (suc i) = P.cong (_∷_ _) $ map-[]≔ f xs i
 []≔-++-inject+ (x ∷ xs) ys zero    = refl
 []≔-++-inject+ (x ∷ xs) ys (suc i) =
   P.cong (_∷_ x) $ []≔-++-inject+ xs ys i
+
+-- Proof irrelevance for _[_]=_.
+
+proof-irrelevance-[]= : ∀ {a} {A : Set a} {n} {xs : Vec A n} {i x} →
+                        (p q : xs [ i ]= x) → p ≡ q
+proof-irrelevance-[]= here            here             = refl
+proof-irrelevance-[]= (there xs[i]=x) (there xs[i]=x') =
+  P.cong there (proof-irrelevance-[]= xs[i]=x xs[i]=x')
+
+-- _[_]=_ can be expressed using lookup and _≡_.
+
+[]=⇒lookup : ∀ {a n i} {A : Set a} {x} {xs : Vec A n} → 
+             xs [ i ]= x → lookup i xs ≡ x
+[]=⇒lookup here            = refl
+[]=⇒lookup (there xs[i]=x) = []=⇒lookup xs[i]=x
+
+lookup⇒[]= : ∀ {a n} {A : Set a} {x : A} (i : Fin n) xs → 
+             lookup i xs ≡ x → xs [ i ]= x
+lookup⇒[]= zero    (x ∷ _)  refl = here
+lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
+
+[]=↔lookup : ∀ {a n i} {A : Set a} {x} {xs : Vec A n} →
+             xs [ i ]= x ↔ lookup i xs ≡ x
+[]=↔lookup {i = i} {x = x} {xs} = record
+  { to         = P.→-to-⟶ []=⇒lookup
+  ; from       = P.→-to-⟶ (lookup⇒[]= i xs)
+  ; inverse-of = record
+    { left-inverse-of  = λ _ → proof-irrelevance-[]= _ _
+    ; right-inverse-of = λ _ → P.proof-irrelevance _ _
+    }
+  }
+
+
+------------------------------------------------------------------------
+-- Some properties related to _∈_
+
+-- The _∈_ predicate is equivalent (in the following sense) to the
+-- corresponding predicate for lists.
+
+∈⇒List-∈ : ∀ {a} {A : Set a} {n x} {xs : Vec A n} →
+           x ∈ xs → x List.∈ toList xs
+∈⇒List-∈ here       = here P.refl
+∈⇒List-∈ (there x∈) = there (∈⇒List-∈ x∈)
+
+List-∈⇒∈ : ∀ {a} {A : Set a} {x : A} {xs} →
+           x List.∈ xs → x ∈ fromList xs
+List-∈⇒∈ (here P.refl) = here
+List-∈⇒∈ (there x∈)    = there (List-∈⇒∈ x∈)
+
+-- tabulate f contains f i.
+
+∈-tabulate : ∀ {n a} {A : Set a} (f : Fin n → A) i → f i ∈ tabulate f
+∈-tabulate f zero    = here
+∈-tabulate f (suc i) = there (∈-tabulate (f ∘ suc) i)
+
+-- allFin n contains all elements in Fin n.
+
+∈-allFin : ∀ {n} (i : Fin n) → i ∈ allFin n
+∈-allFin = ∈-tabulate id
+
+
+
+
+------------------------------------------------------------------------
+-- Other properties
+
+-- sum commutes with _++_.
+
+sum-++-commute : ∀ {m n} (xs : Vec ℕ m) {ys : Vec ℕ n} →
+                 sum (xs ++ ys) ≡ sum xs + sum ys
+sum-++-commute []            = refl
+sum-++-commute (x ∷ xs) {ys} = begin
+  x + sum (xs ++ ys)
+    ≡⟨ P.cong (λ p → x + p) (sum-++-commute xs) ⟩
+  x + (sum xs + sum ys)
+    ≡⟨ P.sym (+-assoc x (sum xs) (sum ys)) ⟩
+  sum (x ∷ xs) + sum ys
+    ∎
+  where
+  open P.≡-Reasoning
+  open CommutativeSemiring Nat.commutativeSemiring hiding (_+_; sym)


### PR DESCRIPTION
Moved many useful lemmas and properties in Properties.agda files that were previously in private scope, either explicitly or within records, into public scope.

This saves having to open records in addition to importing the Properties.agda file.