### PR TITLE
Moved ¬∀⟶∃¬ from Relation.Nullary.Negation to Data.Fin.Dec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Important changes since 0.13:
 * Moved `decTotalOrder` in `Data.Nat` to `≤-decTotalOrder` in
   `Data.Nat.Properties`
 
+* Moved `¬∀⟶∃¬` from `Relation.Nullary.Negation` to `Data.Fin.Dec`
+
 * Added `⊓-idem` and `⊔-idem` to `Data.Nat.Properties`
 
 * Useful lemmas and properties that were previously in private scope,

--- a/src/Data/Fin/Dec.agda
+++ b/src/Data/Fin/Dec.agda
@@ -155,6 +155,14 @@ anySubset? {suc n} {P} dec with anySubset? (restrictS inside  dec)
   extend′ g zero    = P0
   extend′ g (suc j) = g j
 
+
+-- When P is a decidable predicate over a finite set the following
+-- lemma can be proved.
+
+¬∀⟶∃¬ : ∀ n {p} (P : Fin n → Set p) → U.Decidable P →
+        ¬ (∀ i → P i) → ∃ λ i → ¬ P i
+¬∀⟶∃¬ n P dec ¬P = Prod.map id proj₁ $ ¬∀⟶∃¬-smallest n P dec ¬P
+
 -- Decision procedure for _⊆_ (obtained via the natural lattice
 -- order).
 

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -12,8 +12,6 @@ open import Data.Bool.Base using (Bool; false; true; if_then_else_)
 open import Data.Empty
 open import Function
 open import Data.Product as Prod
-open import Data.Fin using (Fin)
-open import Data.Fin.Dec
 open import Data.Sum as Sum
 open import Category.Monad
 open import Level
@@ -61,13 +59,6 @@ private
 ∃¬⟶¬∀ : ∀ {a p} {A : Set a} {P : A → Set p} →
         ∃ (λ x → ¬ P x) → ¬ (∀ x → P x)
 ∃¬⟶¬∀ = flip ∀⟶¬∃¬
-
--- When P is a decidable predicate over a finite set the following
--- lemma can be proved.
-
-¬∀⟶∃¬ : ∀ n {p} (P : Fin n → Set p) → Decidable P →
-        ¬ (∀ i → P i) → ∃ λ i → ¬ P i
-¬∀⟶∃¬ n P dec ¬P = Prod.map id proj₁ $ ¬∀⟶∃¬-smallest n P dec ¬P
 
 ------------------------------------------------------------------------
 -- Double-negation


### PR DESCRIPTION
This addresses #118 by moving the problematic lemma back to `Data.Fin.Dec`. Hopefully it's relatively uncontroversial (?) that any lemma concerning `Fin n` indexed functions doesn't belong in `Relation.Nullary.Negation`....