### PR TITLE
Purer `Data.Table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -371,6 +371,11 @@ Backwards compatible changes
   <-irrelevance     : IrrelevantRel _<_
   ```
 
+* Added new combinators to `Data.List.Base`:
+  ```agda
+  lookup : ∀ {a} {A : Set a} (xs : List A) → Fin (length xs) → A
+  ```
+
 * Added new proofs to `Data.List.Properties`:
   ```agda
   ∷-injectiveˡ  : x ∷ xs ≡ y List.∷ ys → x ≡ y
@@ -389,6 +394,10 @@ Backwards compatible changes
 
   filter-all     : All P xs → dfilter P? xs ≡ xs
   filter-none    : All (¬_ ∘ P) xs → dfilter P? xs ≡ []
+
+  tabulate-cong : ∀ {n a} {A : Set a} {f g : Fin n → A}
+                  → f ≗ g → tabulate f ≡ tabulate g
+  tabulate-lookup : ∀ {a} {A : Set a} {xs : List A} → tabulate (lookup xs) ≡ xs
   ```
 
 * Added new proofs to `Data.List.All.Properties`:
@@ -527,6 +536,7 @@ Backwards compatible changes
   lookup⇒[]=       : lookup i xs ≡ x → xs [ i ]= x
   lookup-replicate : lookup i (replicate x) ≡ x
   lookup-⊛         : lookup i (fs ⊛ xs) ≡ (lookup i fs $ lookup i xs)
+  tabulate-cong : ∀ {n a} {A : Set a} {f g : Fin n → A} → f ≗ g → tabulate f ≡ tabulate g
   ```
 
 * Added new proofs to `Data.Vec.All.Properties`
@@ -1400,6 +1410,13 @@ Backwards compatible changes
   ≅-to-type-≡  : {x : A} {y : B} → x ≅ y → A ≡ B
   ≅-to-subst-≡ : (p : x ≅ y) → subst (λ x → x) (≅-to-type-≡ p) x ≡ y
   ```
+
+* Added new modules `Data.Table`, `Data.Table.Base`,
+  `Data.Table.Relation.Equality` and `Data.Table.Properties`. A `Table` is a
+  fixed-length collection of objects similar to a `Vec` from `Data.Vec`, but
+  implemented as a function `Fin n → A`. This allows ease of lookup as opposed
+  to the ease of adding and removing elements in a `Vec`.
+
 
 Version 0.13
 ============

--- a/src/Algebra/Monoid-solver.agda
+++ b/src/Algebra/Monoid-solver.agda
@@ -10,7 +10,7 @@ module Algebra.Monoid-solver {m₁ m₂} (M : Monoid m₁ m₂) where
 
 open import Data.Fin
 import Data.Fin.Properties as Fin
-open import Data.List.Base
+open import Data.List.Base hiding (lookup)
 import Data.List.Relation.Pointwise as Pointwise
 open import Data.Maybe as Maybe
   using (Maybe; decToMaybe; From-just; from-just)

--- a/src/Data/List/All.agda
+++ b/src/Data/List/All.agda
@@ -6,7 +6,7 @@
 
 module Data.List.All where
 
-open import Data.List.Base as List hiding (map; tabulate; all)
+open import Data.List.Base as List hiding (map; tabulate; lookup; all)
 open import Data.List.Any as Any using (here; there)
 open import Data.List.Any.Membership.Propositional using (_∈_)
 open import Function

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -136,6 +136,11 @@ tabulate : ∀ {a n} {A : Set a} (f : Fin n → A) → List A
 tabulate {_} {zero}  f = []
 tabulate {_} {suc n} f = f fzero ∷ tabulate (f ∘ fsuc)
 
+lookup : ∀ {a} {A : Set a} (xs : List A) → Fin (length xs) → A
+lookup [] ()
+lookup (x ∷ xs) fzero = x
+lookup (x ∷ xs) (fsuc i) = lookup xs i
+
 -- Numerical
 
 upTo : ℕ → List ℕ

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -18,7 +18,7 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Injection
   using (Injection; module Injection)
-open import Data.List
+open import Data.List hiding (lookup)
 open import Data.List.Any as Any using (here; there)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Product

--- a/src/Data/Table.agda
+++ b/src/Data/Table.agda
@@ -1,0 +1,38 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Fixed-size tables of values, implemented as functions from 'Fin n'.
+-- Similar to 'Data.Vec', but focusing on ease of retrieval instead of
+-- ease of adding and removing elements.
+------------------------------------------------------------------------
+
+module Data.Table where
+
+open import Data.Table.Base public
+
+open import Data.Bool using (true; false)
+open import Data.Fin using (Fin)
+open import Data.Fin.Properties using (_≟_)
+import Function.Equality as FE
+open import Function.Inverse using (Inverse; _↔_)
+open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (⌊_⌋)
+
+--------------------------------------------------------------------------------
+--  Combinators
+--------------------------------------------------------------------------------
+
+-- Changes the order of elements in the table according to a permutation (i.e.
+-- an 'Inverse' object on the indices).
+
+permute : ∀ {m n a} {A : Set a} → Fin m ↔ Fin n → Table A n → Table A m
+permute π = rearrange (Inverse.to π FE.⟨$⟩_)
+
+
+-- The result of 'select z i t' takes the value of 'lookup t i' at index 'i',
+-- and 'z' everywhere else.
+
+select : ∀ {n} {a} {A : Set a} → A → Fin n → Table A n → Table A n
+lookup (select z i t) j with ⌊ j ≟ i ⌋
+lookup (select z i t) j | true = lookup t i
+lookup (select z i t) j | false = z

--- a/src/Data/Table/Base.agda
+++ b/src/Data/Table/Base.agda
@@ -1,0 +1,54 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Tables, basic types and operations
+------------------------------------------------------------------------
+
+module Data.Table.Base where
+
+open import Data.Fin
+open import Data.List as List using (List)
+open import Data.Nat using (ℕ)
+open import Function using (_∘_)
+
+record Table {a} (A : Set a) n : Set a where
+  constructor tabulate
+  field
+    lookup : Fin n → A
+
+open Table public
+
+map : ∀ {n a b} {A : Set a} {B : Set b} → (A → B) → Table A n → Table B n
+map f t = tabulate (f ∘ lookup t)
+
+
+-- A contravariant map over the indices
+
+rearrange : ∀ {a} {A : Set a} {m n} → (Fin m → Fin n) → Table A n → Table A m
+rearrange f t = tabulate (lookup t ∘ f)
+
+head : ∀ {n a} {A : Set a} → Table A (ℕ.suc n) → A
+head t = lookup t zero
+
+tail : ∀ {n a} {A : Set a} → Table A (ℕ.suc n) → Table A n
+tail t = tabulate (lookup t ∘ suc)
+
+toList : ∀ {n a} {A : Set a} → Table A n → List A
+toList = List.tabulate ∘ lookup
+
+fromList : ∀ {a} {A : Set a} (xs : List A) → Table A (List.length xs)
+fromList = tabulate ∘ List.lookup
+
+foldr : ∀ {a b} {A : Set a} {B : Set b} {n} → (A → B → B) → B → Table A n → B
+foldr {n = ℕ.zero} f z t = z
+foldr {n = ℕ.suc n} f z t = f (lookup t zero) (foldr f z (tail t))
+
+foldl : ∀ {a b} {A : Set a} {B : Set b} {n} → (B → A → B) → B → Table A n → B
+foldl {n = ℕ.zero} f z t = z
+foldl {n = ℕ.suc n} f z t = foldl f (f z (lookup t zero)) (tail t)
+
+replicate : ∀ {n a} {A : Set a} → A → Table A n
+replicate x = tabulate (λ _ → x)
+
+_⊛_ : ∀ {n a b} {A : Set a} {B : Set b} → Table (A → B) n → Table A n → Table B n
+fs ⊛ xs = tabulate λ i → lookup fs i (lookup xs i)

--- a/src/Data/Table/Properties.agda
+++ b/src/Data/Table/Properties.agda
@@ -1,0 +1,77 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Table-related properties
+------------------------------------------------------------------------
+
+module Data.Table.Properties where
+
+open import Data.Table
+open import Data.Table.Relation.Equality
+
+open import Data.Bool using (true; false; if_then_else_)
+open import Data.Fin as Fin using (Fin)
+open import Data.Fin.Properties using (_≟_)
+open import Data.List as L using (List; _∷_; [])
+open import Data.List.Any using (here; there; index)
+open import Data.List.Any.Membership.Propositional using (_∈_)
+open import Data.Product as Product using (Σ; ∃; _,_; proj₁; proj₂)
+open import Data.Vec as V using (Vec; _∷_; [])
+import Data.Vec.Properties as VP
+open import Function using (_∘_; flip)
+open import Function.Inverse using (Inverse)
+open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Relation.Nullary.Decidable using (⌊_⌋)
+
+module _ {a} {A : Set a} where
+
+  fromList-∈ : ∀ {xs : List A} (i : Fin (L.length xs)) → lookup (fromList xs) i ∈ xs
+  fromList-∈ {[]} ()
+  fromList-∈ {x ∷ xs} Fin.zero = here P.refl
+  fromList-∈ {x ∷ xs} (Fin.suc i) = there (fromList-∈ i)
+
+  index-fromList-∈ : ∀ {xs i} → index (fromList-∈ {xs} i) ≡ i
+  index-fromList-∈ {[]} {()}
+  index-fromList-∈ {x ∷ xs} {Fin.zero} = P.refl
+  index-fromList-∈ {x ∷ xs} {Fin.suc i} = P.cong Fin.suc index-fromList-∈
+
+  fromList-index : ∀ {xs} {x : A} (x∈xs : x ∈ xs) → lookup (fromList xs) (index x∈xs) ≡ x
+  fromList-index (here px) = P.sym px
+  fromList-index (there x∈xs) = fromList-index x∈xs
+
+  lookup∈ : ∀ {xs : List A} (i : Fin (L.length xs)) → ∃ λ x → x ∈ xs
+  lookup∈ i = _ , fromList-∈ i
+
+  private
+    fromVec : ∀ {n} → Vec A n → Table A n
+    fromVec = tabulate ∘ flip V.lookup
+
+    toVec : ∀ {n} → Table A n → Vec A n
+    toVec = V.tabulate ∘ lookup
+
+    fromVec-toVec : ∀ {n} (t : Table A n) → fromVec (toVec t) ≗ t
+    fromVec-toVec _ = VP.lookup∘tabulate _
+
+    toVec-fromVec : ∀ {n} (v : Vec A n) → toVec (fromVec v) ≡ v
+    toVec-fromVec = VP.tabulate∘lookup
+
+
+  -- Isomorphism between tables and vectors.
+
+  ↔Vec : ∀ {n} → Inverse (≡-setoid A n) (P.setoid (Vec A n))
+  ↔Vec = record
+    { to = record { _⟨$⟩_ = toVec ; cong = VP.tabulate-cong }
+    ; from = P.→-to-⟶ fromVec
+    ; inverse-of = record
+      { left-inverse-of = VP.lookup∘tabulate ∘ lookup
+      ; right-inverse-of = VP.tabulate∘lookup
+      }
+    }
+
+
+  -- Selecting from any table is the same as selecting from a constant table.
+
+  select-const : ∀ {n} (z : A) (i : Fin n) t → select z i t ≗ select z i (replicate (lookup t i))
+  select-const z i t j with ⌊ j ≟ i ⌋
+  select-const z i t j | true = P.refl
+  select-const z i t j | false = P.refl

--- a/src/Data/Table/Relation/Equality.agda
+++ b/src/Data/Table/Relation/Equality.agda
@@ -1,0 +1,27 @@
+module Data.Table.Relation.Equality where
+
+open import Relation.Binary using (Setoid)
+open import Data.Table.Base
+open import Data.Nat using (ℕ)
+open import Function using (_∘_)
+open import Relation.Binary.PropositionalEquality
+  as P using (_≡_; _→-setoid_)
+
+setoid : ∀ {c p} → Setoid c p → ℕ → Setoid _ _
+setoid S n = record
+  { Carrier = Table Carrier n
+  ; _≈_ = λ t t′ → ∀ i → lookup t i ≈ lookup t′ i
+  ; isEquivalence = record
+    { refl = λ i → refl
+    ; sym = λ p → sym ∘ p
+    ; trans = λ p q i → trans (p i) (q i)
+    }
+  }
+  where open Setoid S
+
+≡-setoid : ∀ {a} → Set a → ℕ → Setoid _ _
+≡-setoid A = setoid (P.setoid A)
+
+module _ {a} {A : Set a} {n} where
+  open Setoid (≡-setoid A n) public
+    using () renaming (_≈_ to _≗_)

--- a/src/Data/Table/Relation/Equality.agda
+++ b/src/Data/Table/Relation/Equality.agda
@@ -1,3 +1,9 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Pointwise table equality
+------------------------------------------------------------------------
+
 module Data.Table.Relation.Equality where
 
 open import Relation.Binary using (Setoid)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -458,6 +458,10 @@ tabulate-∘ : ∀ {n a b} {A : Set a} {B : Set b}
 tabulate-∘ {zero}  f g = refl
 tabulate-∘ {suc n} f g = P.cong (f (g zero) ∷_) (tabulate-∘ f (g ∘ suc))
 
+tabulate-cong : ∀ {n a} {A : Set a} {f g : Fin n → A} → f ≗ g → tabulate f ≡ tabulate g
+tabulate-cong {zero} p = refl
+tabulate-cong {suc n} p = P.cong₂ _∷_ (p zero) (tabulate-cong (p ∘ suc))
+
 ------------------------------------------------------------------------
 -- allFin
 


### PR DESCRIPTION
Continuing from #212.

> - Move swapFin from Data.Fin.Properties to Data.Fin, rename it swap and provide an explanation of what it does. It should be implemented via pattern matching instead of if_then_else_. This will then allow you to delete the if-dec-true and if-dec-false lemmas.
> - Move the swap-lem₁ and swap-lem₂ in Data.Fin.Properties out of public scope and give them more meaningful names.
> - Remove the permutation lemmas from Data.Fin.Properties from the PR

I've just removed all of these since I realised they're not actually used by any of the `Data.Table` code.

> - Move all the private lemmas in Data.Table (that do not rely on SigmaPropositional) into Data.Table.Properties as well as the proof of isomorphisms with Vec and Table.

I can't prove isomorphism with lists without `SigmaPropositional` so I've removed that proof entirely for now.

> - You seem to have carried out a find and replace for + to | in the changelog. Please can you fix this.

Ouch, I thought that bug in Spacemacs' markdown layer was fixed...