### PR TITLE
Structure homomorphisms + example _^_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ Non-backwards compatible changes
   `Data.X.Properties`.
 
   The numeric datatypes for which this has been done are `Nat`, `Integer`, `Rational` and `Bin`.
-  
+
   As a consequence the module `≤-Reasoning` has also had to have been moved from `Data.Nat` to
   `Data.Nat.Properties`.
 
@@ -87,10 +87,10 @@ Non-backwards compatible changes
   (pattern-matching) definition. Previously it was defined using a private
   internal module which made pattern matching difficult.
 
-* The arguments of `≤pred⇒≤` and `≤⇒pred≤` in `Data.Nat.Properties` are now implicit 
-  rather than explicit (was `∀ m n → m ≤ pred n → m ≤ n` and is now 
-  `∀ {m n} → m ≤ pred n → m ≤ n`). This makes it consistent with `<⇒≤pred` which 
-  already used implicit arguments, and shouldn't introduce any significant problems 
+* The arguments of `≤pred⇒≤` and `≤⇒pred≤` in `Data.Nat.Properties` are now implicit
+  rather than explicit (was `∀ m n → m ≤ pred n → m ≤ n` and is now
+  `∀ {m n} → m ≤ pred n → m ≤ n`). This makes it consistent with `<⇒≤pred` which
+  already used implicit arguments, and shouldn't introduce any significant problems
   as both parameters can be inferred by Agda.
 
 * Moved `¬∀⟶∃¬` from `Relation.Nullary.Negation` to `Data.Fin.Dec`. Its old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@ Non-backwards compatible changes
   respectively. The original names `<-Rec` and `<-well-founded` now refer to new
   corresponding proofs for `_<_`.
 
+#### Overhaul of `Algebra.Morphism`
+
+* Currently `Algebra.Morphism` only gives an example of a `Ring` homomorphism which
+  packs the homomorphism and all the proofs that it behaves the right way.
+
+  Instead we have adopted and `Algebra.Structures`-like approach with proof-only
+  records parametrised by the homomorphism and the structures it acts on. This make
+  it possible to define the proof requirement for e.g. a ring in terms of the proof
+  requirements for its additive abelian group and multiplicative monoid.
+
 #### Other
 
 * Changed the implementation of `map` and `zipWith` in `Data.Vec` to use native
@@ -528,104 +538,112 @@ Backwards compatible changes
 
 * Added proofs to `Data.Nat.Properties`:
   ```agda
-  suc-injective        : suc m ≡ suc n → m ≡ n
-  ≡-isDecEquivalence   : IsDecEquivalence (_≡_ {A = ℕ})
-  ≡-decSetoid          : DecSetoid _ _
+  suc-injective         : suc m ≡ suc n → m ≡ n
+  ≡-isDecEquivalence    : IsDecEquivalence (_≡_ {A = ℕ})
+  ≡-decSetoid           : DecSetoid _ _
 
-  ≤-reflexive          : _≡_ ⇒ _≤_
-  ≤-refl               : Reflexive _≤_
-  ≤-trans              : Antisymmetric _≡_ _≤_
-  ≤-antisymmetric      : Transitive _≤_
-  ≤-total              : Total _≤_
-  ≤-isPreorder         : IsPreorder _≡_ _≤_
-  ≤-isPartialOrder     : IsPartialOrder _≡_ _≤_
-  ≤-isTotalOrder       : IsTotalOrder _≡_ _≤_
-  ≤-isDecTotalOrder    : IsDecTotalOrder _≡_ _≤_
+  ≤-reflexive           : _≡_ ⇒ _≤_
+  ≤-refl                : Reflexive _≤_
+  ≤-trans               : Antisymmetric _≡_ _≤_
+  ≤-antisymmetric       : Transitive _≤_
+  ≤-total               : Total _≤_
+  ≤-isPreorder          : IsPreorder _≡_ _≤_
+  ≤-isPartialOrder      : IsPartialOrder _≡_ _≤_
+  ≤-isTotalOrder        : IsTotalOrder _≡_ _≤_
+  ≤-isDecTotalOrder     : IsDecTotalOrder _≡_ _≤_
 
-  _<?_                 : Decidable _<_
-  <-irrefl             : Irreflexive _≡_ _<_
-  <-asym               : Asymmetric _<_
-  <-transʳ             : Trans _≤_ _<_ _<_
-  <-transˡ             : Trans _<_ _≤_ _<_
-  <-isStrictTotalOrder : IsStrictTotalOrder _≡_ _<_
-  <⇒≤                  : _<_ ⇒ _≤_
-  <⇒≢                  : _<_ ⇒ _≢_
-  <⇒≱                  : _<_ ⇒ _≱_
-  <⇒≯                  : _<_ ⇒ _≯_
-  ≰⇒≮                  : _≰_ ⇒ _≮_
-  ≰⇒≥                  : _≰_ ⇒ _≥_
-  ≮⇒≥                  : _≮_ ⇒ _≥_
-  ≤+≢⇒<                : m ≤ n → m ≢ n → m < n
+  _<?_                  : Decidable _<_
+  <-irrefl              : Irreflexive _≡_ _<_
+  <-asym                : Asymmetric _<_
+  <-transʳ              : Trans _≤_ _<_ _<_
+  <-transˡ              : Trans _<_ _≤_ _<_
+  <-isStrictTotalOrder  : IsStrictTotalOrder _≡_ _<_
+  <⇒≤                   : _<_ ⇒ _≤_
+  <⇒≢                   : _<_ ⇒ _≢_
+  <⇒≱                   : _<_ ⇒ _≱_
+  <⇒≯                   : _<_ ⇒ _≯_
+  ≰⇒≮                   : _≰_ ⇒ _≮_
+  ≰⇒≥                   : _≰_ ⇒ _≥_
+  ≮⇒≥                   : _≮_ ⇒ _≥_
+  ≤+≢⇒<                 : m ≤ n → m ≢ n → m < n
 
-  +-identityˡ          : LeftIdentity 0 _+_
-  +-identity           : Identity 0 _+_
-  +-cancelʳ-≡          : RightCancellative _≡_ _+_
-  +-cancel-≡           : Cancellative _≡_ _+_
-  +-cancelʳ-≤          : RightCancellative _≤_ _+_
-  +-cancel-≤           : Cancellative _≤_ _+_
-  +-isSemigroup        : IsSemigroup _≡_ _+_
-  +-monoˡ-<            : _+_ Preserves₂ _<_ ⟶ _≤_ ⟶ _<_
-  +-monoʳ-<            : _+_ Preserves₂ _≤_ ⟶ _<_ ⟶ _<_
-  +-mono-<             : _+_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
-  m+n≤o⇒m≤o            : m + n ≤ o → m ≤ o
-  m+n≤o⇒n≤o            : m + n ≤ o → n ≤ o
-  m+n≮n                : m + n ≮ n
+  +-identityˡ           : LeftIdentity 0 _+_
+  +-identity            : Identity 0 _+_
+  +-cancelʳ-≡           : RightCancellative _≡_ _+_
+  +-cancel-≡            : Cancellative _≡_ _+_
+  +-cancelʳ-≤           : RightCancellative _≤_ _+_
+  +-cancel-≤            : Cancellative _≤_ _+_
+  +-isSemigroup         : IsSemigroup _≡_ _+_
+  +-semigroup           : Semigroup _ _
+  +-0-monoid            : Monoid _ _
+  +-0-commutativeMonoid : CommutativeMonoid _ _
+  +-monoˡ-<             : _+_ Preserves₂ _<_ ⟶ _≤_ ⟶ _<_
+  +-monoʳ-<             : _+_ Preserves₂ _≤_ ⟶ _<_ ⟶ _<_
+  +-mono-<              : _+_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
+  m+n≤o⇒m≤o             : m + n ≤ o → m ≤ o
+  m+n≤o⇒n≤o             : m + n ≤ o → n ≤ o
+  m+n≮n                 : m + n ≮ n
 
-  *-zeroˡ              : LeftZero 0 _*_
-  *-zero               : Zero 0 _*_
-  *-identityˡ          : LeftIdentity 1 _*_
-  *-identityʳ          : RightIdentity 1 _*_
-  *-identity           : Identity 1 _*_
-  *-distribˡ-+         : _*_ DistributesOverˡ _+_
-  *-distrib-+          : _*_ DistributesOver _+_
-  *-isSemigroup        : IsSemigroup _≡_ _*_
-  *-mono-<             : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
-  *-monoˡ-<            : (_* suc n) Preserves _<_ ⟶ _<_
-  *-monoʳ-<            : (suc n *_) Preserves _<_ ⟶ _<_
-  *-cancelˡ-≡          : suc k * i ≡ suc k * j → i ≡ j
+  *-zeroˡ               : LeftZero 0 _*_
+  *-zero                : Zero 0 _*_
+  *-identityˡ           : LeftIdentity 1 _*_
+  *-identityʳ           : RightIdentity 1 _*_
+  *-identity            : Identity 1 _*_
+  *-distribˡ-+          : _*_ DistributesOverˡ _+_
+  *-distrib-+           : _*_ DistributesOver _+_
+  *-isSemigroup         : IsSemigroup _≡_ _*_
+  *-semigroup           : Semigroup _ _
+  *-1-monoid            : Monoid _ _
+  *-1-commutativeMonoid : CommutativeMonoid _ _
+  *-mono-<              : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
+  *-monoˡ-<             : (_* suc n) Preserves _<_ ⟶ _<_
+  *-monoʳ-<             : (suc n *_) Preserves _<_ ⟶ _<_
+  *-cancelˡ-≡           : suc k * i ≡ suc k * j → i ≡ j
 
-  ^-distribˡ-+-*       : m ^ (n + p) ≡ m ^ n * m ^ p
-  i^j≡0⇒i≡0            : i ^ j ≡ 0 → i ≡ 0
-  i^j≡1⇒j≡0∨i≡1        : i ^ j ≡ 1 → j ≡ 0 ⊎ i ≡ 1
+  ^-distribˡ-+-*        : m ^ (n + p) ≡ m ^ n * m ^ p
+  i^j≡0⇒i≡0             : i ^ j ≡ 0 → i ≡ 0
+  i^j≡1⇒j≡0∨i≡1         : i ^ j ≡ 1 → j ≡ 0 ⊎ i ≡ 1
+  ^-semigroup-morphism  : (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
+  ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid
 
-  ⊔-assoc              : Associative _⊔_
-  ⊔-comm               : Commutative _⊔_
-  ⊔-idem               : Idempotent _⊔_
-  ⊔-identityˡ          : LeftIdentity 0 _⊔_
-  ⊔-identityʳ          : RightIdentity 0 _⊔_
-  ⊔-identity           : Identity 0 _⊔_
-  ⊓-assoc              : Associative _⊓_
-  ⊓-comm               : Commutative _⊓_
-  ⊓-idem               : Idempotent _⊓_
-  ⊓-zeroˡ              : LeftZero 0 _⊓_
-  ⊓-zeroʳ              : RightZero 0 _⊓_
-  ⊓-zero               : Zero 0 _⊓_
-  ⊓-distribʳ-⊔         : _⊓_ DistributesOverʳ _⊔_
-  ⊓-distribˡ-⊔         : _⊓_ DistributesOverˡ _⊔_
-  ⊔-abs-⊓              : _⊔_ Absorbs _⊓_
-  ⊓-abs-⊔              : _⊓_ Absorbs _⊔_
-  m⊓n≤n                : m ⊓ n ≤ n
-  m≤m⊔n                : m ≤ m ⊔ n
-  m⊔n≤m+n              : m ⊔ n ≤ m + n
-  m⊓n≤m+n              : m ⊓ n ≤ m + n
-  m⊓n≤m⊔n              : m ⊔ n ≤ m ⊔ n
-  ⊔-mono-≤             : _⊔_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
-  ⊔-mono-<             : _⊔_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
-  ⊓-mono-≤             : _⊓_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
-  ⊓-mono-<             : _⊓_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
-  +-distribˡ-⊔         : _+_ DistributesOverˡ _⊔_
-  +-distribʳ-⊔         : _+_ DistributesOverʳ _⊔_
-  +-distrib-⊔          : _+_ DistributesOver _⊔_
-  +-distribˡ-⊓         : _+_ DistributesOverˡ _⊓_
-  +-distribʳ-⊓         : _+_ DistributesOverʳ _⊓_
-  +-distrib-⊓          : _+_ DistributesOver _⊓_
-  ⊔-isSemigroup        : IsSemigroup _≡_ _⊔_
-  ⊓-isSemigroup        : IsSemigroup _≡_ _⊓_
-  ⊓-⊔-isLattice        : IsLattice _≡_ _⊓_ _⊔_
+  ⊔-assoc               : Associative _⊔_
+  ⊔-comm                : Commutative _⊔_
+  ⊔-idem                : Idempotent _⊔_
+  ⊔-identityˡ           : LeftIdentity 0 _⊔_
+  ⊔-identityʳ           : RightIdentity 0 _⊔_
+  ⊔-identity            : Identity 0 _⊔_
+  ⊓-assoc               : Associative _⊓_
+  ⊓-comm                : Commutative _⊓_
+  ⊓-idem                : Idempotent _⊓_
+  ⊓-zeroˡ               : LeftZero 0 _⊓_
+  ⊓-zeroʳ               : RightZero 0 _⊓_
+  ⊓-zero                : Zero 0 _⊓_
+  ⊓-distribʳ-⊔          : _⊓_ DistributesOverʳ _⊔_
+  ⊓-distribˡ-⊔          : _⊓_ DistributesOverˡ _⊔_
+  ⊔-abs-⊓               : _⊔_ Absorbs _⊓_
+  ⊓-abs-⊔               : _⊓_ Absorbs _⊔_
+  m⊓n≤n                 : m ⊓ n ≤ n
+  m≤m⊔n                 : m ≤ m ⊔ n
+  m⊔n≤m+n               : m ⊔ n ≤ m + n
+  m⊓n≤m+n               : m ⊓ n ≤ m + n
+  m⊓n≤m⊔n               : m ⊔ n ≤ m ⊔ n
+  ⊔-mono-≤              : _⊔_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
+  ⊔-mono-<              : _⊔_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
+  ⊓-mono-≤              : _⊓_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
+  ⊓-mono-<              : _⊓_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
+  +-distribˡ-⊔          : _+_ DistributesOverˡ _⊔_
+  +-distribʳ-⊔          : _+_ DistributesOverʳ _⊔_
+  +-distrib-⊔           : _+_ DistributesOver _⊔_
+  +-distribˡ-⊓          : _+_ DistributesOverˡ _⊓_
+  +-distribʳ-⊓          : _+_ DistributesOverʳ _⊓_
+  +-distrib-⊓           : _+_ DistributesOver _⊓_
+  ⊔-isSemigroup         : IsSemigroup _≡_ _⊔_
+  ⊓-isSemigroup         : IsSemigroup _≡_ _⊓_
+  ⊓-⊔-isLattice         : IsLattice _≡_ _⊓_ _⊔_
 
-  ∸-distribʳ-⊔         : _∸_ DistributesOverʳ _⊔_
-  ∸-distribʳ-⊓         : _∸_ DistributesOverʳ _⊓_
-  +-∸-comm             : o ≤ m → (m + n) ∸ o ≡ (m ∸ o) + n
+  ∸-distribʳ-⊔          : _∸_ DistributesOverʳ _⊔_
+  ∸-distribʳ-⊓          : _∸_ DistributesOverʳ _⊓_
+  +-∸-comm              : o ≤ m → (m + n) ∸ o ≡ (m ∸ o) + n
   ```
 
 * Added decidability relation to `Data.Nat.GCD`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,14 +36,14 @@ Backwards compatible changes
   +-semigroup           : Semigroup _ _
   +-0-monoid            : Monoid _ _
   +-0-commutativeMonoid : CommutativeMonoid _ _
-  
+
   *-semigroup           : Semigroup _ _
   *-1-monoid            : Monoid _ _
   *-1-commutativeMonoid : CommutativeMonoid _ _
   *-+-semiring          : Semiring _ _
-  
+
   ^-semigroup-morphism  : (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
-  ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid  
+  ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid
   ```
 
 * Added new combinators to `Relation.Unary`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,23 @@ Non-backwards compatible changes
 Deprecated features
 -------------------
 
+Deprecated features still exist and therefore existing code should still work
+but they may be removed in some future release of the library.
+
 Backwards compatible changes
 ----------------------------
 
 * Added new proofs to `Data.Nat.Properties`:
   ```agda
+  +-semigroup           : Semigroup _ _
+  +-0-monoid            : Monoid _ _
+  +-0-commutativeMonoid : CommutativeMonoid _ _
+  
+  *-semigroup           : Semigroup _ _
+  *-1-monoid            : Monoid _ _
+  *-1-commutativeMonoid : CommutativeMonoid _ _
+  *-+-semiring          : Semiring _ _
+  
   ^-semigroup-morphism  : (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
   ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid  
   ```
@@ -604,9 +616,6 @@ Backwards compatible changes
   +-cancelʳ-≤           : RightCancellative _≤_ _+_
   +-cancel-≤            : Cancellative _≤_ _+_
   +-isSemigroup         : IsSemigroup _≡_ _+_
-  +-semigroup           : Semigroup _ _
-  +-0-monoid            : Monoid _ _
-  +-0-commutativeMonoid : CommutativeMonoid _ _
   +-monoˡ-<             : _+_ Preserves₂ _<_ ⟶ _≤_ ⟶ _<_
   +-monoʳ-<             : _+_ Preserves₂ _≤_ ⟶ _<_ ⟶ _<_
   +-mono-<              : _+_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
@@ -622,9 +631,6 @@ Backwards compatible changes
   *-distribˡ-+          : _*_ DistributesOverˡ _+_
   *-distrib-+           : _*_ DistributesOver _+_
   *-isSemigroup         : IsSemigroup _≡_ _*_
-  *-semigroup           : Semigroup _ _
-  *-1-monoid            : Monoid _ _
-  *-1-commutativeMonoid : CommutativeMonoid _ _
   *-mono-<              : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
   *-monoˡ-<             : (_* suc n) Preserves _<_ ⟶ _<_
   *-monoʳ-<             : (suc n *_) Preserves _<_ ⟶ _<_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Important changes since 0.14:
 Non-backwards compatible changes
 --------------------------------
 
+#### Overhaul of `Algebra.Morphism`
+
+* Currently `Algebra.Morphism` only gives an example of a `Ring` homomorphism which
+  packs the homomorphism and all the proofs that it behaves the right way.
+
+  Instead we have adopted and `Algebra.Structures`-like approach with proof-only
+  records parametrised by the homomorphism and the structures it acts on. This make
+  it possible to define the proof requirement for e.g. a ring in terms of the proof
+  requirements for its additive abelian group and multiplicative monoid.
+
 #### Other
 
 * Changed the fixity of `⋃` and `⋂` in `Relation.Unary` to make space for `_⊢_`.
@@ -17,6 +27,12 @@ Deprecated features
 
 Backwards compatible changes
 ----------------------------
+
+* Added new proofs to `Data.Nat.Properties`:
+  ```agda
+  ^-semigroup-morphism  : (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
+  ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid  
+  ```
 
 * Added new combinators to `Relation.Unary`:
   ```agda
@@ -83,16 +99,6 @@ Non-backwards compatible changes
   Therefore `<-Rec` and `<-well-founded` have been renamed to `<′-Rec` and `<′-well-founded`
   respectively. The original names `<-Rec` and `<-well-founded` now refer to new
   corresponding proofs for `_<_`.
-
-#### Overhaul of `Algebra.Morphism`
-
-* Currently `Algebra.Morphism` only gives an example of a `Ring` homomorphism which
-  packs the homomorphism and all the proofs that it behaves the right way.
-
-  Instead we have adopted and `Algebra.Structures`-like approach with proof-only
-  records parametrised by the homomorphism and the structures it acts on. This make
-  it possible to define the proof requirement for e.g. a ring in terms of the proof
-  requirements for its additive abelian group and multiplicative monoid.
 
 #### Other
 
@@ -627,8 +633,6 @@ Backwards compatible changes
   ^-distribˡ-+-*        : m ^ (n + p) ≡ m ^ n * m ^ p
   i^j≡0⇒i≡0             : i ^ j ≡ 0 → i ≡ 0
   i^j≡1⇒j≡0∨i≡1         : i ^ j ≡ 1 → j ≡ 0 ⊎ i ≡ 1
-  ^-semigroup-morphism  : (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
-  ^-monoid-morphism     : (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid
 
   ⊔-assoc               : Associative _⊔_
   ⊔-comm                : Commutative _⊔_

--- a/src/Algebra.agda
+++ b/src/Algebra.agda
@@ -27,9 +27,6 @@ record Semigroup c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open IsSemigroup isSemigroup public
 
-  setoid : Setoid _ _
-  setoid = record { isEquivalence = isEquivalence }
-
 -- A raw monoid is a monoid without any laws.
 
 record RawMonoid c ℓ : Set (suc (c ⊔ ℓ)) where
@@ -56,8 +53,6 @@ record Monoid c ℓ : Set (suc (c ⊔ ℓ)) where
   semigroup : Semigroup _ _
   semigroup = record { isSemigroup = isSemigroup }
 
-  open Semigroup semigroup public using (setoid)
-
   rawMonoid : RawMonoid _ _
   rawMonoid = record
     { _≈_ = _≈_
@@ -80,7 +75,7 @@ record CommutativeMonoid c ℓ : Set (suc (c ⊔ ℓ)) where
   monoid : Monoid _ _
   monoid = record { isMonoid = isMonoid }
 
-  open Monoid monoid public using (setoid; semigroup; rawMonoid)
+  open Monoid monoid public using (semigroup; rawMonoid)
 
 record IdempotentCommutativeMonoid c ℓ : Set (suc (c ⊔ ℓ)) where
   infixl 7 _∙_
@@ -98,7 +93,7 @@ record IdempotentCommutativeMonoid c ℓ : Set (suc (c ⊔ ℓ)) where
   commutativeMonoid = record { isCommutativeMonoid = isCommutativeMonoid }
 
   open CommutativeMonoid commutativeMonoid public
-    using (setoid; semigroup; rawMonoid; monoid)
+    using (semigroup; rawMonoid; monoid)
 
 record Group c ℓ : Set (suc (c ⊔ ℓ)) where
   infix  8 _⁻¹
@@ -117,7 +112,7 @@ record Group c ℓ : Set (suc (c ⊔ ℓ)) where
   monoid : Monoid _ _
   monoid = record { isMonoid = isMonoid }
 
-  open Monoid monoid public using (setoid; semigroup; rawMonoid)
+  open Monoid monoid public using (semigroup; rawMonoid)
 
 record AbelianGroup c ℓ : Set (suc (c ⊔ ℓ)) where
   infix  8 _⁻¹
@@ -136,7 +131,7 @@ record AbelianGroup c ℓ : Set (suc (c ⊔ ℓ)) where
   group : Group _ _
   group = record { isGroup = isGroup }
 
-  open Group group public using (setoid; semigroup; monoid; rawMonoid)
+  open Group group public using (semigroup; monoid; rawMonoid)
 
   commutativeMonoid : CommutativeMonoid _ _
   commutativeMonoid =
@@ -163,7 +158,7 @@ record NearSemiring c ℓ : Set (suc (c ⊔ ℓ)) where
   +-monoid = record { isMonoid = +-isMonoid }
 
   open Monoid +-monoid public
-         using (setoid)
+         using ()
          renaming ( semigroup to +-semigroup
                   ; rawMonoid to +-rawMonoid)
 
@@ -188,8 +183,7 @@ record SemiringWithoutOne c ℓ : Set (suc (c ⊔ ℓ)) where
   nearSemiring = record { isNearSemiring = isNearSemiring }
 
   open NearSemiring nearSemiring public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid
+         using ( +-semigroup; +-rawMonoid; +-monoid
                ; *-semigroup
                )
 
@@ -219,7 +213,7 @@ record SemiringWithoutAnnihilatingZero c ℓ : Set (suc (c ⊔ ℓ)) where
     record { isCommutativeMonoid = +-isCommutativeMonoid }
 
   open CommutativeMonoid +-commutativeMonoid public
-         using (setoid)
+         using ()
          renaming ( semigroup to +-semigroup
                   ; rawMonoid to +-rawMonoid
                   ; monoid    to +-monoid
@@ -257,8 +251,7 @@ record Semiring c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open SemiringWithoutAnnihilatingZero
          semiringWithoutAnnihilatingZero public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid
+         using ( +-semigroup; +-rawMonoid; +-monoid
                ; +-commutativeMonoid
                ; *-semigroup; *-rawMonoid; *-monoid
                )
@@ -291,8 +284,7 @@ record CommutativeSemiringWithoutOne c ℓ : Set (suc (c ⊔ ℓ)) where
     record { isSemiringWithoutOne = isSemiringWithoutOne }
 
   open SemiringWithoutOne semiringWithoutOne public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid
+         using ( +-semigroup; +-rawMonoid; +-monoid
                ; +-commutativeMonoid
                ; *-semigroup
                ; nearSemiring
@@ -317,8 +309,7 @@ record CommutativeSemiring c ℓ : Set (suc (c ⊔ ℓ)) where
   semiring = record { isSemiring = isSemiring }
 
   open Semiring semiring public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid
+         using ( +-semigroup; +-rawMonoid; +-monoid
                ; +-commutativeMonoid
                ; *-semigroup; *-rawMonoid; *-monoid
                ; nearSemiring; semiringWithoutOne
@@ -375,8 +366,7 @@ record Ring c ℓ : Set (suc (c ⊔ ℓ)) where
   semiring = record { isSemiring = isSemiring }
 
   open Semiring semiring public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid
+         using ( +-semigroup; +-rawMonoid; +-monoid
                ; +-commutativeMonoid
                ; *-semigroup; *-rawMonoid; *-monoid
                ; nearSemiring; semiringWithoutOne
@@ -421,8 +411,7 @@ record CommutativeRing c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open Ring ring public using (rawRing; +-group; +-abelianGroup)
   open CommutativeSemiring commutativeSemiring public
-         using ( setoid
-               ; +-semigroup; +-rawMonoid; +-monoid; +-commutativeMonoid
+         using ( +-semigroup; +-rawMonoid; +-monoid; +-commutativeMonoid
                ; *-semigroup; *-rawMonoid; *-monoid; *-commutativeMonoid
                ; nearSemiring; semiringWithoutOne
                ; semiringWithoutAnnihilatingZero; semiring

--- a/src/Algebra/Morphism.agda
+++ b/src/Algebra/Morphism.agda
@@ -34,38 +34,140 @@ module Definitions {f t ℓ}
     ∀ x y → ⟦ x ∙ y ⟧ ≈ (⟦ x ⟧ ∘ ⟦ y ⟧)
 
 ------------------------------------------------------------------------
--- An example showing how a morphism type can be defined
+-- Structure homomorphisms
 
--- Ring homomorphisms.
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : Semigroup c₁ ℓ₁)
+         (To   : Semigroup c₂ ℓ₂) where
 
-record _-Ring⟶_ {r₁ r₂ r₃ r₄}
-                (From : Ring r₁ r₂) (To : Ring r₃ r₄) :
-                Set (r₁ ⊔ r₂ ⊔ r₃ ⊔ r₄) where
+  private
+    module F = Semigroup From
+    module T = Semigroup To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsSemigroupMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      ⟦⟧-cong : ⟦_⟧ Preserves F._≈_ ⟶ T._≈_
+      ∙-homo  : Homomorphic₂ ⟦_⟧ F._∙_ T._∙_
+
+  syntax IsSemigroupMorphism From To F = F Is From -Semigroup⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : Monoid c₁ ℓ₁)
+         (To   : Monoid c₂ ℓ₂) where
+
+  private
+    module F = Monoid From
+    module T = Monoid To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsMonoidMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      sm-homo : IsSemigroupMorphism F.semigroup T.semigroup ⟦_⟧
+      ε-homo  : Homomorphic₀ ⟦_⟧ F.ε T.ε
+
+    open IsSemigroupMorphism sm-homo public
+
+  syntax IsMonoidMorphism From To F = F Is From -Monoid⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : CommutativeMonoid c₁ ℓ₁)
+         (To   : CommutativeMonoid c₂ ℓ₂) where
+
+  private
+    module F = CommutativeMonoid From
+    module T = CommutativeMonoid To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsCommutativeMonoidMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
+
+    open IsMonoidMorphism mn-homo public
+
+  syntax IsCommutativeMonoidMorphism From To F = F Is From -CommutativeMonoid⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : IdempotentCommutativeMonoid c₁ ℓ₁)
+         (To   : IdempotentCommutativeMonoid c₂ ℓ₂) where
+
+  private
+    module F = IdempotentCommutativeMonoid From
+    module T = IdempotentCommutativeMonoid To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsIdempotentCommutativeMonoidMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
+
+    open IsMonoidMorphism mn-homo public
+
+    isCommutativeMonoidMorphism :
+      IsCommutativeMonoidMorphism F.commutativeMonoid T.commutativeMonoid ⟦_⟧
+    isCommutativeMonoidMorphism = record { mn-homo = mn-homo }
+
+  syntax IsIdempotentCommutativeMonoidMorphism From To F = F Is From -IdempotentCommutativeMonoid⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : Group c₁ ℓ₁)
+         (To   : Group c₂ ℓ₂) where
+
+  private
+    module F = Group From
+    module T = Group To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsGroupMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
+
+    open IsMonoidMorphism mn-homo public
+
+    ⁻¹-homo : Homomorphic₁ ⟦_⟧ F._⁻¹ T._⁻¹
+    ⁻¹-homo x = let open EqR T.setoid in T.uniqueˡ-⁻¹ ⟦ x F.⁻¹ ⟧ ⟦ x ⟧ $ begin
+      ⟦ x F.⁻¹ ⟧ T.∙ ⟦ x ⟧ ≈⟨ T.sym (∙-homo (x F.⁻¹) x) ⟩
+      ⟦ x F.⁻¹ F.∙ x ⟧     ≈⟨ ⟦⟧-cong (proj₁ F.inverse x) ⟩
+      ⟦ F.ε ⟧              ≈⟨ ε-homo ⟩
+      T.ε ∎
+
+  syntax IsGroupMorphism From To F = F Is From -Group⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : AbelianGroup c₁ ℓ₁)
+         (To   : AbelianGroup c₂ ℓ₂) where
+
+  private
+    module F = AbelianGroup From
+    module T = AbelianGroup To
+  open Definitions F.Carrier T.Carrier T._≈_
+
+  record IsAbelianGroupMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      gp-homo : IsGroupMorphism F.group T.group ⟦_⟧
+
+    open IsGroupMorphism gp-homo public
+
+  syntax IsAbelianGroupMorphism From To F = F Is From -AbelianGroup⟶ To
+
+module _ {c₁ ℓ₁ c₂ ℓ₂}
+         (From : Ring c₁ ℓ₁)
+         (To   : Ring c₂ ℓ₂) where
+
   private
     module F = Ring From
     module T = Ring To
   open Definitions F.Carrier T.Carrier T._≈_
 
-  field
-    ⟦_⟧     : Morphism
-    ⟦⟧-cong : ⟦_⟧ Preserves F._≈_ ⟶ T._≈_
-    +-homo  : Homomorphic₂ ⟦_⟧ F._+_ T._+_
-    *-homo  : Homomorphic₂ ⟦_⟧ F._*_ T._*_
-    1-homo  : Homomorphic₀ ⟦_⟧ F.1#  T.1#
+  record IsRingMorphism (⟦_⟧ : Morphism) :
+         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+    field
+      +-abgp-homo : ⟦_⟧ Is F.+-abelianGroup -AbelianGroup⟶ T.+-abelianGroup
+      *-mn-homo   : ⟦_⟧ Is F.*-monoid -Monoid⟶ T.*-monoid
 
-  open EqR T.setoid
-
-  0-homo : Homomorphic₀ ⟦_⟧ F.0# T.0#
-  0-homo =
-    GroupP.left-identity-unique T.+-group ⟦ F.0# ⟧ ⟦ F.0# ⟧ (begin
-      T._+_ ⟦ F.0# ⟧ ⟦ F.0# ⟧ ≈⟨ T.sym (+-homo F.0# F.0#) ⟩
-      ⟦ F._+_ F.0# F.0# ⟧     ≈⟨ ⟦⟧-cong (proj₁ F.+-identity F.0#) ⟩
-      ⟦ F.0# ⟧                ∎)
-
-  -‿homo : Homomorphic₁ ⟦_⟧ (F.-_) (T.-_)
-  -‿homo x =
-    GroupP.left-inverse-unique T.+-group ⟦ F.-_ x ⟧ ⟦ x ⟧ (begin
-      T._+_ ⟦ F.-_ x ⟧ ⟦ x ⟧ ≈⟨ T.sym (+-homo (F.-_ x) x) ⟩
-      ⟦ F._+_ (F.-_ x) x ⟧   ≈⟨ ⟦⟧-cong (proj₁ F.-‿inverse x) ⟩
-      ⟦ F.0# ⟧               ≈⟨ 0-homo ⟩
-      T.0#                   ∎)
+  syntax IsRingMorphism From To F = F Is From -Ring⟶ To

--- a/src/Algebra/RingSolver/AlmostCommutativeRing.agda
+++ b/src/Algebra/RingSolver/AlmostCommutativeRing.agda
@@ -52,8 +52,7 @@ record AlmostCommutativeRing c ℓ : Set (suc (c ⊔ ℓ)) where
     record { isCommutativeSemiring = isCommutativeSemiring }
 
   open CommutativeSemiring commutativeSemiring public
-         using ( setoid
-               ; +-semigroup; +-monoid; +-commutativeMonoid
+         using ( +-semigroup; +-monoid; +-commutativeMonoid
                ; *-semigroup; *-monoid; *-commutativeMonoid
                ; semiring
                )

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -28,6 +28,9 @@ record IsSemigroup {a ℓ} {A : Set a} (≈ : Rel A ℓ)
     assoc         : Associative ∙
     ∙-cong        : ∙ Preserves₂ ≈ ⟶ ≈ ⟶ ≈
 
+  setoid : Setoid a ℓ
+  setoid = record { isEquivalence = isEquivalence }
+
   open IsEquivalence isEquivalence public
 
 record IsMonoid {a ℓ} {A : Set a} (≈ : Rel A ℓ)
@@ -88,6 +91,24 @@ record IsGroup {a ℓ} {A : Set a} (≈ : Rel A ℓ)
 
   _-_ : FunctionProperties.Op₂ A
   x - y = x ∙ (y ⁻¹)
+
+  uniqueˡ-⁻¹ : ∀ x y → ≈ (x ∙ y) ε → ≈ x (y ⁻¹)
+  uniqueˡ-⁻¹ x y eq = let open EqR setoid in begin
+    x                ≈⟨ sym (proj₂ identity x) ⟩
+    x ∙ ε            ≈⟨ ∙-cong refl (sym (proj₂ inverse y)) ⟩
+    x ∙ (y ∙ (y ⁻¹)) ≈⟨ sym (assoc x y (y ⁻¹)) ⟩
+    (x ∙ y) ∙ (y ⁻¹) ≈⟨ ∙-cong eq refl ⟩
+    ε ∙ (y ⁻¹)       ≈⟨ proj₁ identity (y ⁻¹) ⟩
+    y ⁻¹ ∎
+
+  uniqueʳ-⁻¹ : ∀ x y → ≈ (x ∙ y) ε → ≈ y (x ⁻¹)
+  uniqueʳ-⁻¹ x y eq = let open EqR setoid in begin
+    y                ≈⟨ sym (proj₁ identity y) ⟩
+    ε ∙ y            ≈⟨ ∙-cong (sym (proj₁ inverse x)) refl ⟩
+    ((x ⁻¹) ∙ x) ∙ y ≈⟨ assoc (x ⁻¹) x y ⟩
+    (x ⁻¹) ∙ (x ∙ y) ≈⟨ ∙-cong refl eq ⟩
+    (x ⁻¹) ∙ ε       ≈⟨ proj₂ identity (x ⁻¹) ⟩
+    x ⁻¹ ∎
 
 record IsAbelianGroup
          {a ℓ} {A : Set a} (≈ : Rel A ℓ)

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -26,7 +26,7 @@ open import Algebra.FunctionProperties (_≡_ {A = ℕ})
 open import Algebra.FunctionProperties
   using (LeftCancellative; RightCancellative; Cancellative)
 open import Algebra.FunctionProperties.Consequences (setoid ℕ)
-
+open import Algebra.Morphism
 open ≡-Reasoning
 
 ------------------------------------------------------------------------
@@ -296,12 +296,21 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
   ; ∙-cong        = cong₂ _+_
   }
 
++-semigroup : Semigroup _ _
++-semigroup = record { isSemigroup = +-isSemigroup }
+
 +-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ 0
 +-0-isCommutativeMonoid = record
   { isSemigroup = +-isSemigroup
   ; identityˡ    = +-identityˡ
   ; comm        = +-comm
   }
+
++-0-monoid : Monoid _ _
++-0-monoid = record { isMonoid = IsCommutativeMonoid.isMonoid +-0-isCommutativeMonoid }
+
++-0-commutativeMonoid : CommutativeMonoid _ _
++-0-commutativeMonoid = record { isCommutativeMonoid = +-0-isCommutativeMonoid }
 
 -- Other properties of _+_ and _≡_
 
@@ -467,12 +476,21 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
   ; ∙-cong        = cong₂ _*_
   }
 
+*-semigroup : Semigroup _ _
+*-semigroup = record { isSemigroup = *-isSemigroup }
+
 *-1-isCommutativeMonoid : IsCommutativeMonoid _≡_ _*_ 1
 *-1-isCommutativeMonoid = record
   { isSemigroup = *-isSemigroup
   ; identityˡ    = *-identityˡ
   ; comm        = *-comm
   }
+
+*-1-monoid : Monoid _ _
+*-1-monoid = record { isMonoid = IsCommutativeMonoid.isMonoid *-1-isCommutativeMonoid }
+
+*-1-commutativeMonoid : CommutativeMonoid _ _
+*-1-commutativeMonoid = record { isCommutativeMonoid = *-1-isCommutativeMonoid }
 
 *-+-isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ 0 1
 *-+-isCommutativeSemiring = record
@@ -481,6 +499,9 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
   ; distribʳ              = *-distribʳ-+
   ; zeroˡ                 = *-zeroˡ
   }
+
+*-+-semiring : Semiring _ _
+*-+-semiring = record { isSemiring = IsCommutativeSemiring.isSemiring *-+-isCommutativeSemiring }
 
 *-+-commutativeSemiring : CommutativeSemiring _ _
 *-+-commutativeSemiring = record
@@ -558,6 +579,19 @@ i^j≡0⇒i≡0 i (suc j) eq = [ id , i^j≡0⇒i≡0 i j ]′ (i*j≡0⇒i≡0�
 i^j≡1⇒j≡0∨i≡1 : ∀ i j → i ^ j ≡ 1 → j ≡ 0 ⊎ i ≡ 1
 i^j≡1⇒j≡0∨i≡1 i zero    _  = inj₁ refl
 i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
+
+
+^-semigroup-morphism : ∀ {x} → (x ^_) Is +-semigroup -Semigroup⟶ *-semigroup
+^-semigroup-morphism = record
+  { ⟦⟧-cong = cong (_ ^_)
+  ; ∙-homo  = ^-distribˡ-+-* _
+  }
+
+^-monoid-morphism : ∀ {x} → (x ^_) Is +-0-monoid -Monoid⟶ *-1-monoid
+^-monoid-morphism = record
+  { sm-homo = ^-semigroup-morphism
+  ; ε-homo  = refl
+  }
 
 ------------------------------------------------------------------------
 -- Properties of _⊔_ and _⊓_


### PR DESCRIPTION
This is a breaking change for `Algebra.Morphism` but I very much doubt that anyone relied heavily on it. I had to put `setoid` as a definition provided by `IsEquivalence` which changes quite a few `open (...) public` but the exported things are exactly the same in the end.