### PR TITLE
Deprivatised properties in Relation.Binary.PropositionalEquality

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,12 @@ Important changes since 0.12:
 * Added the length-filter property to Data.List.Properties (the filter
   equivalent to the pre-existing length-gfilter)
 
+* Useful lemmas and properties that were previously in private scope,
+  either explicitly or within records, have been made public in several
+  Properties.agda files. These include:
+
+    Relation.Binary.PropositionalEquality
+
 ------------------------------------------------------------------------
 -- Release notes for Agda standard library version 0.12
 ------------------------------------------------------------------------

--- a/src/Relation/Binary/PropositionalEquality.agda
+++ b/src/Relation/Binary/PropositionalEquality.agda
@@ -50,13 +50,17 @@ setoid A = record
   ; isEquivalence = isEquivalence
   }
 
+isDecEquivalence : ∀ {a} {A : Set a} → Decidable (_≡_ {A = A})
+                 → IsDecEquivalence _≡_
+isDecEquivalence dec = record
+  { isEquivalence = isEquivalence
+  ; _≟_           = dec
+  }
+
 decSetoid : ∀ {a} {A : Set a} → Decidable (_≡_ {A = A}) → DecSetoid _ _
 decSetoid dec = record
   { _≈_              = _≡_
-  ; isDecEquivalence = record
-      { isEquivalence = isEquivalence
-      ; _≟_           = dec
-      }
+  ; isDecEquivalence = isDecEquivalence dec
   }
 
 isPreorder : ∀ {a} {A : Set a} → IsPreorder {A = A} _≡_ _≡_


### PR DESCRIPTION
Moved useful lemmas and properties in the Relation.Binary.PropositionalEquality file that were previously in private scope, either explicitly or within records, into public scope.
