### PR TITLE
Have makefile compatible with cabal sandboxes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 AGDA=agda
 
 test: Everything.agda
-	fix-agda-whitespace --check
+	cabal exec -- fix-agda-whitespace --check
 	$(AGDA) -i. -isrc README.agda
 
 setup: Everything.agda
@@ -9,7 +9,7 @@ setup: Everything.agda
 .PHONY: Everything.agda
 Everything.agda:
 	cabal clean && cabal install
-	GenerateEverything
+	cabal exec -- GenerateEverything
 
 .PHONY: listings
 listings: Everything.agda


### PR DESCRIPTION
I altered `GNUmakefile` slightly so that it will work even if someone is building the project in a cabal sandbox. It should still work for global installs. Requires cabal 1.18 or later.