### PR TITLE
Fix _<⟨_⟩_ to take a proof of less-than

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ Non-backwards compatible changes
   location was causing dependency cyles to form between `Data.Fin.Dec`,
   `Relation.Nullary.Negation` and `Data.Fin`.
 
+* Changed type of second parameter of `Relation.Binary.StrictPartialOrderReasoning._<⟨_⟩_`
+  from `x < y ⊎ x ≈ y` to `x < y`. `_≈⟨_⟩_` is left unchanged to take a value with type `x ≈ y`.
+
 Deprecated features
 -------------------
 

--- a/src/Relation/Binary/StrictPartialOrderReasoning.agda
+++ b/src/Relation/Binary/StrictPartialOrderReasoning.agda
@@ -12,4 +12,10 @@ module Relation.Binary.StrictPartialOrderReasoning
 
 import Relation.Binary.PreorderReasoning as PreR
 import Relation.Binary.Properties.StrictPartialOrder as SPO
-open PreR (SPO.preorder S) public renaming (_∼⟨_⟩_ to _<⟨_⟩_)
+open PreR (SPO.preorder S) public
+open import Data.Sum
+
+_<⟨_⟩_ : ∀ x {y z} → _ → y IsRelatedTo z → x IsRelatedTo z
+x <⟨ x∼y ⟩ y∼z = x ∼⟨ inj₁ x∼y ⟩ y∼z
+
+infixr 2 _<⟨_⟩_


### PR DESCRIPTION
Previously using `_<⟨_⟩_` StrictPartialOrderReasoning required a value of the sum of the less-than and equal-to relations. With this change the `<` case and `≈` case are accessible via the appropriately named operators.

The existing `_≈⟨_⟩_` already handles the equality
case and after this change `_∼⟨_⟩_` remains available
for the odd-case where the sum-behavior is desired.

This fix is inspired from the following use-case.

(Incidentally I'd love to have from-left and from-right added to Data.Sum in the style of Data.Maybe.from-just.)

```agda
  example : ∀ {a} {A : Set a} (f : A → A) (x : A) (xs : List A) →
            xs ≢ x ∷ x ∷ map f xs
  example f x xs =
    irref-ord List-ord
      $ from-left
      $ begin List-ord                xs  ≈⟨ map-ord f xs ⟩
              List-ord (        map f xs) <⟨ [ lt₁ tt ] ⟩
              List-ord (    x ∷ map f xs) <⟨ [ lt₁ tt ] ⟩
              List-ord (x ∷ x ∷ map f xs) ∎
```

Pretty version at https://glguy.net/ord/Ord.html