### PR TITLE
renamed 'do' -> 'inn' in FreeMonad modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Non-backwards compatible changes
 
 #### Other
 
+* Renamed `Data.Container.FreeMonad.do` and
+  `Data.Container.Indexed.FreeMonad.do` to `inn` in anticipation of Agda
+  supporting proper 'do' notation.
+
 * Changed the fixity of `⋃` and `⋂` in `Relation.Unary` to make space for `_⊢_`.
 
 Deprecated features

--- a/README/Container/FreeMonad.agda
+++ b/README/Container/FreeMonad.agda
@@ -31,12 +31,12 @@ State S = ⊤ ⟶ S ⊎ S ⟶ ⊤
   I ⟶ O = I ▷ λ _ → O
 
 get : ∀ {S} → State S ⋆ S
-get = do (inj₁ _ , return)
+get = inn (inj₁ _ , return)
   where
   open RawMonad rawMonad
 
 put : ∀ {S} → S → State S ⋆ ⊤
-put s = do (inj₂ s , return)
+put s = inn (inj₂ s , return)
   where
   open RawMonad rawMonad
 

--- a/src/Data/Container/FreeMonad.agda
+++ b/src/Data/Container/FreeMonad.agda
@@ -41,8 +41,8 @@ C ⋆C X = const X ⊎ C
 _⋆_ : ∀ {c} → Container c → Set c → Set c
 C ⋆ X = μ (C ⋆C X)
 
-do : ∀ {c} {C : Container c} {X} → ⟦ C ⟧ (C ⋆ X) → C ⋆ X
-do (s , k) = sup (inj₂ s) k
+inn : ∀ {c} {C : Container c} {X} → ⟦ C ⟧ (C ⋆ X) → C ⋆ X
+inn (s , k) = sup (inj₂ s) k
 
 rawMonad : ∀ {c} {C : Container c} → RawMonad (_⋆_ C)
 rawMonad = record { return = return; _>>=_ = _>>=_ }
@@ -52,4 +52,4 @@ rawMonad = record { return = return; _>>=_ = _>>=_ }
 
   _>>=_ : ∀ {c} {C : Container c} {X Y} → C ⋆ X → (X → C ⋆ Y) → C ⋆ Y
   sup (inj₁ x) _ >>= k = k x
-  sup (inj₂ s) f >>= k = do (s , λ p → f p >>= k)
+  sup (inj₂ s) f >>= k = inn (s , λ p → f p >>= k)

--- a/src/Data/Container/Indexed/FreeMonad.agda
+++ b/src/Data/Container/Indexed/FreeMonad.agda
@@ -34,9 +34,9 @@ C ⋆ X = μ (C ⋆C X)
 pattern returnP x = (inj₁ x , _)
 pattern doP c k   = (inj₂ c , k)
 
-do : ∀ {ℓ} {O : Set ℓ} {C : Container O O ℓ ℓ} {X} →
-     ⟦ C ⟧ (C ⋆ X) ⊆ C ⋆ X
-do (c , k) = sup (doP c k)
+inn : ∀ {ℓ} {O : Set ℓ} {C : Container O O ℓ ℓ} {X} →
+      ⟦ C ⟧ (C ⋆ X) ⊆ C ⋆ X
+inn (c , k) = sup (doP c k)
 
 rawPMonad : ∀ {ℓ} {O : Set ℓ} {C : Container O O ℓ ℓ} →
             RawPMonad {ℓ = ℓ} (_⋆_ C)
@@ -50,17 +50,17 @@ rawPMonad {C = C} = record
 
   _=<<_ : ∀ {X Y} → X ⊆ C ⋆ Y → C ⋆ X ⊆ C ⋆ Y
   f =<< sup (returnP x) = f x
-  f =<< sup (doP c k)   = do (c , λ r → f =<< k r)
+  f =<< sup (doP c k)   = inn (c , λ r → f =<< k r)
 
 leaf : ∀ {ℓ} {O : Set ℓ} {C : Container O O ℓ ℓ} {X : Pred O ℓ} →
        ⟦ C ⟧ X ⊆ C ⋆ X
-leaf (c , k) = do (c , return? ∘ k)
+leaf (c , k) = inn (c , return? ∘ k)
   where
   open RawPMonad rawPMonad
 
 generic : ∀ {ℓ} {O : Set ℓ} {C : Container O O ℓ ℓ} {o}
           (c : Command C o) →
           o ∈ C ⋆ (⋃[ r ∶ Response C c ] ｛ next C c r ｝)
-generic c = do (c , λ r → return? (r , refl))
+generic c = inn (c , λ r → return? (r , refl))
   where
   open RawPMonad rawPMonad


### PR DESCRIPTION
In `Data.Container.FreeMonad` and `Data.Container.Indexed.FreeMonad`.
We're adding proper do-notation to Agda which makes 'do' a keyword.

I'm not sure about the new name. The function is the constructor of the fixed point, and this is often called `in`, but maybe there's a better name in this context.