### PR TITLE
Fixing library naming conventions in Data.Nat.Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,22 +98,35 @@ but they may be removed in some future release of the library.
   re-exports the proofs from `Data.Nat.Properties` but will be removed in some
   future release.
 
-* The module `Data.Integer.Addition.Properties` is now deprecated. All proofs
+* The modules `Data.Integer.Addition.Properties` and
+  `Data.Integer.Multiplication.Properties` are now deprecated. All proofs
   have been moved to `Data.Integer.Properties` where they should be used
-  directly. The `Addition.Properties` file still exists for backwards
-  compatability reasons and re-exports the proofs from `Data.Integer.Properties`
-  but will be removed in some future release.
-
-* The module `Data.Integer.Multiplication.Properties` is now deprecated. All
-  proofs have been moved to `Data.Integer.Properties` where they should be used
-  directly. The `Multiplication.Properties` file still exists for backwards
-  compatability reasons and re-exports the proofs from `Data.Integer.Properties`
-  but will be removed in some future release.
+  directly. The `Addition.Properties` and `Multiplication.Properties` files
+  still exist for backwards compatability reasons and re-exports the proofs from
+  `Data.Integer.Properties` but will be removed in some future release.
 
 * The following renaming has occured in `Data.Nat.Properties`
   ```agda
-  _+-mono_  ↦  *-mono-≤
-  _*-mono_  ↦  +-mono-≤
+  _+-mono_          ↦  *-mono-≤
+  _*-mono_          ↦  +-mono-≤
+
+  +-right-identity  ↦  +-identityʳ
+  *-right-zero      ↦  *-zeroʳ
+  distribʳ-*-+      ↦  *-distribʳ-+
+  *-distrib-∸ʳ      ↦  *-distribʳ-∸
+  cancel-+-left     ↦  +-cancelˡ-≡
+  cancel-+-left-≤   ↦  +-cancelˡ-≤
+  cancel-*-right    ↦  *-cancelʳ-≡
+  cancel-*-right-≤  ↦  *-cancelʳ-≤
+
+  strictTotalOrder                      ↦  <-strictTotalOrder
+  isCommutativeSemiring                 ↦  *-+-isCommutativeSemiring
+  commutativeSemiring                   ↦  *-+-commutativeSemiring
+  isDistributiveLattice                 ↦  ⊓-⊔-isDistributiveLattice
+  distributiveLattice                   ↦  ⊓-⊔-distributiveLattice
+  ⊔-⊓-0-isSemiringWithoutOne            ↦  ⊔-⊓-isSemiringWithoutOne
+  ⊔-⊓-0-isCommutativeSemiringWithoutOne ↦  ⊔-⊓-isCommutativeSemiringWithoutOne
+  ⊔-⊓-0-commutativeSemiringWithoutOne   ↦  ⊔-⊓-commutativeSemiringWithoutOne
   ```
 
 * The following renaming has occurred in `Data.Nat.Divisibility`:
@@ -514,31 +527,45 @@ Backwards compatible changes
   ≮⇒≥                  : _≮_ ⇒ _≥_
   ≤+≢⇒<                : m ≤ n → m ≢ n → m < n
 
-  +-left-identity      : LeftIdentity 0 _+_
+  +-identityˡ          : LeftIdentity 0 _+_
   +-identity           : Identity 0 _+_
-  cancel-+-right       : RightCancellative _≡_ _+_
-  +-cancellative       : Cancellative _≡_ _+_
-  cancel-+-right-≤     : RightCancellative _≤_ _+_
-  +-cancellative-≤     : Cancellative _≤_ _+_
+  +-cancelʳ-≡          : RightCancellative _≡_ _+_
+  +-cancel-≡           : Cancellative _≡_ _+_
+  +-cancelʳ-≤          : RightCancellative _≤_ _+_
+  +-cancel-≤           : Cancellative _≤_ _+_
   +-isSemigroup        : IsSemigroup _≡_ _+_
   +-monoˡ-<            : _+_ Preserves₂ _<_ ⟶ _≤_ ⟶ _<_
   +-monoʳ-<            : _+_ Preserves₂ _≤_ ⟶ _<_ ⟶ _<_
   +-mono-<             : _+_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
 
-  *-left-zero          : LeftZero 0 _*_
+  *-zeroˡ              : LeftZero 0 _*_
   *-zero               : Zero 0 _*_
-  *-left-identity      : LeftIdentity 1 _*_
-  *-right-identity     : RightIdentity 1 _*_
+  *-identityˡ          : LeftIdentity 1 _*_
+  *-identityʳ          : RightIdentity 1 _*_
   *-identity           : Identity 1 _*_
-  distribˡ-*-+         : _*_ DistributesOverˡ _+_
-  distrib-*-+          : _*_ DistributesOver _+_
+  *-distribˡ-+         : _*_ DistributesOverˡ _+_
+  *-distrib-+          : _*_ DistributesOver _+_
   *-isSemigroup        : IsSemigroup _≡_ _*_
   *-mono-<             : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
   *-monoˡ-<            : (_* suc n) Preserves _<_ ⟶ _<_
   *-monoʳ-<            : (suc n *_) Preserves _<_ ⟶ _<_
 
-  ⊓-idem               : Idempotent _⊓_
+  ⊔-assoc              : Associative _⊔_
+  ⊔-comm               : Commutative _⊔_
   ⊔-idem               : Idempotent _⊔_
+  ⊔-identityˡ          : LeftIdentity 0 _⊔_
+  ⊔-identityʳ          : RightIdentity 0 _⊔_
+  ⊔-identity           : Identity 0 _⊔_
+  ⊓-assoc              : Associative _⊓_
+  ⊓-comm               : Commutative _⊓_
+  ⊓-idem               : Idempotent _⊓_
+  ⊓-zeroˡ              : LeftZero 0 _⊓_
+  ⊓-zeroʳ              : RightZero 0 _⊓_
+  ⊓-zero               : Zero 0 _⊓_
+  ⊓-distribʳ-⊔         : _⊓_ DistributesOverʳ _⊔_
+  ⊓-distribˡ-⊔         : _⊓_ DistributesOverˡ _⊔_
+  ⊔-abs-⊓              : _⊔_ Absorbs _⊓_
+  ⊓-abs-⊔              : _⊓_ Absorbs _⊔_
   m⊓n≤n                : m ⊓ n ≤ n
   m≤m⊔n                : m ≤ m ⊔ n
   m⊔n≤m+n              : m ⊔ n ≤ m + n

--- a/README/AVL.agda
+++ b/README/AVL.agda
@@ -17,13 +17,11 @@ import Data.AVL
 -- total order, and values, which are indexed by keys. Let us use
 -- natural numbers as keys and vectors of strings as values.
 
-import Data.Nat.Properties as ℕ
+open import Data.Nat.Properties using (<-isStrictTotalOrder)
 open import Data.String using (String)
 open import Data.Vec using (Vec; _∷_; [])
-open import Relation.Binary using (module StrictTotalOrder)
 
-open Data.AVL (Vec String)
-              (StrictTotalOrder.isStrictTotalOrder ℕ.strictTotalOrder)
+open Data.AVL (Vec String) (<-isStrictTotalOrder)
 
 ------------------------------------------------------------------------
 -- Construction of trees

--- a/README/Nat.agda
+++ b/README/Nat.agda
@@ -24,27 +24,22 @@ ex₂ : 3 + 5 ≡ 2 * 4
 ex₂ = refl
 
 -- Data.Nat.Properties contains a number of properties about natural
--- numbers. Algebra defines what a commutative semiring is, among
--- other things.
+-- numbers.
 
-open import Algebra
 import Data.Nat.Properties as Nat
-private
-  module CS = CommutativeSemiring Nat.commutativeSemiring
 
 ex₃ : ∀ m n → m * n ≡ n * m
-ex₃ m n = CS.*-comm m n
+ex₃ m n = Nat.*-comm m n
 
 -- The module ≡-Reasoning in Relation.Binary.PropositionalEquality
 -- provides some combinators for equational reasoning.
 
 open ≡-Reasoning
-open import Data.Product
 
 ex₄ : ∀ m n → m * (n + 0) ≡ n * m
 ex₄ m n = begin
-  m * (n + 0)  ≡⟨ cong (_*_ m) (proj₂ CS.+-identity n) ⟩
-  m * n        ≡⟨ CS.*-comm m n ⟩
+  m * (n + 0)  ≡⟨ cong (_*_ m) (Nat.+-identityʳ n) ⟩
+  m * n        ≡⟨ Nat.*-comm m n ⟩
   n * m        ∎
 
 -- The module SemiringSolver in Data.Nat.Properties contains a solver

--- a/src/Data/Char.agda
+++ b/src/Data/Char.agda
@@ -7,7 +7,7 @@
 module Data.Char where
 
 open import Data.Nat.Base using (ℕ)
-import Data.Nat.Properties as NatProp
+open import Data.Nat.Properties using (<-strictTotalOrder)
 open import Data.Bool.Base using (Bool; true; false)
 open import Relation.Nullary
 open import Relation.Nullary.Decidable
@@ -62,4 +62,4 @@ decSetoid = PropEq.decSetoid _≟_
 -- An ordering induced by the toNat function.
 
 strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder = On.strictTotalOrder NatProp.strictTotalOrder toNat
+strictTotalOrder = On.strictTotalOrder <-strictTotalOrder toNat

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -321,7 +321,7 @@ n≢1+n { -[1+ suc n ]} ()
 neg-distrib-+ : ∀ m n → - (m + n) ≡ (- m) + (- n)
 neg-distrib-+ (+ zero)  (+ zero)  = refl
 neg-distrib-+ (+ zero)  (+ suc n) = refl
-neg-distrib-+ (+ suc m) (+ zero)  = cong -[1+_] (ℕₚ.+-right-identity m)
+neg-distrib-+ (+ suc m) (+ zero)  = cong -[1+_] (ℕₚ.+-identityʳ m)
 neg-distrib-+ (+ suc m) (+ suc n) = cong -[1+_] (ℕₚ.+-suc m n)
 neg-distrib-+ -[1+ m ]  -[1+ n ] = cong (λ v → + suc v) (sym (ℕₚ.+-suc m n))
 neg-distrib-+ (+   m)   -[1+ n ] = -[n⊖m]≡-m+n m (suc n)
@@ -353,8 +353,8 @@ neg-distrib-+ -[1+ m ]  (+   n)  =
 
 *-identityˡ : LeftIdentity (+ 1) _*_
 *-identityˡ (+ zero ) = refl
-*-identityˡ -[1+  n ] rewrite ℕₚ.+-right-identity n = refl
-*-identityˡ (+ suc n) rewrite ℕₚ.+-right-identity n = refl
+*-identityˡ -[1+  n ] rewrite ℕₚ.+-identityʳ n = refl
+*-identityˡ (+ suc n) rewrite ℕₚ.+-identityʳ n = refl
 
 *-identityʳ : RightIdentity (+ 1) _*_
 *-identityʳ = comm+idˡ⇒idʳ *-comm *-identityˡ
@@ -383,11 +383,11 @@ private
 
 *-assoc : Associative _*_
 *-assoc (+ zero) _ _ = refl
-*-assoc x (+ zero) _ rewrite ℕₚ.*-right-zero ∣ x ∣ = refl
+*-assoc x (+ zero) _ rewrite ℕₚ.*-zeroʳ ∣ x ∣ = refl
 *-assoc x y (+ zero) rewrite
-    ℕₚ.*-right-zero ∣ y ∣
-  | ℕₚ.*-right-zero ∣ x ∣
-  | ℕₚ.*-right-zero ∣ sign x 𝕊* sign y ◃ ∣ x ∣ ℕ* ∣ y ∣ ∣
+    ℕₚ.*-zeroʳ ∣ y ∣
+  | ℕₚ.*-zeroʳ ∣ x ∣
+  | ℕₚ.*-zeroʳ ∣ sign x 𝕊* sign y ◃ ∣ x ∣ ℕ* ∣ y ∣ ∣
   = refl
 *-assoc -[1+ a  ] -[1+ b  ] (+ suc c) = cong (+_ ∘ suc) (lemma a b c)
 *-assoc -[1+ a  ] (+ suc b) -[1+ c  ] = cong (+_ ∘ suc) (lemma a b c)
@@ -446,23 +446,23 @@ private
     rewrite ⊖-≥ b≤c
           | ⊖-≥ (ℕₚ.*-mono-≤ b≤c (ℕₚ.≤-refl {x = suc a}))
           | -◃n≡-n ((c ∸ b) ℕ* suc a)
-          | ℕₚ.*-distrib-∸ʳ (suc a) c b
+          | ℕₚ.*-distribʳ-∸ (suc a) c b
           = refl
   ... | no b≰c
     rewrite sign-⊖-≰ b≰c
           | ∣⊖∣-≰ b≰c
           | +◃n≡+n ((b ∸ c) ℕ* suc a)
-          | ⊖-≰ (b≰c ∘ ℕₚ.cancel-*-right-≤ b c a)
+          | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c a)
           | -‿involutive (+ (b ℕ* suc a ∸ c ℕ* suc a))
-          | ℕₚ.*-distrib-∸ʳ (suc a) b c
+          | ℕₚ.*-distribʳ-∸ (suc a) b c
           = refl
 
 distribʳ : _*_ DistributesOverʳ _+_
 
 distribʳ (+ zero) y z
-  rewrite ℕₚ.*-right-zero ∣ y ∣
-        | ℕₚ.*-right-zero ∣ z ∣
-        | ℕₚ.*-right-zero ∣ y + z ∣
+  rewrite ℕₚ.*-zeroʳ ∣ y ∣
+        | ℕₚ.*-zeroʳ ∣ z ∣
+        | ℕₚ.*-zeroʳ ∣ y + z ∣
         = refl
 
 distribʳ x (+ zero) z
@@ -510,15 +510,15 @@ distribʳ (+ suc a) -[1+ b ] (+ suc c)
   rewrite ⊖-≥ b≤c
         | +-comm (- (+ (a ℕ+ b ℕ* suc a))) (+ (a ℕ+ c ℕ* suc a))
         | ⊖-≥ (ℕₚ.*-mono-≤ b≤c (ℕₚ.≤-refl {x = suc a}))
-        | ℕₚ.*-distrib-∸ʳ (suc a) c b
+        | ℕₚ.*-distribʳ-∸ (suc a) c b
         | +◃n≡+n (c ℕ* suc a ∸ b ℕ* suc a)
         = refl
 ... | no b≰c
   rewrite sign-⊖-≰ b≰c
         | ∣⊖∣-≰ b≰c
         | -◃n≡-n ((b ∸ c) ℕ* suc a)
-        | ⊖-≰ (b≰c ∘ ℕₚ.cancel-*-right-≤ b c a)
-        | ℕₚ.*-distrib-∸ʳ (suc a) b c
+        | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c a)
+        | ℕₚ.*-distribʳ-∸ (suc a) b c
         = refl
 
 distribʳ (+ suc c) (+ suc a) -[1+ b ]
@@ -528,14 +528,14 @@ distribʳ (+ suc c) (+ suc a) -[1+ b ]
   rewrite ⊖-≥ b≤a
         | ⊖-≥ (ℕₚ.*-mono-≤ b≤a (ℕₚ.≤-refl {x = suc c}))
         | +◃n≡+n ((a ∸ b) ℕ* suc c)
-        | ℕₚ.*-distrib-∸ʳ (suc c) a b
+        | ℕₚ.*-distribʳ-∸ (suc c) a b
         = refl
 ... | no b≰a
   rewrite sign-⊖-≰ b≰a
         | ∣⊖∣-≰ b≰a
-        | ⊖-≰ (b≰a ∘ ℕₚ.cancel-*-right-≤ b a c)
+        | ⊖-≰ (b≰a ∘ ℕₚ.*-cancelʳ-≤ b a c)
         | -◃n≡-n ((b ∸ a) ℕ* suc c)
-        | ℕₚ.*-distrib-∸ʳ (suc c) b a
+        | ℕₚ.*-distribʳ-∸ (suc c) b a
         = refl
 
 isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ (+ 0) (+ 1)
@@ -589,7 +589,7 @@ cancel-*-right i j .(s ◃ suc n) ≢0 eq | s ◂ suc n
   with ∣ s ◃ suc n ∣ | abs-◃ s (suc n) | sign (s ◃ suc n) | sign-◃ s n
 ...  | .(suc n)      | refl            | .s               | refl =
   ◃-cong (sign-i≡sign-j i j eq) $
-         ℕₚ.cancel-*-right ∣ i ∣ ∣ j ∣ $ abs-cong eq
+         ℕₚ.*-cancelʳ-≡ ∣ i ∣ ∣ j ∣ $ abs-cong eq
   where
   sign-i≡sign-j : ∀ i j →
                   sign i 𝕊* s ◃ ∣ i ∣ ℕ* suc n ≡
@@ -617,7 +617,7 @@ cancel-*-right i j .(s ◃ suc n) ≢0 eq | s ◂ suc n
 
 cancel-*-+-right-≤ : ∀ m n o → m * + suc o ≤ n * + suc o → m ≤ n
 cancel-*-+-right-≤ (-[1+ m ]) (-[1+ n ]) o (-≤- n≤m) =
-  -≤- (≤-pred (ℕₚ.cancel-*-right-≤ (suc n) (suc m) o (s≤s n≤m)))
+  -≤- (≤-pred (ℕₚ.*-cancelʳ-≤ (suc n) (suc m) o (s≤s n≤m)))
 cancel-*-+-right-≤ -[1+ _ ]   (+ _)      _ _         = -≤+
 cancel-*-+-right-≤ (+ 0)      -[1+ _ ]   _ ()
 cancel-*-+-right-≤ (+ suc _)  -[1+ _ ]   _ ()
@@ -625,7 +625,7 @@ cancel-*-+-right-≤ (+ 0)      (+ 0)      _ _         = +≤+ z≤n
 cancel-*-+-right-≤ (+ 0)      (+ suc _)  _ _         = +≤+ z≤n
 cancel-*-+-right-≤ (+ suc _)  (+ 0)      _ (+≤+ ())
 cancel-*-+-right-≤ (+ suc m)  (+ suc n)  o (+≤+ m≤n) =
-  +≤+ (ℕₚ.cancel-*-right-≤ (suc m) (suc n) o m≤n)
+  +≤+ (ℕₚ.*-cancelʳ-≤ (suc m) (suc n) o m≤n)
 
 *-+-right-mono : ∀ n → (_* + suc n) Preserves _≤_ ⟶ _≤_
 *-+-right-mono _ (-≤+             {n = 0})         = -≤+
@@ -640,8 +640,8 @@ cancel-*-+-right-≤ (+ suc m)  (+ suc n)  o (+≤+ m≤n) =
 
 -1*n≡-n : ∀ n → -[1+ 0 ] * n ≡ - n
 -1*n≡-n (+ zero)  = refl
--1*n≡-n (+ suc n) = cong -[1+_] (ℕₚ.+-right-identity n)
--1*n≡-n -[1+ n ]  = cong (λ v → + suc v) (ℕₚ.+-right-identity n)
+-1*n≡-n (+ suc n) = cong -[1+_] (ℕₚ.+-identityʳ n)
+-1*n≡-n -[1+ n ]  = cong (λ v → + suc v) (ℕₚ.+-identityʳ n)
 
 ◃-distrib-* :  ∀ s t m n → (s 𝕊* t) ◃ (m ℕ* n) ≡ (s ◃ m) * (t ◃ n)
 ◃-distrib-* s t zero zero    = refl

--- a/src/Data/List/Any/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Any/Membership/Propositional/Properties.agda
@@ -266,7 +266,7 @@ finite {A = A} inj (x ∷ xs) ∈x∷xs = excluded-middle helper
     ∈xs j  | tri> _ i≢j _       = ∈-if-not-i i≢j
     ∈xs .i | tri≈ _ refl _      =
       ∈-if-not-i (m≢1+m+n i ∘
-                  subst (_≡_ i ∘ suc) (sym (+-right-identity i)))
+                  subst (_≡_ i ∘ suc) (sym (+-identityʳ i)))
 
     injective′ : Inj.Injective {B = P.setoid A} (→-to-⟶ f)
     injective′ {j} {k} eq with STO.compare i j | STO.compare i k

--- a/src/Data/Nat/Coprimality.agda
+++ b/src/Data/Nat/Coprimality.agda
@@ -24,7 +24,6 @@ open import Relation.Binary
 open import Algebra
 private
   module P  = Poset Div.poset
-  module CS = CommutativeSemiring NatProp.commutativeSemiring
 
 -- Coprime m n is inhabited iff m and n are coprime (relatively
 -- prime), i.e. if their only common divisor is 1.
@@ -126,8 +125,8 @@ data GCD′ : ℕ → ℕ → ℕ → Set where
 gcd-gcd′ : ∀ {d m n} → GCD m n d → GCD′ m n d
 gcd-gcd′         g with GCD.commonDivisor g
 gcd-gcd′ {zero}  g | (divides q₁ refl , divides q₂ refl)
-                     with q₁ * 0 | CS.*-comm 0 q₁
-                        | q₂ * 0 | CS.*-comm 0 q₂
+                     with q₁ * 0 | NatProp.*-comm 0 q₁
+                        | q₂ * 0 | NatProp.*-comm 0 q₂
 ...                  | .0 | refl | .0 | refl = gcd-* 1 1 (1-coprimeTo 1)
 gcd-gcd′ {suc d} g | (divides q₁ refl , divides q₂ refl) =
   gcd-* q₁ q₂ (Bézout-coprime (Bézout.identity g))
@@ -152,7 +151,7 @@ prime⇒coprime (suc (suc m)) _  _ _  _ {1} _                       = refl
 prime⇒coprime (suc (suc m)) p  _ _  _ {0} (divides q 2+m≡q*0 , _) =
   ⊥-elim $ NatProp.i+1+j≢i 0 (begin
     2 + m  ≡⟨ 2+m≡q*0 ⟩
-    q * 0  ≡⟨ proj₂ CS.zero q ⟩
+    q * 0  ≡⟨ proj₂ NatProp.*-zero q ⟩
     0      ∎)
   where open PropEq.≡-Reasoning
 prime⇒coprime (suc (suc m)) p (suc n) _ 1+n<2+m {suc (suc i)}

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -83,7 +83,7 @@ private
 
   division-lemma mod-acc div-acc zero n = begin
 
-    mod-acc + div-acc * suc s + zero  ≡⟨ +-right-identity _ ⟩
+    mod-acc + div-acc * suc s + zero  ≡⟨ +-identityʳ _ ⟩
 
     mod-acc + div-acc * suc s         ∎
 

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -51,7 +51,7 @@ quotient (divides q _) = q
   where open ≤-Reasoning
 
 ∣-reflexive : _≡_ ⇒ _∣_
-∣-reflexive {n} refl = divides 1 (sym (*-left-identity n))
+∣-reflexive {n} refl = divides 1 (sym (*-identityˡ n))
 
 ∣-refl : Reflexive _∣_
 ∣-refl = ∣-reflexive refl
@@ -97,7 +97,7 @@ module ∣-Reasoning = PartialOrderReasoning poset
 infix 10 1∣_ _∣0
 
 1∣_ : ∀ n → 1 ∣ n
-1∣ n = divides n (sym (*-right-identity n))
+1∣ n = divides n (sym (*-identityʳ n))
 
 _∣0 : ∀ n → n ∣ 0
 n ∣0 = divides 0 refl
@@ -119,7 +119,7 @@ n|m*n m = divides m refl
 
 ∣m∣n⇒∣m+n : ∀ {i m n} → i ∣ m → i ∣ n → i ∣ m + n
 ∣m∣n⇒∣m+n (divides p refl) (divides q refl) =
-  divides (p + q) (sym (distribʳ-*-+ _ p q))
+  divides (p + q) (sym (*-distribʳ-+ _ p q))
 
 ∣m+n|m⇒|n : ∀ {i m n} → i ∣ m + n → i ∣ m → i ∣ n
 ∣m+n|m⇒|n {i} {m} {n} (divides p m+n≡p*i) (divides q m≡q*i) =
@@ -127,7 +127,7 @@ n|m*n m = divides m refl
     n             ≡⟨ sym (m+n∸n≡m n m) ⟩
     n + m ∸ m     ≡⟨ cong (_∸ m) (+-comm n m) ⟩
     m + n ∸ m     ≡⟨ cong₂ _∸_ m+n≡p*i m≡q*i ⟩
-    p * i ∸ q * i ≡⟨ sym (*-distrib-∸ʳ i p q) ⟩
+    p * i ∸ q * i ≡⟨ sym (*-distribʳ-∸ i p q) ⟩
     (p ∸ q) * i   ∎)
   where open PropEq.≡-Reasoning
 
@@ -137,7 +137,7 @@ n|m*n m = divides m refl
     m             ≡⟨ sym (m+n∸m≡n n≤m) ⟩
     n + (m ∸ n)   ≡⟨ +-comm n (m ∸ n) ⟩
     m ∸ n + n     ≡⟨ cong₂ _+_ m∸n≡p*i n≡q*o ⟩
-    p * i + q * i ≡⟨ sym (distribʳ-*-+ i p q)  ⟩
+    p * i + q * i ≡⟨ sym (*-distribʳ-+ i p q)  ⟩
     (p + q) * i   ∎)
   where open PropEq.≡-Reasoning
 
@@ -152,7 +152,7 @@ n|m*n m = divides m refl
 
 /-cong : ∀ {i j} k → suc k * i ∣ suc k * j → i ∣ j
 /-cong {i} {j} k (divides q eq) =
-  divides q (cancel-*-right j (q * i) (begin
+  divides q (*-cancelʳ-≡ j (q * i) (begin
     j * (suc k)        ≡⟨ *-comm j (suc k) ⟩
     (suc k) * j        ≡⟨ eq ⟩
     q * ((suc k) * i)  ≡⟨ cong (q *_) (*-comm (suc k) i) ⟩
@@ -167,7 +167,7 @@ nonZeroDivisor-lemma
   : ∀ m q (r : Fin (1 + m)) → toℕ r ≢ 0 →
     1 + m ∤ toℕ r + q * (1 + m)
 nonZeroDivisor-lemma m zero r r≢zero (divides zero eq) = r≢zero $ begin
-  toℕ r      ≡⟨ sym (*-left-identity (toℕ r)) ⟩
+  toℕ r      ≡⟨ sym (*-identityˡ (toℕ r)) ⟩
   1 * toℕ r  ≡⟨ eq ⟩
   0          ∎
   where open PropEq.≡-Reasoning
@@ -175,7 +175,7 @@ nonZeroDivisor-lemma m zero r r≢zero (divides (suc q) eq) =
   ¬i+1+j≤i m $ begin
     m + suc (q * suc m) ≡⟨ +-suc m (q * suc m) ⟩
     suc (m + q * suc m) ≡⟨ sym eq ⟩
-    1 * toℕ r           ≡⟨ *-left-identity (toℕ r) ⟩
+    1 * toℕ r           ≡⟨ *-identityˡ (toℕ r) ⟩
     toℕ r               ≤⟨ ≤-pred $ FP.bounded r ⟩
     m                   ∎
   where open ≤-Reasoning

--- a/src/Data/Nat/GCD/Lemmas.agda
+++ b/src/Data/Nat/GCD/Lemmas.agda
@@ -138,7 +138,7 @@ lem₁₀ : ∀ {a′} b c {d} e f → let a = suc a′ in
 lem₁₀ {a′} b c {d} e f eq =
   NatProp.i*j≡1⇒j≡1 (e * f ∸ b * c) d
     (NatProp.im≡jm+n⇒[i∸j]m≡n (e * f) (b * c) d 1
-       (NatProp.cancel-*-right (e * f * d) (b * c * d + 1) (begin
+       (NatProp.*-cancelʳ-≡ (e * f * d) (b * c * d + 1) (begin
           e * f * d * a        ≡⟨ solve 4 (λ e f d a → e :* f :* d :* a
                                                    :=  e :* (f :* d :* a))
                                           refl e f d a ⟩

--- a/src/Data/Nat/InfinitelyOften.agda
+++ b/src/Data/Nat/InfinitelyOften.agda
@@ -12,7 +12,7 @@ open import Category.Monad
 open import Data.Empty
 open import Function
 open import Data.Nat
-import Data.Nat.Properties as NatProp
+open import Data.Nat.Properties
 open import Data.Product as Prod hiding (map)
 open import Data.Sum hiding (map)
 open import Relation.Binary.PropositionalEquality
@@ -20,8 +20,6 @@ open import Relation.Nullary
 open import Relation.Nullary.Negation
 open import Relation.Unary using (_∪_; _⊆_)
 open RawMonad (¬¬-Monad {p = Level.zero})
-private
-  module NatLattice = DistributiveLattice NatProp.distributiveLattice
 
 -- Only true finitely often.
 
@@ -33,16 +31,16 @@ Fin P = ∃ λ i → ∀ j → i ≤ j → ¬ P j
 _∪-Fin_ : ∀ {P Q} → Fin P → Fin Q → Fin (P ∪ Q)
 _∪-Fin_ {P} {Q} (i , ¬p) (j , ¬q) = (i ⊔ j , helper)
   where
-  open NatProp.≤-Reasoning
+  open ≤-Reasoning
 
   helper : ∀ k → i ⊔ j ≤ k → ¬ (P ∪ Q) k
   helper k i⊔j≤k (inj₁ p) = ¬p k (begin
-    i      ≤⟨ NatProp.m≤m⊔n i j ⟩
+    i      ≤⟨ m≤m⊔n i j ⟩
     i ⊔ j  ≤⟨ i⊔j≤k ⟩
     k      ∎) p
   helper k i⊔j≤k (inj₂ q) = ¬q k (begin
-    j      ≤⟨ NatProp.m≤m⊔n j i ⟩
-    j ⊔ i  ≡⟨ NatLattice.∧-comm j i ⟩
+    j      ≤⟨ m≤m⊔n j i ⟩
+    j ⊔ i  ≡⟨ ⊔-comm j i ⟩
     i ⊔ j  ≤⟨ i⊔j≤k ⟩
     k      ∎) q
 
@@ -88,4 +86,4 @@ twoDifferentWitnesses
 twoDifferentWitnesses inf =
   witness inf                     >>= λ w₁ →
   witness (up (1 + proj₁ w₁) inf) >>= λ w₂ →
-  return (_ , _ , NatProp.m≢1+m+n (proj₁ w₁) , proj₂ w₁ , proj₂ w₂)
+  return (_ , _ , m≢1+m+n (proj₁ w₁) , proj₂ w₁ , proj₂ w₂)

--- a/src/Data/Nat/LCM.agda
+++ b/src/Data/Nat/LCM.agda
@@ -20,7 +20,6 @@ open import Algebra
 open import Relation.Binary
 private
   module P  = Poset Div.poset
-  module CS = CommutativeSemiring NatProp.commutativeSemiring
 
 ------------------------------------------------------------------------
 -- Least common multiple (lcm).
@@ -91,7 +90,7 @@ lcm .(q₁ * d) .(q₂ * d) | (d , gcd-* q₁ q₂ q₁-q₂-coprime) =
 
     q₂∣q₃ : q₂ ∣ q₃
     q₂∣q₃ = coprime-divisor (Coprime.sym q₁-q₂-coprime)
-              (divides q₄ $ NatProp.cancel-*-right _ _ (begin
+              (divides q₄ $ NatProp.*-cancelʳ-≡ _ _ (begin
                  q₁ * q₃ * d′    ≡⟨ lem₁ q₁ q₃ d′ ⟩
                  q₃ * (q₁ * d′)  ≡⟨ PropEq.sym eq₃ ⟩
                  m               ≡⟨ eq₄ ⟩

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -177,8 +177,8 @@ x <? y = suc x ≤? y
   ; compare       = <-cmp
   }
 
-strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder = record
+<-strictTotalOrder : StrictTotalOrder _ _ _
+<-strictTotalOrder = record
   { isStrictTotalOrder = <-isStrictTotalOrder
   }
 
@@ -271,18 +271,18 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
 +-assoc zero    _ _ = refl
 +-assoc (suc m) n o = cong suc (+-assoc m n o)
 
-+-left-identity : LeftIdentity 0 _+_
-+-left-identity _ = refl
++-identityˡ : LeftIdentity 0 _+_
++-identityˡ _ = refl
 
-+-right-identity : RightIdentity 0 _+_
-+-right-identity zero    = refl
-+-right-identity (suc n) = cong suc (+-right-identity n)
++-identityʳ : RightIdentity 0 _+_
++-identityʳ zero    = refl
++-identityʳ (suc n) = cong suc (+-identityʳ n)
 
 +-identity : Identity 0 _+_
-+-identity = +-left-identity , +-right-identity
++-identity = +-identityˡ , +-identityʳ
 
 +-comm : Commutative _+_
-+-comm zero    n = sym (+-right-identity n)
++-comm zero    n = sym (+-identityʳ n)
 +-comm (suc m) n = begin
   suc m + n   ≡⟨⟩
   suc (m + n) ≡⟨ cong suc (+-comm m n) ⟩
@@ -299,33 +299,33 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
 +-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ 0
 +-0-isCommutativeMonoid = record
   { isSemigroup = +-isSemigroup
-  ; identityˡ    = +-left-identity
+  ; identityˡ    = +-identityˡ
   ; comm        = +-comm
   }
 
 -- Other properties of _+_
 
-cancel-+-left : LeftCancellative _≡_ _+_
-cancel-+-left zero    eq = eq
-cancel-+-left (suc m) eq = cancel-+-left m (cong pred eq)
++-cancelˡ-≡ : LeftCancellative _≡_ _+_
++-cancelˡ-≡ zero    eq = eq
++-cancelˡ-≡ (suc m) eq = +-cancelˡ-≡ m (cong pred eq)
 
-cancel-+-right : RightCancellative _≡_ _+_
-cancel-+-right {m} n o eq =
-  cancel-+-left m (subst₂ _≡_ (+-comm n m) (+-comm o m) eq)
++-cancelʳ-≡ : RightCancellative _≡_ _+_
++-cancelʳ-≡ {m} n o eq =
+  +-cancelˡ-≡ m (subst₂ _≡_ (+-comm n m) (+-comm o m) eq)
 
-+-cancellative : Cancellative _≡_ _+_
-+-cancellative = cancel-+-left , cancel-+-right
++-cancel-≡ : Cancellative _≡_ _+_
++-cancel-≡ = +-cancelˡ-≡ , +-cancelʳ-≡
 
-cancel-+-left-≤ : LeftCancellative _≤_ _+_
-cancel-+-left-≤ zero    le       = le
-cancel-+-left-≤ (suc m) (s≤s le) = cancel-+-left-≤ m le
++-cancelˡ-≤ : LeftCancellative _≤_ _+_
++-cancelˡ-≤ zero    le       = le
++-cancelˡ-≤ (suc m) (s≤s le) = +-cancelˡ-≤ m le
 
-cancel-+-right-≤ : RightCancellative _≤_ _+_
-cancel-+-right-≤ {m} n o le =
-  cancel-+-left-≤ m (subst₂ _≤_ (+-comm n m) (+-comm o m) le)
++-cancelʳ-≤ : RightCancellative _≤_ _+_
++-cancelʳ-≤ {m} n o le =
+  +-cancelˡ-≤ m (subst₂ _≤_ (+-comm n m) (+-comm o m) le)
 
-+-cancellative-≤ : Cancellative _≤_ _+_
-+-cancellative-≤ = cancel-+-left-≤ , cancel-+-right-≤
++-cancel-≤ : Cancellative _≤_ _+_
++-cancel-≤ = +-cancelˡ-≤ , +-cancelʳ-≤
 
 ≤-steps : ∀ {m n} k → m ≤ n → m ≤ k + n
 ≤-steps zero    m≤n = m≤n
@@ -394,54 +394,54 @@ i+j≡0⇒j≡0 i {j} i+j≡0 = i+j≡0⇒i≡0 j (trans (+-comm j i) (i+j≡0))
   suc (m + (n + m * n)) ≡⟨⟩
   suc m + suc m * n     ∎
 
-*-left-identity : LeftIdentity 1 _*_
-*-left-identity x = +-right-identity x
+*-identityˡ : LeftIdentity 1 _*_
+*-identityˡ x = +-identityʳ x
 
-*-right-identity : RightIdentity 1 _*_
-*-right-identity zero    = refl
-*-right-identity (suc x) = cong suc (*-right-identity x)
+*-identityʳ : RightIdentity 1 _*_
+*-identityʳ zero    = refl
+*-identityʳ (suc x) = cong suc (*-identityʳ x)
 
 *-identity : Identity 1 _*_
-*-identity = *-left-identity , *-right-identity
+*-identity = *-identityˡ , *-identityʳ
 
-*-left-zero : LeftZero 0 _*_
-*-left-zero _ = refl
+*-zeroˡ : LeftZero 0 _*_
+*-zeroˡ _ = refl
 
-*-right-zero : RightZero 0 _*_
-*-right-zero zero    = refl
-*-right-zero (suc n) = *-right-zero n
+*-zeroʳ : RightZero 0 _*_
+*-zeroʳ zero    = refl
+*-zeroʳ (suc n) = *-zeroʳ n
 
 *-zero : Zero 0 _*_
-*-zero = *-left-zero , *-right-zero
+*-zero = *-zeroˡ , *-zeroʳ
 
 *-comm : Commutative _*_
-*-comm zero    n = sym (*-right-zero n)
+*-comm zero    n = sym (*-zeroʳ n)
 *-comm (suc m) n = begin
   suc m * n  ≡⟨⟩
   n + m * n  ≡⟨ cong (n +_) (*-comm m n) ⟩
   n + n * m  ≡⟨ sym (+-*-suc n m) ⟩
   n * suc m  ∎
 
-distribʳ-*-+ : _*_ DistributesOverʳ _+_
-distribʳ-*-+ m zero    o = refl
-distribʳ-*-+ m (suc n) o = begin
+*-distribʳ-+ : _*_ DistributesOverʳ _+_
+*-distribʳ-+ m zero    o = refl
+*-distribʳ-+ m (suc n) o = begin
   (suc n + o) * m     ≡⟨⟩
-  m + (n + o) * m     ≡⟨ cong (m +_) (distribʳ-*-+ m n o) ⟩
+  m + (n + o) * m     ≡⟨ cong (m +_) (*-distribʳ-+ m n o) ⟩
   m + (n * m + o * m) ≡⟨ sym (+-assoc m (n * m) (o * m)) ⟩
   m + n * m + o * m   ≡⟨⟩
   suc n * m + o * m   ∎
 
-distribˡ-*-+ : _*_ DistributesOverˡ _+_
-distribˡ-*-+ = comm+distrʳ⇒distrˡ (cong₂ _+_) *-comm distribʳ-*-+
+*-distribˡ-+ : _*_ DistributesOverˡ _+_
+*-distribˡ-+ = comm+distrʳ⇒distrˡ (cong₂ _+_) *-comm *-distribʳ-+
 
-distrib-*-+ : _*_ DistributesOver _+_
-distrib-*-+ = distribˡ-*-+ , distribʳ-*-+
+*-distrib-+ : _*_ DistributesOver _+_
+*-distrib-+ = *-distribˡ-+ , *-distribʳ-+
 
 *-assoc : Associative _*_
 *-assoc zero    n o = refl
 *-assoc (suc m) n o = begin
   (suc m * n) * o     ≡⟨⟩
-  (n + m * n) * o     ≡⟨ distribʳ-*-+ o n (m * n) ⟩
+  (n + m * n) * o     ≡⟨ *-distribʳ-+ o n (m * n) ⟩
   n * o + (m * n) * o ≡⟨ cong (n * o +_) (*-assoc m n o) ⟩
   n * o + m * (n * o) ≡⟨⟩
   suc m * (n * o)     ∎
@@ -456,37 +456,37 @@ distrib-*-+ = distribˡ-*-+ , distribʳ-*-+
 *-1-isCommutativeMonoid : IsCommutativeMonoid _≡_ _*_ 1
 *-1-isCommutativeMonoid = record
   { isSemigroup = *-isSemigroup
-  ; identityˡ    = *-left-identity
+  ; identityˡ    = *-identityˡ
   ; comm        = *-comm
   }
 
-isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ 0 1
-isCommutativeSemiring = record
+*-+-isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ 0 1
+*-+-isCommutativeSemiring = record
   { +-isCommutativeMonoid = +-0-isCommutativeMonoid
   ; *-isCommutativeMonoid = *-1-isCommutativeMonoid
-  ; distribʳ              = distribʳ-*-+
-  ; zeroˡ                 = *-left-zero
+  ; distribʳ              = *-distribʳ-+
+  ; zeroˡ                 = *-zeroˡ
   }
 
-commutativeSemiring : CommutativeSemiring _ _
-commutativeSemiring = record
-  { isCommutativeSemiring = isCommutativeSemiring
+*-+-commutativeSemiring : CommutativeSemiring _ _
+*-+-commutativeSemiring = record
+  { isCommutativeSemiring = *-+-isCommutativeSemiring
   }
 
 -- Other properties of _*_
 
-cancel-*-right : ∀ i j {k} → i * suc k ≡ j * suc k → i ≡ j
-cancel-*-right zero    zero        eq = refl
-cancel-*-right zero    (suc j)     ()
-cancel-*-right (suc i) zero        ()
-cancel-*-right (suc i) (suc j) {k} eq =
-  cong suc (cancel-*-right i j (cancel-+-left (suc k) eq))
+*-cancelʳ-≡ : ∀ i j {k} → i * suc k ≡ j * suc k → i ≡ j
+*-cancelʳ-≡ zero    zero        eq = refl
+*-cancelʳ-≡ zero    (suc j)     ()
+*-cancelʳ-≡ (suc i) zero        ()
+*-cancelʳ-≡ (suc i) (suc j) {k} eq =
+  cong suc (*-cancelʳ-≡ i j (+-cancelˡ-≡ (suc k) eq))
 
-cancel-*-right-≤ : ∀ i j k → i * suc k ≤ j * suc k → i ≤ j
-cancel-*-right-≤ zero    _       _ _  = z≤n
-cancel-*-right-≤ (suc i) zero    _ ()
-cancel-*-right-≤ (suc i) (suc j) k le =
-  s≤s (cancel-*-right-≤ i j k (cancel-+-left-≤ (suc k) le))
+*-cancelʳ-≤ : ∀ i j k → i * suc k ≤ j * suc k → i ≤ j
+*-cancelʳ-≤ zero    _       _ _  = z≤n
+*-cancelʳ-≤ (suc i) zero    _ ()
+*-cancelʳ-≤ (suc i) (suc j) k le =
+  s≤s (*-cancelʳ-≤ i j k (+-cancelˡ-≤ (suc k) le))
 
 *-mono-≤ : _*_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
 *-mono-≤ z≤n       _   = z≤n
@@ -532,18 +532,18 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊔-assoc (suc m) (suc n) zero    = refl
 ⊔-assoc (suc m) (suc n) (suc o) = cong suc $ ⊔-assoc m n o
 
-⊔-left-identity : LeftIdentity 0 _⊔_
-⊔-left-identity _ = refl
+⊔-identityˡ : LeftIdentity 0 _⊔_
+⊔-identityˡ _ = refl
 
-⊔-right-identity : RightIdentity 0 _⊔_
-⊔-right-identity zero    = refl
-⊔-right-identity (suc n) = refl
+⊔-identityʳ : RightIdentity 0 _⊔_
+⊔-identityʳ zero    = refl
+⊔-identityʳ (suc n) = refl
 
 ⊔-identity : Identity 0 _⊔_
-⊔-identity = ⊔-left-identity , ⊔-right-identity
+⊔-identity = ⊔-identityˡ , ⊔-identityʳ
 
 ⊔-comm : Commutative _⊔_
-⊔-comm zero    n       = sym $ ⊔-right-identity n
+⊔-comm zero    n       = sym $ ⊔-identityʳ n
 ⊔-comm (suc m) zero    = refl
 ⊔-comm (suc m) (suc n) = cong suc (⊔-comm m n)
 
@@ -565,18 +565,18 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊓-assoc (suc m) (suc n) zero    = refl
 ⊓-assoc (suc m) (suc n) (suc o) = cong suc $ ⊓-assoc m n o
 
-⊓-left-zero : LeftZero 0 _⊓_
-⊓-left-zero _ = refl
+⊓-zeroˡ : LeftZero 0 _⊓_
+⊓-zeroˡ _ = refl
 
-⊓-right-zero : RightZero 0 _⊓_
-⊓-right-zero zero    = refl
-⊓-right-zero (suc n) = refl
+⊓-zeroʳ : RightZero 0 _⊓_
+⊓-zeroʳ zero    = refl
+⊓-zeroʳ (suc n) = refl
 
 ⊓-zero : Zero 0 _⊓_
-⊓-zero = ⊓-left-zero , ⊓-right-zero
+⊓-zero = ⊓-zeroˡ , ⊓-zeroʳ
 
 ⊓-comm : Commutative _⊓_
-⊓-comm zero    n       = sym $ ⊓-right-zero n
+⊓-comm zero    n       = sym $ ⊓-zeroʳ n
 ⊓-comm (suc m) zero    = refl
 ⊓-comm (suc m) (suc n) = cong suc (⊓-comm m n)
 
@@ -617,7 +617,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊓-abs-⊔ zero    n       = refl
 ⊓-abs-⊔ (suc m) (suc n) = cong suc $ ⊓-abs-⊔ m n
 ⊓-abs-⊔ (suc m) zero    = cong suc $ begin
-  m ⊓ m       ≡⟨ cong (_⊓_ m) $ sym $ ⊔-right-identity m ⟩
+  m ⊓ m       ≡⟨ cong (m ⊓_) $ sym $ ⊔-identityʳ m ⟩
   m ⊓ (m ⊔ 0) ≡⟨ ⊓-abs-⊔ m zero ⟩
   m           ∎
 
@@ -634,7 +634,7 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
 ⊔-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _⊔_ 0
 ⊔-0-isCommutativeMonoid = record
   { isSemigroup = ⊔-isSemigroup
-  ; identityˡ    = ⊔-left-identity
+  ; identityˡ    = ⊔-identityˡ
   ; comm        = ⊔-comm
   }
 
@@ -645,25 +645,25 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
   ; ∙-cong        = cong₂ _⊓_
   }
 
-⊔-⊓-0-isSemiringWithoutOne : IsSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
-⊔-⊓-0-isSemiringWithoutOne = record
+⊔-⊓-isSemiringWithoutOne : IsSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
+⊔-⊓-isSemiringWithoutOne = record
   { +-isCommutativeMonoid = ⊔-0-isCommutativeMonoid
   ; *-isSemigroup         = ⊓-isSemigroup
   ; distrib               = ⊓-distrib-⊔
   ; zero                  = ⊓-zero
   }
 
-⊔-⊓-0-isCommutativeSemiringWithoutOne
+⊔-⊓-isCommutativeSemiringWithoutOne
   : IsCommutativeSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
-⊔-⊓-0-isCommutativeSemiringWithoutOne = record
-  { isSemiringWithoutOne = ⊔-⊓-0-isSemiringWithoutOne
+⊔-⊓-isCommutativeSemiringWithoutOne = record
+  { isSemiringWithoutOne = ⊔-⊓-isSemiringWithoutOne
   ; *-comm               = ⊓-comm
   }
 
-⊔-⊓-0-commutativeSemiringWithoutOne : CommutativeSemiringWithoutOne _ _
-⊔-⊓-0-commutativeSemiringWithoutOne = record
+⊔-⊓-commutativeSemiringWithoutOne : CommutativeSemiringWithoutOne _ _
+⊔-⊓-commutativeSemiringWithoutOne = record
   { isCommutativeSemiringWithoutOne =
-      ⊔-⊓-0-isCommutativeSemiringWithoutOne
+      ⊔-⊓-isCommutativeSemiringWithoutOne
   }
 
 ⊓-⊔-isLattice : IsLattice _≡_ _⊓_ _⊔_
@@ -678,15 +678,15 @@ i*j≡1⇒j≡1 i j eq = i*j≡1⇒i≡1 j i (trans (*-comm j i) eq)
   ; absorptive    = ⊓-⊔-absorptive
   }
 
-isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
-isDistributiveLattice = record
+⊓-⊔-isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
+⊓-⊔-isDistributiveLattice = record
   { isLattice   = ⊓-⊔-isLattice
   ; ∨-∧-distribʳ = ⊓-distribʳ-⊔
   }
 
-distributiveLattice : DistributiveLattice _ _
-distributiveLattice = record
-  { isDistributiveLattice = isDistributiveLattice
+⊓-⊔-distributiveLattice : DistributiveLattice _ _
+⊓-⊔-distributiveLattice = record
+  { isDistributiveLattice = ⊓-⊔-isDistributiveLattice
   }
 
 -- Ordering properties of _⊔_ and _⊓_
@@ -765,7 +765,7 @@ n∸n≡0 zero    = refl
 n∸n≡0 (suc n) = n∸n≡0 n
 
 ∸-+-assoc : ∀ m n o → (m ∸ n) ∸ o ≡ m ∸ (n + o)
-∸-+-assoc m       n       zero    = cong (m ∸_) (sym $ +-right-identity n)
+∸-+-assoc m       n       zero    = cong (m ∸_) (sym $ +-identityʳ n)
 ∸-+-assoc zero    zero    (suc o) = refl
 ∸-+-assoc zero    (suc n) (suc o) = refl
 ∸-+-assoc (suc m) zero    (suc o) = refl
@@ -792,8 +792,8 @@ n≤m+n∸m (suc m) (suc n) = s≤s (n≤m+n∸m m n)
 m+n∸n≡m : ∀ m n → (m + n) ∸ n ≡ m
 m+n∸n≡m m n = begin
   (m + n) ∸ n  ≡⟨ +-∸-assoc m (≤-refl {x = n}) ⟩
-  m + (n ∸ n)  ≡⟨ cong (_+_ m) (n∸n≡0 n) ⟩
-  m + 0        ≡⟨ +-right-identity m ⟩
+  m + (n ∸ n)  ≡⟨ cong (m +_) (n∸n≡0 n) ⟩
+  m + 0        ≡⟨ +-identityʳ m ⟩
   m            ∎
 
 m+n∸m≡n : ∀ {m n} → m ≤ n → m + (n ∸ m) ≡ n
@@ -830,30 +830,30 @@ i∸k∸j+j∸k≡i+j∸k (suc i) j zero = begin
   suc i ∸ 0 + j       ≡⟨⟩
   suc (i + j)         ∎
 i∸k∸j+j∸k≡i+j∸k (suc i) zero (suc k) = begin
-  i ∸ k + 0  ≡⟨ +-right-identity _ ⟩
-  i ∸ k      ≡⟨ cong (_∸ k) (sym (+-right-identity _)) ⟩
+  i ∸ k + 0  ≡⟨ +-identityʳ _ ⟩
+  i ∸ k      ≡⟨ cong (_∸ k) (sym (+-identityʳ _)) ⟩
   i + 0 ∸ k  ∎
 i∸k∸j+j∸k≡i+j∸k (suc i) (suc j) (suc k) = begin
   suc i ∸ (k ∸ j) + (j ∸ k) ≡⟨ i∸k∸j+j∸k≡i+j∸k (suc i) j k ⟩
   suc i + j ∸ k             ≡⟨ cong (_∸ k) (sym (+-suc i j)) ⟩
   i + suc j ∸ k             ∎
 
-*-distrib-∸ʳ : _*_ DistributesOverʳ _∸_
-*-distrib-∸ʳ i zero k = begin
+*-distribʳ-∸ : _*_ DistributesOverʳ _∸_
+*-distribʳ-∸ i zero k = begin
   (0 ∸ k) * i  ≡⟨ cong₂ _*_ (0∸n≡0 k) refl ⟩
   0            ≡⟨ sym $ 0∸n≡0 (k * i) ⟩
   0 ∸ k * i    ∎
-*-distrib-∸ʳ i (suc j) zero    = begin i + j * i ∎
-*-distrib-∸ʳ i (suc j) (suc k) = begin
-  (j ∸ k) * i             ≡⟨ *-distrib-∸ʳ i j k ⟩
+*-distribʳ-∸ i (suc j) zero    = begin i + j * i ∎
+*-distribʳ-∸ i (suc j) (suc k) = begin
+  (j ∸ k) * i             ≡⟨ *-distribʳ-∸ i j k ⟩
   j * i ∸ k * i           ≡⟨ sym $ [i+j]∸[i+k]≡j∸k i _ _ ⟩
   i + j * i ∸ (i + k * i) ∎
 
 im≡jm+n⇒[i∸j]m≡n : ∀ i j m n → i * m ≡ j * m + n → (i ∸ j) * m ≡ n
 im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
-  (i ∸ j) * m            ≡⟨ *-distrib-∸ʳ m i j ⟩
-  (i * m) ∸ (j * m)      ≡⟨ cong₂ _∸_ eq (refl {x = j * m}) ⟩
-  (j * m + n) ∸ (j * m)  ≡⟨ cong₂ _∸_ (+-comm (j * m) n) (refl {x = j * m}) ⟩
+  (i ∸ j) * m            ≡⟨ *-distribʳ-∸ m i j ⟩
+  (i * m) ∸ (j * m)      ≡⟨ cong (_∸ j * m) eq ⟩
+  (j * m + n) ∸ (j * m)  ≡⟨ cong (_∸ j * m) (+-comm (j * m) n) ⟩
   (n + j * m) ∸ (j * m)  ≡⟨ m+n∸n≡m n (j * m) ⟩
   n                      ∎
 
@@ -883,11 +883,11 @@ im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
 ⌊n/2⌋≤′n (suc n) = ≤′-step (⌈n/2⌉≤′n n)
 
 ------------------------------------------------------------------------
--- Submodules for reasoning about natural number relations
+-- Modules for reasoning about natural number relations
 
 -- A module for automatically solving propositional equivalences
 module SemiringSolver =
-  Solver (ACR.fromCommutativeSemiring commutativeSemiring) _≟_
+  Solver (ACR.fromCommutativeSemiring *-+-commutativeSemiring) _≟_
 
 -- A module for reasoning about the _≤_ relation
 module ≤-Reasoning where
@@ -901,8 +901,29 @@ module ≤-Reasoning where
   x <⟨ x<y ⟩ y≤z = suc x ≤⟨ x<y ⟩ y≤z
 
 ------------------------------------------------------------------------
--- DEPRECATED - please use new names as continuing support for the old
--- names is not guaranteed.
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as support for the old is not guaranteed.
 
+{-
 _*-mono_ = *-mono-≤
 _+-mono_ = +-mono-≤
+
++-right-identity = +-identityʳ
+*-right-zero     = *-zeroʳ
+distribʳ-*-+     = *-distribʳ-+
+*-distrib-∸ʳ     = *-distribʳ-∸
+cancel-+-left    = +-cancelˡ-≡
+cancel-+-left-≤  = +-cancelˡ-≤
+cancel-*-right   = *-cancelʳ-≡
+cancel-*-right-≤ = *-cancelʳ-≤
+
+strictTotalOrder                      = <-strictTotalOrder
+isCommutativeSemiring                 = *-+-isCommutativeSemiring
+commutativeSemiring                   = *-+-commutativeSemiring
+isDistributiveLattice                 = ⊓-⊔-isDistributiveLattice
+distributiveLattice                   = ⊓-⊔-distributiveLattice
+⊔-⊓-0-isSemiringWithoutOne            = ⊔-⊓-isSemiringWithoutOne
+⊔-⊓-0-isCommutativeSemiringWithoutOne = ⊔-⊓-isCommutativeSemiringWithoutOne
+⊔-⊓-0-commutativeSemiringWithoutOne   = ⊔-⊓-commutativeSemiringWithoutOne
+-}

--- a/src/Data/Nat/Properties/Simple.agda
+++ b/src/Data/Nat/Properties/Simple.agda
@@ -10,14 +10,15 @@ module Data.Nat.Properties.Simple where
 
 open import Data.Nat.Properties public using
   ( +-assoc
-  ; +-right-identity
-  ; +-left-identity
   ; +-suc
   ; +-comm
   ; +-*-suc
-  ; *-right-zero
-  ; *-left-zero
   ; *-comm
-  ; distribʳ-*-+
   ; *-assoc
+  ) renaming
+  ( +-identityʳ  to +-right-identity
+  ; +-identityˡ  to +-left-identity
+  ; *-zeroʳ      to *-right-zero
+  ; *-zeroˡ      to *-left-zero
+  ; *-distribʳ-+ to distribʳ-*-+
   )


### PR DESCRIPTION
This pull request fixes the main instances of inconsistent naming in the `Data.Nat.Properties` file. Currently the inconsistencies mean that its difficult to use the file without looking up each lemma individually. This change should make the names of the standard properties nearly entirely predictable.

This pull request should be entirely backwards compatible with existing code as I have left the old deprecated names in at the bottom of the file. The changes since the last release of the library are (old name -> new name):
```
+-right-identity = +-identityʳ
*-right-zero     = *-zeroʳ
distribʳ-*-+     = *-distribʳ-+
*-distrib-∸ʳ     = *-distribʳ-∸
cancel-+-left    = +-cancelˡ-≡
cancel-+-left-≤  = +-cancelˡ-≤
cancel-*-right   = *-cancelʳ-≡
cancel-*-right-≤ = *-cancelʳ-≤

strictTotalOrder                      = <-strictTotalOrder
isCommutativeSemiring                 = *-+-isCommutativeSemiring
commutativeSemiring                   = *-+-commutativeSemiring
isDistributiveLattice                 = ⊓-⊔-isDistributiveLattice
distributiveLattice                   = ⊓-⊔-distributiveLattice
⊔-⊓-0-isSemiringWithoutOne            = ⊔-⊓-isSemiringWithoutOne
⊔-⊓-0-isCommutativeSemiringWithoutOne = ⊔-⊓-isCommutativeSemiringWithoutOne
⊔-⊓-0-commutativeSemiringWithoutOne   = ⊔-⊓-commutativeSemiringWithoutOne
```
Does anyone have any comments or thoughts?