### PR TITLE
[ refactor ] Factoring out the unsafe parts

### DIFF
--- a/src/Data/Char.agda
+++ b/src/Data/Char.agda
@@ -6,58 +6,19 @@
 
 module Data.Char where
 
-open import Data.Nat.Base using (ℕ)
 import Data.Nat.Properties as NatProp
-open import Data.Bool.Base using (Bool; true; false)
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
+
 open import Relation.Binary
 import Relation.Binary.On as On
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
-open import Relation.Binary.PropositionalEquality.TrustMe
 
-open import Data.String.Base using (String)
 open import Data.Char.Base
 open        Data.Char.Base public using (Char; show; toNat)
 
 -- Informative equality test.
 
-infix 4 _≟_
-
-_≟_ : Decidable {A = Char} _≡_
-s₁ ≟ s₂ with primCharEquality s₁ s₂
-... | true  = yes trustMe
-... | false = no whatever
-  where postulate whatever : _
-
--- Boolean equality test.
---
--- Why is the definition _==_ = primCharEquality not used? One reason
--- is that the present definition can sometimes improve type
--- inference, at least with the version of Agda that is current at the
--- time of writing: see unit-test below.
-
-infix 4 _==_
-
-_==_ : Char → Char → Bool
-c₁ == c₂ = ⌊ c₁ ≟ c₂ ⌋
-
-private
-
-  -- The following unit test does not type-check (at the time of
-  -- writing) if _==_ is replaced by primCharEquality.
-
-  data P : (Char → Bool) → Set where
-    p : (c : Char) → P (_==_ c)
-
-  unit-test : P (_==_ 'x')
-  unit-test = p _
-
 setoid : Setoid _ _
 setoid = PropEq.setoid Char
-
-decSetoid : DecSetoid _ _
-decSetoid = PropEq.decSetoid _≟_
 
 -- An ordering induced by the toNat function.
 

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -7,36 +7,16 @@
 module Data.Digit where
 
 open import Data.Nat
-open import Data.Nat.Properties
-open SemiringSolver
 open import Data.Fin as Fin using (Fin; zero; suc; toℕ)
 open import Relation.Nullary.Decidable
 open import Data.Char using (Char)
 open import Data.List.Base
 open import Data.Product
 open import Data.Vec as Vec using (Vec; _∷_; [])
-open import Induction.Nat
 open import Data.Nat.DivMod
 open ≤-Reasoning
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
 open import Function
-
-------------------------------------------------------------------------
--- A boring lemma
-
-private
-
-  lem : ∀ x k r → 2 + x ≤′ r + (1 + x) * (2 + k)
-  lem x k r = ≤⇒≤′ $ begin
-    2 + x
-      ≤⟨ m≤m+n _ _ ⟩
-    2 + x + (x + (1 + x) * k + r)
-      ≡⟨ solve 3 (λ x r k → con 2 :+ x :+ (x :+ (con 1 :+ x) :* k :+ r)
-                              :=
-                            r :+ (con 1 :+ x) :* (con 2 :+ k))
-                 refl x r k ⟩
-    r + (1 + x) * (2 + k)
-      ∎
 
 ------------------------------------------------------------------------
 -- Digits
@@ -86,26 +66,3 @@ showDigit {base≤16 = base≤16} d =
 fromDigits : ∀ {base} → List (Fin base) → ℕ
 fromDigits        []       = 0
 fromDigits {base} (d ∷ ds) = toℕ d + fromDigits ds * base
-
--- toDigits b n yields the digits of n, in base b, starting with the
--- _least_ significant digit.
---
--- Note that the list of digits is always non-empty.
-
-toDigits : (base : ℕ) {base≥2 : True (2 ≤? base)} (n : ℕ) →
-           ∃ λ (ds : List (Fin base)) → fromDigits ds ≡ n
-toDigits zero       {base≥2 = ()} _
-toDigits (suc zero) {base≥2 = ()} _
-toDigits (suc (suc k)) n = <-rec Pred helper n
-  where
-  base = suc (suc k)
-  Pred = λ n → ∃ λ ds → fromDigits ds ≡ n
-
-  cons : ∀ {m} (r : Fin base) → Pred m → Pred (toℕ r + m * base)
-  cons r (ds , eq) = (r ∷ ds , P.cong (λ i → toℕ r + i * base) eq)
-
-  helper : ∀ n → <-Rec Pred n → Pred n
-  helper n                       rec with n divMod base
-  helper .(toℕ r + 0     * base) rec | result zero    r refl = ([ r ] , refl)
-  helper .(toℕ r + suc x * base) rec | result (suc x) r refl =
-    cons r (rec (suc x) (lem (pred (suc x)) k (toℕ r)))

--- a/src/Data/Float.agda
+++ b/src/Data/Float.agda
@@ -6,11 +6,6 @@
 
 module Data.Float where
 
-open import Data.Bool.Base using (Bool; false; true)
-open import Relation.Nullary.Decidable
-open import Relation.Nullary
-open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
-open import Relation.Binary.PropositionalEquality.TrustMe
 open import Data.String.Base using (String)
 
 open import Agda.Builtin.Float public
@@ -18,11 +13,3 @@ open import Agda.Builtin.Float public
 
 show : Float → String
 show = primShowFloat
-
-infix 4 _≟_
-
-_≟_ : (x y : Float) → Dec (x ≡ y)
-x ≟ y with primFloatEquality x y
-... | true  = yes trustMe
-... | false = no whatever
-  where postulate whatever : _

--- a/src/Data/Integer.agda
+++ b/src/Data/Integer.agda
@@ -7,9 +7,7 @@
 module Data.Integer where
 
 import Data.Nat as ℕ
-import Data.Nat.Show as ℕ
 open import Data.Sign as Sign using (Sign)
-open import Data.String.Base using (String; _++_)
 open import Function
 open import Data.Sum
 open import Relation.Nullary
@@ -23,18 +21,6 @@ open PropEq.≡-Reasoning
 -- Integers, basic types and operations
 
 open import Data.Integer.Base public
-
-------------------------------------------------------------------------
--- Conversions
-
--- Decimal string representation.
-
-show : ℤ → String
-show i = showSign (sign i) ++ ℕ.show ∣ i ∣
-  where
-  showSign : Sign → String
-  showSign Sign.- = "-"
-  showSign Sign.+ = ""
 
 ------------------------------------------------------------------------
 -- Properties of the view of integers as sign + absolute value

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -11,7 +11,6 @@ open import Function using (_∘_)
 open import Relation.Binary
 open import Relation.Binary.Core
 open import Relation.Binary.PropositionalEquality.Core
-import Relation.Binary.PropositionalEquality.TrustMe as TrustMe
 open import Relation.Nullary using (¬_; Dec; yes; no)
 
 infix 4 _≤_ _<_ _≥_ _>_ _≰_ _≮_ _≱_ _≯_
@@ -86,8 +85,6 @@ m ≥″ n = n ≤″ m
 _>″_ : Rel ℕ Level.zero
 m >″ n = n <″ m
 
-erase : ∀ {m n} → m ≤″ n → m ≤″ n
-erase (less-than-or-equal eq) = less-than-or-equal (TrustMe.erase eq)
 
 ------------------------------------------------------------------------
 -- A generalisation of the arithmetic operations

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -7,23 +7,13 @@
 module Data.Nat.DivMod where
 
 open import Data.Fin as Fin using (Fin; toℕ)
-import Data.Fin.Properties as FinP
-open import Data.Nat as Nat
-open import Data.Nat.Properties as NatP
-open import Data.Nat.Properties.Simple
+open import Data.Nat.Base
 open import Relation.Nullary.Decidable
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
-import Relation.Binary.PropositionalEquality.TrustMe as TrustMe
-  using (erase)
 
-open import Agda.Builtin.Nat using ( div-helper; mod-helper )
+open import Agda.Builtin.Nat using ( div-helper )
 
-open NatP.SemiringSolver
-open P.≡-Reasoning
-open Nat.≤-Reasoning
-  renaming (begin_ to start_; _∎ to _□; _≡⟨_⟩_ to _≡⟨_⟩′_)
-
-infixl 7 _div_ _mod_ _divMod_
+infixl 7 _div_
 
 -- A specification of integer division.
 
@@ -40,110 +30,3 @@ _div_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
 (d div 0) {}
 (d div suc s) = div-helper 0 s d s
 
--- The remainder after integer division.
-
-private
-  -- The remainder is not too large.
-
-  mod-lemma : (acc d n : ℕ) →
-              let s = acc + n in
-              mod-helper acc s d n ≤ s
-
-  mod-lemma acc zero n = start
-    acc      ≤⟨ m≤m+n acc n ⟩
-    acc + n  □
-
-  mod-lemma acc (suc d) zero = start
-    mod-helper zero (acc + 0) d (acc + 0)  ≤⟨ mod-lemma zero d (acc + 0) ⟩
-    acc + 0                                □
-
-  mod-lemma acc (suc d) (suc n) =
-    P.subst (λ x → mod-helper (suc acc) x d n ≤ x)
-            (P.sym (+-suc acc n))
-            (mod-lemma (suc acc) d n)
-
-_mod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → Fin divisor
-(d mod 0) {}
-(d mod suc s) =
-  Fin.fromℕ≤″ (mod-helper 0 s d s)
-              (Nat.erase (≤⇒≤″ (s≤s (mod-lemma 0 d s))))
-
--- Integer division with remainder.
-
-private
-
-  -- The quotient and remainder are related to the dividend and
-  -- divisor in the right way.
-
-  division-lemma :
-    (mod-acc div-acc d n : ℕ) →
-    let s = mod-acc + n in
-    mod-acc + div-acc * suc s + d
-      ≡
-    mod-helper mod-acc s d n + div-helper div-acc s d n * suc s
-
-  division-lemma mod-acc div-acc zero n = begin
-
-    mod-acc + div-acc * suc s + zero  ≡⟨ +-right-identity _ ⟩
-
-    mod-acc + div-acc * suc s         ∎
-
-    where s = mod-acc + n
-
-  division-lemma mod-acc div-acc (suc d) zero = begin
-
-    mod-acc + div-acc * suc s + suc d                ≡⟨ solve 3
-                                                              (λ mod-acc div-acc d →
-                                                                   let s = mod-acc :+ con 0 in
-                                                                   mod-acc :+ div-acc :* (con 1 :+ s) :+ (con 1 :+ d)
-                                                                     :=
-                                                                   (con 1 :+ div-acc) :* (con 1 :+ s) :+ d)
-                                                              P.refl mod-acc div-acc d ⟩
-    suc div-acc * suc s + d                          ≡⟨ division-lemma zero (suc div-acc) d s ⟩
-
-    mod-helper zero          s      d  s    +
-    div-helper (suc div-acc) s      d  s    * suc s  ≡⟨⟩
-
-    mod-helper      mod-acc  s (suc d) zero +
-    div-helper      div-acc  s (suc d) zero * suc s  ∎
-
-    where s = mod-acc + 0
-
-  division-lemma mod-acc div-acc (suc d) (suc n) = begin
-
-    mod-acc + div-acc * suc s + suc d                   ≡⟨ solve 4
-                                                                 (λ mod-acc div-acc n d →
-                                                                      mod-acc :+ div-acc :* (con 1 :+ (mod-acc :+ (con 1 :+ n))) :+ (con 1 :+ d)
-                                                                        :=
-                                                                      con 1 :+ mod-acc :+ div-acc :* (con 2 :+ mod-acc :+ n) :+ d)
-                                                                 P.refl mod-acc div-acc n d ⟩
-    suc mod-acc + div-acc * suc s′ + d                  ≡⟨ division-lemma (suc mod-acc) div-acc d n ⟩
-
-    mod-helper (suc mod-acc) s′ d n +
-    div-helper      div-acc  s′ d n * suc s′            ≡⟨ P.cong (λ s → mod-helper (suc mod-acc) s d n +
-                                                                         div-helper div-acc s d n * suc s)
-                                                                  (P.sym (+-suc mod-acc n)) ⟩
-
-    mod-helper (suc mod-acc) s d n +
-    div-helper      div-acc  s d n * suc s              ≡⟨⟩
-
-    mod-helper      mod-acc  s (suc d) (suc n) +
-    div-helper      div-acc  s (suc d) (suc n) * suc s  ∎
-
-    where
-    s  = mod-acc + suc n
-    s′ = suc mod-acc + n
-
-_divMod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} →
-           DivMod dividend divisor
-(d divMod 0) {}
-(d divMod suc s) =
-  result (d div suc s) (d mod suc s) (TrustMe.erase (begin
-    d                                                        ≡⟨ division-lemma 0 0 d s ⟩
-    mod-helper 0 s d s         + div-helper 0 s d s * suc s  ≡⟨ P.cong₂ _+_ (P.sym (FinP.toℕ-fromℕ≤ lemma)) P.refl ⟩
-    toℕ (Fin.fromℕ≤    lemma)  + div-helper 0 s d s * suc s  ≡⟨ P.cong (λ n → toℕ n + div-helper 0 s d s * suc s)
-                                                                       (FinP.fromℕ≤≡fromℕ≤″ lemma _) ⟩
-    toℕ (Fin.fromℕ≤″ _ lemma′) + div-helper 0 s d s * suc s  ∎))
-  where
-  lemma  = s≤s (mod-lemma 0 d s)
-  lemma′ = Nat.erase (≤⇒≤″ lemma)

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -197,16 +197,3 @@ nonZeroDivisor-lemma m (suc q) r r≢zero d =
   lem = solve 3 (λ m r q → r :+ (m :+ q)  :=  m :+ (r :+ q))
                 refl (suc m) (Fin.toℕ r) (q * suc m)
   d' = subst (λ x → (1 + m) ∣ x) lem d
-
--- Divisibility is decidable.
-
-infix 4 _∣?_
-
-_∣?_ : Decidable _∣_
-zero  ∣? zero                         = yes (0 ∣0)
-zero  ∣? suc n                        = no ((λ ()) ∘′ 0∣⇒≡0)
-suc m ∣? n                            with n divMod suc m
-suc m ∣? .(q * suc m)                 | result q zero    refl =
-  yes $ divides q refl
-suc m ∣? .(1 + Fin.toℕ r + q * suc m) | result q (suc r) refl =
-  no $ nonZeroDivisor-lemma m q (suc r) (λ())

--- a/src/Data/Nat/Primality.agda
+++ b/src/Data/Nat/Primality.agda
@@ -8,13 +8,9 @@ module Data.Nat.Primality where
 
 open import Data.Empty
 open import Data.Fin as Fin hiding (_+_)
-open import Data.Fin.Dec
 open import Data.Nat
 open import Data.Nat.Divisibility
 open import Relation.Nullary
-open import Relation.Nullary.Decidable
-open import Relation.Nullary.Negation
-open import Relation.Unary
 
 -- Definition of primality.
 
@@ -22,17 +18,3 @@ Prime : ℕ → Set
 Prime 0             = ⊥
 Prime 1             = ⊥
 Prime (suc (suc n)) = (i : Fin n) → ¬ (2 + Fin.toℕ i ∣ 2 + n)
-
--- Decision procedure for primality.
-
-prime? : Decidable Prime
-prime? 0             = no λ()
-prime? 1             = no λ()
-prime? (suc (suc n)) = all? λ _ → ¬? (_ ∣? _)
-
-private
-
-  -- Example: 2 is prime.
-
-  2-is-prime : Prime 2
-  2-is-prime = from-yes (prime? 2)

--- a/src/Data/String.agda
+++ b/src/Data/String.agda
@@ -10,15 +10,11 @@ open import Data.List.Base as List using (_∷_; []; List)
 open import Data.Vec as Vec using (Vec)
 open import Data.Colist as Colist using (Colist)
 open import Data.Char as Char using (Char)
-open import Data.Bool.Base using (Bool; true; false)
 open import Function
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
 open import Relation.Binary
 open import Relation.Binary.List.StrictLex as StrictLex
 import Relation.Binary.On as On
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
-open import Relation.Binary.PropositionalEquality.TrustMe
 
 open import Data.String.Base public
 
@@ -31,49 +27,13 @@ Costring = Colist Char
 -- Operations
 
 toVec : (s : String) → Vec Char (List.length (toList s))
-toVec s = Vec.fromList (toList s)
+toVec = Vec.fromList ∘ toList
 
 toCostring : String → Costring
 toCostring = Colist.fromList ∘ toList
 
--- Informative equality test.
-
-infix 4 _≟_
-
-_≟_ : Decidable {A = String} _≡_
-s₁ ≟ s₂ with primStringEquality s₁ s₂
-... | true  = yes trustMe
-... | false = no whatever
-  where postulate whatever : _
-
--- Boolean equality test.
---
--- Why is the definition _==_ = primStringEquality not used? One
--- reason is that the present definition can sometimes improve type
--- inference, at least with the version of Agda that is current at the
--- time of writing: see unit-test below.
-
-infix 4 _==_
-
-_==_ : String → String → Bool
-s₁ == s₂ = ⌊ s₁ ≟ s₂ ⌋
-
-private
-
-  -- The following unit test does not type-check (at the time of
-  -- writing) if _==_ is replaced by primStringEquality.
-
-  data P : (String → Bool) → Set where
-    p : (c : String) → P (_==_ c)
-
-  unit-test : P (_==_ "")
-  unit-test = p _
-
 setoid : Setoid _ _
 setoid = PropEq.setoid String
-
-decSetoid : DecSetoid _ _
-decSetoid = PropEq.decSetoid _≟_
 
 -- Lexicographic ordering of strings.
 

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -10,7 +10,6 @@ open import Data.List.Base as List using (_∷_; []; List)
 open import Data.Bool.Base using (Bool)
 open import Data.Char.Core using (Char)
 open import Relation.Binary.Core using (_≡_)
-open import Relation.Binary.PropositionalEquality.TrustMe using (trustMe)
 
 ------------------------------------------------------------------------
 -- From Agda.Builtin
@@ -36,12 +35,6 @@ toList = primStringToList
 
 fromList : List Char → String
 fromList = primStringFromList
-
-toList∘fromList : ∀ s → toList (fromList s) ≡ s
-toList∘fromList s = trustMe
-
-fromList∘toList : ∀ s → fromList (toList s) ≡ s
-fromList∘toList s = trustMe
 
 unlines : List String → String
 unlines []       = ""

--- a/src/IO.agda
+++ b/src/IO.agda
@@ -4,14 +4,13 @@
 -- IO
 ------------------------------------------------------------------------
 
-module IO where
+module IO (PrimIO : ∀ {a} → Set a → Set a) where
 
 open import Coinduction
 open import Data.Unit
 open import Data.String
 open import Data.Colist
 open import Function
-import IO.Primitive as Prim
 open import Level
 
 ------------------------------------------------------------------------
@@ -27,18 +26,10 @@ open import Level
 infixl 1 _>>=_ _>>_
 
 data IO {a} (A : Set a) : Set (suc a) where
-  lift   : (m : Prim.IO A) → IO A
+  lift   : (m : PrimIO A) → IO A
   return : (x : A) → IO A
   _>>=_  : {B : Set a} (m : ∞ (IO B)) (f : (x : B) → ∞ (IO A)) → IO A
   _>>_   : {B : Set a} (m₁ : ∞ (IO B)) (m₂ : ∞ (IO A)) → IO A
-
-{-# NON_TERMINATING #-}
-
-run : ∀ {a} {A : Set a} → IO A → Prim.IO A
-run (lift m)   = m
-run (return x) = Prim.return x
-run (m  >>= f) = Prim._>>=_ (run (♭ m )) λ x → run (♭ (f x))
-run (m₁ >> m₂) = Prim._>>=_ (run (♭ m₁)) λ _ → run (♭ m₂)
 
 ------------------------------------------------------------------------
 -- Utilities
@@ -64,59 +55,3 @@ mapM f = sequence ∘ map f
 
 mapM′ : {A B : Set} → (A → IO B) → Colist A → IO (Lift ⊤)
 mapM′ f = sequence′ ∘ map f
-
-------------------------------------------------------------------------
--- Simple lazy IO
-
--- Note that the functions below produce commands which, when
--- executed, may raise exceptions.
-
--- Note also that the semantics of these functions depends on the
--- version of the Haskell base library. If the version is 4.2.0.0 (or
--- later?), then the functions use the character encoding specified by
--- the locale. For older versions of the library (going back to at
--- least version 3) the functions use ISO-8859-1.
-
-getContents : IO Costring
-getContents = lift Prim.getContents
-
-readFile : String → IO Costring
-readFile f = lift (Prim.readFile f)
-
--- Reads a finite file. Raises an exception if the file path refers to
--- a non-physical file (like "/dev/zero").
-
-readFiniteFile : String → IO String
-readFiniteFile f = lift (Prim.readFiniteFile f)
-
-writeFile∞ : String → Costring → IO ⊤
-writeFile∞ f s =
-  ♯ lift (Prim.writeFile f s) >>
-  ♯ return _
-
-writeFile : String → String → IO ⊤
-writeFile f s = writeFile∞ f (toCostring s)
-
-appendFile∞ : String → Costring → IO ⊤
-appendFile∞ f s =
-  ♯ lift (Prim.appendFile f s) >>
-  ♯ return _
-
-appendFile : String → String → IO ⊤
-appendFile f s = appendFile∞ f (toCostring s)
-
-putStr∞ : Costring → IO ⊤
-putStr∞ s =
-  ♯ lift (Prim.putStr s) >>
-  ♯ return _
-
-putStr : String → IO ⊤
-putStr s = putStr∞ (toCostring s)
-
-putStrLn∞ : Costring → IO ⊤
-putStrLn∞ s =
-  ♯ lift (Prim.putStrLn s) >>
-  ♯ return _
-
-putStrLn : String → IO ⊤
-putStrLn s = putStrLn∞ (toCostring s)

--- a/src/Unsafe/Data/Char.agda
+++ b/src/Unsafe/Data/Char.agda
@@ -1,0 +1,52 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on characters
+------------------------------------------------------------------------
+
+module Unsafe.Data.Char where
+
+open import Data.Char public
+
+open import Data.Char.Base
+open import Data.Bool.Base using (Bool ; true ; false)
+open import Relation.Nullary.Decidable
+open import Relation.Nullary
+open import Relation.Binary
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe
+open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
+
+
+infix 4 _≟_
+
+_≟_ : Decidable {A = Char} _≡_
+s₁ ≟ s₂ with primCharEquality s₁ s₂
+... | true  = yes trustMe
+... | false = no whatever
+  where postulate whatever : _
+
+-- Boolean equality test.
+--
+-- Why is the definition _==_ = primCharEquality not used? One reason
+-- is that the present definition can sometimes improve type
+-- inference, at least with the version of Agda that is current at the
+-- time of writing: see unit-test below.
+
+infix 4 _==_
+
+_==_ : Char → Char → Bool
+c₁ == c₂ = ⌊ c₁ ≟ c₂ ⌋
+
+private
+
+  -- The following unit test does not type-check (at the time of
+  -- writing) if _==_ is replaced by primCharEquality.
+
+  data P : (Char → Bool) → Set where
+    p : (c : Char) → P (_==_ c)
+
+  unit-test : P (_==_ 'x')
+  unit-test = p _
+
+decSetoid : DecSetoid _ _
+decSetoid = PropEq.decSetoid _≟_

--- a/src/Unsafe/Data/Digit.agda
+++ b/src/Unsafe/Data/Digit.agda
@@ -1,0 +1,64 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on digits and digit expansions
+------------------------------------------------------------------------
+
+module Unsafe.Data.Digit where
+
+open import Data.Digit public
+
+open import Data.Nat
+open import Data.Nat.Properties
+open SemiringSolver
+open import Data.Fin as Fin using (Fin; zero; suc; toℕ)
+open import Relation.Nullary.Decidable
+open import Data.Char using (Char)
+open import Data.List.Base
+open import Data.Product
+open import Data.Vec as Vec using (Vec; _∷_; [])
+open import Induction.Nat
+open import Unsafe.Data.Nat.DivMod
+open ≤-Reasoning
+open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
+open import Function
+
+------------------------------------------------------------------------
+-- A boring lemma
+
+private
+
+  lem : ∀ x k r → 2 + x ≤′ r + (1 + x) * (2 + k)
+  lem x k r = ≤⇒≤′ $ begin
+    2 + x
+      ≤⟨ m≤m+n _ _ ⟩
+    2 + x + (x + (1 + x) * k + r)
+      ≡⟨ solve 3 (λ x r k → con 2 :+ x :+ (x :+ (con 1 :+ x) :* k :+ r)
+                              :=
+                            r :+ (con 1 :+ x) :* (con 2 :+ k))
+                 refl x r k ⟩
+    r + (1 + x) * (2 + k)
+      ∎
+
+-- toDigits b n yields the digits of n, in base b, starting with the
+-- _least_ significant digit.
+--
+-- Note that the list of digits is always non-empty.
+
+toDigits : (base : ℕ) {base≥2 : True (2 ≤? base)} (n : ℕ) →
+           ∃ λ (ds : List (Fin base)) → fromDigits ds ≡ n
+toDigits zero       {base≥2 = ()} _
+toDigits (suc zero) {base≥2 = ()} _
+toDigits (suc (suc k)) n = <-rec Pred helper n
+  where
+  base = suc (suc k)
+  Pred = λ n → ∃ λ ds → fromDigits ds ≡ n
+
+  cons : ∀ {m} (r : Fin base) → Pred m → Pred (toℕ r + m * base)
+  cons r (ds , eq) = (r ∷ ds , P.cong (λ i → toℕ r + i * base) eq)
+
+  helper : ∀ n → <-Rec Pred n → Pred n
+  helper n                       rec with n divMod base
+  helper .(toℕ r + 0     * base) rec | result zero    r refl = ([ r ] , refl)
+  helper .(toℕ r + suc x * base) rec | result (suc x) r refl =
+    cons r (rec (suc x) (lem (pred (suc x)) k (toℕ r)))

--- a/src/Unsafe/Data/Float.agda
+++ b/src/Unsafe/Data/Float.agda
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on floats
+------------------------------------------------------------------------
+
+module Unsafe.Data.Float where
+
+open import Data.Float public
+
+open import Data.Bool.Base using (Bool ; true ; false)
+open import Relation.Nullary
+open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe
+
+infix 4 _≟_
+
+_≟_ : (x y : Float) → Dec (x ≡ y)
+x ≟ y with primFloatEquality x y
+... | true  = yes trustMe
+... | false = no whatever
+  where postulate whatever : _

--- a/src/Unsafe/Data/Integer.agda
+++ b/src/Unsafe/Data/Integer.agda
@@ -1,0 +1,25 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on integers
+------------------------------------------------------------------------
+
+module Unsafe.Data.Integer where
+
+open import Data.Integer public
+
+open import Data.Sign as Sign using (Sign)
+import Unsafe.Data.Nat.Show as ℕ
+open import Data.String.Base using (String ; _++_)
+
+------------------------------------------------------------------------
+-- Conversions
+
+-- Decimal string representation.
+
+show : ℤ → String
+show i = showSign (sign i) ++ ℕ.show ∣ i ∣
+  where
+  showSign : Sign → String
+  showSign Sign.- = "-"
+  showSign Sign.+ = ""

--- a/src/Unsafe/Data/Nat/Base.agda
+++ b/src/Unsafe/Data/Nat/Base.agda
@@ -1,0 +1,13 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on natural numbers, basic types and operations
+------------------------------------------------------------------------
+
+module Unsafe.Data.Nat.Base where
+
+open import Data.Nat.Base public
+import Unsafe.Relation.Binary.PropositionalEquality.TrustMe as TrustMe
+
+erase : ∀ {m n} → m ≤″ n → m ≤″ n
+erase (less-than-or-equal eq) = less-than-or-equal (TrustMe.erase eq)

--- a/src/Unsafe/Data/Nat/DivMod.agda
+++ b/src/Unsafe/Data/Nat/DivMod.agda
@@ -1,0 +1,135 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on integer division
+------------------------------------------------------------------------
+
+module Unsafe.Data.Nat.DivMod where
+
+open import Data.Nat.DivMod public
+
+open import Data.Fin as Fin using (Fin; toℕ)
+import Data.Fin.Properties as FinP
+open import Unsafe.Data.Nat.Base as Nat
+open import Data.Nat
+open import Data.Nat.Properties as NatP
+open import Data.Nat.Properties.Simple
+open import Relation.Nullary.Decidable
+open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe as TrustMe
+
+open import Agda.Builtin.Nat using ( div-helper; mod-helper )
+
+open NatP.SemiringSolver
+open P.≡-Reasoning
+open Data.Nat.≤-Reasoning
+  renaming (begin_ to start_; _∎ to _□; _≡⟨_⟩_ to _≡⟨_⟩′_)
+
+-- The remainder after integer division.
+
+infixl 7 _mod_ _divMod_
+
+private
+  -- The remainder is not too large.
+
+  mod-lemma : (acc d n : ℕ) →
+              let s = acc + n in
+              mod-helper acc s d n ≤ s
+
+  mod-lemma acc zero n = start
+    acc      ≤⟨ m≤m+n acc n ⟩
+    acc + n  □
+
+  mod-lemma acc (suc d) zero = start
+    mod-helper zero (acc + 0) d (acc + 0)  ≤⟨ mod-lemma zero d (acc + 0) ⟩
+    acc + 0                                □
+
+  mod-lemma acc (suc d) (suc n) =
+    P.subst (λ x → mod-helper (suc acc) x d n ≤ x)
+            (P.sym (+-suc acc n))
+            (mod-lemma (suc acc) d n)
+
+_mod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → Fin divisor
+(d mod 0) {}
+(d mod suc s) =
+  Fin.fromℕ≤″ (mod-helper 0 s d s)
+              (Nat.erase (≤⇒≤″ (s≤s (mod-lemma 0 d s))))
+-- Integer division with remainder.
+
+private
+
+  -- The quotient and remainder are related to the dividend and
+  -- divisor in the right way.
+
+  division-lemma :
+    (mod-acc div-acc d n : ℕ) →
+    let s = mod-acc + n in
+    mod-acc + div-acc * suc s + d
+      ≡
+    mod-helper mod-acc s d n + div-helper div-acc s d n * suc s
+
+  division-lemma mod-acc div-acc zero n = begin
+
+    mod-acc + div-acc * suc s + zero  ≡⟨ +-right-identity _ ⟩
+
+    mod-acc + div-acc * suc s         ∎
+
+    where s = mod-acc + n
+
+  division-lemma mod-acc div-acc (suc d) zero = begin
+
+    mod-acc + div-acc * suc s + suc d                ≡⟨ solve 3
+                                                              (λ mod-acc div-acc d →
+                                                                   let s = mod-acc :+ con 0 in
+                                                                   mod-acc :+ div-acc :* (con 1 :+ s) :+ (con 1 :+ d)
+                                                                     :=
+                                                                   (con 1 :+ div-acc) :* (con 1 :+ s) :+ d)
+                                                              P.refl mod-acc div-acc d ⟩
+    suc div-acc * suc s + d                          ≡⟨ division-lemma zero (suc div-acc) d s ⟩
+
+    mod-helper zero          s      d  s    +
+    div-helper (suc div-acc) s      d  s    * suc s  ≡⟨⟩
+
+    mod-helper      mod-acc  s (suc d) zero +
+    div-helper      div-acc  s (suc d) zero * suc s  ∎
+
+    where s = mod-acc + 0
+
+  division-lemma mod-acc div-acc (suc d) (suc n) = begin
+
+    mod-acc + div-acc * suc s + suc d                   ≡⟨ solve 4
+                                                                 (λ mod-acc div-acc n d →
+                                                                      mod-acc :+ div-acc :* (con 1 :+ (mod-acc :+ (con 1 :+ n))) :+ (con 1 :+ d)
+                                                                        :=
+                                                                      con 1 :+ mod-acc :+ div-acc :* (con 2 :+ mod-acc :+ n) :+ d)
+                                                                 P.refl mod-acc div-acc n d ⟩
+    suc mod-acc + div-acc * suc s′ + d                  ≡⟨ division-lemma (suc mod-acc) div-acc d n ⟩
+
+    mod-helper (suc mod-acc) s′ d n +
+    div-helper      div-acc  s′ d n * suc s′            ≡⟨ P.cong (λ s → mod-helper (suc mod-acc) s d n +
+                                                                         div-helper div-acc s d n * suc s)
+                                                                  (P.sym (+-suc mod-acc n)) ⟩
+
+    mod-helper (suc mod-acc) s d n +
+    div-helper      div-acc  s d n * suc s              ≡⟨⟩
+
+    mod-helper      mod-acc  s (suc d) (suc n) +
+    div-helper      div-acc  s (suc d) (suc n) * suc s  ∎
+
+    where
+    s  = mod-acc + suc n
+    s′ = suc mod-acc + n
+
+_divMod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} →
+           DivMod dividend divisor
+(d divMod 0) {}
+(d divMod suc s) =
+  result (d div suc s) (d mod suc s) (TrustMe.erase (begin
+    d                                                        ≡⟨ division-lemma 0 0 d s ⟩
+    mod-helper 0 s d s         + div-helper 0 s d s * suc s  ≡⟨ P.cong₂ _+_ (P.sym (FinP.toℕ-fromℕ≤ lemma)) P.refl ⟩
+    toℕ (Fin.fromℕ≤    lemma)  + div-helper 0 s d s * suc s  ≡⟨ P.cong (λ n → toℕ n + div-helper 0 s d s * suc s)
+                                                                       (FinP.fromℕ≤≡fromℕ≤″ lemma _) ⟩
+    toℕ (Fin.fromℕ≤″ _ lemma′) + div-helper 0 s d s * suc s  ∎))
+  where
+  lemma  = s≤s (mod-lemma 0 d s)
+  lemma′ = Nat.erase (≤⇒≤″ lemma)

--- a/src/Unsafe/Data/Nat/Divisibility.agda
+++ b/src/Unsafe/Data/Nat/Divisibility.agda
@@ -1,0 +1,30 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on divisibility
+------------------------------------------------------------------------
+
+module Unsafe.Data.Nat.Divisibility where
+
+open import Data.Nat.Divisibility public
+
+open import Data.Nat
+open import Data.Fin as Fin using (Fin ; zero ; suc)
+open import Unsafe.Data.Nat.DivMod
+open import Function
+open import Relation.Nullary
+open import Relation.Binary
+open import Relation.Binary.PropositionalEquality
+
+-- Divisibility is decidable.
+
+infix 4 _∣?_
+
+_∣?_ : Decidable _∣_
+zero  ∣? zero                         = yes (0 ∣0)
+zero  ∣? suc n                        = no ((λ ()) ∘′ 0∣⇒≡0)
+suc m ∣? n                            with n divMod suc m
+suc m ∣? .(q * suc m)                 | result q zero    refl =
+  yes $ divides q refl
+suc m ∣? .(1 + Fin.toℕ r + q * suc m) | result q (suc r) refl =
+  no $ nonZeroDivisor-lemma m q (suc r) (λ())

--- a/src/Unsafe/Data/Nat/Primality.agda
+++ b/src/Unsafe/Data/Nat/Primality.agda
@@ -1,0 +1,33 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on primality
+------------------------------------------------------------------------
+
+module Unsafe.Data.Nat.Primality where
+
+open import Data.Nat.Primality public
+
+open import Data.Empty
+open import Data.Fin as Fin hiding (_+_)
+open import Data.Fin.Dec
+open import Data.Nat
+open import Unsafe.Data.Nat.Divisibility
+open import Relation.Nullary
+open import Relation.Nullary.Decidable
+open import Relation.Nullary.Negation
+open import Relation.Unary
+
+-- Decision procedure for primality.
+
+prime? : Decidable Prime
+prime? 0             = no λ()
+prime? 1             = no λ()
+prime? (suc (suc n)) = all? λ _ → ¬? (_ ∣? _)
+
+private
+
+  -- Example: 2 is prime.
+
+  2-is-prime : Prime 2
+  2-is-prime = from-yes (prime? 2)

--- a/src/Unsafe/Data/Nat/Show.agda
+++ b/src/Unsafe/Data/Nat/Show.agda
@@ -4,12 +4,12 @@
 -- Showing natural numbers
 ------------------------------------------------------------------------
 
-module Data.Nat.Show where
+module Unsafe.Data.Nat.Show where
 
 open import Data.Nat
 open import Relation.Nullary.Decidable using (True)
 open import Data.String.Base as String using (String)
-open import Data.Digit
+open import Unsafe.Data.Digit
 open import Data.Product using (proj₁)
 open import Function
 open import Data.List.Base

--- a/src/Unsafe/Data/String.agda
+++ b/src/Unsafe/Data/String.agda
@@ -1,0 +1,54 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on strings
+------------------------------------------------------------------------
+
+module Unsafe.Data.String where
+
+open import Data.String public
+
+open import Data.Bool.Base using (Bool ; true ; false)
+open import Relation.Nullary.Decidable
+open import Relation.Nullary
+open import Relation.Binary
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe
+open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
+
+
+-- Informative equality test.
+
+infix 4 _≟_
+
+_≟_ : Decidable {A = String} _≡_
+s₁ ≟ s₂ with primStringEquality s₁ s₂
+... | true  = yes trustMe
+... | false = no whatever
+  where postulate whatever : _
+
+-- Boolean equality test.
+--
+-- Why is the definition _==_ = primStringEquality not used? One
+-- reason is that the present definition can sometimes improve type
+-- inference, at least with the version of Agda that is current at the
+-- time of writing: see unit-test below.
+
+infix 4 _==_
+
+_==_ : String → String → Bool
+s₁ == s₂ = ⌊ s₁ ≟ s₂ ⌋
+
+private
+
+  -- The following unit test does not type-check (at the time of
+  -- writing) if _==_ is replaced by primStringEquality.
+
+  data P : (String → Bool) → Set where
+    p : (c : String) → P (_==_ c)
+
+  unit-test : P (_==_ "")
+  unit-test = p _
+
+decSetoid : DecSetoid _ _
+decSetoid = PropEq.decSetoid _≟_
+

--- a/src/Unsafe/Data/String/Base.agda
+++ b/src/Unsafe/Data/String/Base.agda
@@ -1,0 +1,18 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on strings
+------------------------------------------------------------------------
+
+module Unsafe.Data.String.Base where
+
+open import Data.String.Base public
+
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe
+
+toList∘fromList : ∀ s → toList (fromList s) ≡ s
+toList∘fromList s = trustMe
+
+fromList∘toList : ∀ s → fromList (toList s) ≡ s
+fromList∘toList s = trustMe

--- a/src/Unsafe/IO.agda
+++ b/src/Unsafe/IO.agda
@@ -1,0 +1,79 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Unsafe functions on IO
+------------------------------------------------------------------------
+
+module Unsafe.IO where
+
+import Unsafe.IO.Primitive as Prim
+open import IO Prim.IO public
+
+open import Coinduction
+open import Data.Unit.Base
+open import Data.String
+
+{-# NON_TERMINATING #-}
+
+run : ∀ {a} {A : Set a} → IO A → Prim.IO A
+run (lift m)   = m
+run (return x) = Prim.return x
+run (m  >>= f) = Prim._>>=_ (run (♭ m )) λ x → run (♭ (f x))
+run (m₁ >> m₂) = Prim._>>=_ (run (♭ m₁)) λ _ → run (♭ m₂)
+
+------------------------------------------------------------------------
+-- Simple lazy IO
+
+-- Note that the functions below produce commands which, when
+-- executed, may raise exceptions.
+
+-- Note also that the semantics of these functions depends on the
+-- version of the Haskell base library. If the version is 4.2.0.0 (or
+-- later?), then the functions use the character encoding specified by
+-- the locale. For older versions of the library (going back to at
+-- least version 3) the functions use ISO-8859-1.
+
+getContents : IO Costring
+getContents = lift Prim.getContents
+
+readFile : String → IO Costring
+readFile f = lift (Prim.readFile f)
+
+-- Reads a finite file. Raises an exception if the file path refers to
+-- a non-physical file (like "/dev/zero").
+
+readFiniteFile : String → IO String
+readFiniteFile f = lift (Prim.readFiniteFile f)
+
+writeFile∞ : String → Costring → IO ⊤
+writeFile∞ f s =
+  ♯ lift (Prim.writeFile f s) >>
+  ♯ return _
+
+writeFile : String → String → IO ⊤
+writeFile f s = writeFile∞ f (toCostring s)
+
+appendFile∞ : String → Costring → IO ⊤
+appendFile∞ f s =
+  ♯ lift (Prim.appendFile f s) >>
+  ♯ return _
+
+appendFile : String → String → IO ⊤
+appendFile f s = appendFile∞ f (toCostring s)
+
+putStr∞ : Costring → IO ⊤
+putStr∞ s =
+  ♯ lift (Prim.putStr s) >>
+  ♯ return _
+
+putStr : String → IO ⊤
+putStr s = putStr∞ (toCostring s)
+
+putStrLn∞ : Costring → IO ⊤
+putStrLn∞ s =
+  ♯ lift (Prim.putStrLn s) >>
+  ♯ return _
+
+putStrLn : String → IO ⊤
+putStrLn s = putStrLn∞ (toCostring s)
+

--- a/src/Unsafe/IO/Primitive.agda
+++ b/src/Unsafe/IO/Primitive.agda
@@ -1,10 +1,10 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Primitive IO: simple bindings to Haskell types and functions
+-- Unsafe primitive IO: simple bindings to Haskell types and functions
 ------------------------------------------------------------------------
 
-module IO.Primitive where
+module Unsafe.IO.Primitive where
 
 open import Data.Char.Base
 open import Data.String

--- a/src/Unsafe/README/Record.agda
+++ b/src/Unsafe/README/Record.agda
@@ -7,7 +7,7 @@
 -- Taken from Randy Pollack's paper "Dependently Typed Records in Type
 -- Theory".
 
-module README.Record where
+module Unsafe.README.Record where
 
 open import Data.Product
 open import Unsafe.Data.String

--- a/src/Unsafe/Reflection.agda
+++ b/src/Unsafe/Reflection.agda
@@ -1,24 +1,24 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Support for reflection
+-- Unsafe support for reflection
 ------------------------------------------------------------------------
 
-module Reflection where
+module Unsafe.Reflection where
 
 open import Data.Unit.Base using (⊤)
 open import Data.Bool.Base using (Bool; false; true)
 open import Data.List.Base using (List); open Data.List.Base.List
 open import Data.Nat using (ℕ) renaming (_≟_ to _≟-ℕ_)
-open import Data.Nat.Show renaming (show to showNat)
-open import Data.Float using (Float) renaming (_≟_ to _≟f_; show to showFloat)
-open import Data.Char using (Char) renaming (_≟_ to _≟c_; show to showChar)
-open import Data.String using (String) renaming (_≟_ to _≟s_; show to showString)
+open import Unsafe.Data.Nat.Show renaming (show to showNat)
+open import Unsafe.Data.Float using (Float) renaming (_≟_ to _≟f_; show to showFloat)
+open import Unsafe.Data.Char using (Char) renaming (_≟_ to _≟c_; show to showChar)
+open import Unsafe.Data.String using (String) renaming (_≟_ to _≟s_; show to showString)
 open import Data.Product
 open import Function
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
-open import Relation.Binary.PropositionalEquality.TrustMe
+open import Unsafe.Relation.Binary.PropositionalEquality.TrustMe
 open import Relation.Nullary hiding (module Dec)
 open import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Product

--- a/src/Unsafe/Relation/Binary/PropositionalEquality/TrustMe.agda
+++ b/src/Unsafe/Relation/Binary/PropositionalEquality/TrustMe.agda
@@ -4,7 +4,7 @@
 -- An equality postulate which evaluates
 ------------------------------------------------------------------------
 
-module Relation.Binary.PropositionalEquality.TrustMe where
+module Unsafe.Relation.Binary.PropositionalEquality.TrustMe where
 
 open import Relation.Binary.Core using (_≡_)
 


### PR DESCRIPTION
It is currently impossible to typecheck a development relying on
the standard library with the --safe option because it does not
isolate properly its uses of unsafe features

The main culprits are "primTrustMe" and "erase" but also
"NON_TERMINATING" or "postulate" + "COMPILED" in the IO module.

This patch isolates the unsafe-tainted functions in Unsafe.*
modules (each of which re-exports its safe counterpart so that
switching from one to the other is as simple as adding the
prefix "Unsafe." to the module's name in the import statement).