### PR TITLE
Deprivatised Data.Nat.Properties and added a few simple lemmas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,12 @@ Important changes since 0.13:
 
   ```agda
   Data.List.Any.Properties
+  Data.Nat.Properties
   ```
+
+* Added `suc-injective`, `<-irrefl` and `<-asym` to `Data.Nat.Properties`
+
+* Added `+-left-identity` and `*-left-zero` to `Data.Nat.Properties.Simple`
 
 * Changed `Data.Vec.All.All₂` to a native version which allows better
   pattern matching. The new version (and the associated proofs in

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -23,10 +23,16 @@ import Algebra.FunctionProperties as P; open P (_≡_ {A = ℕ})
 open import Data.Product
 open import Data.Sum
 
+------------------------------------------------------------------------
+-- Properties of _≡_
+
+suc-injective : ∀ {m n} → suc m ≡ suc n → m ≡ n
+suc-injective refl = refl
 
 ------------------------------------------------------------------------
--- Ordering
+-- Properties of _≤_
 
+-- Relation-theoretic properties of _≤_
 ≤-reflexive : _≡_ ⇒ _≤_
 ≤-reflexive {zero}  refl = z≤n
 ≤-reflexive {suc m} refl = s≤s (≤-reflexive refl)
@@ -84,8 +90,30 @@ open import Data.Sum
   ; isDecTotalOrder = ≤-isDecTotalOrder
   }
 
+-- Other properties of _≤_
+≤-step : ∀ {m n} → m ≤ n → m ≤ 1 + n
+≤-step z≤n       = z≤n
+≤-step (s≤s m≤n) = s≤s (≤-step m≤n)
 
+n≤1+n : ∀ n → n ≤ 1 + n
+n≤1+n _ = ≤-step ≤-refl
 
+1+n≰n : ∀ {n} → ¬ 1 + n ≤ n
+1+n≰n (s≤s le) = 1+n≰n le
+
+pred-mono : pred Preserves _≤_ ⟶ _≤_
+pred-mono z≤n      = z≤n
+pred-mono (s≤s le) = le
+
+≤pred⇒≤ : ∀ m n → m ≤ pred n → m ≤ n
+≤pred⇒≤ m zero    le = le
+≤pred⇒≤ m (suc n) le = ≤-step le
+
+≤⇒pred≤ : ∀ m n → m ≤ n → pred m ≤ n
+≤⇒pred≤ zero    n le = le
+≤⇒pred≤ (suc m) n le = ≤-trans (n≤1+n m) le
+
+-- A module for reasoning about the _≤_ relation
 module ≤-Reasoning where
   open POR (DecTotalOrder.poset ≤-decTotalOrder) public
     renaming (_≈⟨_⟩_ to _≡⟨_⟩_)
@@ -99,33 +127,131 @@ open ≤-Reasoning
   renaming (begin_ to start_; _∎ to _□; _≡⟨_⟩_ to _≡⟨_⟩'_)
 
 ------------------------------------------------------------------------
+-- Properties of _<_
 
--- basic lemmas about (ℕ, +, *, 0, 1):
+-- Relation theoretic properties of _<_
+<-irrefl : Irreflexive _≡_ _<_
+<-irrefl refl (s≤s n<n) = <-irrefl refl n<n
+
+<-asym : Asymmetric _<_
+<-asym (s≤s n<m) (s≤s m<n) = <-asym n<m m<n
+
+<-trans : Transitive _<_
+<-trans (s≤s i≤j) (s≤s j<k) = s≤s (≤-trans i≤j (≤⇒pred≤ _ _ j<k))
+
+<-cmp : Trichotomous _≡_ _<_
+<-cmp zero    zero    = tri≈ (λ())     refl  (λ())
+<-cmp zero    (suc n) = tri< (s≤s z≤n) (λ()) (λ())
+<-cmp (suc m) zero    = tri> (λ())     (λ()) (s≤s z≤n)
+<-cmp (suc m) (suc n) with <-cmp m n
+... | tri< ≤ ≢ ≱ = tri< (s≤s ≤)      (≢ ∘ suc-injective) (≱ ∘ ≤-pred)
+... | tri≈ ≰ ≡ ≱ = tri≈ (≰ ∘ ≤-pred) (cong suc ≡)        (≱ ∘ ≤-pred)
+... | tri> ≰ ≢ ≥ = tri> (≰ ∘ ≤-pred) (≢ ∘ suc-injective) (s≤s ≥)
+
+<-isStrictTotalOrder : IsStrictTotalOrder _≡_ _<_
+<-isStrictTotalOrder = record
+  { isEquivalence = PropEq.isEquivalence
+  ; trans         = <-trans
+  ; compare       = <-cmp
+  }
+
+strictTotalOrder : StrictTotalOrder _ _ _
+strictTotalOrder = record
+  { Carrier            = ℕ
+  ; _≈_                = _≡_
+  ; _<_                = _<_
+  ; isStrictTotalOrder = <-isStrictTotalOrder
+  }
+
+-- Other properties of _<_
+<⇒≤pred : ∀ {m n} → m < n → m ≤ pred n
+<⇒≤pred (s≤s le) = le
+
+≰⇒> : _≰_ ⇒ _>_
+≰⇒> {zero}          z≰n with z≰n z≤n
+... | ()
+≰⇒> {suc m} {zero}  _   = s≤s z≤n
+≰⇒> {suc m} {suc n} m≰n = s≤s (≰⇒> (m≰n ∘ s≤s))
+
+------------------------------------------------------------------------
+-- Properties of _≤′_
+
+z≤′n : ∀ {n} → zero ≤′ n
+z≤′n {zero}  = ≤′-refl
+z≤′n {suc n} = ≤′-step z≤′n
+
+s≤′s : ∀ {m n} → m ≤′ n → suc m ≤′ suc n
+s≤′s ≤′-refl        = ≤′-refl
+s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
+
+≤′⇒≤ : _≤′_ ⇒ _≤_
+≤′⇒≤ ≤′-refl        = ≤-refl
+≤′⇒≤ (≤′-step m≤′n) = ≤-step (≤′⇒≤ m≤′n)
+
+≤⇒≤′ : _≤_ ⇒ _≤′_
+≤⇒≤′ z≤n       = z≤′n
+≤⇒≤′ (s≤s m≤n) = s≤′s (≤⇒≤′ m≤n)
+
+------------------------------------------------------------------------
+-- Properties of _≤″_
+
+≤″⇒≤ : _≤″_ ⇒ _≤_
+≤″⇒≤ {zero}  (less-than-or-equal refl) = z≤n
+≤″⇒≤ {suc m} (less-than-or-equal refl) =
+  s≤s (≤″⇒≤ (less-than-or-equal refl))
+
+≤⇒≤″ : _≤_ ⇒ _≤″_
+≤⇒≤″ m≤n = less-than-or-equal (proof m≤n)
+  where
+  k : ∀ m n → m ≤ n → ℕ
+  k zero    n       _   = n
+  k (suc m) zero    ()
+  k (suc m) (suc n) m≤n = k m n (≤-pred m≤n)
+
+  proof : ∀ {m n} (m≤n : m ≤ n) → m + k m n m≤n ≡ n
+  proof z≤n       = refl
+  proof (s≤s m≤n) = cong suc (proof m≤n)
+
+------------------------------------------------------------------------
+-- Properties of _+_ and _*_
+
+-- Algebraic properties of _+_ and _*_
 open import Data.Nat.Properties.Simple
 
--- (ℕ, +, *, 0, 1) is a commutative semiring
++-isSemigroup : IsSemigroup _≡_ _+_
++-isSemigroup = record
+  { isEquivalence = PropEq.isEquivalence
+  ; assoc         = +-assoc
+  ; ∙-cong        = cong₂ _+_
+  }
+
++-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ 0
++-0-isCommutativeMonoid = record
+  { isSemigroup = +-isSemigroup
+  ; identityˡ    = +-left-identity
+  ; comm        = +-comm
+  }
+
+*-isSemigroup : IsSemigroup _≡_ _*_
+*-isSemigroup = record
+  { isEquivalence = PropEq.isEquivalence
+  ; assoc         = *-assoc
+  ; ∙-cong        = cong₂ _*_
+  }
+
+*-1-isCommutativeMonoid : IsCommutativeMonoid _≡_ _*_ 1
+*-1-isCommutativeMonoid = record
+  { isSemigroup = *-isSemigroup
+  ; identityˡ    = +-right-identity
+  ; comm        = *-comm
+  }
+
 isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ 0 1
 isCommutativeSemiring = record
-  { +-isCommutativeMonoid = record
-    { isSemigroup = record
-      { isEquivalence = PropEq.isEquivalence
-      ; assoc         = +-assoc
-      ; ∙-cong        = cong₂ _+_
-      }
-    ; identityˡ = λ _ → refl
-    ; comm      = +-comm
-    }
-  ; *-isCommutativeMonoid = record
-    { isSemigroup = record
-      { isEquivalence = PropEq.isEquivalence
-      ; assoc         = *-assoc
-      ; ∙-cong        = cong₂ _*_
-      }
-    ; identityˡ = +-right-identity
-    ; comm      = *-comm
-    }
-  ; distribʳ = distribʳ-*-+
-  ; zeroˡ    = λ _ → refl
+  { +-isCommutativeMonoid = +-0-isCommutativeMonoid
+  ; *-isCommutativeMonoid = *-1-isCommutativeMonoid
+  ; distribʳ              = distribʳ-*-+
+  ; zeroˡ                 = *-left-zero
   }
 
 commutativeSemiring : CommutativeSemiring _ _
@@ -142,224 +268,28 @@ import Algebra.RingSolver.AlmostCommutativeRing as ACR
 module SemiringSolver =
   Solver (ACR.fromCommutativeSemiring commutativeSemiring) _≟_
 
-------------------------------------------------------------------------
--- (ℕ, ⊔, ⊓, 0) is a commutative semiring without one
+-- Other properties of _+_ and _*_
 
-private
+cancel-+-left : ∀ i {j k} → i + j ≡ i + k → j ≡ k
+cancel-+-left zero    eq = eq
+cancel-+-left (suc i) eq = cancel-+-left i (cong pred eq)
 
-  ⊔-assoc : Associative _⊔_
-  ⊔-assoc zero    _       _       = refl
-  ⊔-assoc (suc m) zero    o       = refl
-  ⊔-assoc (suc m) (suc n) zero    = refl
-  ⊔-assoc (suc m) (suc n) (suc o) = cong suc $ ⊔-assoc m n o
+cancel-+-left-≤ : ∀ i {j k} → i + j ≤ i + k → j ≤ k
+cancel-+-left-≤ zero    le       = le
+cancel-+-left-≤ (suc i) (s≤s le) = cancel-+-left-≤ i le
 
-  ⊔-identity : Identity 0 _⊔_
-  ⊔-identity = (λ _ → refl) , n⊔0≡n
-    where
-    n⊔0≡n : RightIdentity 0 _⊔_
-    n⊔0≡n zero    = refl
-    n⊔0≡n (suc n) = refl
+cancel-*-right : ∀ i j {k} → i * suc k ≡ j * suc k → i ≡ j
+cancel-*-right zero    zero        eq = refl
+cancel-*-right zero    (suc j)     ()
+cancel-*-right (suc i) zero        ()
+cancel-*-right (suc i) (suc j) {k} eq =
+  cong suc (cancel-*-right i j (cancel-+-left (suc k) eq))
 
-  ⊔-comm : Commutative _⊔_
-  ⊔-comm zero    n       = sym $ proj₂ ⊔-identity n
-  ⊔-comm (suc m) zero    = refl
-  ⊔-comm (suc m) (suc n) =
-    begin
-      suc m ⊔ suc n
-    ≡⟨ refl ⟩
-      suc (m ⊔ n)
-    ≡⟨ cong suc (⊔-comm m n) ⟩
-      suc (n ⊔ m)
-    ≡⟨ refl ⟩
-      suc n ⊔ suc m
-    ∎
-
-  ⊓-assoc : Associative _⊓_
-  ⊓-assoc zero    _       _       = refl
-  ⊓-assoc (suc m) zero    o       = refl
-  ⊓-assoc (suc m) (suc n) zero    = refl
-  ⊓-assoc (suc m) (suc n) (suc o) = cong suc $ ⊓-assoc m n o
-
-  ⊓-zero : Zero 0 _⊓_
-  ⊓-zero = (λ _ → refl) , n⊓0≡0
-    where
-    n⊓0≡0 : RightZero 0 _⊓_
-    n⊓0≡0 zero    = refl
-    n⊓0≡0 (suc n) = refl
-
-  ⊓-comm : Commutative _⊓_
-  ⊓-comm zero    n       = sym $ proj₂ ⊓-zero n
-  ⊓-comm (suc m) zero    = refl
-  ⊓-comm (suc m) (suc n) =
-    begin
-      suc m ⊓ suc n
-    ≡⟨ refl ⟩
-      suc (m ⊓ n)
-    ≡⟨ cong suc (⊓-comm m n) ⟩
-      suc (n ⊓ m)
-    ≡⟨ refl ⟩
-      suc n ⊓ suc m
-    ∎
-
-  distrib-⊓-⊔ : _⊓_ DistributesOver _⊔_
-  distrib-⊓-⊔ = (distribˡ-⊓-⊔ , distribʳ-⊓-⊔)
-    where
-    distribʳ-⊓-⊔ : _⊓_ DistributesOverʳ _⊔_
-    distribʳ-⊓-⊔ (suc m) (suc n) (suc o) = cong suc $ distribʳ-⊓-⊔ m n o
-    distribʳ-⊓-⊔ (suc m) (suc n) zero    = cong suc $ refl
-    distribʳ-⊓-⊔ (suc m) zero    o       = refl
-    distribʳ-⊓-⊔ zero    n       o       = begin
-      (n ⊔ o) ⊓ 0    ≡⟨ ⊓-comm (n ⊔ o) 0 ⟩
-      0 ⊓ (n ⊔ o)    ≡⟨ refl ⟩
-      0 ⊓ n ⊔ 0 ⊓ o  ≡⟨ ⊓-comm 0 n ⟨ cong₂ _⊔_ ⟩ ⊓-comm 0 o ⟩
-      n ⊓ 0 ⊔ o ⊓ 0  ∎
-
-    distribˡ-⊓-⊔ : _⊓_ DistributesOverˡ _⊔_
-    distribˡ-⊓-⊔ m n o = begin
-      m ⊓ (n ⊔ o)    ≡⟨ ⊓-comm m _ ⟩
-      (n ⊔ o) ⊓ m    ≡⟨ distribʳ-⊓-⊔ m n o ⟩
-      n ⊓ m ⊔ o ⊓ m  ≡⟨ ⊓-comm n m ⟨ cong₂ _⊔_ ⟩ ⊓-comm o m ⟩
-      m ⊓ n ⊔ m ⊓ o  ∎
-
-⊔-⊓-0-isCommutativeSemiringWithoutOne
-  : IsCommutativeSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
-⊔-⊓-0-isCommutativeSemiringWithoutOne = record
-  { isSemiringWithoutOne = record
-    { +-isCommutativeMonoid = record
-      { isSemigroup = record
-        { isEquivalence = PropEq.isEquivalence
-        ; assoc         = ⊔-assoc
-        ; ∙-cong        = cong₂ _⊔_
-        }
-      ; identityˡ = proj₁ ⊔-identity
-      ; comm      = ⊔-comm
-      }
-    ; *-isSemigroup = record
-      { isEquivalence = PropEq.isEquivalence
-      ; assoc         = ⊓-assoc
-      ; ∙-cong        = cong₂ _⊓_
-      }
-    ; distrib = distrib-⊓-⊔
-    ; zero    = ⊓-zero
-    }
-  ; *-comm = ⊓-comm
-  }
-
-⊔-⊓-0-commutativeSemiringWithoutOne : CommutativeSemiringWithoutOne _ _
-⊔-⊓-0-commutativeSemiringWithoutOne = record
-  { _+_                             = _⊔_
-  ; _*_                             = _⊓_
-  ; 0#                              = 0
-  ; isCommutativeSemiringWithoutOne =
-      ⊔-⊓-0-isCommutativeSemiringWithoutOne
-  }
-
-------------------------------------------------------------------------
--- (ℕ, ⊓, ⊔) is a lattice
-
-private
-
-  absorptive-⊓-⊔ : Absorptive _⊓_ _⊔_
-  absorptive-⊓-⊔ = abs-⊓-⊔ , abs-⊔-⊓
-    where
-    abs-⊔-⊓ : _⊔_ Absorbs _⊓_
-    abs-⊔-⊓ zero    n       = refl
-    abs-⊔-⊓ (suc m) zero    = refl
-    abs-⊔-⊓ (suc m) (suc n) = cong suc $ abs-⊔-⊓ m n
-
-    abs-⊓-⊔ : _⊓_ Absorbs _⊔_
-    abs-⊓-⊔ zero    n       = refl
-    abs-⊓-⊔ (suc m) (suc n) = cong suc $ abs-⊓-⊔ m n
-    abs-⊓-⊔ (suc m) zero    = cong suc $
-                   begin
-      m ⊓ m
-                   ≡⟨ cong (_⊓_ m) $ sym $ proj₂ ⊔-identity m ⟩
-      m ⊓ (m ⊔ 0)
-                   ≡⟨ abs-⊓-⊔ m zero ⟩
-      m
-                   ∎
-
-isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
-isDistributiveLattice = record
-  { isLattice = record
-      { isEquivalence = PropEq.isEquivalence
-      ; ∨-comm        = ⊓-comm
-      ; ∨-assoc       = ⊓-assoc
-      ; ∨-cong        = cong₂ _⊓_
-      ; ∧-comm        = ⊔-comm
-      ; ∧-assoc       = ⊔-assoc
-      ; ∧-cong        = cong₂ _⊔_
-      ; absorptive    = absorptive-⊓-⊔
-      }
-  ; ∨-∧-distribʳ = proj₂ distrib-⊓-⊔
-  }
-
-distributiveLattice : DistributiveLattice _ _
-distributiveLattice = record
-  { _∨_                   = _⊓_
-  ; _∧_                   = _⊔_
-  ; isDistributiveLattice = isDistributiveLattice
-  }
-
--- Selectivity and idempotence of ⊓ and ⊔
-
--- ∀ x y → (x ⊓ y ≡ x) ⊎ (x ⊓ y ≡ y)
-
-⊓-sel : Selective _⊓_
-⊓-sel zero    _    = inj₁ refl
-⊓-sel (suc m) zero = inj₂ refl
-⊓-sel (suc m) (suc n) with ⊓-sel m n
-... | inj₁ m⊓n≡m = inj₁ (cong suc m⊓n≡m)
-... | inj₂ m⊓n≡n = inj₂ (cong suc m⊓n≡n)
-
--- ∀ x y → (x ⊔ y ≡ x) ⊎ (x ⊔ y ≡ y)
-
-⊔-sel : Selective _⊔_
-⊔-sel zero    _    = inj₂ refl
-⊔-sel (suc m) zero = inj₁ refl
-⊔-sel (suc m) (suc n) with ⊔-sel m n
-... | inj₁ m⊔n≡m = inj₁ (cong suc m⊔n≡m)
-... | inj₂ m⊔n≡n = inj₂ (cong suc m⊔n≡n)
-
--- ∀ x → x ⊓ x ≡ x
-
-⊓-idem : Idempotent _⊓_
-⊓-idem x with ⊓-sel x x
-... | inj₁ x⊓x≈x = x⊓x≈x
-... | inj₂ x⊓x≈x = x⊓x≈x
-
--- ∀ x → x ⊔ x ≡ x
-
-⊔-idem : Idempotent _⊔_
-⊔-idem x with ⊔-sel x x
-... | inj₁ x⊔x≈x = x⊔x≈x
-... | inj₂ x⊔x≈x = x⊔x≈x
-
-------------------------------------------------------------------------
--- Converting between ≤ and ≤′
-
-≤-step : ∀ {m n} → m ≤ n → m ≤ 1 + n
-≤-step z≤n       = z≤n
-≤-step (s≤s m≤n) = s≤s (≤-step m≤n)
-
-≤′⇒≤ : _≤′_ ⇒ _≤_
-≤′⇒≤ ≤′-refl        = ≤-refl
-≤′⇒≤ (≤′-step m≤′n) = ≤-step (≤′⇒≤ m≤′n)
-
-z≤′n : ∀ {n} → zero ≤′ n
-z≤′n {zero}  = ≤′-refl
-z≤′n {suc n} = ≤′-step z≤′n
-
-s≤′s : ∀ {m n} → m ≤′ n → suc m ≤′ suc n
-s≤′s ≤′-refl        = ≤′-refl
-s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
-
-≤⇒≤′ : _≤_ ⇒ _≤′_
-≤⇒≤′ z≤n       = z≤′n
-≤⇒≤′ (s≤s m≤n) = s≤′s (≤⇒≤′ m≤n)
-
-------------------------------------------------------------------------
--- Various order-related properties
+cancel-*-right-≤ : ∀ i j k → i * suc k ≤ j * suc k → i ≤ j
+cancel-*-right-≤ zero    _       _ _  = z≤n
+cancel-*-right-≤ (suc i) zero    _ ()
+cancel-*-right-≤ (suc i) (suc j) k le =
+  s≤s (cancel-*-right-≤ i j k (cancel-+-left-≤ (suc k) le))
 
 ≤-steps : ∀ {m n} k → m ≤ n → m ≤ k + n
 ≤-steps zero    m≤n = m≤n
@@ -379,209 +309,24 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
 n≤m+n : ∀ m n → n ≤ m + n
 n≤m+n m n = ≤′⇒≤ (n≤′m+n m n)
 
-n≤1+n : ∀ n → n ≤ 1 + n
-n≤1+n _ = ≤-step ≤-refl
+_+-mono_ : _+_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
+_+-mono_ {zero} {m₂} {n₁} {n₂} z≤n n₁≤n₂ = start
+  n₁      ≤⟨ n₁≤n₂ ⟩
+  n₂      ≤⟨ n≤m+n m₂ n₂ ⟩
+  m₂ + n₂ □
+s≤s m₁≤m₂ +-mono n₁≤n₂ = s≤s (m₁≤m₂ +-mono n₁≤n₂)
 
-1+n≰n : ∀ {n} → ¬ 1 + n ≤ n
-1+n≰n (s≤s le) = 1+n≰n le
-
-≤pred⇒≤ : ∀ m n → m ≤ pred n → m ≤ n
-≤pred⇒≤ m zero    le = le
-≤pred⇒≤ m (suc n) le = ≤-step le
-
-≤⇒pred≤ : ∀ m n → m ≤ n → pred m ≤ n
-≤⇒pred≤ zero    n le = le
-≤⇒pred≤ (suc m) n le = start
-  m     ≤⟨ n≤1+n m ⟩
-  suc m ≤⟨ le ⟩
-  n     □
-
-<⇒≤pred : ∀ {m n} → m < n → m ≤ pred n
-<⇒≤pred (s≤s le) = le
+_*-mono_ : _*_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
+z≤n       *-mono n₁≤n₂ = z≤n
+s≤s m₁≤m₂ *-mono n₁≤n₂ = n₁≤n₂ +-mono (m₁≤m₂ *-mono n₁≤n₂)
 
 ¬i+1+j≤i : ∀ i {j} → ¬ i + suc j ≤ i
 ¬i+1+j≤i zero    ()
 ¬i+1+j≤i (suc i) le = ¬i+1+j≤i i (≤-pred le)
 
-n∸m≤n : ∀ m n → n ∸ m ≤ n
-n∸m≤n zero    n       = ≤-refl
-n∸m≤n (suc m) zero    = ≤-refl
-n∸m≤n (suc m) (suc n) = start
-  n ∸ m  ≤⟨ n∸m≤n m n ⟩
-  n      ≤⟨ n≤1+n n ⟩
-  suc n  □
-
-n≤m+n∸m : ∀ m n → n ≤ m + (n ∸ m)
-n≤m+n∸m m       zero    = z≤n
-n≤m+n∸m zero    (suc n) = ≤-refl
-n≤m+n∸m (suc m) (suc n) = s≤s (n≤m+n∸m m n)
-
-m⊓n≤m : ∀ m n → m ⊓ n ≤ m
-m⊓n≤m zero    _       = z≤n
-m⊓n≤m (suc m) zero    = z≤n
-m⊓n≤m (suc m) (suc n) = s≤s $ m⊓n≤m m n
-
-m≤m⊔n : ∀ m n → m ≤ m ⊔ n
-m≤m⊔n zero    _       = z≤n
-m≤m⊔n (suc m) zero    = ≤-refl
-m≤m⊔n (suc m) (suc n) = s≤s $ m≤m⊔n m n
-
-⌈n/2⌉≤′n : ∀ n → ⌈ n /2⌉ ≤′ n
-⌈n/2⌉≤′n zero          = ≤′-refl
-⌈n/2⌉≤′n (suc zero)    = ≤′-refl
-⌈n/2⌉≤′n (suc (suc n)) = s≤′s (≤′-step (⌈n/2⌉≤′n n))
-
-⌊n/2⌋≤′n : ∀ n → ⌊ n /2⌋ ≤′ n
-⌊n/2⌋≤′n zero    = ≤′-refl
-⌊n/2⌋≤′n (suc n) = ≤′-step (⌈n/2⌉≤′n n)
-
-<-trans : Transitive _<_
-<-trans {i} {j} {k} i<j j<k = start
-  1 + i  ≤⟨ i<j ⟩
-  j      ≤⟨ n≤1+n j ⟩
-  1 + j  ≤⟨ j<k ⟩
-  k      □
-
-≰⇒> : _≰_ ⇒ _>_
-≰⇒> {zero}          z≰n with z≰n z≤n
-... | ()
-≰⇒> {suc m} {zero}  _   = s≤s z≤n
-≰⇒> {suc m} {suc n} m≰n = s≤s (≰⇒> (m≰n ∘ s≤s))
-
-------------------------------------------------------------------------
--- Converting between ≤ and ≤″
-
-≤″⇒≤ : _≤″_ ⇒ _≤_
-≤″⇒≤ (less-than-or-equal refl) = m≤m+n _ _
-
-≤⇒≤″ : _≤_ ⇒ _≤″_
-≤⇒≤″ m≤n = less-than-or-equal (proof m≤n)
-  where
-  k : ∀ m n → m ≤ n → ℕ
-  k zero    n       _   = n
-  k (suc m) zero    ()
-  k (suc m) (suc n) m≤n = k m n (≤-pred m≤n)
-
-  proof : ∀ {m n} (m≤n : m ≤ n) → m + k m n m≤n ≡ n
-  proof z≤n       = refl
-  proof (s≤s m≤n) = cong suc (proof m≤n)
-
-------------------------------------------------------------------------
--- (ℕ, _≡_, _<_) is a strict total order
-
 m≢1+m+n : ∀ m {n} → m ≢ suc (m + n)
 m≢1+m+n zero    ()
 m≢1+m+n (suc m) eq = m≢1+m+n m (cong pred eq)
-
-strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder = record
-  { Carrier            = ℕ
-  ; _≈_                = _≡_
-  ; _<_                = _<_
-  ; isStrictTotalOrder = record
-    { isEquivalence = PropEq.isEquivalence
-    ; trans         = <-trans
-    ; compare       = cmp
-    }
-  }
-  where
-  2+m+n≰m : ∀ {m n} → ¬ 2 + (m + n) ≤ m
-  2+m+n≰m (s≤s le) = 2+m+n≰m le
-
-  cmp : Trichotomous _≡_ _<_
-  cmp m n with compare m n
-  cmp .m .(suc (m + k)) | less    m k = tri< (m≤m+n (suc m) k) (m≢1+m+n _) 2+m+n≰m
-  cmp .n             .n | equal   n   = tri≈ 1+n≰n refl 1+n≰n
-  cmp .(suc (n + k)) .n | greater n k = tri> 2+m+n≰m (m≢1+m+n _ ∘ sym) (m≤m+n (suc n) k)
-
-------------------------------------------------------------------------
--- Miscellaneous other properties
-
-0∸n≡0 : LeftZero zero _∸_
-0∸n≡0 zero    = refl
-0∸n≡0 (suc _) = refl
-
-n∸n≡0 : ∀ n → n ∸ n ≡ 0
-n∸n≡0 zero    = refl
-n∸n≡0 (suc n) = n∸n≡0 n
-
-∸-+-assoc : ∀ m n o → (m ∸ n) ∸ o ≡ m ∸ (n + o)
-∸-+-assoc m       n       zero    = cong (_∸_ m) (sym $ +-right-identity n)
-∸-+-assoc zero    zero    (suc o) = refl
-∸-+-assoc zero    (suc n) (suc o) = refl
-∸-+-assoc (suc m) zero    (suc o) = refl
-∸-+-assoc (suc m) (suc n) (suc o) = ∸-+-assoc m n (suc o)
-
-+-∸-assoc : ∀ m {n o} → o ≤ n → (m + n) ∸ o ≡ m + (n ∸ o)
-+-∸-assoc m (z≤n {n = n})             = begin m + n ∎
-+-∸-assoc m (s≤s {m = o} {n = n} o≤n) = begin
-  (m + suc n) ∸ suc o  ≡⟨ cong (λ n → n ∸ suc o) (+-suc m n) ⟩
-  suc (m + n) ∸ suc o  ≡⟨ refl ⟩
-  (m + n) ∸ o          ≡⟨ +-∸-assoc m o≤n ⟩
-  m + (n ∸ o)          ∎
-
-m+n∸n≡m : ∀ m n → (m + n) ∸ n ≡ m
-m+n∸n≡m m n = begin
-  (m + n) ∸ n  ≡⟨ +-∸-assoc m (≤-refl {x = n}) ⟩
-  m + (n ∸ n)  ≡⟨ cong (_+_ m) (n∸n≡0 n) ⟩
-  m + 0        ≡⟨ +-right-identity m ⟩
-  m            ∎
-
-m+n∸m≡n : ∀ {m n} → m ≤ n → m + (n ∸ m) ≡ n
-m+n∸m≡n {m} {n} m≤n = begin
-  m + (n ∸ m)  ≡⟨ sym $ +-∸-assoc m m≤n ⟩
-  (m + n) ∸ m  ≡⟨ cong (λ n → n ∸ m) (+-comm m n) ⟩
-  (n + m) ∸ m  ≡⟨ m+n∸n≡m n m ⟩
-  n            ∎
-
-m⊓n+n∸m≡n : ∀ m n → (m ⊓ n) + (n ∸ m) ≡ n
-m⊓n+n∸m≡n zero    n       = refl
-m⊓n+n∸m≡n (suc m) zero    = refl
-m⊓n+n∸m≡n (suc m) (suc n) = cong suc $ m⊓n+n∸m≡n m n
-
-[m∸n]⊓[n∸m]≡0 : ∀ m n → (m ∸ n) ⊓ (n ∸ m) ≡ 0
-[m∸n]⊓[n∸m]≡0 zero zero       = refl
-[m∸n]⊓[n∸m]≡0 zero (suc n)    = refl
-[m∸n]⊓[n∸m]≡0 (suc m) zero    = refl
-[m∸n]⊓[n∸m]≡0 (suc m) (suc n) = [m∸n]⊓[n∸m]≡0 m n
-
-[i+j]∸[i+k]≡j∸k : ∀ i j k → (i + j) ∸ (i + k) ≡ j ∸ k
-[i+j]∸[i+k]≡j∸k zero    j k = refl
-[i+j]∸[i+k]≡j∸k (suc i) j k = [i+j]∸[i+k]≡j∸k i j k
-
--- TODO: Can this proof be simplified? An automatic solver which can
--- handle ∸ would be nice...
-
-i∸k∸j+j∸k≡i+j∸k : ∀ i j k → i ∸ (k ∸ j) + (j ∸ k) ≡ i + j ∸ k
-i∸k∸j+j∸k≡i+j∸k zero j k = begin
-  0 ∸ (k ∸ j) + (j ∸ k)
-                         ≡⟨ cong (λ x → x + (j ∸ k)) (0∸n≡0 (k ∸ j)) ⟩
-  0 + (j ∸ k)
-                         ≡⟨ refl ⟩
-  j ∸ k
-                         ∎
-i∸k∸j+j∸k≡i+j∸k (suc i) j zero = begin
-  suc i ∸ (0 ∸ j) + j
-                       ≡⟨ cong (λ x → suc i ∸ x + j) (0∸n≡0 j) ⟩
-  suc i ∸ 0 + j
-                       ≡⟨ refl ⟩
-  suc (i + j)
-                       ∎
-i∸k∸j+j∸k≡i+j∸k (suc i) zero (suc k) = begin
-  i ∸ k + 0
-             ≡⟨ +-right-identity _ ⟩
-  i ∸ k
-             ≡⟨ cong (λ x → x ∸ k) (sym (+-right-identity _)) ⟩
-  i + 0 ∸ k
-             ∎
-i∸k∸j+j∸k≡i+j∸k (suc i) (suc j) (suc k) = begin
-  suc i ∸ (k ∸ j) + (j ∸ k)
-                             ≡⟨ i∸k∸j+j∸k≡i+j∸k (suc i) j k ⟩
-  suc i + j ∸ k
-                             ≡⟨ cong (λ x → x ∸ k)
-                                     (sym (+-suc i j)) ⟩
-  i + suc j ∸ k
-                             ∎
 
 i+j≡0⇒i≡0 : ∀ i {j} → i + j ≡ 0 → i ≡ 0
 i+j≡0⇒i≡0 zero    eq = refl
@@ -618,26 +363,301 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (begin
   i * j  ≡⟨ eq ⟩
   1      ∎)
 
-cancel-+-left : ∀ i {j k} → i + j ≡ i + k → j ≡ k
-cancel-+-left zero    eq = eq
-cancel-+-left (suc i) eq = cancel-+-left i (cong pred eq)
+------------------------------------------------------------------------
+-- Properties of _⊔_ and _⊓_
 
-cancel-+-left-≤ : ∀ i {j k} → i + j ≤ i + k → j ≤ k
-cancel-+-left-≤ zero    le       = le
-cancel-+-left-≤ (suc i) (s≤s le) = cancel-+-left-≤ i le
+⊔-assoc : Associative _⊔_
+⊔-assoc zero    _       _       = refl
+⊔-assoc (suc m) zero    o       = refl
+⊔-assoc (suc m) (suc n) zero    = refl
+⊔-assoc (suc m) (suc n) (suc o) = cong suc $ ⊔-assoc m n o
 
-cancel-*-right : ∀ i j {k} → i * suc k ≡ j * suc k → i ≡ j
-cancel-*-right zero    zero        eq = refl
-cancel-*-right zero    (suc j)     ()
-cancel-*-right (suc i) zero        ()
-cancel-*-right (suc i) (suc j) {k} eq =
-  cong suc (cancel-*-right i j (cancel-+-left (suc k) eq))
+⊔-left-identity : LeftIdentity 0 _⊔_
+⊔-left-identity _ = refl
 
-cancel-*-right-≤ : ∀ i j k → i * suc k ≤ j * suc k → i ≤ j
-cancel-*-right-≤ zero    _       _ _  = z≤n
-cancel-*-right-≤ (suc i) zero    _ ()
-cancel-*-right-≤ (suc i) (suc j) k le =
-  s≤s (cancel-*-right-≤ i j k (cancel-+-left-≤ (suc k) le))
+⊔-right-identity : RightIdentity 0 _⊔_
+⊔-right-identity zero    = refl
+⊔-right-identity (suc n) = refl
+
+⊔-identity : Identity 0 _⊔_
+⊔-identity = ⊔-left-identity , ⊔-right-identity
+
+⊔-comm : Commutative _⊔_
+⊔-comm zero    n       = sym $ proj₂ ⊔-identity n
+⊔-comm (suc m) zero    = refl
+⊔-comm (suc m) (suc n) =
+  begin
+    suc m ⊔ suc n
+  ≡⟨ refl ⟩
+    suc (m ⊔ n)
+  ≡⟨ cong suc (⊔-comm m n) ⟩
+    suc (n ⊔ m)
+  ≡⟨ refl ⟩
+    suc n ⊔ suc m
+  ∎
+
+-- ∀ x y → (x ⊔ y ≡ x) ⊎ (x ⊔ y ≡ y)
+⊔-sel : Selective _⊔_
+⊔-sel zero    _    = inj₂ refl
+⊔-sel (suc m) zero = inj₁ refl
+⊔-sel (suc m) (suc n) with ⊔-sel m n
+... | inj₁ m⊔n≡m = inj₁ (cong suc m⊔n≡m)
+... | inj₂ m⊔n≡n = inj₂ (cong suc m⊔n≡n)
+
+-- ∀ x → x ⊔ x ≡ x
+⊔-idem : Idempotent _⊔_
+⊔-idem x with ⊔-sel x x
+... | inj₁ x⊔x≈x = x⊔x≈x
+... | inj₂ x⊔x≈x = x⊔x≈x
+
+⊓-assoc : Associative _⊓_
+⊓-assoc zero    _       _       = refl
+⊓-assoc (suc m) zero    o       = refl
+⊓-assoc (suc m) (suc n) zero    = refl
+⊓-assoc (suc m) (suc n) (suc o) = cong suc $ ⊓-assoc m n o
+
+⊓-left-zero : LeftZero 0 _⊓_
+⊓-left-zero _ = refl
+
+⊓-right-zero : RightZero 0 _⊓_
+⊓-right-zero zero    = refl
+⊓-right-zero (suc n) = refl
+
+⊓-zero : Zero 0 _⊓_
+⊓-zero = ⊓-left-zero , ⊓-right-zero
+
+⊓-comm : Commutative _⊓_
+⊓-comm zero    n       = sym $ proj₂ ⊓-zero n
+⊓-comm (suc m) zero    = refl
+⊓-comm (suc m) (suc n) =
+  begin
+    suc m ⊓ suc n
+  ≡⟨ refl ⟩
+    suc (m ⊓ n)
+  ≡⟨ cong suc (⊓-comm m n) ⟩
+    suc (n ⊓ m)
+  ≡⟨ refl ⟩
+    suc n ⊓ suc m
+  ∎
+
+-- ∀ x y → (x ⊓ y ≡ x) ⊎ (x ⊓ y ≡ y)
+⊓-sel : Selective _⊓_
+⊓-sel zero    _    = inj₁ refl
+⊓-sel (suc m) zero = inj₂ refl
+⊓-sel (suc m) (suc n) with ⊓-sel m n
+... | inj₁ m⊓n≡m = inj₁ (cong suc m⊓n≡m)
+... | inj₂ m⊓n≡n = inj₂ (cong suc m⊓n≡n)
+
+-- ∀ x → x ⊓ x ≡ x
+⊓-idem : Idempotent _⊓_
+⊓-idem x with ⊓-sel x x
+... | inj₁ x⊓x≈x = x⊓x≈x
+... | inj₂ x⊓x≈x = x⊓x≈x
+
+⊓-distribʳ-⊔ : _⊓_ DistributesOverʳ _⊔_
+⊓-distribʳ-⊔ (suc m) (suc n) (suc o) = cong suc $ ⊓-distribʳ-⊔ m n o
+⊓-distribʳ-⊔ (suc m) (suc n) zero    = cong suc $ refl
+⊓-distribʳ-⊔ (suc m) zero    o       = refl
+⊓-distribʳ-⊔ zero    n       o       = begin
+  (n ⊔ o) ⊓ 0    ≡⟨ ⊓-comm (n ⊔ o) 0 ⟩
+  0 ⊓ (n ⊔ o)    ≡⟨ refl ⟩
+  0 ⊓ n ⊔ 0 ⊓ o  ≡⟨ ⊓-comm 0 n ⟨ cong₂ _⊔_ ⟩ ⊓-comm 0 o ⟩
+  n ⊓ 0 ⊔ o ⊓ 0  ∎
+
+⊓-distribˡ-⊔ : _⊓_ DistributesOverˡ _⊔_
+⊓-distribˡ-⊔ m n o = begin
+  m ⊓ (n ⊔ o)    ≡⟨ ⊓-comm m _ ⟩
+  (n ⊔ o) ⊓ m    ≡⟨ ⊓-distribʳ-⊔ m n o ⟩
+  n ⊓ m ⊔ o ⊓ m  ≡⟨ ⊓-comm n m ⟨ cong₂ _⊔_ ⟩ ⊓-comm o m ⟩
+  m ⊓ n ⊔ m ⊓ o  ∎
+
+⊓-distrib-⊔ : _⊓_ DistributesOver _⊔_
+⊓-distrib-⊔ = ⊓-distribˡ-⊔ , ⊓-distribʳ-⊔
+
+⊔-abs-⊓ : _⊔_ Absorbs _⊓_
+⊔-abs-⊓ zero    n       = refl
+⊔-abs-⊓ (suc m) zero    = refl
+⊔-abs-⊓ (suc m) (suc n) = cong suc $ ⊔-abs-⊓ m n
+
+⊓-abs-⊔ : _⊓_ Absorbs _⊔_
+⊓-abs-⊔ zero    n       = refl
+⊓-abs-⊔ (suc m) (suc n) = cong suc $ ⊓-abs-⊔ m n
+⊓-abs-⊔ (suc m) zero    = cong suc $ begin
+  m ⊓ m       ≡⟨ cong (_⊓_ m) $ sym $ proj₂ ⊔-identity m ⟩
+  m ⊓ (m ⊔ 0) ≡⟨ ⊓-abs-⊔ m zero ⟩
+  m           ∎
+
+⊓-⊔-absorptive : Absorptive _⊓_ _⊔_
+⊓-⊔-absorptive = ⊓-abs-⊔ , ⊔-abs-⊓
+
+⊔-isSemigroup : IsSemigroup _≡_ _⊔_
+⊔-isSemigroup = record
+  { isEquivalence = PropEq.isEquivalence
+  ; assoc         = ⊔-assoc
+  ; ∙-cong        = cong₂ _⊔_
+  }
+
+⊔-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _⊔_ 0
+⊔-0-isCommutativeMonoid = record
+  { isSemigroup = ⊔-isSemigroup
+  ; identityˡ    = ⊔-left-identity
+  ; comm        = ⊔-comm
+  }
+
+⊓-isSemigroup : IsSemigroup _≡_ _⊓_
+⊓-isSemigroup = record
+  { isEquivalence = PropEq.isEquivalence
+  ; assoc         = ⊓-assoc
+  ; ∙-cong        = cong₂ _⊓_
+  }
+
+⊔-⊓-0-isSemiringWithoutOne : IsSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
+⊔-⊓-0-isSemiringWithoutOne = record
+  { +-isCommutativeMonoid = ⊔-0-isCommutativeMonoid
+  ; *-isSemigroup         = ⊓-isSemigroup
+  ; distrib               = ⊓-distrib-⊔
+  ; zero                  = ⊓-zero
+  }
+
+⊔-⊓-0-isCommutativeSemiringWithoutOne
+  : IsCommutativeSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
+⊔-⊓-0-isCommutativeSemiringWithoutOne = record
+  { isSemiringWithoutOne = ⊔-⊓-0-isSemiringWithoutOne
+  ; *-comm               = ⊓-comm
+  }
+
+⊔-⊓-0-commutativeSemiringWithoutOne : CommutativeSemiringWithoutOne _ _
+⊔-⊓-0-commutativeSemiringWithoutOne = record
+  { _+_                             = _⊔_
+  ; _*_                             = _⊓_
+  ; 0#                              = 0
+  ; isCommutativeSemiringWithoutOne =
+      ⊔-⊓-0-isCommutativeSemiringWithoutOne
+  }
+
+⊓-⊔-isLattice : IsLattice _≡_ _⊓_ _⊔_
+⊓-⊔-isLattice = record
+  { isEquivalence = PropEq.isEquivalence
+  ; ∨-comm        = ⊓-comm
+  ; ∨-assoc       = ⊓-assoc
+  ; ∨-cong        = cong₂ _⊓_
+  ; ∧-comm        = ⊔-comm
+  ; ∧-assoc       = ⊔-assoc
+  ; ∧-cong        = cong₂ _⊔_
+  ; absorptive    = ⊓-⊔-absorptive
+  }
+
+isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
+isDistributiveLattice = record
+  { isLattice   = ⊓-⊔-isLattice
+  ; ∨-∧-distribʳ = ⊓-distribʳ-⊔
+  }
+
+distributiveLattice : DistributiveLattice _ _
+distributiveLattice = record
+  { _∨_                   = _⊓_
+  ; _∧_                   = _⊔_
+  ; isDistributiveLattice = isDistributiveLattice
+  }
+
+-- Other properties of _⊔_ and _⊓_
+m⊓n≤m : ∀ m n → m ⊓ n ≤ m
+m⊓n≤m zero    _       = z≤n
+m⊓n≤m (suc m) zero    = z≤n
+m⊓n≤m (suc m) (suc n) = s≤s $ m⊓n≤m m n
+
+m≤m⊔n : ∀ m n → m ≤ m ⊔ n
+m≤m⊔n zero    _       = z≤n
+m≤m⊔n (suc m) zero    = ≤-refl
+m≤m⊔n (suc m) (suc n) = s≤s $ m≤m⊔n m n
+
+------------------------------------------------------------------------
+-- Properties of _∸_
+
+0∸n≡0 : LeftZero zero _∸_
+0∸n≡0 zero    = refl
+0∸n≡0 (suc _) = refl
+
+n∸n≡0 : ∀ n → n ∸ n ≡ 0
+n∸n≡0 zero    = refl
+n∸n≡0 (suc n) = n∸n≡0 n
+
+∸-+-assoc : ∀ m n o → (m ∸ n) ∸ o ≡ m ∸ (n + o)
+∸-+-assoc m       n       zero    = cong (_∸_ m) (sym $ +-right-identity n)
+∸-+-assoc zero    zero    (suc o) = refl
+∸-+-assoc zero    (suc n) (suc o) = refl
+∸-+-assoc (suc m) zero    (suc o) = refl
+∸-+-assoc (suc m) (suc n) (suc o) = ∸-+-assoc m n (suc o)
+
++-∸-assoc : ∀ m {n o} → o ≤ n → (m + n) ∸ o ≡ m + (n ∸ o)
++-∸-assoc m (z≤n {n = n})             = begin m + n ∎
++-∸-assoc m (s≤s {m = o} {n = n} o≤n) = begin
+  (m + suc n) ∸ suc o  ≡⟨ cong (λ n → n ∸ suc o) (+-suc m n) ⟩
+  suc (m + n) ∸ suc o  ≡⟨ refl ⟩
+  (m + n) ∸ o          ≡⟨ +-∸-assoc m o≤n ⟩
+  m + (n ∸ o)          ∎
+
+n∸m≤n : ∀ m n → n ∸ m ≤ n
+n∸m≤n zero    n       = ≤-refl
+n∸m≤n (suc m) zero    = ≤-refl
+n∸m≤n (suc m) (suc n) = start
+  n ∸ m  ≤⟨ n∸m≤n m n ⟩
+  n      ≤⟨ n≤1+n n ⟩
+  suc n  □
+
+n≤m+n∸m : ∀ m n → n ≤ m + (n ∸ m)
+n≤m+n∸m m       zero    = z≤n
+n≤m+n∸m zero    (suc n) = ≤-refl
+n≤m+n∸m (suc m) (suc n) = s≤s (n≤m+n∸m m n)
+
+m+n∸n≡m : ∀ m n → (m + n) ∸ n ≡ m
+m+n∸n≡m m n = begin
+  (m + n) ∸ n  ≡⟨ +-∸-assoc m (≤-refl {x = n}) ⟩
+  m + (n ∸ n)  ≡⟨ cong (_+_ m) (n∸n≡0 n) ⟩
+  m + 0        ≡⟨ +-right-identity m ⟩
+  m            ∎
+
+m+n∸m≡n : ∀ {m n} → m ≤ n → m + (n ∸ m) ≡ n
+m+n∸m≡n {m} {n} m≤n = begin
+  m + (n ∸ m)  ≡⟨ sym $ +-∸-assoc m m≤n ⟩
+  (m + n) ∸ m  ≡⟨ cong (λ n → n ∸ m) (+-comm m n) ⟩
+  (n + m) ∸ m  ≡⟨ m+n∸n≡m n m ⟩
+  n            ∎
+
+m⊓n+n∸m≡n : ∀ m n → (m ⊓ n) + (n ∸ m) ≡ n
+m⊓n+n∸m≡n zero    n       = refl
+m⊓n+n∸m≡n (suc m) zero    = refl
+m⊓n+n∸m≡n (suc m) (suc n) = cong suc $ m⊓n+n∸m≡n m n
+
+[m∸n]⊓[n∸m]≡0 : ∀ m n → (m ∸ n) ⊓ (n ∸ m) ≡ 0
+[m∸n]⊓[n∸m]≡0 zero zero       = refl
+[m∸n]⊓[n∸m]≡0 zero (suc n)    = refl
+[m∸n]⊓[n∸m]≡0 (suc m) zero    = refl
+[m∸n]⊓[n∸m]≡0 (suc m) (suc n) = [m∸n]⊓[n∸m]≡0 m n
+
+[i+j]∸[i+k]≡j∸k : ∀ i j k → (i + j) ∸ (i + k) ≡ j ∸ k
+[i+j]∸[i+k]≡j∸k zero    j k = refl
+[i+j]∸[i+k]≡j∸k (suc i) j k = [i+j]∸[i+k]≡j∸k i j k
+
+-- TODO: Can this proof be simplified? An automatic solver which can
+-- handle ∸ would be nice...
+i∸k∸j+j∸k≡i+j∸k : ∀ i j k → i ∸ (k ∸ j) + (j ∸ k) ≡ i + j ∸ k
+i∸k∸j+j∸k≡i+j∸k zero j k = begin
+  0 ∸ (k ∸ j) + (j ∸ k) ≡⟨ cong (λ x → x + (j ∸ k)) (0∸n≡0 (k ∸ j)) ⟩
+  0 + (j ∸ k)           ≡⟨ refl ⟩
+  j ∸ k                 ∎
+i∸k∸j+j∸k≡i+j∸k (suc i) j zero = begin
+  suc i ∸ (0 ∸ j) + j ≡⟨ cong (λ x → suc i ∸ x + j) (0∸n≡0 j) ⟩
+  suc i ∸ 0 + j       ≡⟨ refl ⟩
+  suc (i + j)         ∎
+i∸k∸j+j∸k≡i+j∸k (suc i) zero (suc k) = begin
+  i ∸ k + 0  ≡⟨ +-right-identity _ ⟩
+  i ∸ k      ≡⟨ cong (λ x → x ∸ k) (sym (+-right-identity _)) ⟩
+  i + 0 ∸ k  ∎
+i∸k∸j+j∸k≡i+j∸k (suc i) (suc j) (suc k) = begin
+  suc i ∸ (k ∸ j) + (j ∸ k) ≡⟨ i∸k∸j+j∸k≡i+j∸k (suc i) j k ⟩
+  suc i + j ∸ k             ≡⟨ cong (λ x → x ∸ k) (sym (+-suc i j)) ⟩
+  i + suc j ∸ k             ∎
 
 *-distrib-∸ʳ : _*_ DistributesOverʳ _∸_
 *-distrib-∸ʳ i zero k = begin
@@ -663,6 +683,17 @@ im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
 i+1+j≢i : ∀ i {j} → i + suc j ≢ i
 i+1+j≢i i eq = ¬i+1+j≤i i (≤-reflexive eq)
 
+∸-mono : _∸_ Preserves₂ _≤_ ⟶ _≥_ ⟶ _≤_
+∸-mono           z≤n         (s≤s n₁≥n₂)    = z≤n
+∸-mono           (s≤s m₁≤m₂) (s≤s n₁≥n₂)    = ∸-mono m₁≤m₂ n₁≥n₂
+∸-mono {m₁} {m₂} m₁≤m₂       (z≤n {n = n₁}) = start
+  m₁ ∸ n₁  ≤⟨ n∸m≤n n₁ m₁ ⟩
+  m₁       ≤⟨ m₁≤m₂ ⟩
+  m₂       □
+
+------------------------------------------------------------------------
+-- Properties of ⌊_/2⌋
+
 ⌊n/2⌋-mono : ⌊_/2⌋ Preserves _≤_ ⟶ _≤_
 ⌊n/2⌋-mono z≤n             = z≤n
 ⌊n/2⌋-mono (s≤s z≤n)       = z≤n
@@ -671,25 +702,11 @@ i+1+j≢i i eq = ¬i+1+j≤i i (≤-reflexive eq)
 ⌈n/2⌉-mono : ⌈_/2⌉ Preserves _≤_ ⟶ _≤_
 ⌈n/2⌉-mono m≤n = ⌊n/2⌋-mono (s≤s m≤n)
 
-pred-mono : pred Preserves _≤_ ⟶ _≤_
-pred-mono z≤n      = z≤n
-pred-mono (s≤s le) = le
+⌈n/2⌉≤′n : ∀ n → ⌈ n /2⌉ ≤′ n
+⌈n/2⌉≤′n zero          = ≤′-refl
+⌈n/2⌉≤′n (suc zero)    = ≤′-refl
+⌈n/2⌉≤′n (suc (suc n)) = s≤′s (≤′-step (⌈n/2⌉≤′n n))
 
-_+-mono_ : _+_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
-_+-mono_ {zero} {m₂} {n₁} {n₂} z≤n n₁≤n₂ = start
-  n₁      ≤⟨ n₁≤n₂ ⟩
-  n₂      ≤⟨ n≤m+n m₂ n₂ ⟩
-  m₂ + n₂ □
-s≤s m₁≤m₂ +-mono n₁≤n₂ = s≤s (m₁≤m₂ +-mono n₁≤n₂)
-
-_*-mono_ : _*_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
-z≤n       *-mono n₁≤n₂ = z≤n
-s≤s m₁≤m₂ *-mono n₁≤n₂ = n₁≤n₂ +-mono (m₁≤m₂ *-mono n₁≤n₂)
-
-∸-mono : _∸_ Preserves₂ _≤_ ⟶ _≥_ ⟶ _≤_
-∸-mono           z≤n         (s≤s n₁≥n₂)    = z≤n
-∸-mono           (s≤s m₁≤m₂) (s≤s n₁≥n₂)    = ∸-mono m₁≤m₂ n₁≥n₂
-∸-mono {m₁} {m₂} m₁≤m₂       (z≤n {n = n₁}) = start
-  m₁ ∸ n₁  ≤⟨ n∸m≤n n₁ m₁ ⟩
-  m₁       ≤⟨ m₁≤m₂ ⟩
-  m₂       □
+⌊n/2⌋≤′n : ∀ n → ⌊ n /2⌋ ≤′ n
+⌊n/2⌋≤′n zero    = ≤′-refl
+⌊n/2⌋≤′n (suc n) = ≤′-step (⌈n/2⌉≤′n n)

--- a/src/Data/Nat/Properties/Simple.agda
+++ b/src/Data/Nat/Properties/Simple.agda
@@ -24,6 +24,9 @@ open import Data.Sum
 +-right-identity zero = refl
 +-right-identity (suc n) = cong suc $ +-right-identity n
 
++-left-identity : ∀ n → 0 + n ≡ n
++-left-identity _ = refl
+
 +-suc : ∀ m n → m + suc n ≡ suc (m + n)
 +-suc zero    n = refl
 +-suc (suc m) n = cong suc (+-suc m n)
@@ -65,6 +68,9 @@ open import Data.Sum
 *-right-zero : ∀ n → n * 0 ≡ 0
 *-right-zero zero = refl
 *-right-zero (suc n) = *-right-zero n
+
+*-left-zero : ∀ n → 0 * n ≡ 0
+*-left-zero _ = refl
 
 *-comm : ∀ m n → m * n ≡ n * m
 *-comm zero    n = sym $ *-right-zero n


### PR DESCRIPTION
Moved many of the proofs hidden in private scope and records in `Data.Nat.Properties` out into public scope. Also rearranged the more messy bits of the file so that they're more logically ordered and hence easier to manually search. The proofs are now in the order:

1. Equality
2. Orderings
3. Addition and multiplication
4. Min and max
5. Subtraction
6. Other

Also added the proofs `<-irrefl` and `<-asym` to `Data.Nat.Properties` and `+-left-identity` and `*-left-zero` to `Data.Nat.Properties.Simple`.

These changes should be entirely backwards compatible. `Data.Nat.Properties` exports everything it used to export with no names changes. I've run `make test` in the std-lib and manually gone through the commit to check that I haven't lost any properties in my rearrangement of the file.