### PR TITLE
Abstracting and adding a native definition of `All₂`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Important changes since 0.13:
 
 * Changed `Data.Vec.All.All₂` to a native version which allows better
   pattern matching. The new version (and the associated proofs in
-  `Data.Vec.All.Properties` are more generic with respect to types and
+  `Data.Vec.All.Properties`) are more generic with respect to types and
   levels.
 
 Version 0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ Important changes since 0.13:
   Data.List.Any.Properties
   ```
 
+* Changed `Data.Vec.All.All₂` to a native version which allows better
+  pattern matching. The new version (and the associated proofs in
+  `Data.Vec.All.Properties` are more generic with respect to types and
+  levels.
 
 Version 0.13
 ============

--- a/src/Data/Vec/All.agda
+++ b/src/Data/Vec/All.agda
@@ -80,8 +80,8 @@ data All₂ {a b p} {A : Set a} {B : Set b} (P : A → B → Set p) :
 lookup₂ : ∀ {a b p} {A : Set a} {B : Set b} {P : A → B → Set p} {k}
             {xs : Vec A k} {ys : Vec B k} →
             ∀ i → All₂ P xs ys → P (Vec.lookup i xs) (Vec.lookup i ys)
-lookup₂ zero    (pxy ∷ _)   = pxy
-lookup₂ (suc i) (x₁ ∷ pxys) = lookup₂ i pxys
+lookup₂ zero    (pxy ∷ _)    = pxy
+lookup₂ (suc i) (_   ∷ pxys) = lookup₂ i pxys
 
 map₂ : ∀ {a b p q} {A : Set a} {B : Set b}
          {P : A → B → Set p} {Q : A → B → Set q} →

--- a/src/Data/Vec/All.agda
+++ b/src/Data/Vec/All.agda
@@ -17,6 +17,7 @@ import Relation.Nullary.Decidable as Dec
 open import Relation.Unary using (Decidable) renaming (_⊆_ to _⋐_)
 open import Relation.Binary.PropositionalEquality using (subst)
 
+------------------------------------------------------------------------
 -- All P xs means that all elements in xs satisfy P.
 
 infixr 5 _∷_
@@ -67,23 +68,24 @@ zipWith _⊕_ {xs = x ∷ xs} {y ∷ ys} (px ∷ pxs) (qy ∷ qys) =
   px ⊕ qy ∷ zipWith _⊕_ pxs qys
 
 
--- A shorthand for a pair of vectors being point-wise related.
+------------------------------------------------------------------------
+-- All₂ P xs ys means that every pointwise pair in xs ys satisfy P.
 
-All₂ : ∀ {a p} {A B : Set a} (P : A → B → Set p) {k} →
-       Vec A k → Vec B k → Set _
-All₂ P xs ys = All (uncurry P) (zip xs ys)
+data All₂ {a b p} {A : Set a} {B : Set b} (P : A → B → Set p) :
+          ∀ {n} → Vec A n → Vec B n → Set (a ⊔ b ⊔ p) where
+    []  : All₂ P [] []
+    _∷_ : ∀ {n x y} {xs : Vec A n} {ys : Vec B n} →
+            P x y → All₂ P xs ys → All₂ P (x ∷ xs) (y ∷ ys)
 
--- A variant of lookup tailored to All₂.
-
-lookup₂ : ∀ {a p} {A B : Set a} {P : A → B → Set p} {k}
+lookup₂ : ∀ {a b p} {A : Set a} {B : Set b} {P : A → B → Set p} {k}
             {xs : Vec A k} {ys : Vec B k} →
-          (i : Fin k) → All₂ P xs ys → P (Vec.lookup i xs) (Vec.lookup i ys)
-lookup₂ {P = P} {xs = xs} {ys} i pxys =
-  subst (uncurry P) (lookup-zip i xs ys) (lookup i pxys)
+            ∀ i → All₂ P xs ys → P (Vec.lookup i xs) (Vec.lookup i ys)
+lookup₂ zero    (pxy ∷ _)   = pxy
+lookup₂ (suc i) (x₁ ∷ pxys) = lookup₂ i pxys
 
--- A variant of map tailored to All₂.
-
-map₂ : ∀ {a p q} {A B : Set a} {P : A → B → Set p} {Q : A → B → Set q} →
-       (∀ {x y} → P x y → Q x y) →
-       ∀ {k xs ys} → All₂ P {k} xs ys → All₂ Q {k} xs ys
-map₂ g = map g
+map₂ : ∀ {a b p q} {A : Set a} {B : Set b}
+         {P : A → B → Set p} {Q : A → B → Set q} →
+         (∀ {x y} → P x y → Q x y) →
+         ∀ {k xs ys} → All₂ P {k} xs ys → All₂ Q {k} xs ys
+map₂ g [] = []
+map₂ g (pxy ∷ pxys) = g pxy  ∷ map₂ g pxys

--- a/src/Data/Vec/All/Properties.agda
+++ b/src/Data/Vec/All/Properties.agda
@@ -38,47 +38,50 @@ gmap : ∀ {a b p q}
        P ⋐ Q ∘ f → All P {k} ⋐ All Q {k} ∘ Vec.map f
 gmap g = All-map ∘ All.map g
 
--- A variant of All-map tailored to All₂.
+-- A variant of All-map for All₂.
 
-All₂-map : ∀ {a b p} {A₁ A₂ : Set a} {B₁ B₂ : Set b} {P : B₁ → B₂ → Set p}
-           {f₁ : A₁ → B₁} {f₂ : A₂ → B₂} {k} {xs : Vec A₁ k} {ys : Vec A₂ k} →
+All₂-map : ∀ {a b c d p} {A : Set a} {B : Set b} {C : Set c} {D : Set d}
+           {P : C → D → Set p}
+           {f₁ : A → C} {f₂ : B → D} {k} {xs : Vec A k} {ys : Vec B k} →
            All₂ (λ x y → P (f₁ x) (f₂ y)) xs ys →
            All₂ P (Vec.map f₁ xs) (Vec.map f₂ ys)
-All₂-map {xs = []}    {ys = []}    []         = []
-All₂-map {xs = _ ∷ _} {ys = _ ∷ _} (px ∷ pxs) = px ∷ All₂-map pxs
+All₂-map []         = []
+All₂-map (px ∷ pxs) = px ∷ All₂-map pxs
 
--- A variant of gmap tailored to All₂.
+-- A variant of gmap for All₂.
 
-gmap₂ : ∀ {a b p q} {A₁ A₂ : Set a} {B₁ B₂ : Set b}
-          {P : A₁ → A₂ → Set p} {Q : B₁ → B₂ → Set q}
-          {f₁ : A₁ → B₁} {f₂ : A₂ → B₂} →
+gmap₂ : ∀ {a b c d p q} {A : Set a} {B : Set b} {C : Set c} {D : Set d}
+          {P : A → B → Set p} {Q : C → D → Set q}
+          {f₁ : A → C} {f₂ : B → D} →
         (∀ {x y} → P x y → Q (f₁ x) (f₂ y)) → ∀ {k xs ys} →
         All₂ P {k} xs ys → All₂ Q {k} (Vec.map f₁ xs) (Vec.map f₂ ys)
-gmap₂ g = All₂-map ∘ All.map g
+gmap₂ g [] = []
+gmap₂ g (pxy ∷ pxys) = g pxy ∷ gmap₂ g pxys
 
 -- A variant of gmap₂ shifting only the first function from the binary
 -- relation to the vector.
 
-gmap₂₁ : ∀ {a p q} {A₁ A₂ : Set a} {B : Set a}
-           {P : A₁ → A₂ → Set p} {Q : B → A₂ → Set q} {f : A₁ → B} →
+gmap₂₁ : ∀ {a b c p q} {A : Set a} {B : Set b} {C : Set c}
+           {P : A → B → Set p} {Q : C → B → Set q} {f : A → C} →
          (∀ {x y} → P x y → Q (f x) y) → ∀ {k xs ys} →
          All₂ P {k} xs ys → All₂ Q {k} (Vec.map f xs) ys
-gmap₂₁ g = P.subst (All₂ _ _) (map-id _) ∘ All₂-map {f₂ = id} ∘ All.map g
+gmap₂₁ g [] = []
+gmap₂₁ g (pxy ∷ pxys) = g pxy ∷ gmap₂₁ g pxys
 
 -- A variant of gmap₂ shifting only the second function from the
 -- binary relation to the vector.
 
-gmap₂₂ : ∀ {a p q} {A₁ A₂ : Set a} {B : Set a}
-           {P : A₁ → A₂ → Set p} {Q : A₁ → B → Set q} {f : A₂ → B} →
+gmap₂₂ : ∀ {a b c p q} {A : Set a} {B : Set b} {C : Set c}
+           {P : A → B → Set p} {Q : A → C → Set q} {f : B → C} →
          (∀ {x y} → P x y → Q x (f y)) → ∀ {k xs ys} →
          All₂ P {k} xs ys → All₂ Q {k} xs (Vec.map f ys)
-gmap₂₂ g =
-  P.subst (flip (All₂ _) _) (map-id _) ∘ All₂-map {f₁ = id} ∘ All.map g
+gmap₂₂ g [] = []
+gmap₂₂ g (pxy ∷ pxys) = g pxy ∷ gmap₂₂ g pxys
 
 -- Abstract composition of binary relations lifted to All₂.
 
-comp : ∀ {a p} {A : Set a} {B : Set a} {C : Set a}
-       {P : A → B → Set p} {Q : B → C → Set p} {R : A → C → Set p} →
+comp : ∀ {a b c p q r} {A : Set a} {B : Set b} {C : Set c}
+       {P : A → B → Set p} {Q : B → C → Set q} {R : A → C → Set r} →
        (∀ {x y z} → P x y → Q y z → R x z) →
        ∀ {k xs ys zs} → All₂ P {k} xs ys → All₂ Q {k} ys zs → All₂ R {k} xs zs
 comp _⊙_ {xs = []}     {[]}     {[]}     []           []           = []


### PR DESCRIPTION
The new `All₂` definition is very useful but the current implementation has two problems:

1) Not sufficiently generic with respect to levels and types
2) Unable to pattern match directly on terms of type `All₂ P xs ys` because of its definition as the `zip` of two lists (see the old version of lemma `All₂-map`).

This patch fixes these two problems by adding a native, more generic implementation of `All₂`. Due to the aliasing of the new constructors, while proofs of properties about it may need updating, actual usage and construction of terms of that type should be mostly compatible.