### PR TITLE
Adding `Algebra.FunctionProperties.Consequences`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,20 @@ Backwards compatible changes
   Cancellative      _•_ = LeftCancellative _•_ × RightCancellative _•_
   ```
 
+* Added new module `Algebra.FunctionProperties.Consequences` for basic causal relationships between
+  properties, containing:
+  ```agda
+  comm+idˡ⇒idʳ       : Commutative _•_ → LeftIdentity e _•_ → RightIdentity e _•_
+  comm+idʳ⇒idˡ       : Commutative _•_ → RightIdentity e _•_ → LeftIdentity e _•_
+  comm+zeˡ⇒zeʳ       : Commutative _•_ → LeftZero e _•_ → RightZero e _•_
+  comm+zeʳ⇒zeˡ       : Commutative _•_ → RightZero e _•_ → LeftZero e _•_
+  comm+invˡ⇒invʳ     : Commutative _•_ → LeftInverse e _⁻¹ _•_ → RightInverse e _⁻¹ _•_
+  comm+invʳ⇒invˡ     : Commutative _•_ → RightInverse e _⁻¹ _•_ → LeftInverse e _⁻¹ _•_
+  comm+distrˡ⇒distrʳ : Commutative _•_ → _•_ DistributesOverˡ _◦_ → _•_ DistributesOverʳ _◦_
+  comm+distrʳ⇒distrˡ : Commutative _•_ → _•_ DistributesOverʳ _◦_ → _•_ DistributesOverˡ _◦_
+  sel⇒idem           : Selective _•_ → Idempotent _•_
+  ```
+
 * Added proofs to `Algebra.Properties.BooleanAlgebra`:
   ```agda
   ∨-complementˡ : LeftInverse ⊤ ¬_ _∨_

--- a/src/Algebra/FunctionProperties/Consequences.agda
+++ b/src/Algebra/FunctionProperties/Consequences.agda
@@ -1,0 +1,94 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Relations between properties of functions, such as associativity and
+-- commutativity
+------------------------------------------------------------------------
+
+open import Relation.Binary using (Setoid)
+
+module Algebra.FunctionProperties.Consequences
+  {a ℓ} (S : Setoid a ℓ) where
+
+open Setoid S
+open import Algebra.FunctionProperties _≈_
+open import Relation.Binary.EqReasoning S
+open import Data.Sum using (inj₁; inj₂)
+
+------------------------------------------------------------------------
+-- Transposing identity elements
+
+comm+idˡ⇒idʳ : ∀ {_•_} → Commutative _•_ →
+              ∀ {e} → LeftIdentity e _•_ → RightIdentity e _•_
+comm+idˡ⇒idʳ {_•_} comm {e} idˡ x = begin
+  x • e ≈⟨ comm x e ⟩
+  e • x ≈⟨ idˡ x ⟩
+  x     ∎
+
+comm+idʳ⇒idˡ : ∀ {_•_} → Commutative _•_ →
+              ∀ {e} → RightIdentity e _•_ → LeftIdentity e _•_
+comm+idʳ⇒idˡ {_•_} comm {e} idʳ x = begin
+  e • x ≈⟨ comm e x ⟩
+  x • e ≈⟨ idʳ x ⟩
+  x     ∎
+
+------------------------------------------------------------------------
+-- Transposing zero elements
+
+comm+zeˡ⇒zeʳ : ∀ {_•_} → Commutative _•_ →
+              ∀ {e} → LeftZero e _•_ → RightZero e _•_
+comm+zeˡ⇒zeʳ {_•_} comm {e} zeˡ x = begin
+  x • e ≈⟨ comm x e ⟩
+  e • x ≈⟨ zeˡ x ⟩
+  e     ∎
+
+comm+zeʳ⇒zeˡ : ∀ {_•_} → Commutative _•_ →
+              ∀ {e} → RightZero e _•_ → LeftZero e _•_
+comm+zeʳ⇒zeˡ {_•_} comm {e} zeʳ x = begin
+  e • x ≈⟨ comm e x ⟩
+  x • e ≈⟨ zeʳ x ⟩
+  e     ∎
+
+------------------------------------------------------------------------
+-- Transposing inverse elements
+
+comm+invˡ⇒invʳ : ∀ {e _⁻¹ _•_} → Commutative _•_ →
+                LeftInverse e _⁻¹ _•_ → RightInverse e _⁻¹ _•_
+comm+invˡ⇒invʳ {e} {_⁻¹} {_•_} comm invˡ x = begin
+  x • (x ⁻¹) ≈⟨ comm x (x ⁻¹) ⟩
+  (x ⁻¹) • x ≈⟨ invˡ x ⟩
+  e          ∎
+
+comm+invʳ⇒invˡ : ∀ {e _⁻¹ _•_} → Commutative _•_ →
+                RightInverse e _⁻¹ _•_ → LeftInverse e _⁻¹ _•_
+comm+invʳ⇒invˡ {e} {_⁻¹} {_•_} comm invʳ x = begin
+  (x ⁻¹) • x ≈⟨ comm (x ⁻¹) x ⟩
+  x • (x ⁻¹) ≈⟨ invʳ x ⟩
+  e          ∎
+
+------------------------------------------------------------------------
+-- Transposing distributivity
+
+comm+distrˡ⇒distrʳ : ∀ {_•_ _◦_} → Congruent₂ _◦_ → Commutative _•_ →
+                   _•_ DistributesOverˡ _◦_ → _•_ DistributesOverʳ _◦_
+comm+distrˡ⇒distrʳ {_•_} {_◦_} cong comm distrˡ x y z = begin
+  (y ◦ z) • x       ≈⟨ comm (y ◦ z) x ⟩
+  x • (y ◦ z)       ≈⟨ distrˡ x y z ⟩
+  (x • y) ◦ (x • z) ≈⟨ cong (comm x y) (comm x z) ⟩
+  (y • x) ◦ (z • x) ∎
+
+comm+distrʳ⇒distrˡ : ∀ {_•_ _◦_} → Congruent₂ _◦_ → Commutative _•_ →
+                   _•_ DistributesOverʳ _◦_ → _•_ DistributesOverˡ _◦_
+comm+distrʳ⇒distrˡ {_•_} {_◦_} cong comm distrˡ x y z = begin
+  x • (y ◦ z)       ≈⟨ comm x (y ◦ z) ⟩
+  (y ◦ z) • x       ≈⟨ distrˡ x y z ⟩
+  (y • x) ◦ (z • x) ≈⟨ cong (comm y x) (comm z x) ⟩
+  (x • y) ◦ (x • z) ∎
+
+------------------------------------------------------------------------
+-- Selectivity implies idempotence
+
+sel⇒idem : ∀ {_•_} → Selective _•_ → Idempotent _•_
+sel⇒idem sel x with sel x x
+... | inj₁ x•x≈x = x•x≈x
+... | inj₂ x•x≈x = x•x≈x

--- a/src/Algebra/Properties/BooleanAlgebra.agda
+++ b/src/Algebra/Properties/BooleanAlgebra.agda
@@ -18,6 +18,8 @@ private
     hiding (replace-equality)
 open import Algebra.Structures
 open import Algebra.FunctionProperties _≈_
+open import Algebra.FunctionProperties.Consequences
+  record {isEquivalence = isEquivalence}
 open import Relation.Binary.EqReasoning setoid
 open import Relation.Binary
 open import Function
@@ -29,19 +31,13 @@ open import Data.Product
 -- Some simple generalisations
 
 ∨-complementˡ : LeftInverse ⊤ ¬_ _∨_
-∨-complementˡ x = begin
-  ¬ x ∨ x    ≈⟨ ∨-comm _ _ ⟩
-  x   ∨ ¬ x  ≈⟨ ∨-complementʳ _ ⟩
-  ⊤          ∎
+∨-complementˡ = comm+invʳ⇒invˡ ∨-comm ∨-complementʳ
 
 ∨-complement : Inverse ⊤ ¬_ _∨_
 ∨-complement = ∨-complementˡ , ∨-complementʳ
 
 ∧-complementˡ : LeftInverse ⊥ ¬_ _∧_
-∧-complementˡ x = begin
-  ¬ x ∧ x    ≈⟨ ∧-comm _ _ ⟩
-  x   ∧ ¬ x  ≈⟨ ∧-complementʳ _ ⟩
-  ⊥          ∎
+∧-complementˡ = comm+invʳ⇒invˡ ∧-comm ∧-complementʳ
 
 ∧-complement : Inverse ⊥ ¬_ _∧_
 ∧-complement = ∧-complementˡ , ∧-complementʳ
@@ -76,7 +72,7 @@ open import Data.Product
   x              ∎
 
 ∧-identityˡ : LeftIdentity ⊤ _∧_
-∧-identityˡ _ = ∧-comm _ _ ⟨ trans ⟩ ∧-identityʳ _
+∧-identityˡ = comm+idʳ⇒idˡ ∧-comm ∧-identityʳ
 
 ∧-identity : Identity ⊤ _∧_
 ∧-identity = ∧-identityˡ , ∧-identityʳ
@@ -88,7 +84,7 @@ open import Data.Product
   x              ∎
 
 ∨-identityˡ : LeftIdentity ⊥ _∨_
-∨-identityˡ _ = ∨-comm _ _ ⟨ trans ⟩ ∨-identityʳ _
+∨-identityˡ = comm+idʳ⇒idˡ ∨-comm ∨-identityʳ
 
 ∨-identity : Identity ⊥ _∨_
 ∨-identity = ∨-identityˡ , ∨-identityʳ
@@ -102,7 +98,7 @@ open import Data.Product
   ⊥              ∎
 
 ∧-zeroˡ : LeftZero ⊥ _∧_
-∧-zeroˡ _ = ∧-comm _ _ ⟨ trans ⟩ ∧-zeroʳ _
+∧-zeroˡ = comm+zeʳ⇒zeˡ ∧-comm ∧-zeroʳ
 
 ∧-zero : Zero ⊥ _∧_
 ∧-zero = ∧-zeroˡ , ∧-zeroʳ
@@ -428,11 +424,7 @@ module XorRing
         (x ∧ (y ∨ z)) ∧ ¬ x    ∎
 
   ∧-distribʳ-⊕ : _∧_ DistributesOverʳ _⊕_
-  ∧-distribʳ-⊕ x y z = begin
-    (y ⊕ z) ∧ x        ≈⟨ ∧-comm _ _ ⟩
-    x ∧ (y ⊕ z)        ≈⟨ ∧-distribˡ-⊕ _ _ _ ⟩
-    (x ∧ y) ⊕ (x ∧ z)  ≈⟨ ∧-comm _ _ ⟨ ⊕-cong ⟩ ∧-comm _ _ ⟩
-    (y ∧ x) ⊕ (z ∧ x)  ∎
+  ∧-distribʳ-⊕ = comm+distrˡ⇒distrʳ ⊕-cong ∧-comm ∧-distribˡ-⊕
 
   ∧-distrib-⊕ : _∧_ DistributesOver _⊕_
   ∧-distrib-⊕ = ∧-distribˡ-⊕ , ∧-distribʳ-⊕

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -8,6 +8,7 @@ module Data.Integer.Properties where
 
 open import Algebra
 import Algebra.FunctionProperties
+import Algebra.FunctionProperties.Consequences
 import Algebra.Morphism as Morphism
 import Algebra.Properties.AbelianGroup
 open import Algebra.Structures
@@ -28,6 +29,7 @@ open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 
 open Algebra.FunctionProperties (_≡_ {A = ℤ})
+open Algebra.FunctionProperties.Consequences (setoid ℤ)
 open Morphism.Definitions ℤ ℕ _≡_
 open ℕₚ.SemiringSolver
 open ≡-Reasoning
@@ -173,7 +175,7 @@ sign-⊖-≰ = sign-⊖-< ∘ ℕₚ.≰⇒>
 +-identityˡ (+   _ ) = refl
 
 +-identityʳ : RightIdentity (+ 0) _+_
-+-identityʳ x rewrite +-comm x (+ 0) = +-identityˡ x
++-identityʳ = comm+idˡ⇒idʳ +-comm +-identityˡ
 
 +-identity : Identity (+ 0) _+_
 +-identity = +-identityˡ , +-identityʳ
@@ -241,10 +243,7 @@ inverseˡ (+ zero)  = refl
 inverseˡ (+ suc n) = n⊖n≡0 n
 
 inverseʳ : RightInverse (+ 0) -_ _+_
-inverseʳ i = begin
-  i + - i  ≡⟨ +-comm i (- i) ⟩
-  - i + i  ≡⟨ inverseˡ i ⟩
-  + 0      ∎
+inverseʳ = comm+invˡ⇒invʳ +-comm inverseˡ
 
 +-inverse : Inverse (+ 0) -_ _+_
 +-inverse = inverseˡ , inverseʳ
@@ -345,11 +344,7 @@ neg-distrib-+ -[1+ m ]  (+   n)  =
 *-identityˡ (+ suc n) rewrite ℕₚ.+-right-identity n = refl
 
 *-identityʳ : RightIdentity (+ 1) _*_
-*-identityʳ x rewrite
-    𝕊ₚ.*-identityʳ (sign x)
-  | ℕₚ.*-right-identity ∣ x ∣
-  | signₙ◃∣n∣≡n x
-  = refl
+*-identityʳ = comm+idˡ⇒idʳ *-comm *-identityˡ
 
 *-identity : Identity (+ 1) _*_
 *-identity = *-identityˡ , *-identityʳ
@@ -358,7 +353,7 @@ neg-distrib-+ -[1+ m ]  (+   n)  =
 *-zeroˡ n = refl
 
 *-zeroʳ : RightZero (+ 0) _*_
-*-zeroʳ n rewrite *-comm n (+ 0) = refl
+*-zeroʳ = comm+zeˡ⇒zeʳ *-comm *-zeroˡ
 
 *-zero : Zero (+ 0) _*_
 *-zero = *-zeroˡ , *-zeroʳ

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -18,6 +18,7 @@ open import Relation.Nullary
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary.PropositionalEquality
 open import Algebra.FunctionProperties (_≡_ {A = ℕ})
+open import Algebra.FunctionProperties.Consequences (setoid ℕ)
 open import Data.Product
 open import Data.Sum
 open ≡-Reasoning
@@ -271,12 +272,12 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
 +-assoc zero    _ _ = refl
 +-assoc (suc m) n o = cong suc (+-assoc m n o)
 
++-left-identity : LeftIdentity 0 _+_
++-left-identity _ = refl
+
 +-right-identity : RightIdentity 0 _+_
 +-right-identity zero    = refl
 +-right-identity (suc n) = cong suc (+-right-identity n)
-
-+-left-identity : LeftIdentity 0 _+_
-+-left-identity _ = refl
 
 +-identity : Identity 0 _+_
 +-identity = +-left-identity , +-right-identity
@@ -429,11 +430,7 @@ distribʳ-*-+ m (suc n) o = begin
   suc n * m + o * m   ∎
 
 distribˡ-*-+ : _*_ DistributesOverˡ _+_
-distribˡ-*-+ x y z = begin
-  x * (y + z)       ≡⟨ *-comm x (y + z) ⟩
-  (y + z) * x       ≡⟨ distribʳ-*-+ x y z ⟩
-  (y * x) + (z * x) ≡⟨ cong₂ _+_ (*-comm y x) (*-comm z x) ⟩
-  (x * y) + (x * z) ∎
+distribˡ-*-+ = comm+distrʳ⇒distrˡ (cong₂ _+_) *-comm distribʳ-*-+
 
 distrib-*-+ : _*_ DistributesOver _+_
 distrib-*-+ = distribˡ-*-+ , distribʳ-*-+
@@ -559,11 +556,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊔-comm : Commutative _⊔_
 ⊔-comm zero    n       = sym $ ⊔-right-identity n
 ⊔-comm (suc m) zero    = refl
-⊔-comm (suc m) (suc n) = begin
-  suc m ⊔ suc n ≡⟨ refl ⟩
-  suc (m ⊔ n)   ≡⟨ cong suc (⊔-comm m n) ⟩
-  suc (n ⊔ m)   ≡⟨ refl ⟩
-  suc n ⊔ suc m ∎
+⊔-comm (suc m) (suc n) = cong suc (⊔-comm m n)
 
 -- ∀ x y → (x ⊔ y ≡ x) ⊎ (x ⊔ y ≡ y)
 ⊔-sel : Selective _⊔_
@@ -575,9 +568,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 
 -- ∀ x → x ⊔ x ≡ x
 ⊔-idem : Idempotent _⊔_
-⊔-idem x with ⊔-sel x x
-... | inj₁ x⊔x≈x = x⊔x≈x
-... | inj₂ x⊔x≈x = x⊔x≈x
+⊔-idem = sel⇒idem ⊔-sel
 
 ⊓-assoc : Associative _⊓_
 ⊓-assoc zero    _       _       = refl
@@ -598,11 +589,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊓-comm : Commutative _⊓_
 ⊓-comm zero    n       = sym $ ⊓-right-zero n
 ⊓-comm (suc m) zero    = refl
-⊓-comm (suc m) (suc n) = begin
-  suc m ⊓ suc n  ≡⟨ refl ⟩
-  suc (m ⊓ n)    ≡⟨ cong suc (⊓-comm m n) ⟩
-  suc (n ⊓ m)    ≡⟨ refl ⟩
-  suc n ⊓ suc m  ∎
+⊓-comm (suc m) (suc n) = cong suc (⊓-comm m n)
 
 -- ∀ x y → (x ⊓ y ≡ x) ⊎ (x ⊓ y ≡ y)
 ⊓-sel : Selective _⊓_
@@ -614,9 +601,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 
 -- ∀ x → x ⊓ x ≡ x
 ⊓-idem : Idempotent _⊓_
-⊓-idem x with ⊓-sel x x
-... | inj₁ x⊓x≈x = x⊓x≈x
-... | inj₂ x⊓x≈x = x⊓x≈x
+⊓-idem = sel⇒idem ⊓-sel
 
 ⊓-distribʳ-⊔ : _⊓_ DistributesOverʳ _⊔_
 ⊓-distribʳ-⊔ (suc m) (suc n) (suc o) = cong suc $ ⊓-distribʳ-⊔ m n o
@@ -629,11 +614,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
   n ⊓ 0 ⊔ o ⊓ 0  ∎
 
 ⊓-distribˡ-⊔ : _⊓_ DistributesOverˡ _⊔_
-⊓-distribˡ-⊔ m n o = begin
-  m ⊓ (n ⊔ o)    ≡⟨ ⊓-comm m _ ⟩
-  (n ⊔ o) ⊓ m    ≡⟨ ⊓-distribʳ-⊔ m n o ⟩
-  n ⊓ m ⊔ o ⊓ m  ≡⟨ ⊓-comm n m ⟨ cong₂ _⊔_ ⟩ ⊓-comm o m ⟩
-  m ⊓ n ⊔ m ⊓ o  ∎
+⊓-distribˡ-⊔ = comm+distrʳ⇒distrˡ (cong₂ _⊔_) ⊓-comm ⊓-distribʳ-⊔
 
 ⊓-distrib-⊔ : _⊓_ DistributesOver _⊔_
 ⊓-distrib-⊔ = ⊓-distribˡ-⊔ , ⊓-distribʳ-⊔
@@ -773,11 +754,7 @@ m⊓n≤m+n m n with ⊓-sel m n
 +-distribˡ-⊔ (suc x) y z = cong suc (+-distribˡ-⊔ x y z)
 
 +-distribʳ-⊔ : _+_ DistributesOverʳ _⊔_
-+-distribʳ-⊔ x y z = begin
-  (y ⊔ z) + x       ≡⟨ +-comm (y ⊔ z) x ⟩
-  x + (y ⊔ z)       ≡⟨ +-distribˡ-⊔ x y z ⟩
-  (x + y) ⊔ (x + z) ≡⟨ cong₂ _⊔_ (+-comm x y) (+-comm x z) ⟩
-  (y + x) ⊔ (z + x) ∎
++-distribʳ-⊔ = comm+distrˡ⇒distrʳ (cong₂ _⊔_) +-comm +-distribˡ-⊔
 
 +-distrib-⊔ : _+_ DistributesOver _⊔_
 +-distrib-⊔ = +-distribˡ-⊔ , +-distribʳ-⊔
@@ -787,11 +764,7 @@ m⊓n≤m+n m n with ⊓-sel m n
 +-distribˡ-⊓ (suc x) y z = cong suc (+-distribˡ-⊓ x y z)
 
 +-distribʳ-⊓ : _+_ DistributesOverʳ _⊓_
-+-distribʳ-⊓ x y z = begin
-  (y ⊓ z) + x       ≡⟨ +-comm (y ⊓ z) x ⟩
-  x + (y ⊓ z)       ≡⟨ +-distribˡ-⊓ x y z ⟩
-  (x + y) ⊓ (x + z) ≡⟨ cong₂ _⊓_ (+-comm x y) (+-comm x z) ⟩
-  (y + x) ⊓ (z + x) ∎
++-distribʳ-⊓ = comm+distrˡ⇒distrʳ (cong₂ _⊓_) +-comm +-distribˡ-⊓
 
 +-distrib-⊓ : _+_ DistributesOver _⊓_
 +-distrib-⊓ = +-distribˡ-⊓ , +-distribʳ-⊓


### PR DESCRIPTION
Fed up of proving certain basic relations between algebraic properties over and over again. Many of these proofs already have many copies floating around the library at the moment (e.g. `Data.Nat.Properties`, `Data.Integer.Properties`, `Algebra.Properties.BooleanAlgebra`, `Algebra.Properties.DistributiveLattice`). These are just the basic ones, the file can be updated with more when people come across them.

If no one has any objections, I'll start cleaning up their occurrences in the rest of the library some time towards the end of the week.