### PR TITLE
Added irrelevant version of bot-elim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ Important changes since 0.13:
 
 * Added syntax for existential quantifiers as `∃[ x ] B` and `∄[ x ] B`.
 
+* Added an irrelevant version of `⊥-elim` in `Data.Empty.Irrelevant`
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/src/Data/Empty/Irrelevant.agda
+++ b/src/Data/Empty/Irrelevant.agda
@@ -1,0 +1,6 @@
+module Data.Empty.Irrelevant where
+
+open import Data.Empty hiding (⊥-elim)
+
+⊥-elim : ∀ {w} {Whatever : Set w} → .⊥ → Whatever
+⊥-elim ()

--- a/src/Data/Empty/Irrelevant.agda
+++ b/src/Data/Empty/Irrelevant.agda
@@ -1,3 +1,9 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- An irrelevant version of ⊥-elim
+------------------------------------------------------------------------
+
 module Data.Empty.Irrelevant where
 
 open import Data.Empty hiding (⊥-elim)


### PR DESCRIPTION
In separate module `Irrelevant` under `Data.Empty`, as discussed in #115.