### PR TITLE
Strengthen gmap for Data.Vec.Relation.InductivePointwise.

### DIFF
--- a/src/Data/Vec/Relation/InductivePointwise.agda
+++ b/src/Data/Vec/Relation/InductivePointwise.agda
@@ -51,11 +51,18 @@ module _ {a b} {A : Set a} {B : Set b} where
   map ~⇒~′ []             = []
   map ~⇒~′ (x∼y ∷ xs~ys) = ~⇒~′ x∼y ∷ map ~⇒~′ xs~ys
 
+  gmap′ : ∀ {c d ℓ} {C : Set c} {D : Set d} {_~_ : REL A C ℓ} {_~′_ : REL B D ℓ}
+            {f : A → B} {g : C → D} →
+          (∀ {x y} → x ~ y → f x ~′ g y) →
+          ∀ {n xs ys} → Pointwise _~_ {n} xs ys →
+            Pointwise _~′_ (Vec.map f xs) (Vec.map g ys)
+  gmap′ ~⇒~′ []             = []
+  gmap′ ~⇒~′ (x∼y ∷ xs~ys) = ~⇒~′ x∼y ∷ gmap′ ~⇒~′ xs~ys
+
   gmap : ∀ {ℓ} {_~_ : Rel A ℓ} {_~′_ : Rel B ℓ} {f : A → B} {n} →
          _~_ =[ f ]⇒ _~′_ →
          Pointwise _~_ =[ Vec.map {n = n} f ]⇒ Pointwise _~′_
-  gmap ~⇒~′ []             = []
-  gmap ~⇒~′ (x∼y ∷ xs~ys) = ~⇒~′ x∼y ∷ gmap ~⇒~′ xs~ys
+  gmap ~⇒~′ xs~ys = gmap′ ~⇒~′ xs~ys
 
 -- Appending
 module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where


### PR DESCRIPTION
The removal of `All₂` from `Data.Vec.All` (and the associated properties from `Data.Vec.All.Properties`) in 81fc9c6 has lead to a slight regression since the discarded `gmap₂` function was stronger than the corresponding `gmap` function in `Data.Vec.Relation.InductivePointwise`. The `gmap` function only applies to homogeneous relations (i.e. those in some `Rel A ℓ`), where as the old `gmap₂` also worked for heterogeneous relations (those in some `REL A B ℓ`).

Since I use `gmap₂` in some of my projects, I won't be able to migrate those to the latest version of the standard library unless `gmap` for `InductivePointwise` is strengthened. I'm afraid this might break other people's code, so for now, I have added a stronger version of `gmap` called `gmap′` (not an ideal name, I know) and redefined `gmap` as an alias of `gmap′`.

The two functions `gmap₂₁` and `gmap₂₂` seem to have been completely discarded in 81fc9c6. I didn't reintroduce them in the PR since I don't currently use them myself and I don't know whether they are used by anyone else. See [the old version of Data.Vec.All.Properties](https://github.com/agda/agda-stdlib/blob/v0.14/src/Data/Vec/All/Properties.agda) for comparison.

