### PR TITLE
Add order-theoretic lattices and some related properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Important changes since 0.12:
 * Added an `All` predicate and related properties for `Data.Vec` (see
   `Data.Vec.All` and `Data.Vec.All.Properties`).
 
+* Added order-theoretic lattices and some related properties in
+  `Relation.Binary.Lattice` and `Relation.Binary.Properties`.
+
 Version 0.12
 ============
 

--- a/src/Relation/Binary/Lattice.agda
+++ b/src/Relation/Binary/Lattice.agda
@@ -1,0 +1,251 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Order-theoretic lattices
+------------------------------------------------------------------------
+
+module Relation.Binary.Lattice where
+
+open import Algebra.FunctionProperties
+open import Data.Product
+open import Function using (flip)
+open import Level
+open import Relation.Binary
+import Relation.Binary.PropositionalEquality as PropEq
+
+------------------------------------------------------------------------
+-- Bounds and extrema
+
+Supremum : ∀ {a ℓ} {A : Set a} → Rel A ℓ → Op₂ A → Set _
+Supremum _≤_ _∨_ =
+  ∀ x y → x ≤ (x ∨ y) × y ≤ (x ∨ y) × ∀ z → x ≤ z → y ≤ z → (x ∨ y) ≤ z
+
+Infimum : ∀ {a ℓ} {A : Set a} → Rel A ℓ → Op₂ A → Set _
+Infimum _≤_ = Supremum (flip _≤_)
+
+Maximum : ∀ {a ℓ} {A : Set a} → Rel A ℓ → A → Set _
+Maximum _≤_ ⊤ = ∀ x → x ≤ ⊤
+
+Minimum : ∀ {a ℓ} {A : Set a} → Rel A ℓ → A → Set _
+Minimum _≤_ = Maximum (flip _≤_)
+
+
+------------------------------------------------------------------------
+-- Semilattices
+
+record IsJoinSemilattice {a ℓ₁ ℓ₂} {A : Set a}
+                         (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                         (_≤_ : Rel A ℓ₂) -- The partial order.
+                         (_∨_ : Op₂ A)    -- The join operation.
+                         : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isPartialOrder : IsPartialOrder _≈_ _≤_
+    supremum       : Supremum _≤_ _∨_
+
+  open IsPartialOrder isPartialOrder public
+
+record JoinSemilattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 6 _∨_
+  field
+    Carrier           : Set c
+    _≈_               : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_               : Rel Carrier ℓ₂  -- The partial order.
+    _∨_               : Op₂ Carrier     -- The join operation.
+    isJoinSemilattice : IsJoinSemilattice _≈_ _≤_ _∨_
+
+  open IsJoinSemilattice isJoinSemilattice public
+
+  poset : Poset c ℓ₁ ℓ₂
+  poset = record { isPartialOrder = isPartialOrder }
+
+  open Poset poset public using (preorder)
+
+record IsMeetSemilattice {a ℓ₁ ℓ₂} {A : Set a}
+                         (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                         (_≤_ : Rel A ℓ₂) -- The partial order.
+                         (_∧_ : Op₂ A)    -- The meet operation.
+                         : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isPartialOrder : IsPartialOrder _≈_ _≤_
+    infimum        : Infimum _≤_ _∧_
+
+  open IsPartialOrder isPartialOrder public
+
+record MeetSemilattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 7 _∧_
+  field
+    Carrier           : Set c
+    _≈_               : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_               : Rel Carrier ℓ₂  -- The partial order.
+    _∧_               : Op₂ Carrier     -- The meet operation.
+    isMeetSemilattice : IsMeetSemilattice _≈_ _≤_ _∧_
+
+  open IsMeetSemilattice isMeetSemilattice public
+
+  poset : Poset c ℓ₁ ℓ₂
+  poset = record { isPartialOrder = isPartialOrder }
+
+  open Poset poset public using (preorder)
+
+record IsBoundedJoinSemilattice {a ℓ₁ ℓ₂} {A : Set a}
+                                (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                                (_≤_ : Rel A ℓ₂) -- The partial order.
+                                (_∨_ : Op₂ A)    -- The join operation.
+                                (⊥   : A)        -- The minimum.
+                                : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isJoinSemilattice : IsJoinSemilattice _≈_ _≤_ _∨_
+    minimum           : Minimum _≤_ ⊥
+
+  open IsJoinSemilattice isJoinSemilattice public
+
+record BoundedJoinSemilattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 6 _∨_
+  field
+    Carrier                  : Set c
+    _≈_                      : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_                      : Rel Carrier ℓ₂  -- The partial order.
+    _∨_                      : Op₂ Carrier     -- The join operation.
+    ⊥                        : Carrier         -- The minimum.
+    isBoundedJoinSemilattice : IsBoundedJoinSemilattice _≈_ _≤_ _∨_ ⊥
+
+  open IsBoundedJoinSemilattice isBoundedJoinSemilattice public
+
+  joinSemiLattice : JoinSemilattice c ℓ₁ ℓ₂
+  joinSemiLattice = record { isJoinSemilattice = isJoinSemilattice }
+
+  open JoinSemilattice joinSemiLattice public using (preorder; poset)
+
+record IsBoundedMeetSemilattice {a ℓ₁ ℓ₂} {A : Set a}
+                                (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                                (_≤_ : Rel A ℓ₂) -- The partial order.
+                                (_∧_ : Op₂ A)    -- The join operation.
+                                (⊤   : A)        -- The maximum.
+                                : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isMeetSemilattice : IsMeetSemilattice _≈_ _≤_ _∧_
+    maximum           : Maximum _≤_ ⊤
+
+  open IsMeetSemilattice isMeetSemilattice public
+
+record BoundedMeetSemilattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 7 _∧_
+  field
+    Carrier                  : Set c
+    _≈_                      : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_                      : Rel Carrier ℓ₂  -- The partial order.
+    _∧_                      : Op₂ Carrier     -- The join operation.
+    ⊤                        : Carrier         -- The maximum.
+    isBoundedMeetSemilattice : IsBoundedMeetSemilattice _≈_ _≤_ _∧_ ⊤
+
+  open IsBoundedMeetSemilattice isBoundedMeetSemilattice public
+
+  meetSemiLattice : MeetSemilattice c ℓ₁ ℓ₂
+  meetSemiLattice = record { isMeetSemilattice = isMeetSemilattice }
+
+  open MeetSemilattice meetSemiLattice public using (preorder; poset)
+
+------------------------------------------------------------------------
+-- Lattices
+
+record IsLattice {a ℓ₁ ℓ₂} {A : Set a}
+                 (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                 (_≤_ : Rel A ℓ₂) -- The partial order.
+                 (_∨_ : Op₂ A)    -- The join operation.
+                 (_∧_ : Op₂ A)    -- The meet operation.
+                 : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isPartialOrder : IsPartialOrder _≈_ _≤_
+    supremum       : Supremum _≤_ _∨_
+    infimum        : Infimum _≤_ _∧_
+
+  isJoinSemilattice : IsJoinSemilattice _≈_ _≤_ _∨_
+  isJoinSemilattice = record
+    { isPartialOrder = isPartialOrder
+    ; supremum       = supremum
+    }
+
+  isMeetSemilattice : IsMeetSemilattice _≈_ _≤_ _∧_
+  isMeetSemilattice = record
+    { isPartialOrder = isPartialOrder
+    ; infimum        = infimum
+    }
+
+  open IsPartialOrder isPartialOrder public
+
+record Lattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 6 _∨_
+  infixr 7 _∧_
+  field
+    Carrier   : Set c
+    _≈_       : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_       : Rel Carrier ℓ₂  -- The partial order.
+    _∨_       : Op₂ Carrier     -- The join operation.
+    _∧_       : Op₂ Carrier     -- The meet operation.
+    isLattice : IsLattice _≈_ _≤_ _∨_ _∧_
+
+  open IsLattice isLattice public
+
+  joinSemilattice : JoinSemilattice c ℓ₁ ℓ₂
+  joinSemilattice = record { isJoinSemilattice = isJoinSemilattice }
+
+  meetSemilattice : MeetSemilattice c ℓ₁ ℓ₂
+  meetSemilattice = record { isMeetSemilattice = isMeetSemilattice }
+
+  open JoinSemilattice joinSemilattice public using (poset; preorder)
+
+record IsBoundedLattice {a ℓ₁ ℓ₂} {A : Set a}
+                        (_≈_ : Rel A ℓ₁) -- The underlying equality.
+                        (_≤_ : Rel A ℓ₂) -- The partial order.
+                        (_∨_ : Op₂ A)    -- The join operation.
+                        (_∧_ : Op₂ A)    -- The meet operation.
+                        (⊤   : A)        -- The maximum.
+                        (⊥   : A)        -- The minimum.
+                        : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isLattice : IsLattice _≈_ _≤_ _∨_ _∧_
+    maximum   : Maximum _≤_ ⊤
+    minimum   : Minimum _≤_ ⊥
+
+  open IsLattice isLattice public
+
+  isBoundedJoinSemilattice : IsBoundedJoinSemilattice _≈_ _≤_ _∨_ ⊥
+  isBoundedJoinSemilattice = record
+    { isJoinSemilattice = isJoinSemilattice
+    ; minimum           = minimum
+    }
+
+  isBoundedMeetSemilattice : IsBoundedMeetSemilattice _≈_ _≤_ _∧_ ⊤
+  isBoundedMeetSemilattice = record
+    { isMeetSemilattice = isMeetSemilattice
+    ; maximum           = maximum
+    }
+
+record BoundedLattice c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
+  infix  4 _≈_ _≤_
+  infixr 6 _∨_
+  infixr 7 _∧_
+  field
+    Carrier          : Set c
+    _≈_              : Rel Carrier ℓ₁  -- The underlying equality.
+    _≤_              : Rel Carrier ℓ₂  -- The partial order.
+    _∨_              : Op₂ Carrier     -- The join operation.
+    _∧_              : Op₂ Carrier     -- The meet operation.
+    ⊤                : Carrier         -- The maximum.
+    ⊥                : Carrier         -- The minimum.
+    isBoundedLattice : IsBoundedLattice _≈_ _≤_ _∨_ _∧_ ⊤ ⊥
+
+  open IsBoundedLattice isBoundedLattice public
+
+  boundedJoinSemilattice : BoundedJoinSemilattice c ℓ₁ ℓ₂
+  boundedJoinSemilattice = record
+    { isBoundedJoinSemilattice = isBoundedJoinSemilattice }
+
+  boundedMeetSemilattice : BoundedMeetSemilattice c ℓ₁ ℓ₂
+  boundedMeetSemilattice = record
+    { isBoundedMeetSemilattice = isBoundedMeetSemilattice }

--- a/src/Relation/Binary/Properties/BoundedJoinSemilattice.agda
+++ b/src/Relation/Binary/Properties/BoundedJoinSemilattice.agda
@@ -1,0 +1,51 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties satisfied by bounded join semilattices
+------------------------------------------------------------------------
+
+open import Relation.Binary.Lattice
+
+module Relation.Binary.Properties.BoundedJoinSemilattice
+  {c ℓ₁ ℓ₂} (J : BoundedJoinSemilattice c ℓ₁ ℓ₂) where
+
+open BoundedJoinSemilattice J
+
+import Algebra.FunctionProperties as P; open P _≈_
+open import Data.Product
+open import Function using (_∘_; flip)
+open import Relation.Binary
+open import Relation.Binary.Properties.Poset poset
+
+-- Bottom is an identity of the meet operation.
+
+identityˡ : LeftIdentity ⊥ _∨_
+identityˡ x =
+  let _ , x≤⊥∨x , least = supremum ⊥ x
+  in antisym (least x (minimum x) refl) x≤⊥∨x
+
+identityʳ : RightIdentity ⊥ _∨_
+identityʳ x =
+  let x≤x∨⊥ , _ , least = supremum x ⊥
+  in antisym (least x refl (minimum x)) x≤x∨⊥
+
+identity : Identity ⊥ _∨_
+identity = identityˡ , identityʳ
+
+
+-- The dual construction is a bounded meet semilattice.
+
+dualIsBoundedMeetSemilattice : IsBoundedMeetSemilattice _≈_ (flip _≤_) _∨_ ⊥
+dualIsBoundedMeetSemilattice = record
+  { isMeetSemilattice = record
+    { isPartialOrder  = invIsPartialOrder
+    ; infimum         = supremum
+    }
+  ; maximum           = minimum
+  }
+
+dualBoundedMeetSemilattice : BoundedMeetSemilattice c ℓ₁ ℓ₂
+dualBoundedMeetSemilattice = record
+  { ⊤                        = ⊥
+  ; isBoundedMeetSemilattice = dualIsBoundedMeetSemilattice
+  }

--- a/src/Relation/Binary/Properties/BoundedMeetSemilattice.agda
+++ b/src/Relation/Binary/Properties/BoundedMeetSemilattice.agda
@@ -1,0 +1,38 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties satisfied by bounded meet semilattices
+------------------------------------------------------------------------
+
+open import Relation.Binary.Lattice
+
+module Relation.Binary.Properties.BoundedMeetSemilattice
+  {c ℓ₁ ℓ₂} (M : BoundedMeetSemilattice c ℓ₁ ℓ₂) where
+
+open BoundedMeetSemilattice M
+
+import Algebra.FunctionProperties as P; open P _≈_
+open import Data.Product
+open import Function using (_∘_; flip)
+open import Relation.Binary
+open import Relation.Binary.Properties.Poset poset
+import Relation.Binary.Properties.BoundedJoinSemilattice as J
+
+-- The dual construction is a bounded join semilattice.
+
+dualIsBoundedJoinSemilattice : IsBoundedJoinSemilattice _≈_ (flip _≤_) _∧_ ⊤
+dualIsBoundedJoinSemilattice = record
+  { isJoinSemilattice = record
+    { isPartialOrder  = invIsPartialOrder
+    ; supremum        = infimum
+    }
+  ; minimum           = maximum
+  }
+
+dualBoundedJoinSemilattice : BoundedJoinSemilattice c ℓ₁ ℓ₂
+dualBoundedJoinSemilattice = record
+  { ⊥                        = ⊤
+  ; isBoundedJoinSemilattice = dualIsBoundedJoinSemilattice
+  }
+
+open J dualBoundedJoinSemilattice public

--- a/src/Relation/Binary/Properties/JoinSemilattice.agda
+++ b/src/Relation/Binary/Properties/JoinSemilattice.agda
@@ -1,0 +1,70 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties satisfied by join semilattices
+------------------------------------------------------------------------
+
+open import Relation.Binary.Lattice
+
+module Relation.Binary.Properties.JoinSemilattice
+  {c ℓ₁ ℓ₂} (J : JoinSemilattice c ℓ₁ ℓ₂) where
+
+open JoinSemilattice J
+
+import Algebra.FunctionProperties as P; open P _≈_
+open import Data.Product
+open import Function using (_∘_; flip)
+open import Relation.Binary
+open import Relation.Binary.Properties.Poset poset
+
+-- The join operation is monotonic.
+
+∨-monotonic : _∨_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
+∨-monotonic {x} {y} {u} {v} x≤y u≤v =
+  let _     , _     , least  = supremum x u
+      y≤y∨v , v≤y∨v , _      = supremum y v
+  in least (y ∨ v) (trans x≤y y≤y∨v) (trans u≤v v≤y∨v)
+
+∨-cong : _∨_ Preserves₂ _≈_ ⟶ _≈_ ⟶ _≈_
+∨-cong x≈y u≈v = antisym (∨-monotonic (reflexive x≈y) (reflexive u≈v))
+                         (∨-monotonic (reflexive (Eq.sym x≈y))
+                                      (reflexive (Eq.sym u≈v)))
+
+-- The join operation is commutative, associative and idempotent.
+
+∨-comm : Commutative _∨_
+∨-comm x y =
+  let x≤x∨y , y≤x∨y , least  = supremum x y
+      y≤y∨x , x≤y∨x , least′ = supremum y x
+  in antisym (least (y ∨ x) x≤y∨x y≤y∨x) (least′ (x ∨ y) y≤x∨y x≤x∨y)
+
+∨-assoc : Associative _∨_
+∨-assoc x y z =
+  let x∨y≤[x∨y]∨z , z≤[x∨y]∨z   , least  = supremum (x ∨ y) z
+      x≤x∨[y∨z]   , y∨z≤x∨[y∨z] , least′ = supremum x (y ∨ z)
+      y≤y∨z       , z≤y∨z       , _      = supremum y z
+      x≤x∨y       , y≤x∨y       , _      = supremum x y
+  in antisym (least  (x ∨ (y ∨ z)) (∨-monotonic refl y≤y∨z)
+                     (trans z≤y∨z y∨z≤x∨[y∨z]))
+             (least′ ((x ∨ y) ∨ z) (trans x≤x∨y x∨y≤[x∨y]∨z)
+                     (∨-monotonic y≤x∨y refl))
+
+∨-idempotent : Idempotent _∨_
+∨-idempotent x =
+  let x≤x∨x , _ , least = supremum x x
+  in antisym (least x refl refl) x≤x∨x
+
+
+-- The dual construction is a meet semilattice.
+
+dualIsMeetSemilattice : IsMeetSemilattice _≈_ (flip _≤_) _∨_
+dualIsMeetSemilattice = record
+  { isPartialOrder = invIsPartialOrder
+  ; infimum        = supremum
+  }
+
+dualMeetSemilattice : MeetSemilattice c ℓ₁ ℓ₂
+dualMeetSemilattice = record
+  { _∧_               = _∨_
+  ; isMeetSemilattice = dualIsMeetSemilattice
+  }

--- a/src/Relation/Binary/Properties/Lattice.agda
+++ b/src/Relation/Binary/Properties/Lattice.agda
@@ -1,0 +1,70 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties satisfied by lattices
+------------------------------------------------------------------------
+
+open import Relation.Binary.Lattice
+
+module Relation.Binary.Properties.Lattice
+  {c ℓ₁ ℓ₂} (L : Lattice c ℓ₁ ℓ₂) where
+
+open Lattice L
+
+import Algebra as Alg
+import Algebra.Structures as AlgS
+import Algebra.FunctionProperties as P; open P _≈_
+open import Data.Product using (_,_)
+open import Function using (flip)
+open import Relation.Binary
+open import Relation.Binary.Properties.Poset poset
+import Relation.Binary.Properties.JoinSemilattice joinSemilattice as J
+import Relation.Binary.Properties.MeetSemilattice meetSemilattice as M
+
+∨-absorbs-∧ : _∨_ Absorbs _∧_
+∨-absorbs-∧ x y =
+  let x≤x∨[x∧y] , _ , least = supremum  x (x ∧ y)
+      x∧y≤x     , _ , _     = infimum x y
+  in antisym (least x refl x∧y≤x) x≤x∨[x∧y]
+
+∧-absorbs-∨ : _∧_ Absorbs _∨_
+∧-absorbs-∨ x y =
+  let x∧[x∨y]≤x , _ , greatest = infimum  x (x ∨ y)
+      x≤x∨y     , _ , _        = supremum x y
+  in antisym x∧[x∨y]≤x (greatest x refl x≤x∨y)
+
+absorptive : Absorptive _∨_ _∧_
+absorptive = ∨-absorbs-∧ , ∧-absorbs-∨
+
+-- The dual construction is also a lattice.
+
+∧-∨-isLattice : IsLattice _≈_ (flip _≤_) _∧_ _∨_
+∧-∨-isLattice = record
+  { isPartialOrder = invIsPartialOrder
+  ; supremum       = infimum
+  ; infimum        = supremum
+  }
+
+∧-∨-lattice : Lattice c ℓ₁ ℓ₂
+∧-∨-lattice = record
+  { _∧_       = _∨_
+  ; _∨_       = _∧_
+  ; isLattice = ∧-∨-isLattice
+  }
+
+-- Every order-theoretic lattice can be turned into an algebraic one.
+
+isAlgLattice : AlgS.IsLattice _≈_ _∨_ _∧_
+isAlgLattice = record
+  { isEquivalence = isEquivalence
+  ; ∨-comm        = J.∨-comm
+  ; ∨-assoc       = J.∨-assoc
+  ; ∨-cong        = J.∨-cong
+  ; ∧-comm        = M.∧-comm
+  ; ∧-assoc       = M.∧-assoc
+  ; ∧-cong        = M.∧-cong
+  ; absorptive    = absorptive
+  }
+
+algLattice : Alg.Lattice c ℓ₁
+algLattice = record { isLattice = isAlgLattice }

--- a/src/Relation/Binary/Properties/MeetSemilattice.agda
+++ b/src/Relation/Binary/Properties/MeetSemilattice.agda
@@ -1,0 +1,42 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties satisfied by meet semilattices
+------------------------------------------------------------------------
+
+open import Relation.Binary.Lattice
+
+module Relation.Binary.Properties.MeetSemilattice
+  {c ℓ₁ ℓ₂} (M : MeetSemilattice c ℓ₁ ℓ₂) where
+
+open MeetSemilattice M
+
+import Algebra.FunctionProperties as P; open P _≈_
+open import Data.Product
+open import Function using (flip)
+open import Relation.Binary
+open import Relation.Binary.Properties.Poset poset
+import Relation.Binary.Properties.JoinSemilattice as J
+
+-- The dual construction is a join semilattice.
+
+dualIsJoinSemilattice : IsJoinSemilattice _≈_ (flip _≤_) _∧_
+dualIsJoinSemilattice = record
+  { isPartialOrder = invIsPartialOrder
+  ; supremum       = infimum
+  }
+
+dualJoinSemilattice : JoinSemilattice c ℓ₁ ℓ₂
+dualJoinSemilattice = record
+  { _∨_               = _∧_
+  ; isJoinSemilattice = dualIsJoinSemilattice
+  }
+
+open J dualJoinSemilattice public renaming
+  ( ∨-monotonic  to ∧-monotonic
+  ; ∨-cong       to ∧-cong
+  ; ∨-comm       to ∧-comm
+  ; ∨-assoc      to ∧-assoc
+  ; ∨-idempotent to ∧-idempotent
+  )
+

--- a/src/Relation/Binary/Properties/Poset.agda
+++ b/src/Relation/Binary/Properties/Poset.agda
@@ -12,6 +12,19 @@ module Relation.Binary.Properties.Poset
 open Relation.Binary.Poset P hiding (trans)
 import Relation.Binary.NonStrictToStrict as Conv
 open Conv _≈_ _≤_
+open import Relation.Binary.Properties.Preorder preorder
+open import Function using (flip)
+
+-- The inverse relation is also a poset.
+
+invIsPartialOrder : IsPartialOrder _≈_ (flip _≤_)
+invIsPartialOrder = record
+  { isPreorder   = invIsPreorder
+  ; antisym      = flip antisym
+  }
+
+invPoset : Poset p₁ p₂ p₃
+invPoset = record { isPartialOrder = invIsPartialOrder }
 
 ------------------------------------------------------------------------
 -- Posets can be turned into strict partial orders

--- a/src/Relation/Binary/Properties/Preorder.agda
+++ b/src/Relation/Binary/Properties/Preorder.agda
@@ -14,6 +14,18 @@ open import Data.Product as Prod
 
 open Relation.Binary.Preorder P
 
+-- The inverse relation is also a preorder.
+
+invIsPreorder : IsPreorder _≈_ (flip _∼_)
+invIsPreorder = record
+  { isEquivalence = isEquivalence
+  ; reflexive     = reflexive ∘ Eq.sym
+  ; trans         = flip trans
+  }
+
+invPreorder : Preorder p₁ p₂ p₃
+invPreorder = record { isPreorder = invIsPreorder }
+
 ------------------------------------------------------------------------
 -- For every preorder there is an induced equivalence
 


### PR DESCRIPTION
This adds various order-theoretic lattice structures extending `Relation.Binary.Poset`, namely
 * join/meet semilattices
 * bounded join/meet semilattices
 * lattices and bounded lattices

along with related properties, in particular conversions between order-theoretic and algebraic lattices (i.e. instances of `Algebra.Lattice`).