### PR TITLE
Added additional equality and ordering properties in Data.Fin.Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ Important changes since 0.13:
      zipWith-map
      ```
 
+* Added `isDecEquivalence` proof for `_≡_` to `Data.Fin.Properties`
+
+* Added additional ordering properties to `Data.Fin.Properties` including:
+  ```agda
+  ≤-reflexive
+  ≤-refl
+  ≤-trans
+  ≤-antisymmetric
+  ≤-total
+  ≤-isPreorder
+  ≤-isPartialOrder
+  ≤-isTotalOrder
+
+  _<?_
+  <-trans
+  <-isStrictTotalOrder
+  ```
 
 Version 0.13
 ============


### PR DESCRIPTION
For some of these the equivalent property from the orderings over `Data.Nat` can be applied immediately, however for most this is not the case.

I've also reorganised the file a tiny bit under headings in the style of other `Properties` files.