### PR TITLE
[ new ] Predicate Update & syntax for Universal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ Non-backwards compatible changes
   from `x < y ⊎ x ≈ y` to `x < y`. `_≈⟨_⟩_` is left unchanged to take a value with type `x ≈ y`.
   Old code may be fixed by prefixing the contents of `_<⟨_⟩_` with `inj₁`.
 
+* Changed the fixity of `⋃` and `⋂` in `Relation.Unary` to make space for `_⊢_`.
+
 Deprecated features
 -------------------
 
@@ -771,6 +773,12 @@ Backwards compatible changes
   ```agda
   ≅-to-type-≡  : {x : A} {y : B} → x ≅ y → A ≡ B
   ≅-to-subst-≡ : (p : x ≅ y) → subst (λ x → x) (≅-to-type-≡ p) x ≡ y
+  ```
+
+* Added new combinators to `Relation.Binary`:
+  ```agda
+  ∀[_] : Pred A ℓ → Set _
+  _⊢_  : (A → B) → Pred B ℓ → Pred A ℓ
   ```
 
 Version 0.13

--- a/src/Relation/Unary.agda
+++ b/src/Relation/Unary.agda
@@ -63,8 +63,12 @@ module _ {a} {A : Set a} -- The universe of discourse.
 
   -- The property of being universal.
 
+  infix 10 Universal
+
   Universal : ∀ {ℓ} → Pred A ℓ → Set _
   Universal P = ∀ x → x ∈ P
+
+  syntax Universal P = ∀[ P ]
 
   U-Universal : Universal U
   U-Universal = λ _ → _
@@ -132,7 +136,7 @@ module _ {a} {A : Set a} -- The universe of discourse.
 
   -- Infinitary union and intersection.
 
-  infix 9 ⋃ ⋂
+  infix 10 ⋃ ⋂
 
   ⋃ : ∀ {ℓ i} (I : Set i) → (I → Pred A ℓ) → Pred A _
   ⋃ I P = λ x → Σ[ i ∈ I ] P i x
@@ -143,6 +147,13 @@ module _ {a} {A : Set a} -- The universe of discourse.
   ⋂ I P = λ x → (i : I) → P i x
 
   syntax ⋂ I (λ i → P) = ⋂[ i ∶ I ] P
+
+-- Update.
+
+infixl 9 _⊢_
+
+_⊢_ : ∀ {a b} {A : Set a} {B : Set b} {ℓ} → (A → B) → Pred B ℓ → Pred A ℓ
+f ⊢ P = λ x → P (f x)
 
 ------------------------------------------------------------------------
 -- Unary relation combinators


### PR DESCRIPTION
Typical use case: silently threading a context and patching it
up on the fly. For instance, this definition of the well-scoped
untyped lambda-calculus:

    data Tm : Nat → Set where
      var : ∀[ Fin      ⇒ Tm ]
      lam : ∀[ suc ⊢ Tm ⇒ Tm ]
      app : ∀[ Tm ⇒ Tm  ⇒ Tm ]