### PR TITLE
[ new ] Support for Agda.Builtin.Strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,12 @@ but they may be removed in some future release of the library.
 Backwards compatible changes
 ----------------------------
 
+* Giving access to `primForce` and `primForceLemma` via `Strict`. Also providing
+  the call-by-value application combinator `_$!_`.
+
+* Systematically providing non-dependent versions of the application combinators
+  for use cases where the most general one leads to unsolved meta variables.
+
 * Added support for GHC 8.0.2 and 8.2.1.
 
 * Removed the empty `Irrelevance` module

--- a/src/Function.agda
+++ b/src/Function.agda
@@ -7,12 +7,13 @@
 module Function where
 
 open import Level
+open import Strict
 
 infixr 9 _∘_ _∘′_
 infixl 8 _ˢ_
 infixl 1 _on_
 infixl 1 _⟨_⟩_
-infixr 0 _-[_]-_ _$_
+infixr 0 _-[_]-_ _$_ _$′_ _$!_ _$!′_
 infixl 0 _∋_
 
 ------------------------------------------------------------------------
@@ -70,6 +71,21 @@ flip f = λ y x → f x y
 _$_ : ∀ {a b} {A : Set a} {B : A → Set b} →
       ((x : A) → B x) → ((x : A) → B x)
 f $ x = f x
+
+_$′_ : ∀ {a b} {A : Set a} {B : Set b} →
+       (A → B) → (A → B)
+_$′_ = _$_
+
+-- Strict (call-by-value) application
+
+_$!_ : ∀ {a b} {A : Set a} {B : A → Set b} →
+       ((x : A) → B x) → ((x : A) → B x)
+_$!_ = flip force
+
+_$!′_ : ∀ {a b} {A : Set a} {B : Set b} →
+        (A → B) → (A → B)
+_$!′_ = _$!_
+
 
 _⟨_⟩_ : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c} →
         A → (A → B → C) → B → C

--- a/src/Strict.agda
+++ b/src/Strict.agda
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Strictness combinators
+------------------------------------------------------------------------
+
+module Strict where
+
+open import Level
+open import Agda.Builtin.Equality
+
+open import Agda.Builtin.Strict
+     renaming ( primForce to force
+              ; primForceLemma to force-≡) public
+
+-- Derived combinators
+module _ {ℓ ℓ′ : Level} {A : Set ℓ} {B : Set ℓ′} where
+
+  force′ : A → (A → B) → B
+  force′ = force
+
+  force′-≡ : (a : A) (f : A → B) → force′ a f ≡ f a
+  force′-≡ = force-≡
+
+  seq : A → B → B
+  seq a b = force a (λ _ → b)
+
+  seq-≡ : (a : A) (b : B) → seq a b ≡ b
+  seq-≡ a b = force-≡ a (λ _ → b)


### PR DESCRIPTION
Agda.Builtin.Strict was introduced in February 2016 but we
somehow missed it and it's not part of the standard library.
This fixes this issue.

Also, I've taken the opportunity to introduce ticked version
of various apply functions which, just like the ticked
composition operator, expect their function *not* to be a
dependent function. This makes type-inference a lot easier
and is usefull to make unsolved metas go away!