### PR TITLE
Add `Congruent₁` and `Congruent₂` to Algebra.FunctionProperties

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,10 @@ Important changes since 0.12:
 * Added the length-filter property to Data.List.Properties (the filter
   equivalent to the pre-existing length-gfilter)
 
+* Added `Congruent₁` and `Congruent₂` to Algebra.FunctionProperties.
+  These are aliases for `_Preserves _≈_ ⟶ _≈_` and
+  `_Preserves₂ _≈_ ⟶ _≈_ ⟶ _≈_` from Relation.Binary.Core
+
 ------------------------------------------------------------------------
 -- Release notes for Agda standard library version 0.12
 ------------------------------------------------------------------------

--- a/src/Algebra/FunctionProperties.agda
+++ b/src/Algebra/FunctionProperties.agda
@@ -91,3 +91,9 @@ Absorptive ∙ ∘ = (∙ Absorbs ∘) × (∘ Absorbs ∙)
 
 Involutive : Op₁ A → Set _
 Involutive f = ∀ x → f (f x) ≈ x
+
+Congruent₁ : Op₁ A → Set _
+Congruent₁ f = f Preserves _≈_ ⟶ _≈_
+
+Congruent₂ : Op₂ A → Set _
+Congruent₂ ∙ = ∙ Preserves₂ _≈_ ⟶ _≈_ ⟶ _≈_


### PR DESCRIPTION
In my opinion these aliases have three advantages over the existing solution of `_Preserves₂_⟶ _ ⟶ _`

1. More meaningful name
2. Much shorter and therefore cleaner code (`_∙_ Preserves₂ _≈_ ⟶ _≈_ ⟶ _≈_` takes up nearly half a line)
3. More intuitively placed for new-comers to the library who are using the `Algebra` modules. For a property so vital during algebraic reasoning, I personally don't find it obvious that in order to find it (well actually a generalisation of it) it's necessary to look in `Relation.Binary.Core`.

As for uses in the library, this would replace the uses of `_Preserves₂_⟶ _ ⟶ _` throughout the `Algebra` modules. As an added bonus, most of the algebraic records which require this property already call it `cong`.