### PR TITLE
Add some extra properties and an All predicate for Data.Vec

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -17,6 +17,11 @@ Important changes since 0.12:
 * Added the length-filter property to Data.List.Properties (the filter
   equivalent to the pre-existing length-gfilter)
 
+* Added some zip/unzip-related properties to Data.Vec.Properties.
+
+* Added an All predicate and related properties for Data.Vec (see
+  Data.Vec.All and Data.Vec.All.Properties).
+
 ------------------------------------------------------------------------
 -- Release notes for Agda standard library version 0.12
 ------------------------------------------------------------------------

--- a/src/Data/Vec/All.agda
+++ b/src/Data/Vec/All.agda
@@ -1,0 +1,89 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors where all elements satisfy a given property
+------------------------------------------------------------------------
+
+module Data.Vec.All where
+
+open import Data.Vec as Vec using (Vec; []; _∷_; zip)
+open import Data.Vec.Properties using (lookup-zip)
+open import Data.Fin using (Fin; zero; suc)
+open import Function using (_∘_)
+open import Level using (_⊔_)
+open import Data.Product using (uncurry)
+open import Relation.Nullary
+import Relation.Nullary.Decidable as Dec
+open import Relation.Unary using (Decidable) renaming (_⊆_ to _⋐_)
+open import Relation.Binary.PropositionalEquality using (subst)
+
+-- All P xs means that all elements in xs satisfy P.
+
+infixr 5 _∷_
+
+data All {a p} {A : Set a}
+         (P : A → Set p) : ∀ {k} → Vec A k → Set (p ⊔ a) where
+  []  : All P []
+  _∷_ : ∀ {k x} {xs : Vec A k} (px : P x) (pxs : All P xs) → All P (x ∷ xs)
+
+head : ∀ {a p} {A : Set a} {P : A → Set p} {k x} {xs : Vec A k} →
+       All P (x ∷ xs) → P x
+head (px ∷ pxs) = px
+
+tail : ∀ {a p} {A : Set a} {P : A → Set p} {k x} {xs : Vec A k} →
+       All P (x ∷ xs) → All P xs
+tail (px ∷ pxs) = pxs
+
+lookup : ∀ {a p} {A : Set a} {P : A → Set p} {k} {xs : Vec A k} →
+         (i : Fin k) → All P xs → P (Vec.lookup i xs)
+lookup ()      []
+lookup zero    (px ∷ pxs) = px
+lookup (suc i) (px ∷ pxs) = lookup i pxs
+
+tabulate : ∀ {a p} {A : Set a} {P : A → Set p} {k} {xs : Vec A k} →
+           (∀ x → P x) → All P xs
+tabulate {xs = []}     hyp = []
+tabulate {xs = x ∷ xs} hyp = hyp x ∷ tabulate hyp
+
+map : ∀ {a p q} {A : Set a} {P : A → Set p} {Q : A → Set q} {k} →
+      P ⋐ Q → All P {k} ⋐ All Q {k}
+map g []         = []
+map g (px ∷ pxs) = g px ∷ map g pxs
+
+all : ∀ {a p} {A : Set a} {P : A → Set p} {k} →
+      Decidable P → Decidable (All P {k})
+all p []       = yes []
+all p (x ∷ xs) with p x
+all p (x ∷ xs) | yes px = Dec.map′ (_∷_ px) tail (all p xs)
+all p (x ∷ xs) | no ¬px = no (¬px ∘ head)
+
+zipWith : ∀ {a b c p q r} {A : Set a} {B : Set b} {C : Set c} {_⊕_ : A → B → C}
+          {P : A → Set p} {Q : B → Set q} {R : C → Set r} →
+          (∀ {x y} → P x → Q y → R (x ⊕ y)) →
+          ∀ {k xs ys} → All P {k} xs → All Q {k} ys →
+          All R {k} (Vec.zipWith _⊕_ xs ys)
+zipWith _⊕_ {xs = []}     {[]}     []         []         = []
+zipWith _⊕_ {xs = x ∷ xs} {y ∷ ys} (px ∷ pxs) (qy ∷ qys) =
+  px ⊕ qy ∷ zipWith _⊕_ pxs qys
+
+
+-- A shorthand for a pair of vectors being point-wise related.
+
+All₂ : ∀ {a p} {A B : Set a} (P : A → B → Set p) {k} →
+       Vec A k → Vec B k → Set _
+All₂ P xs ys = All (uncurry P) (zip xs ys)
+
+-- A variant of lookup tailored to All₂.
+
+lookup₂ : ∀ {a p} {A B : Set a} {P : A → B → Set p} {k}
+            {xs : Vec A k} {ys : Vec B k} →
+          (i : Fin k) → All₂ P xs ys → P (Vec.lookup i xs) (Vec.lookup i ys)
+lookup₂ {P = P} {xs = xs} {ys} i pxys =
+  subst (uncurry P) (lookup-zip i xs ys) (lookup i pxys)
+
+-- A variant of map tailored to All₂.
+
+map₂ : ∀ {a p q} {A B : Set a} {P : A → B → Set p} {Q : A → B → Set q} →
+       (∀ {x y} → P x y → Q x y) →
+       ∀ {k xs ys} → All₂ P {k} xs ys → All₂ Q {k} xs ys
+map₂ g = map g

--- a/src/Data/Vec/All/Properties.agda
+++ b/src/Data/Vec/All/Properties.agda
@@ -1,0 +1,125 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties related to All
+------------------------------------------------------------------------
+
+module Data.Vec.All.Properties where
+
+open import Data.Vec as Vec using (Vec; []; _∷_; zip)
+open import Data.Vec.Properties using (map-id; lookup-zip)
+open import Data.Product as Prod using (_×_; _,_; uncurry; uncurry′)
+open import Data.Vec using (Vec; _++_)
+open import Data.Vec.All as All using (All; All₂; []; _∷_)
+open import Function
+open import Function.Inverse using (_↔_)
+open import Relation.Unary using () renaming (_⊆_ to _⋐_)
+open import Relation.Binary.PropositionalEquality as P using (_≡_)
+
+-- Functions can be shifted between the predicate and the vector.
+
+All-map : ∀ {a b p} {A : Set a} {B : Set b} {P : B → Set p}
+            {f : A → B} {k} {xs : Vec A k} →
+          All (P ∘ f) xs → All P (Vec.map f xs)
+All-map []         = []
+All-map (px ∷ pxs) = px ∷ All-map pxs
+
+map-All : ∀ {a b p} {A : Set a} {B : Set b} {P : B → Set p}
+            {f : A → B} {k} {xs : Vec A k} →
+          All P (Vec.map f xs) → All (P ∘ f) xs
+map-All {xs = []}    []       = []
+map-All {xs = _ ∷ _} (px ∷ pxs) = px ∷ map-All pxs
+
+-- A variant of All.map.
+
+gmap : ∀ {a b p q}
+         {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q}
+         {f : A → B} {k} →
+       P ⋐ Q ∘ f → All P {k} ⋐ All Q {k} ∘ Vec.map f
+gmap g = All-map ∘ All.map g
+
+-- A variant of All-map tailored to All₂.
+
+All₂-map : ∀ {a b p} {A₁ A₂ : Set a} {B₁ B₂ : Set b} {P : B₁ → B₂ → Set p}
+           {f₁ : A₁ → B₁} {f₂ : A₂ → B₂} {k} {xs : Vec A₁ k} {ys : Vec A₂ k} →
+           All₂ (λ x y → P (f₁ x) (f₂ y)) xs ys →
+           All₂ P (Vec.map f₁ xs) (Vec.map f₂ ys)
+All₂-map {xs = []}    {ys = []}    []         = []
+All₂-map {xs = _ ∷ _} {ys = _ ∷ _} (px ∷ pxs) = px ∷ All₂-map pxs
+
+-- A variant of gmap tailored to All₂.
+
+gmap₂ : ∀ {a b p q} {A₁ A₂ : Set a} {B₁ B₂ : Set b}
+          {P : A₁ → A₂ → Set p} {Q : B₁ → B₂ → Set q}
+          {f₁ : A₁ → B₁} {f₂ : A₂ → B₂} →
+        (∀ {x y} → P x y → Q (f₁ x) (f₂ y)) → ∀ {k xs ys} →
+        All₂ P {k} xs ys → All₂ Q {k} (Vec.map f₁ xs) (Vec.map f₂ ys)
+gmap₂ g = All₂-map ∘ All.map g
+
+-- A variant of gmap₂ shifting only the first function from the binary
+-- relation to the vector.
+
+gmap₂₁ : ∀ {a p q} {A₁ A₂ : Set a} {B : Set a}
+           {P : A₁ → A₂ → Set p} {Q : B → A₂ → Set q} {f : A₁ → B} →
+         (∀ {x y} → P x y → Q (f x) y) → ∀ {k xs ys} →
+         All₂ P {k} xs ys → All₂ Q {k} (Vec.map f xs) ys
+gmap₂₁ g = P.subst (All₂ _ _) (map-id _) ∘ All₂-map {f₂ = id} ∘ All.map g
+
+-- A variant of gmap₂ shifting only the second function from the
+-- binary relation to the vector.
+
+gmap₂₂ : ∀ {a p q} {A₁ A₂ : Set a} {B : Set a}
+           {P : A₁ → A₂ → Set p} {Q : A₁ → B → Set q} {f : A₂ → B} →
+         (∀ {x y} → P x y → Q x (f y)) → ∀ {k xs ys} →
+         All₂ P {k} xs ys → All₂ Q {k} xs (Vec.map f ys)
+gmap₂₂ g =
+  P.subst (flip (All₂ _) _) (map-id _) ∘ All₂-map {f₁ = id} ∘ All.map g
+
+-- Abstract composition of binary relations lifted to All₂.
+
+comp : ∀ {a p} {A : Set a} {B : Set a} {C : Set a}
+       {P : A → B → Set p} {Q : B → C → Set p} {R : A → C → Set p} →
+       (∀ {x y z} → P x y → Q y z → R x z) →
+       ∀ {k xs ys zs} → All₂ P {k} xs ys → All₂ Q {k} ys zs → All₂ R {k} xs zs
+comp _⊙_ {xs = []}     {[]}     {[]}     []           []           = []
+comp _⊙_ {xs = x ∷ xs} {y ∷ ys} {z ∷ zs} (pxy ∷ pxys) (qzx ∷ qzxs) =
+  pxy ⊙ qzx ∷ comp _⊙_ pxys qzxs
+
+-- All P (xs ++ ys) is isomorphic to All P xs and All P ys.
+
+private
+
+  ++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {k i}
+        {xs : Vec A k} {ys : Vec A i} →
+        All P xs → All P ys → All P (xs ++ ys)
+  ++⁺ []         pys = pys
+  ++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
+
+  ++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {k i}
+        (xs : Vec A k) {ys : Vec A i} →
+        All P (xs ++ ys) → All P xs × All P ys
+  ++⁻ []       p          = [] , p
+  ++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (_∷_ px) id $ ++⁻ _ pxs
+
+  ++⁺∘++⁻ : ∀ {a p} {A : Set a} {P : A → Set p} {k i}
+            (xs : Vec A k) {ys : Vec A i} (p : All P (xs ++ ys)) →
+            uncurry′ ++⁺ (++⁻ xs p) ≡ p
+  ++⁺∘++⁻ []       p          = P.refl
+  ++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = P.cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
+
+  ++⁻∘++⁺ : ∀ {a p} {A : Set a} {P : A → Set p} {k i}
+            {xs : Vec A k} {ys : Vec A i} (p : All P xs × All P ys) →
+            ++⁻ xs (uncurry ++⁺ p) ≡ p
+  ++⁻∘++⁺ ([]       , pys) = P.refl
+  ++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = P.refl
+
+++↔ : ∀ {a p} {A : Set a} {P : A → Set p} {k i} {xs : Vec A k} {ys : Vec A i} →
+      (All P xs × All P ys) ↔ All P (xs ++ ys)
+++↔ {P = P} {xs = xs} = record
+  { to         = P.→-to-⟶ $ uncurry ++⁺
+  ; from       = P.→-to-⟶ $ ++⁻ xs
+  ; inverse-of = record
+    { left-inverse-of  = ++⁻∘++⁺
+    ; right-inverse-of = ++⁺∘++⁻ xs
+    }
+  }


### PR DESCRIPTION
This adds some extra support for vectors, in particular
 * some `zip`/`unzip`-related properties in `Data.Vec.Properties`, and
 * an `All` predicate (similar to `Data.List.All`) and related properties for `Data.Vec`.