### PR TITLE
Add recompute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -743,6 +743,11 @@ Backwards compatible changes
   ∁? : Decidable P → Decidable (∁ P)
   ```
 
+* Added `recompute` to `Relation.Nullary`:
+  ```agda
+  recompute : ∀ {a} {A : Set a} → Dec A → .A → A
+  ```
+
 Version 0.14
 ============
 

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -29,5 +29,5 @@ data Dec {p} (P : Set p) : Set p where
 -- be recomputed and subsequently used in relevant contexts.
 recompute : ∀ {a} {A : Set a} → Dec A → .A → A
 recompute (yes x) _ = x
-recompute {A = A} (no ¬p) x = ⊥-elim (¬p x)
+recompute (no ¬p) x = ⊥-elim (¬p x)
 

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -23,3 +23,18 @@ infix 3 ¬_
 data Dec {p} (P : Set p) : Set p where
   yes : ( p :   P) → Dec P
   no  : (¬p : ¬ P) → Dec P
+
+
+-- Given an irrelevant proof of a decidable type, a proof can
+-- be recomputed and subsequently used in relevant contexts.
+recompute : ∀ {a} {A : Set a} → Dec A → .A → A
+recompute (yes x) _ = x
+recompute {A = A} (no ¬p) x with ¬-i ¬p x
+  where
+    ⊥-i : ∀ .(_ : ⊥) → ⊥
+    ⊥-i ()
+    
+    ¬-i : (A → ⊥) → .A → ⊥
+    ¬-i f x = ⊥-i (f x)
+... | ()
+

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -24,7 +24,6 @@ data Dec {p} (P : Set p) : Set p where
   yes : ( p :   P) → Dec P
   no  : (¬p : ¬ P) → Dec P
 
-
 -- Given an irrelevant proof of a decidable type, a proof can
 -- be recomputed and subsequently used in relevant contexts.
 recompute : ∀ {a} {A : Set a} → Dec A → .A → A
@@ -33,7 +32,7 @@ recompute {A = A} (no ¬p) x with ¬-i ¬p x
   where
     ⊥-i : ∀ .(_ : ⊥) → ⊥
     ⊥-i ()
-    
+
     ¬-i : (A → ⊥) → .A → ⊥
     ¬-i f x = ⊥-i (f x)
 ... | ()

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -8,7 +8,8 @@
 
 module Relation.Nullary where
 
-open import Data.Empty
+open import Data.Empty hiding (⊥-elim)
+open import Data.Empty.Irrelevant
 open import Level
 
 -- Negation.
@@ -30,10 +31,7 @@ recompute : ∀ {a} {A : Set a} → Dec A → .A → A
 recompute (yes x) _ = x
 recompute {A = A} (no ¬p) x with ¬-i ¬p x
   where
-    ⊥-i : ∀ .(_ : ⊥) → ⊥
-    ⊥-i ()
-
     ¬-i : (A → ⊥) → .A → ⊥
-    ¬-i f x = ⊥-i (f x)
+    ¬-i f x = ⊥-elim (f x)
 ... | ()
 

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -29,9 +29,5 @@ data Dec {p} (P : Set p) : Set p where
 -- be recomputed and subsequently used in relevant contexts.
 recompute : ∀ {a} {A : Set a} → Dec A → .A → A
 recompute (yes x) _ = x
-recompute {A = A} (no ¬p) x with ¬-i ¬p x
-  where
-    ¬-i : (A → ⊥) → .A → ⊥
-    ¬-i f x = ⊥-elim (f x)
-... | ()
+recompute {A = A} (no ¬p) x = ⊥-elim (¬p x)
 


### PR DESCRIPTION
See https://github.com/agda/agda/issues/2992

I decided against the `Unique` requirement since it just amounted to an unused parameter, even though I still think from a pragmatic standpoint it only makes sense to recompute unique proofs.