### PR TITLE
Tidying up lexicographic orderings over lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ but they may be removed in some future release of the library.
   the definitions about particular data types in the same directory and 3) provides a location
   to reason about how operations on the data types affects the relations over them.
 
+  Some shared content has been moved out of `Data.List.Relation.StrictLex` and `Data.List.Relation.NonStrictLex` into `Data.List.Relation.Lex.Core`
+
+  The contents of `Relation.Binary.Vec.Pointwise` has been split into `Data.Vec.Relation.InductivePointwise` and `Data.Vec.Relation.ExtensionalPointwise`.
+
   The old files in `Relation.Binary.X` still exist for backwards compatability reasons and
   re-exports the contents of files' new location in `Data.X.Relation` but may be removed in some
   future release.
@@ -126,11 +130,14 @@ Backwards compatible changes
 
   Decidable equality for new builtin type `Agda.Builtin.Word.Word64`.
 
-* The contents of `Data.Covec` is now polymorphic with respect to levels
-
-* The contents of `Data.Vec.Relation.InductivePointwise` is now more polymorphic with respect to levels
-
-* The contents of `Data.Vec.Relation.ExtensionalPointwise` is now more polymorphic with respect to levels
+* The contents of the following modules are now more polymorphic with respect to levels:
+  ```agda
+  Data.Covec
+  Data.List.Relation.StrictLex
+  Data.List.Relation.NonStrictLex
+  Data.Vec.Relation.InductivePointwise
+  Data.Vec.Relation.ExtensionalPointwise
+  ```
 
 * Added new proof to `asymmetric : Asymmetric _<_` to the `IsStrictPartialOrder` record.
 
@@ -235,6 +242,28 @@ Backwards compatible changes
 * Added new proofs to `Data.List.All.Properties`:
   ```agda
   All-irrelevance : IrrelevantPred P → IrrelevantPred (All P)
+  ```
+
+* Added new proofs to `Data.List.Relation.NonStrictLex`:
+  ```agda
+  <-antisymmetric : Symmetric _≈_ → Antisymmetric _≈_ _≼_ → Antisymmetric _≋_ _<_
+  <-transitive    : IsPartialOrder _≈_ _≼_ → Transitive _<_
+  <-resp₂         : IsEquivalence _≈_ → _≼_ Respects₂ _≈_ → _<_ Respects₂ _≋_
+
+  ≤-antisymmetric : Symmetric _≈_ → Antisymmetric _≈_ _≼_ → Antisymmetric _≋_ _≤_
+  ≤-transitive    : IsPartialOrder _≈_ _≼_ → Transitive _≤_
+  ≤-resp₂         : IsEquivalence _≈_ → _≼_ Respects₂ _≈_ → _≤_ Respects₂ _≋_
+  ```
+
+* Added new proofs to `Data.List.Relation.StrictLex`:
+  ```agda
+  <-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →  Asymmetric _≺_ → Antisymmetric _≋_ _<_
+  <-transitive    : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → Transitive _≺_ → Transitive _<_
+  <-respects₂     : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → _<_ Respects₂ _≋_
+
+  ≤-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →  Asymmetric _≺_ → Antisymmetric _≋_ _≤_
+  ≤-transitive    : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → Transitive _≺_ → Transitive _≤_
+  ≤-respects₂     : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → _≤_ Respects₂ _≋_
   ```
 
 * Added new proofs to `Data.Maybe.Base`:

--- a/src/Data/List/Relation/Lex/Core.agda
+++ b/src/Data/List/Relation/Lex/Core.agda
@@ -1,0 +1,106 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Lexicographic ordering of lists
+------------------------------------------------------------------------
+
+module Data.List.Relation.Lex.Core where
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Unit.Base using (⊤; tt)
+open import Function using (_∘_; flip; id)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.List.Base using (List; []; _∷_)
+open import Level using (_⊔_)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Binary
+open import Data.List.Relation.Pointwise as Pointwise
+   using ([]; _∷_; head; tail)
+
+-- The lexicographic ordering itself can be either strict or non-strict,
+-- depending on whether type P is inhabited.
+
+data Lex {a ℓ₁ ℓ₂} {A : Set a} (P : Set)
+         (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) : Rel (List A) (ℓ₁ ⊔ ℓ₂) where
+  base : P                             → Lex P _≈_ _≺_ []       []
+  halt : ∀ {y ys}                      → Lex P _≈_ _≺_ []       (y ∷ ys)
+  this : ∀ {x xs y ys} (x≺y : x ≺ y)   → Lex P _≈_ _≺_ (x ∷ xs) (y ∷ ys)
+  next : ∀ {x xs y ys} (x≈y : x ≈ y)
+         (xs<ys : Lex P _≈_ _≺_ xs ys) → Lex P _≈_ _≺_ (x ∷ xs) (y ∷ ys)
+
+-- Properties
+
+module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
+         {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
+
+  private
+    _≋_ = Pointwise.Rel _≈_
+    _<_ = Lex P _≈_ _≺_
+
+  ¬≤-this : ∀ {x y xs ys} → ¬ (x ≈ y) → ¬ (x ≺ y) →
+            ¬ (x ∷ xs) < (y ∷ ys)
+  ¬≤-this x≉y x≮y (this x≺y)       = x≮y x≺y
+  ¬≤-this x≉y x≮y (next x≈y xs<ys) = x≉y x≈y
+
+  ¬≤-next : ∀ {x y xs ys} → ¬ x ≺ y → ¬ xs < ys →
+            ¬ (x ∷ xs) < (y ∷ ys)
+  ¬≤-next x≮y xs≮ys (this x≺y)     = x≮y x≺y
+  ¬≤-next x≮y xs≮ys (next _ xs<ys) = xs≮ys xs<ys
+
+  transitive : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → Transitive _≺_ →
+               Transitive _<_
+  transitive eq resp tr = trans
+    where
+    trans : Transitive (Lex P _≈_ _≺_)
+    trans (base p)         (base _)         = base p
+    trans (base y)         halt             = halt
+    trans halt             (this y≺z)       = halt
+    trans halt             (next y≈z ys<zs) = halt
+    trans (this x≺y)       (this y≺z)       = this (tr x≺y y≺z)
+    trans (this x≺y)       (next y≈z ys<zs) = this (proj₁ resp y≈z x≺y)
+    trans (next x≈y xs<ys) (this y≺z)       =
+      this (proj₂ resp (IsEquivalence.sym eq x≈y) y≺z)
+    trans (next x≈y xs<ys) (next y≈z ys<zs) =
+      next (IsEquivalence.trans eq x≈y y≈z) (trans xs<ys ys<zs)
+
+  antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →
+                  Asymmetric _≺_ → Antisymmetric _≋_ _<_
+  antisymmetric sym ir asym = as
+    where
+    as : Antisymmetric _≋_ _<_
+    as (base _)         (base _)         = []
+    as halt             ()
+    as (this x≺y)       (this y≺x)       = ⊥-elim (asym x≺y y≺x)
+    as (this x≺y)       (next y≈x ys<xs) = ⊥-elim (ir (sym y≈x) x≺y)
+    as (next x≈y xs<ys) (this y≺x)       = ⊥-elim (ir (sym x≈y) y≺x)
+    as (next x≈y xs<ys) (next y≈x ys<xs) = x≈y ∷ as xs<ys ys<xs
+
+  respects₂ : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → _<_ Respects₂ _≋_
+  respects₂ eq (resp₁ , resp₂) = resp¹ , resp²
+    where
+    open IsEquivalence eq using (sym; trans)
+    resp¹ : ∀ {xs} → Lex P _≈_ _≺_ xs Respects _≋_
+    resp¹ []            xs<[]            = xs<[]
+    resp¹ (_   ∷ _)     halt             = halt
+    resp¹ (x≈y ∷ _)     (this z≺x)       = this (resp₁ x≈y z≺x)
+    resp¹ (x≈y ∷ xs≋ys) (next z≈x zs<xs) =
+      next (trans z≈x x≈y) (resp¹ xs≋ys zs<xs)
+
+    resp² : ∀ {ys} → flip (Lex P _≈_ _≺_) ys Respects _≋_
+    resp² []            []<ys            = []<ys
+    resp² (x≈z ∷ _)     (this x≺y)       = this (resp₂ x≈z x≺y)
+    resp² (x≈z ∷ xs≋zs) (next x≈y xs<ys) =
+      next (trans (sym x≈z) x≈y) (resp² xs≋zs xs<ys)
+
+  decidable : Dec P → Decidable _≈_ → Decidable _≺_ → Decidable _<_
+  decidable (yes p) dec-≈ dec-≺ []       []       = yes (base p)
+  decidable (no ¬p) dec-≈ dec-≺ []       []       = no λ{(base p) → ¬p p}
+  decidable dec-P   dec-≈ dec-≺ []       (y ∷ ys) = yes halt
+  decidable dec-P   dec-≈ dec-≺ (x ∷ xs) []       = no λ()
+  decidable dec-P   dec-≈ dec-≺ (x ∷ xs) (y ∷ ys) with dec-≺ x y
+  ... | yes x≺y = yes (this x≺y)
+  ... | no x≮y with dec-≈ x y
+  ...   | no x≉y = no (¬≤-this x≉y x≮y)
+  ...   | yes x≈y with decidable dec-P dec-≈ dec-≺ xs ys
+  ...     | yes xs<ys = yes (next x≈y xs<ys)
+  ...     | no  xs≮ys = no (¬≤-next x≮y xs≮ys)

--- a/src/Data/List/Relation/StrictLex.agda
+++ b/src/Data/List/Relation/StrictLex.agda
@@ -4,15 +4,15 @@
 -- Lexicographic ordering of lists
 ------------------------------------------------------------------------
 
--- The definition of lexicographic ordering used here is suitable if
--- the argument order is a strict partial order. 
+-- The definitions of lexicographic ordering used here are suitable if
+-- the argument order is a strict partial order.
 
 module Data.List.Relation.StrictLex where
 
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤; tt)
 open import Function using (_∘_; flip; id)
-open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Product using (_,_)
 open import Data.Sum using (inj₁; inj₂)
 open import Data.List.Base using (List; []; _∷_)
 open import Level using (_⊔_)
@@ -22,126 +22,42 @@ open import Relation.Binary.Consequences
 open import Data.List.Relation.Pointwise as Pointwise
    using ([]; _∷_; head; tail)
 
--- The lexicographic ordering itself can be either strict or non-strict,
--- depending on whether type P is inhabited.
+open import Data.List.Relation.Lex.Core as Core public
+  using (base; halt; this; next; ¬≤-this; ¬≤-next)
 
-data Lex {a ℓ₁ ℓ₂} {A : Set a} (P : Set) (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) : Rel (List A) (ℓ₁ ⊔ ℓ₂) where
-  base : P                             → Lex P _≈_ _<_ []       []
-  halt : ∀ {y ys}                      → Lex P _≈_ _<_ []       (y ∷ ys)
-  this : ∀ {x xs y ys} (x<y : x < y)   → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
-  next : ∀ {x xs y ys} (x≈y : x ≈ y)
-         (xs⊴ys : Lex P _≈_ _<_ xs ys) → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
-
--- General properties
-
-module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set} {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
-
-  private
-    _≋_ = Pointwise.Rel _≈_
-    _≺_ = Lex P _≈_ _<_
-  
-  ¬≤-this : ∀ {x y xs ys} → ¬ (x ≈ y) → ¬ (x < y) →
-            ¬ (x ∷ xs) ≺ (y ∷ ys)
-  ¬≤-this x≉y x≮y (this x<y)       = x≮y x<y
-  ¬≤-this x≉y x≮y (next x≈y xs⊴ys) = x≉y x≈y
-
-  ¬≤-next : ∀ {x y xs ys} → ¬ x < y → ¬ xs ≺ ys →
-            ¬ (x ∷ xs) ≺ (y ∷ ys)
-  ¬≤-next x≮y ¬xs⊴ys (this x<y)       = x≮y x<y
-  ¬≤-next x≮y ¬xs⊴ys (next x≈y xs⊴ys) = ¬xs⊴ys xs⊴ys
-
-  transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
-               Transitive _≺_
-  transitive eq resp tr = trans
-    where
-    trans : Transitive (Lex P _≈_ _<_)
-    trans (base p)         (base _)         = base p
-    trans (base y)         halt             = halt
-    trans halt             (this y<z)       = halt
-    trans halt             (next y≈z ys⊴zs) = halt
-    trans (this x<y)       (this y<z)       = this (tr x<y y<z)
-    trans (this x<y)       (next y≈z ys⊴zs) = this (proj₁ resp y≈z x<y)
-    trans (next x≈y xs⊴ys) (this y<z)       =
-      this (proj₂ resp (IsEquivalence.sym eq x≈y) y<z)
-    trans (next x≈y xs⊴ys) (next y≈z ys⊴zs) =
-      next (IsEquivalence.trans eq x≈y y≈z) (trans xs⊴ys ys⊴zs)
-
-  antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
-                  Antisymmetric _≋_ _≺_
-  antisymmetric sym ir asym = as
-    where
-    as : Antisymmetric _≋_ _≺_
-    as (base _)         (base _)         = []
-    as halt             ()
-    as (this x<y)       (this y<x)       = ⊥-elim (asym x<y y<x)
-    as (this x<y)       (next y≈x ys⊴xs) = ⊥-elim (ir (sym y≈x) x<y)
-    as (next x≈y xs⊴ys) (this y<x)       = ⊥-elim (ir (sym x≈y) y<x)
-    as (next x≈y xs⊴ys) (next y≈x ys⊴xs) = x≈y ∷ as xs⊴ys ys⊴xs
-
-  respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≺_ Respects₂ _≋_
-  respects₂ eq (resp₁ , resp₂) = resp¹ , resp²
-    where
-    open IsEquivalence eq using () renaming (sym to ≈-sym; trans to ≈-trans)
-    
-    resp¹ : ∀ {xs} → Lex P _≈_ _<_ xs Respects _≋_
-    resp¹ []            xs⊴[]            = xs⊴[]
-    resp¹ (_   ∷ _)     halt             = halt
-    resp¹ (x≈y ∷ _)     (this z<x)       = this (resp₁ x≈y z<x)
-    resp¹ (x≈y ∷ xs≋ys) (next z≈x zs⊴xs) =
-      next (≈-trans z≈x x≈y) (resp¹ xs≋ys zs⊴xs)
-
-    resp² : ∀ {ys} → flip (Lex P _≈_ _<_) ys Respects _≋_
-    resp² []            []⊴ys            = []⊴ys
-    resp² (x≈z ∷ _)     (this x<y)       = this (resp₂ x≈z x<y)
-    resp² (x≈z ∷ xs≋zs) (next x≈y xs⊴ys) =
-      next (≈-trans (≈-sym x≈z) x≈y) (resp² xs≋zs xs⊴ys)
-
-  decidable : Dec P → Decidable _≈_ → Decidable _<_ → Decidable _≺_
-  decidable (yes p) dec-≈ dec-< []       []       = yes (base p)
-  decidable (no ¬p) dec-≈ dec-< []       []       = no λ{(base p) → ¬p p}
-  decidable dec-P   dec-≈ dec-< []       (y ∷ ys) = yes halt
-  decidable dec-P   dec-≈ dec-< (x ∷ xs) []       = no λ()
-  decidable dec-P   dec-≈ dec-< (x ∷ xs) (y ∷ ys) with dec-< x y
-  ... | yes x<y = yes (this x<y)
-  ... | no x≮y with dec-≈ x y
-  ...   | no x≉y = no (¬≤-this x≉y x≮y)
-  ...   | yes x≈y with decidable dec-P dec-≈ dec-< xs ys
-  ...     | yes xs⊴ys = yes (next x≈y xs⊴ys)
-  ...     | no ¬xs⊴ys = no (¬≤-next x≮y ¬xs⊴ys)
-  
 ----------------------------------------------------------------------
 -- Strict lexicographic ordering.
 
 module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
-  Lex-< : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
-  Lex-< = Lex ⊥
-  
+  Lex-< : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
+  Lex-< = Core.Lex ⊥
+
   -- Properties
 
-  module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
-  
+  module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
+
     private
       _≋_ = Pointwise.Rel _≈_
-      _≺_ = Lex-< _≈_ _<_
-    
-    ¬[]<[] : ¬ [] ≺ []
+      _<_ = Lex-< _≈_ _≺_
+
+    ¬[]<[] : ¬ [] < []
     ¬[]<[] (base ())
 
-    <-irreflexive : Irreflexive _≈_ _<_ → Irreflexive _≋_ _≺_
+    <-irreflexive : Irreflexive _≈_ _≺_ → Irreflexive _≋_ _<_
     <-irreflexive irr []            (base ())
     <-irreflexive irr (x≈y ∷ xs≋ys) (this x<y)     = irr x≈y x<y
     <-irreflexive irr (x≈y ∷ xs≋ys) (next _ xs⊴ys) =
       <-irreflexive irr xs≋ys xs⊴ys
 
-    <-asymmetric : Symmetric _≈_ → _<_ Respects₂ _≈_ → Asymmetric _<_ →
-                   Asymmetric _≺_
+    <-asymmetric : Symmetric _≈_ → _≺_ Respects₂ _≈_ → Asymmetric _≺_ →
+                   Asymmetric _<_
     <-asymmetric sym resp as = asym
       where
-      irrefl : Irreflexive _≈_ _<_
+      irrefl : Irreflexive _≈_ _≺_
       irrefl = asym⟶irr resp sym as
 
-      asym : Asymmetric _≺_
+      asym : Asymmetric _<_
       asym (halt)           ()
       asym (base bot)       _                = bot
       asym (this x<y)       (this y<x)       = as x<y y<x
@@ -149,64 +65,64 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
       asym (next x≈y xs⊴ys) (this y<x)       = irrefl (sym x≈y) y<x
       asym (next x≈y xs⊴ys) (next y≈x ys⊴xs) = asym xs⊴ys ys⊴xs
 
-    <-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
-                      Antisymmetric _≋_ _≺_
-    <-antisymmetric = antisymmetric
-    
-    <-transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
-                   Transitive _≺_
-    <-transitive = transitive
-    
-    <-decidable : Decidable _≈_ → Decidable _<_ → Decidable _≺_
-    <-decidable = decidable (no id)
+    <-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →
+                      Asymmetric _≺_ → Antisymmetric _≋_ _<_
+    <-antisymmetric = Core.antisymmetric
 
-    <-respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≺_ Respects₂ _≋_
-    <-respects₂ = respects₂
-    
-    <-compare : Symmetric _≈_ → Trichotomous _≈_ _<_ → Trichotomous _≋_ _≺_
-    <-compare sym tri = cmp
-      where
-      cmp : Trichotomous _≋_ _≺_
-      cmp []       []       = tri≈ ¬[]<[] []    ¬[]<[]
-      cmp []       (y ∷ ys) = tri< halt   (λ()) (λ())
-      cmp (x ∷ xs) []       = tri> (λ())  (λ()) halt
-      cmp (x ∷ xs) (y ∷ ys) with tri x y
-      ... | tri< x<y x≉y y≮x =
-            tri< (this x<y) (x≉y ∘ head) (¬≤-this (x≉y ∘ sym) y≮x)
-      ... | tri> x≮y x≉y y<x =
-            tri> (¬≤-this x≉y x≮y) (x≉y ∘ head) (this y<x)
-      ... | tri≈ x≮y x≈y y≮x with cmp xs ys
-      ...   | tri< xs<ys xs≉ys ys≮xs =
-              tri< (next x≈y xs<ys) (xs≉ys ∘ tail) (¬≤-next y≮x ys≮xs)
-      ...   | tri≈ ¬xs<ys xs≈ys ys≮xs =
-              tri≈ (¬≤-next x≮y ¬xs<ys) (x≈y ∷ xs≈ys) (¬≤-next y≮x ys≮xs)
-      ...   | tri> ¬xs<ys xs≉ys ys<xs =
-              tri> (¬≤-next x≮y ¬xs<ys) (xs≉ys ∘ tail) (next (sym x≈y) ys<xs)
+    <-transitive : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ →
+                   Transitive _≺_ → Transitive _<_
+    <-transitive = Core.transitive
 
-    
-    <-isStrictPartialOrder : IsStrictPartialOrder _≈_ _<_ →
-                           IsStrictPartialOrder _≋_ _≺_
+    <-compare : Symmetric _≈_ → Trichotomous _≈_ _≺_ →
+                Trichotomous _≋_ _<_
+    <-compare sym tri []       []       = tri≈ ¬[]<[] []    ¬[]<[]
+    <-compare sym tri []       (y ∷ ys) = tri< halt   (λ()) (λ())
+    <-compare sym tri (x ∷ xs) []       = tri> (λ())  (λ()) halt
+    <-compare sym tri (x ∷ xs) (y ∷ ys) with tri x y
+    ... | tri< x<y x≉y y≮x =
+          tri< (this x<y) (x≉y ∘ head) (¬≤-this (x≉y ∘ sym) y≮x)
+    ... | tri> x≮y x≉y y<x =
+          tri> (¬≤-this x≉y x≮y) (x≉y ∘ head) (this y<x)
+    ... | tri≈ x≮y x≈y y≮x with <-compare sym tri xs ys
+    ...   | tri< xs<ys xs≉ys ys≮xs =
+            tri< (next x≈y xs<ys) (xs≉ys ∘ tail) (¬≤-next y≮x ys≮xs)
+    ...   | tri≈ xs≮ys xs≈ys ys≮xs =
+            tri≈ (¬≤-next x≮y xs≮ys) (x≈y ∷ xs≈ys) (¬≤-next y≮x ys≮xs)
+    ...   | tri> xs≮ys xs≉ys ys<xs =
+            tri> (¬≤-next x≮y xs≮ys) (xs≉ys ∘ tail) (next (sym x≈y) ys<xs)
+
+    <-decidable : Decidable _≈_ → Decidable _≺_ → Decidable _<_
+    <-decidable = Core.decidable (no id)
+
+    <-respects₂ : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ →
+                  _<_ Respects₂ _≋_
+    <-respects₂ = Core.respects₂
+
+    <-isStrictPartialOrder : IsStrictPartialOrder _≈_ _≺_ →
+                             IsStrictPartialOrder _≋_ _<_
     <-isStrictPartialOrder spo = record
       { isEquivalence = Pointwise.isEquivalence isEquivalence
       ; irrefl        = <-irreflexive irrefl
-      ; trans         = transitive isEquivalence <-resp-≈ trans
-      ; <-resp-≈      = respects₂ isEquivalence <-resp-≈
+      ; trans         = Core.transitive isEquivalence <-resp-≈ trans
+      ; <-resp-≈      = Core.respects₂ isEquivalence <-resp-≈
       } where open IsStrictPartialOrder spo
 
-    <-isStrictTotalOrder : IsStrictTotalOrder _≈_ _<_ →
-                         IsStrictTotalOrder _≋_ _≺_
+    <-isStrictTotalOrder : IsStrictTotalOrder _≈_ _≺_ →
+                           IsStrictTotalOrder _≋_ _<_
     <-isStrictTotalOrder sto = record
       { isEquivalence = Pointwise.isEquivalence isEquivalence
       ; trans         = <-transitive isEquivalence <-resp-≈ trans
       ; compare       = <-compare Eq.sym compare
       } where open IsStrictTotalOrder sto
 
-<-strictPartialOrder : ∀ {a ℓ₁ ℓ₂} → StrictPartialOrder a ℓ₁ ℓ₂ → StrictPartialOrder _ _ _
+<-strictPartialOrder : ∀ {a ℓ₁ ℓ₂} → StrictPartialOrder a ℓ₁ ℓ₂ →
+                       StrictPartialOrder _ _ _
 <-strictPartialOrder spo = record
   { isStrictPartialOrder = <-isStrictPartialOrder isStrictPartialOrder
   } where open StrictPartialOrder spo
-  
-<-strictTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ → StrictTotalOrder _ _ _
+
+<-strictTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ →
+                       StrictTotalOrder _ _ _
 <-strictTotalOrder sto = record
   { isStrictTotalOrder = <-isStrictTotalOrder isStrictTotalOrder
   } where open StrictTotalOrder sto
@@ -216,34 +132,35 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
 module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
-  Lex-≤ : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
-  Lex-≤ = Lex ⊤
+  Lex-≤ : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
+  Lex-≤ = Core.Lex ⊤
 
   -- Properties
 
-  ≤-reflexive : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Pointwise.Rel _≈_ ⇒ Lex-≤ _≈_ _<_
-  ≤-reflexive _≈_ _<_ []            = base tt
-  ≤-reflexive _≈_ _<_ (x≈y ∷ xs≈ys) =
-    next x≈y (≤-reflexive _≈_ _<_ xs≈ys)
+  ≤-reflexive : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
+                Pointwise.Rel _≈_ ⇒ Lex-≤ _≈_ _≺_
+  ≤-reflexive _≈_ _≺_ []            = base tt
+  ≤-reflexive _≈_ _≺_ (x≈y ∷ xs≈ys) =
+    next x≈y (≤-reflexive _≈_ _≺_ xs≈ys)
 
-  module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
+  module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
 
     private
       _≋_ = Pointwise.Rel _≈_
-      _≼_ = Lex-≤ _≈_ _<_
+      _≤_ = Lex-≤ _≈_ _≺_
 
-    ≤-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
-                      Antisymmetric _≋_ _≼_
-    ≤-antisymmetric = antisymmetric
-    
-    ≤-transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
-                   Transitive _≼_
-    ≤-transitive = transitive
+    ≤-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →
+                      Asymmetric _≺_ → Antisymmetric _≋_ _≤_
+    ≤-antisymmetric = Core.antisymmetric
+
+    ≤-transitive : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ →
+                   Transitive _≺_ → Transitive _≤_
+    ≤-transitive = Core.transitive
 
     -- Note that trichotomy is an unnecessarily strong precondition for
     -- the following lemma.
 
-    ≤-total : Symmetric _≈_ → Trichotomous _≈_ _<_ → Total _≼_
+    ≤-total : Symmetric _≈_ → Trichotomous _≈_ _≺_ → Total _≤_
     ≤-total _   _   []       []       = inj₁ (base tt)
     ≤-total _   _   []       (x ∷ xs) = inj₁ halt
     ≤-total _   _   (x ∷ xs) []       = inj₂ halt
@@ -253,45 +170,45 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
     ... | tri≈ _ x≈y _ with ≤-total sym tri xs ys
     ...   | inj₁ xs≲ys = inj₁ (next      x≈y  xs≲ys)
     ...   | inj₂ ys≲xs = inj₂ (next (sym x≈y) ys≲xs)
-    
-    ≤-decidable : Decidable _≈_ → Decidable _<_ → Decidable _≼_
-    ≤-decidable = decidable (yes tt)
 
-    ≤-respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≼_ Respects₂ _≋_
-    ≤-respects₂ = respects₂
-    
-    ≤-isPreorder : IsEquivalence _≈_ → Transitive _<_ → _<_ Respects₂ _≈_ →
-                   IsPreorder _≋_ _≼_
+    ≤-decidable : Decidable _≈_ → Decidable _≺_ → Decidable _≤_
+    ≤-decidable = Core.decidable (yes tt)
+
+    ≤-respects₂ : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ →
+                  _≤_ Respects₂ _≋_
+    ≤-respects₂ = Core.respects₂
+
+    ≤-isPreorder : IsEquivalence _≈_ → Transitive _≺_ →
+                   _≺_ Respects₂ _≈_ → IsPreorder _≋_ _≤_
     ≤-isPreorder eq tr resp = record
       { isEquivalence = Pointwise.isEquivalence eq
-      ; reflexive     = ≤-reflexive _≈_ _<_
-      ; trans         = transitive eq resp tr
+      ; reflexive     = ≤-reflexive _≈_ _≺_
+      ; trans         = Core.transitive eq resp tr
       }
 
-    ≤-isPartialOrder : IsStrictPartialOrder _≈_ _<_ → IsPartialOrder _≋_ _≼_
+    ≤-isPartialOrder : IsStrictPartialOrder _≈_ _≺_ →
+                       IsPartialOrder _≋_ _≤_
     ≤-isPartialOrder  spo = record
       { isPreorder = ≤-isPreorder isEquivalence trans <-resp-≈
-      ; antisym    = antisymmetric Eq.sym irrefl
-                                   (trans∧irr⟶asym {_≈_ = _≈_} Eq.refl trans irrefl)
+      ; antisym    = Core.antisymmetric Eq.sym irrefl asymmetric
       }
       where open IsStrictPartialOrder spo
 
-    ≤-isTotalOrder : IsStrictTotalOrder _≈_ _<_ → IsTotalOrder _≋_ _≼_
+    ≤-isTotalOrder : IsStrictTotalOrder _≈_ _≺_ → IsTotalOrder _≋_ _≤_
     ≤-isTotalOrder sto = record
       { isPartialOrder = ≤-isPartialOrder isStrictPartialOrder
       ; total          = ≤-total Eq.sym compare
       }
       where open IsStrictTotalOrder sto
 
-    ≤-isDecTotalOrder : IsStrictTotalOrder _≈_ _<_ → IsDecTotalOrder _≋_ _≼_
+    ≤-isDecTotalOrder : IsStrictTotalOrder _≈_ _≺_ →
+                        IsDecTotalOrder _≋_ _≤_
     ≤-isDecTotalOrder sto = record
       { isTotalOrder = ≤-isTotalOrder sto
       ; _≟_          = Pointwise.decidable _≟_
       ; _≤?_         = ≤-decidable _≟_ _<?_
       }
       where open IsStrictTotalOrder sto
-
--- "Packages" (e.g. preorders) can also be handled.
 
 ≤-preorder : ∀ {a ℓ₁ ℓ₂} → Preorder a ℓ₁ ℓ₂ → Preorder _ _ _
 ≤-preorder pre = record
@@ -303,7 +220,8 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
   { isPartialOrder = ≤-isPartialOrder isStrictPartialOrder
   } where open StrictPartialOrder spo
 
-≤-decTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ → DecTotalOrder _ _ _
+≤-decTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ →
+                  DecTotalOrder _ _ _
 ≤-decTotalOrder sto = record
   { isDecTotalOrder = ≤-isDecTotalOrder isStrictTotalOrder
   } where open StrictTotalOrder sto

--- a/src/Data/List/Relation/StrictLex.agda
+++ b/src/Data/List/Relation/StrictLex.agda
@@ -5,79 +5,54 @@
 ------------------------------------------------------------------------
 
 -- The definition of lexicographic ordering used here is suitable if
--- the argument order is a strict partial order. The lexicographic
--- ordering itself can be either strict or non-strict, depending on
--- the value of a parameter.
+-- the argument order is a strict partial order. 
 
 module Data.List.Relation.StrictLex where
 
-open import Data.Empty
+open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤; tt)
-open import Function
-open import Data.Product
-open import Data.Sum
-open import Data.List.Base
-open import Level
-open import Relation.Nullary
+open import Function using (_∘_; flip; id)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Sum using (inj₁; inj₂)
+open import Data.List.Base using (List; []; _∷_)
+open import Level using (_⊔_)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
 open import Relation.Binary
 open import Relation.Binary.Consequences
 open import Data.List.Relation.Pointwise as Pointwise
    using ([]; _∷_; head; tail)
 
-module _ {A : Set} where
+-- The lexicographic ordering itself can be either strict or non-strict,
+-- depending on whether type P is inhabited.
 
-  data Lex (P : Set) (_≈_ _<_ : Rel A zero) : Rel (List A) zero where
-    base : P                             → Lex P _≈_ _<_ []       []
-    halt : ∀ {y ys}                      → Lex P _≈_ _<_ []       (y ∷ ys)
-    this : ∀ {x xs y ys} (x<y : x < y)   → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
-    next : ∀ {x xs y ys} (x≈y : x ≈ y)
-           (xs⊴ys : Lex P _≈_ _<_ xs ys) → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
+data Lex {a ℓ₁ ℓ₂} {A : Set a} (P : Set) (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) : Rel (List A) (ℓ₁ ⊔ ℓ₂) where
+  base : P                             → Lex P _≈_ _<_ []       []
+  halt : ∀ {y ys}                      → Lex P _≈_ _<_ []       (y ∷ ys)
+  this : ∀ {x xs y ys} (x<y : x < y)   → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
+  next : ∀ {x xs y ys} (x≈y : x ≈ y)
+         (xs⊴ys : Lex P _≈_ _<_ xs ys) → Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
 
-  -- Strict lexicographic ordering.
+-- General properties
 
-  Lex-< : (_≈_ _<_ : Rel A zero) → Rel (List A) zero
-  Lex-< = Lex ⊥
+module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set} {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
 
-  ¬[]<[] : ∀ {_≈_ _<_} → ¬ Lex-< _≈_ _<_ [] []
-  ¬[]<[] (base ())
+  private
+    _≋_ = Pointwise.Rel _≈_
+    _≺_ = Lex P _≈_ _<_
+  
+  ¬≤-this : ∀ {x y xs ys} → ¬ (x ≈ y) → ¬ (x < y) →
+            ¬ (x ∷ xs) ≺ (y ∷ ys)
+  ¬≤-this x≉y x≮y (this x<y)       = x≮y x<y
+  ¬≤-this x≉y x≮y (next x≈y xs⊴ys) = x≉y x≈y
 
-  -- Non-strict lexicographic ordering.
+  ¬≤-next : ∀ {x y xs ys} → ¬ x < y → ¬ xs ≺ ys →
+            ¬ (x ∷ xs) ≺ (y ∷ ys)
+  ¬≤-next x≮y ¬xs⊴ys (this x<y)       = x≮y x<y
+  ¬≤-next x≮y ¬xs⊴ys (next x≈y xs⊴ys) = ¬xs⊴ys xs⊴ys
 
-  Lex-≤ : (_≈_ _<_ : Rel A zero) → Rel (List A) zero
-  Lex-≤ = Lex ⊤
-
-  -- Utilities.
-
-  ¬≤-this : ∀ {P _≈_ _<_ x y xs ys} → ¬ (x ≈ y) → ¬ (x < y) →
-            ¬ Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
-  ¬≤-this ¬x≈y ¬x<y (this x<y)       = ¬x<y x<y
-  ¬≤-this ¬x≈y ¬x<y (next x≈y xs⊴ys) = ¬x≈y x≈y
-
-  ¬≤-next : ∀ {P _≈_ _<_ x y xs ys} →
-            ¬ (x < y) → ¬ Lex P _≈_ _<_ xs ys →
-            ¬ Lex P _≈_ _<_ (x ∷ xs) (y ∷ ys)
-  ¬≤-next ¬x<y ¬xs⊴ys (this x<y)       = ¬x<y x<y
-  ¬≤-next ¬x<y ¬xs⊴ys (next x≈y xs⊴ys) = ¬xs⊴ys xs⊴ys
-
-  ----------------------------------------------------------------------
-  -- Properties
-
-  ≤-reflexive : ∀ _≈_ _<_ → Pointwise.Rel _≈_ ⇒ Lex-≤ _≈_ _<_
-  ≤-reflexive _≈_ _<_ []            = base tt
-  ≤-reflexive _≈_ _<_ (x≈y ∷ xs≈ys) =
-    next x≈y (≤-reflexive _≈_ _<_ xs≈ys)
-
-  <-irreflexive : ∀ {_≈_ _<_} → Irreflexive _≈_ _<_ →
-                  Irreflexive (Pointwise.Rel _≈_) (Lex-< _≈_ _<_)
-  <-irreflexive irr []            (base ())
-  <-irreflexive irr (x≈y ∷ xs≈ys) (this x<y)       = irr x≈y x<y
-  <-irreflexive irr (x≈y ∷ xs≈ys) (next x≊y xs⊴ys) =
-    <-irreflexive irr xs≈ys xs⊴ys
-
-  transitive : ∀ {P _≈_ _<_} →
-               IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
-               Transitive (Lex P _≈_ _<_)
-  transitive {P} {_≈_} {_<_} eq resp tr = trans
+  transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
+               Transitive _≺_
+  transitive eq resp tr = trans
     where
     trans : Transitive (Lex P _≈_ _<_)
     trans (base p)         (base _)         = base p
@@ -87,17 +62,15 @@ module _ {A : Set} where
     trans (this x<y)       (this y<z)       = this (tr x<y y<z)
     trans (this x<y)       (next y≈z ys⊴zs) = this (proj₁ resp y≈z x<y)
     trans (next x≈y xs⊴ys) (this y<z)       =
-       this (proj₂ resp (IsEquivalence.sym eq x≈y) y<z)
+      this (proj₂ resp (IsEquivalence.sym eq x≈y) y<z)
     trans (next x≈y xs⊴ys) (next y≈z ys⊴zs) =
-       next (IsEquivalence.trans eq x≈y y≈z) (trans xs⊴ys ys⊴zs)
+      next (IsEquivalence.trans eq x≈y y≈z) (trans xs⊴ys ys⊴zs)
 
-  antisymmetric :
-    ∀ {P _≈_ _<_} →
-    Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
-    Antisymmetric (Pointwise.Rel _≈_) (Lex P _≈_ _<_)
-  antisymmetric {P} {_≈_} {_<_} sym ir asym = as
+  antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
+                  Antisymmetric _≋_ _≺_
+  antisymmetric sym ir asym = as
     where
-    as : Antisymmetric (Pointwise.Rel _≈_) (Lex P _≈_ _<_)
+    as : Antisymmetric _≋_ _≺_
     as (base _)         (base _)         = []
     as halt             ()
     as (this x<y)       (this y<x)       = ⊥-elim (asym x<y y<x)
@@ -105,198 +78,232 @@ module _ {A : Set} where
     as (next x≈y xs⊴ys) (this y<x)       = ⊥-elim (ir (sym x≈y) y<x)
     as (next x≈y xs⊴ys) (next y≈x ys⊴xs) = x≈y ∷ as xs⊴ys ys⊴xs
 
-  <-asymmetric : ∀ {_≈_ _<_} →
-                 Symmetric _≈_ → _<_ Respects₂ _≈_ → Asymmetric _<_ →
-                 Asymmetric (Lex-< _≈_ _<_)
-  <-asymmetric {_≈_} {_<_} sym resp as = asym
+  respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≺_ Respects₂ _≋_
+  respects₂ eq (resp₁ , resp₂) = resp¹ , resp²
     where
-    irrefl : Irreflexive _≈_ _<_
-    irrefl = asym⟶irr resp sym as
-
-    asym : Asymmetric (Lex-< _≈_ _<_)
-    asym (base bot)       _                = bot
-    asym halt             ()
-    asym (this x<y)       (this y<x)       = as x<y y<x
-    asym (this x<y)       (next y≈x ys⊴xs) = irrefl (sym y≈x) x<y
-    asym (next x≈y xs⊴ys) (this y<x)       = irrefl (sym x≈y) y<x
-    asym (next x≈y xs⊴ys) (next y≈x ys⊴xs) = asym xs⊴ys ys⊴xs
-
-  respects₂ : ∀ {P _≈_ _<_} →
-              IsEquivalence _≈_ → _<_ Respects₂ _≈_ →
-              Lex P _≈_ _<_ Respects₂ Pointwise.Rel _≈_
-  respects₂ {P} {_≈_} {_<_} eq resp =
-    (λ {xs} {ys} {zs} → resp¹ {xs} {ys} {zs}) ,
-    (λ {xs} {ys} {zs} → resp² {xs} {ys} {zs})
-    where
-    resp¹ : ∀ {xs} → Lex P _≈_ _<_ xs Respects Pointwise.Rel _≈_
+    open IsEquivalence eq using () renaming (sym to ≈-sym; trans to ≈-trans)
+    
+    resp¹ : ∀ {xs} → Lex P _≈_ _<_ xs Respects _≋_
     resp¹ []            xs⊴[]            = xs⊴[]
-    resp¹ (x≈y ∷ xs≈ys) halt             = halt
-    resp¹ (x≈y ∷ xs≈ys) (this z<x)       = this (proj₁ resp x≈y z<x)
-    resp¹ (x≈y ∷ xs≈ys) (next z≈x zs⊴xs) =
-      next (Eq.trans z≈x x≈y) (resp¹ xs≈ys zs⊴xs)
-      where module Eq = IsEquivalence eq
+    resp¹ (_   ∷ _)     halt             = halt
+    resp¹ (x≈y ∷ _)     (this z<x)       = this (resp₁ x≈y z<x)
+    resp¹ (x≈y ∷ xs≋ys) (next z≈x zs⊴xs) =
+      next (≈-trans z≈x x≈y) (resp¹ xs≋ys zs⊴xs)
 
-    resp² : ∀ {ys} → flip (Lex P _≈_ _<_) ys Respects Pointwise.Rel _≈_
+    resp² : ∀ {ys} → flip (Lex P _≈_ _<_) ys Respects _≋_
     resp² []            []⊴ys            = []⊴ys
-    resp² (x≈z ∷ xs≈zs) (this x<y)       = this (proj₂ resp x≈z x<y)
-    resp² (x≈z ∷ xs≈zs) (next x≈y xs⊴ys) =
-      next (Eq.trans (Eq.sym x≈z) x≈y) (resp² xs≈zs xs⊴ys)
-      where module Eq = IsEquivalence eq
+    resp² (x≈z ∷ _)     (this x<y)       = this (resp₂ x≈z x<y)
+    resp² (x≈z ∷ xs≋zs) (next x≈y xs⊴ys) =
+      next (≈-trans (≈-sym x≈z) x≈y) (resp² xs≋zs xs⊴ys)
 
-  decidable : ∀ {P _≈_ _<_} →
-              Dec P → Decidable _≈_ → Decidable _<_ →
-              Decidable (Lex P _≈_ _<_)
+  decidable : Dec P → Decidable _≈_ → Decidable _<_ → Decidable _≺_
   decidable (yes p) dec-≈ dec-< []       []       = yes (base p)
   decidable (no ¬p) dec-≈ dec-< []       []       = no λ{(base p) → ¬p p}
   decidable dec-P   dec-≈ dec-< []       (y ∷ ys) = yes halt
-  decidable dec-P   dec-≈ dec-< (x ∷ xs) []       = no (λ ())
+  decidable dec-P   dec-≈ dec-< (x ∷ xs) []       = no λ()
   decidable dec-P   dec-≈ dec-< (x ∷ xs) (y ∷ ys) with dec-< x y
   ... | yes x<y = yes (this x<y)
-  ... | no ¬x<y with dec-≈ x y
-  ...           | no ¬x≈y = no (¬≤-this ¬x≈y ¬x<y)
-  ...           | yes x≈y with decidable dec-P dec-≈ dec-< xs ys
-  ...                     | yes xs⊴ys = yes (next x≈y xs⊴ys)
-  ...                     | no ¬xs⊴ys = no (¬≤-next ¬x<y ¬xs⊴ys)
+  ... | no x≮y with dec-≈ x y
+  ...   | no x≉y = no (¬≤-this x≉y x≮y)
+  ...   | yes x≈y with decidable dec-P dec-≈ dec-< xs ys
+  ...     | yes xs⊴ys = yes (next x≈y xs⊴ys)
+  ...     | no ¬xs⊴ys = no (¬≤-next x≮y ¬xs⊴ys)
+  
+----------------------------------------------------------------------
+-- Strict lexicographic ordering.
 
-  <-decidable :
-    ∀ {_≈_ _<_} →
-    Decidable _≈_ → Decidable _<_ → Decidable (Lex-< _≈_ _<_)
-  <-decidable = decidable (no id)
+module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
-  ≤-decidable :
-    ∀ {_≈_ _<_} →
-    Decidable _≈_ → Decidable _<_ → Decidable (Lex-≤ _≈_ _<_)
-  ≤-decidable = decidable (yes tt)
+  Lex-< : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
+  Lex-< = Lex ⊥
+  
+  -- Properties
 
-  -- Note that trichotomy is an unnecessarily strong precondition for
-  -- the following lemma.
+  module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
+  
+    private
+      _≋_ = Pointwise.Rel _≈_
+      _≺_ = Lex-< _≈_ _<_
+    
+    ¬[]<[] : ¬ [] ≺ []
+    ¬[]<[] (base ())
 
-  ≤-total :
-    ∀ {_≈_ _<_} →
-    Symmetric _≈_ → Trichotomous _≈_ _<_ → Total (Lex-≤ _≈_ _<_)
-  ≤-total {_≈_} {_<_} sym tri = total
-    where
-    total : Total (Lex-≤ _≈_ _<_)
-    total []       []       = inj₁ (base tt)
-    total []       (x ∷ xs) = inj₁ halt
-    total (x ∷ xs) []       = inj₂ halt
-    total (x ∷ xs) (y ∷ ys) with tri x y
+    <-irreflexive : Irreflexive _≈_ _<_ → Irreflexive _≋_ _≺_
+    <-irreflexive irr []            (base ())
+    <-irreflexive irr (x≈y ∷ xs≋ys) (this x<y)     = irr x≈y x<y
+    <-irreflexive irr (x≈y ∷ xs≋ys) (next _ xs⊴ys) =
+      <-irreflexive irr xs≋ys xs⊴ys
+
+    <-asymmetric : Symmetric _≈_ → _<_ Respects₂ _≈_ → Asymmetric _<_ →
+                   Asymmetric _≺_
+    <-asymmetric sym resp as = asym
+      where
+      irrefl : Irreflexive _≈_ _<_
+      irrefl = asym⟶irr resp sym as
+
+      asym : Asymmetric _≺_
+      asym (halt)           ()
+      asym (base bot)       _                = bot
+      asym (this x<y)       (this y<x)       = as x<y y<x
+      asym (this x<y)       (next y≈x ys⊴xs) = irrefl (sym y≈x) x<y
+      asym (next x≈y xs⊴ys) (this y<x)       = irrefl (sym x≈y) y<x
+      asym (next x≈y xs⊴ys) (next y≈x ys⊴xs) = asym xs⊴ys ys⊴xs
+
+    <-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
+                      Antisymmetric _≋_ _≺_
+    <-antisymmetric = antisymmetric
+    
+    <-transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
+                   Transitive _≺_
+    <-transitive = transitive
+    
+    <-decidable : Decidable _≈_ → Decidable _<_ → Decidable _≺_
+    <-decidable = decidable (no id)
+
+    <-respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≺_ Respects₂ _≋_
+    <-respects₂ = respects₂
+    
+    <-compare : Symmetric _≈_ → Trichotomous _≈_ _<_ → Trichotomous _≋_ _≺_
+    <-compare sym tri = cmp
+      where
+      cmp : Trichotomous _≋_ _≺_
+      cmp []       []       = tri≈ ¬[]<[] []    ¬[]<[]
+      cmp []       (y ∷ ys) = tri< halt   (λ()) (λ())
+      cmp (x ∷ xs) []       = tri> (λ())  (λ()) halt
+      cmp (x ∷ xs) (y ∷ ys) with tri x y
+      ... | tri< x<y x≉y y≮x =
+            tri< (this x<y) (x≉y ∘ head) (¬≤-this (x≉y ∘ sym) y≮x)
+      ... | tri> x≮y x≉y y<x =
+            tri> (¬≤-this x≉y x≮y) (x≉y ∘ head) (this y<x)
+      ... | tri≈ x≮y x≈y y≮x with cmp xs ys
+      ...   | tri< xs<ys xs≉ys ys≮xs =
+              tri< (next x≈y xs<ys) (xs≉ys ∘ tail) (¬≤-next y≮x ys≮xs)
+      ...   | tri≈ ¬xs<ys xs≈ys ys≮xs =
+              tri≈ (¬≤-next x≮y ¬xs<ys) (x≈y ∷ xs≈ys) (¬≤-next y≮x ys≮xs)
+      ...   | tri> ¬xs<ys xs≉ys ys<xs =
+              tri> (¬≤-next x≮y ¬xs<ys) (xs≉ys ∘ tail) (next (sym x≈y) ys<xs)
+
+    
+    <-isStrictPartialOrder : IsStrictPartialOrder _≈_ _<_ →
+                           IsStrictPartialOrder _≋_ _≺_
+    <-isStrictPartialOrder spo = record
+      { isEquivalence = Pointwise.isEquivalence isEquivalence
+      ; irrefl        = <-irreflexive irrefl
+      ; trans         = transitive isEquivalence <-resp-≈ trans
+      ; <-resp-≈      = respects₂ isEquivalence <-resp-≈
+      } where open IsStrictPartialOrder spo
+
+    <-isStrictTotalOrder : IsStrictTotalOrder _≈_ _<_ →
+                         IsStrictTotalOrder _≋_ _≺_
+    <-isStrictTotalOrder sto = record
+      { isEquivalence = Pointwise.isEquivalence isEquivalence
+      ; trans         = <-transitive isEquivalence <-resp-≈ trans
+      ; compare       = <-compare Eq.sym compare
+      } where open IsStrictTotalOrder sto
+
+<-strictPartialOrder : ∀ {a ℓ₁ ℓ₂} → StrictPartialOrder a ℓ₁ ℓ₂ → StrictPartialOrder _ _ _
+<-strictPartialOrder spo = record
+  { isStrictPartialOrder = <-isStrictPartialOrder isStrictPartialOrder
+  } where open StrictPartialOrder spo
+  
+<-strictTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ → StrictTotalOrder _ _ _
+<-strictTotalOrder sto = record
+  { isStrictTotalOrder = <-isStrictTotalOrder isStrictTotalOrder
+  } where open StrictTotalOrder sto
+
+----------------------------------------------------------------------
+-- Non-strict lexicographic ordering.
+
+module _ {a ℓ₁ ℓ₂} {A : Set a} where
+
+  Lex-≤ : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Rel (List A) (ℓ₁ ⊔ ℓ₂)
+  Lex-≤ = Lex ⊤
+
+  -- Properties
+
+  ≤-reflexive : (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂) → Pointwise.Rel _≈_ ⇒ Lex-≤ _≈_ _<_
+  ≤-reflexive _≈_ _<_ []            = base tt
+  ≤-reflexive _≈_ _<_ (x≈y ∷ xs≈ys) =
+    next x≈y (≤-reflexive _≈_ _<_ xs≈ys)
+
+  module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
+
+    private
+      _≋_ = Pointwise.Rel _≈_
+      _≼_ = Lex-≤ _≈_ _<_
+
+    ≤-antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _<_ →  Asymmetric _<_ →
+                      Antisymmetric _≋_ _≼_
+    ≤-antisymmetric = antisymmetric
+    
+    ≤-transitive : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → Transitive _<_ →
+                   Transitive _≼_
+    ≤-transitive = transitive
+
+    -- Note that trichotomy is an unnecessarily strong precondition for
+    -- the following lemma.
+
+    ≤-total : Symmetric _≈_ → Trichotomous _≈_ _<_ → Total _≼_
+    ≤-total _   _   []       []       = inj₁ (base tt)
+    ≤-total _   _   []       (x ∷ xs) = inj₁ halt
+    ≤-total _   _   (x ∷ xs) []       = inj₂ halt
+    ≤-total sym tri (x ∷ xs) (y ∷ ys) with tri x y
     ... | tri< x<y _ _ = inj₁ (this x<y)
     ... | tri> _ _ y<x = inj₂ (this y<x)
-    ... | tri≈ _ x≈y _ with total xs ys
-    ...                | inj₁ xs≲ys = inj₁ (next      x≈y  xs≲ys)
-    ...                | inj₂ ys≲xs = inj₂ (next (sym x≈y) ys≲xs)
+    ... | tri≈ _ x≈y _ with ≤-total sym tri xs ys
+    ...   | inj₁ xs≲ys = inj₁ (next      x≈y  xs≲ys)
+    ...   | inj₂ ys≲xs = inj₂ (next (sym x≈y) ys≲xs)
+    
+    ≤-decidable : Decidable _≈_ → Decidable _<_ → Decidable _≼_
+    ≤-decidable = decidable (yes tt)
 
-  <-compare : ∀ {_≈_ _<_} →
-              Symmetric _≈_ → Trichotomous _≈_ _<_ →
-              Trichotomous (Pointwise.Rel _≈_) (Lex-< _≈_ _<_)
-  <-compare {_≈_} {_<_} sym tri = cmp
-   where
-   cmp : Trichotomous (Pointwise.Rel _≈_) (Lex-< _≈_ _<_)
-   cmp []       []       = tri≈ ¬[]<[] [] ¬[]<[]
-   cmp []       (y ∷ ys) = tri< halt (λ ()) (λ ())
-   cmp (x ∷ xs) []       = tri> (λ ()) (λ ()) halt
-   cmp (x ∷ xs) (y ∷ ys) with tri x y
-   ... | tri< x<y ¬x≈y ¬y<x =
-         tri< (this x<y) (¬x≈y ∘ head) (¬≤-this (¬x≈y ∘ sym) ¬y<x)
-   ... | tri> ¬x<y ¬x≈y y<x =
-         tri> (¬≤-this ¬x≈y ¬x<y) (¬x≈y ∘ head) (this y<x)
-   ... | tri≈ ¬x<y x≈y ¬y<x with cmp xs ys
-   ...    | tri< xs<ys ¬xs≈ys ¬ys<xs =
-            tri< (next x≈y xs<ys) (¬xs≈ys ∘ tail) (¬≤-next ¬y<x ¬ys<xs)
-   ...    | tri≈ ¬xs<ys xs≈ys ¬ys<xs =
-            tri≈ (¬≤-next ¬x<y ¬xs<ys) (x≈y ∷ xs≈ys) (¬≤-next ¬y<x ¬ys<xs)
-   ...    | tri> ¬xs<ys ¬xs≈ys ys<xs =
-            tri> (¬≤-next ¬x<y ¬xs<ys) (¬xs≈ys ∘ tail) (next (sym x≈y) ys<xs)
+    ≤-respects₂ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≼_ Respects₂ _≋_
+    ≤-respects₂ = respects₂
+    
+    ≤-isPreorder : IsEquivalence _≈_ → Transitive _<_ → _<_ Respects₂ _≈_ →
+                   IsPreorder _≋_ _≼_
+    ≤-isPreorder eq tr resp = record
+      { isEquivalence = Pointwise.isEquivalence eq
+      ; reflexive     = ≤-reflexive _≈_ _<_
+      ; trans         = transitive eq resp tr
+      }
 
-  -- Some collections of properties which are preserved by Lex-≤ or
-  -- Lex-<.
+    ≤-isPartialOrder : IsStrictPartialOrder _≈_ _<_ → IsPartialOrder _≋_ _≼_
+    ≤-isPartialOrder  spo = record
+      { isPreorder = ≤-isPreorder isEquivalence trans <-resp-≈
+      ; antisym    = antisymmetric Eq.sym irrefl
+                                   (trans∧irr⟶asym {_≈_ = _≈_} Eq.refl trans irrefl)
+      }
+      where open IsStrictPartialOrder spo
 
-  ≤-isPreorder : ∀ {_≈_ _<_} →
-                 IsEquivalence _≈_ → Transitive _<_ → _<_ Respects₂ _≈_ →
-                 IsPreorder (Pointwise.Rel _≈_) (Lex-≤ _≈_ _<_)
-  ≤-isPreorder {_≈_} {_<_} eq tr resp = record
-    { isEquivalence = Pointwise.isEquivalence eq
-    ; reflexive     = ≤-reflexive _≈_ _<_
-    ; trans         = transitive eq resp tr
-    }
+    ≤-isTotalOrder : IsStrictTotalOrder _≈_ _<_ → IsTotalOrder _≋_ _≼_
+    ≤-isTotalOrder sto = record
+      { isPartialOrder = ≤-isPartialOrder isStrictPartialOrder
+      ; total          = ≤-total Eq.sym compare
+      }
+      where open IsStrictTotalOrder sto
 
-  ≤-isPartialOrder : ∀ {_≈_ _<_} →
-                     IsStrictPartialOrder _≈_ _<_ →
-                     IsPartialOrder (Pointwise.Rel _≈_) (Lex-≤ _≈_ _<_)
-  ≤-isPartialOrder {_≈_} {_<_} spo = record
-    { isPreorder = ≤-isPreorder isEquivalence trans <-resp-≈
-    ; antisym    = antisymmetric Eq.sym irrefl
-                     (trans∧irr⟶asym {_≈_ = _≈_} {_<_ = _<_}
-                                     Eq.refl trans irrefl)
-    } where open IsStrictPartialOrder spo
-
-  ≤-isTotalOrder : ∀ {_≈_ _<_} →
-                   IsStrictTotalOrder _≈_ _<_ →
-                   IsTotalOrder (Pointwise.Rel _≈_) (Lex-≤ _≈_ _<_)
-  ≤-isTotalOrder sto = record
-    { isPartialOrder =
-        ≤-isPartialOrder (record
-          { isEquivalence = isEquivalence
-          ; irrefl        = tri⟶irr compare
-          ; trans         = trans
-          ; <-resp-≈      = <-resp-≈
-          })
-    ; total          = ≤-total Eq.sym compare
-    } where open IsStrictTotalOrder sto
-
-  ≤-isDecTotalOrder : ∀ {_≈_ _<_} →
-                      IsStrictTotalOrder _≈_ _<_ →
-                      IsDecTotalOrder (Pointwise.Rel _≈_) (Lex-≤ _≈_ _<_)
-  ≤-isDecTotalOrder sto = record
-    { isTotalOrder = ≤-isTotalOrder sto
-    ; _≟_          = Pointwise.decidable _≟_
-    ; _≤?_         = ≤-decidable _≟_ (tri⟶dec< compare)
-    } where open IsStrictTotalOrder sto
-
-  <-isStrictPartialOrder
-    : ∀ {_≈_ _<_} → IsStrictPartialOrder _≈_ _<_ →
-      IsStrictPartialOrder (Pointwise.Rel _≈_) (Lex-< _≈_ _<_)
-  <-isStrictPartialOrder spo = record
-    { isEquivalence = Pointwise.isEquivalence isEquivalence
-    ; irrefl        = <-irreflexive irrefl
-    ; trans         = transitive isEquivalence <-resp-≈ trans
-    ; <-resp-≈      = respects₂ isEquivalence <-resp-≈
-    } where open IsStrictPartialOrder spo
-
-  <-isStrictTotalOrder
-    : ∀ {_≈_ _<_} → IsStrictTotalOrder _≈_ _<_ →
-      IsStrictTotalOrder (Pointwise.Rel _≈_) (Lex-< _≈_ _<_)
-  <-isStrictTotalOrder sto = record
-    { isEquivalence = Pointwise.isEquivalence isEquivalence
-    ; trans         = transitive isEquivalence <-resp-≈ trans
-    ; compare       = <-compare Eq.sym compare
-    } where open IsStrictTotalOrder sto
+    ≤-isDecTotalOrder : IsStrictTotalOrder _≈_ _<_ → IsDecTotalOrder _≋_ _≼_
+    ≤-isDecTotalOrder sto = record
+      { isTotalOrder = ≤-isTotalOrder sto
+      ; _≟_          = Pointwise.decidable _≟_
+      ; _≤?_         = ≤-decidable _≟_ _<?_
+      }
+      where open IsStrictTotalOrder sto
 
 -- "Packages" (e.g. preorders) can also be handled.
 
-≤-preorder : Preorder _ _ _ → Preorder _ _ _
+≤-preorder : ∀ {a ℓ₁ ℓ₂} → Preorder a ℓ₁ ℓ₂ → Preorder _ _ _
 ≤-preorder pre = record
   { isPreorder = ≤-isPreorder isEquivalence trans ∼-resp-≈
   } where open Preorder pre
 
-≤-partialOrder : StrictPartialOrder _ _ _ → Poset _ _ _
+≤-partialOrder : ∀ {a ℓ₁ ℓ₂} → StrictPartialOrder a ℓ₁ ℓ₂ → Poset _ _ _
 ≤-partialOrder spo = record
   { isPartialOrder = ≤-isPartialOrder isStrictPartialOrder
   } where open StrictPartialOrder spo
 
-≤-decTotalOrder : StrictTotalOrder _ _ _ → DecTotalOrder _ _ _
+≤-decTotalOrder : ∀ {a ℓ₁ ℓ₂} → StrictTotalOrder a ℓ₁ ℓ₂ → DecTotalOrder _ _ _
 ≤-decTotalOrder sto = record
   { isDecTotalOrder = ≤-isDecTotalOrder isStrictTotalOrder
-  } where open StrictTotalOrder sto
-
-<-strictPartialOrder :
-  StrictPartialOrder _ _ _ → StrictPartialOrder _ _ _
-<-strictPartialOrder spo = record
-  { isStrictPartialOrder = <-isStrictPartialOrder isStrictPartialOrder
-  } where open StrictPartialOrder spo
-
-<-strictTotalOrder : StrictTotalOrder _ _ _ → StrictTotalOrder _ _ _
-<-strictTotalOrder sto = record
-  { isStrictTotalOrder = <-isStrictTotalOrder isStrictTotalOrder
   } where open StrictTotalOrder sto

--- a/src/Relation/Binary/List/NonStrictLex.agda
+++ b/src/Relation/Binary/List/NonStrictLex.agda
@@ -15,3 +15,5 @@
 module Relation.Binary.List.NonStrictLex where
 
 open import Data.List.Relation.NonStrictLex public
+  hiding (base; halt; this; next; ¬≤-this; ¬≤-next)
+open import Data.List.Relation.Lex.Core public

--- a/src/Relation/Binary/List/StrictLex.agda
+++ b/src/Relation/Binary/List/StrictLex.agda
@@ -14,4 +14,6 @@
 
 module Relation.Binary.List.StrictLex where
 
+open import Data.List.Relation.Lex.Core
 open import Data.List.Relation.StrictLex
+  hiding (base; halt; this; next; ¬≤-this; ¬≤-next)


### PR DESCRIPTION
Achieves:
 - increasing the level polymorphism as per #180 
 - moves the content shared by `StrictLex` and `NonStrictLex` into `Lex.Core`
 - standardised the notation used within the modules. Now uses `_≼_` for the base relation and `_<_` and `_≤_` for the resulting lexicographic
 - added a few extra proofs

Hopefully everyone agrees that this makes the files far easier to read.

EDIT: definitely backwards compatible as everything is re-exported from the deprecated `Relation.Binary.List.(Non)StrictLex`