### PR TITLE
Add missing bindings to Char functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -560,6 +560,10 @@ Backwards compatible changes
   ∁? : Decidable P → Decidable (∁ P)
   ```
 
+* Added missing bindings to functions on Char - character class checks and conversion from Nat:
+  `isLower, isDigit, isAlpha, isSpace, isAscii, isLatin1, isPrint, isHexDigit, fromNat`.
+
+
 Version 0.14
 ============
 

--- a/src/Data/Char.agda
+++ b/src/Data/Char.agda
@@ -16,9 +16,10 @@ import Relation.Binary.On as On
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_)
 open import Relation.Binary.PropositionalEquality.TrustMe
 
+open import Agda.Builtin.Char using (primCharEquality)
 open import Data.String.Base using (String)
 open import Data.Char.Base
-open        Data.Char.Base public using (Char; show; toNat)
+open        Data.Char.Base public using (Char; show; toNat; fromNat)
 
 -- Informative equality test.
 

--- a/src/Data/Char/Base.agda
+++ b/src/Data/Char/Base.agda
@@ -17,11 +17,38 @@ open import Data.Char.Core using (Char) public
 ------------------------------------------------------------------------
 -- Primitive operations
 
-open import Agda.Builtin.Char   public using (primCharToNat; primCharEquality)
-open import Agda.Builtin.String public using (primShowChar)
+open import Agda.Builtin.Char
+open import Agda.Builtin.String using (primShowChar)
 
 show : Char → String
 show = primShowChar
 
+isLower : Char → Bool
+isLower = primIsLower
+
+isDigit : Char → Bool
+isDigit = primIsDigit
+
+isAlpha : Char → Bool
+isAlpha = primIsAlpha
+
+isSpace : Char → Bool
+isSpace = primIsSpace
+
+isAscii : Char → Bool
+isAscii = primIsAscii
+
+isLatin1 : Char → Bool
+isLatin1 = primIsLatin1
+
+isPrint : Char → Bool
+isPrint = primIsPrint
+
+isHexDigit : Char → Bool
+isHexDigit = primIsHexDigit
+
 toNat : Char → ℕ
 toNat = primCharToNat
+
+fromNat : ℕ → Char
+fromNat = primNatToChar


### PR DESCRIPTION
Not sure if Data.Char should be exporting all those is* checks. Also I moved the import of primCharEquality to Data.Char where it is actually used.