### PR TITLE
Added syntax for existential quantifiers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ Important changes since 0.13:
   pattern matching. The new version (and the associated proofs in
   `Data.Vec.All.Properties`) are more generic with respect to types and
   levels.
+  
+* Added syntax for existential quantifiers as `∃[ x ] B` and `∄[ x ] B`.
 
 Version 0.13
 ============

--- a/src/Data/Product.agda
+++ b/src/Data/Product.agda
@@ -38,8 +38,18 @@ syntax Σ-syntax A (λ x → B) = Σ[ x ∈ A ] B
 ∃ : ∀ {a b} {A : Set a} → (A → Set b) → Set (a ⊔ b)
 ∃ = Σ _
 
+∃-syntax : ∀ {a b} {A : Set a} → (A → Set b) → Set (a ⊔ b)
+∃-syntax = ∃
+
+syntax ∃-syntax (λ x → B) = ∃[ x ] B
+
 ∄ : ∀ {a b} {A : Set a} → (A → Set b) → Set (a ⊔ b)
 ∄ P = ¬ ∃ P
+
+∄-syntax : ∀ {a b} {A : Set a} → (A → Set b) → Set (a ⊔ b)
+∄-syntax = ∄
+
+syntax ∄-syntax (λ x → B) = ∄[ x ] B
 
 ∃₂ : ∀ {a b c} {A : Set a} {B : A → Set b}
      (C : (x : A) → B x → Set c) → Set (a ⊔ b ⊔ c)


### PR DESCRIPTION
Is there any particular reason these weren't added years ago? I might have missed some particular discussion about this.