### PR TITLE
Parameterising `Algebra.Structures` by equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,18 @@ Backwards compatible changes
 
 * Added new proofs to `Data.Bool.Properties`:
   ```agda
-  ∨-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∨_ false
+  ∧-semigroup                     : Semigroup _ _
+  ∧-commutativeMonoid             : CommutativeMonoid _
+  ∧-idempotentCommutativeMonoid   : IdempotentCommutativeMonoid _ _
   ∧-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∧_ true
+
+  ∨-semigroup                     : Semigroup _ _
+  ∨-commutativeMonoid             : CommutativeMonoid _ _
+  ∨-idempotentCommutativeMonoid   : IdempotentCommutativeMonoid _ _
+  ∨-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∨_ false
+
+  ∨-∧-lattice                     : Lattice _ _
+  ∨-∧-distributiveLattice         : DistributiveLattice _ _
   ```
 
 * Added new proofs to `Data.Nat.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,30 @@ Removed features
 Backwards compatible changes
 ----------------------------
 
+* In `Algebra.Structures` the algebraic structures now export left and right versions of various properties where applicable, for example:
+  ```agda
+  identityˡ : LeftIdentity ε _∙_
+  identityʳ : RightIdentity ε _∙_
+  inverseˡ  : LeftInverse ε _⁻¹ _∙_
+  inverseʳ  : RightInverse ε _⁻¹ _∙_
+  zeroˡ     : LeftZero 0# _*_
+  zeroʳ     : RightZero 0# _*_
+  distribˡ  : _*_ DistributesOverˡ _+_
+  distribʳ  : _*_ DistributesOverʳ _+_
+  ```
+
+* Added new proofs to `Data.Bool.Properties`:
+  ```agda
+  ∨-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∨_ false
+  ∧-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∧_ true
+  ```
+
+* Added new proofs to `Data.Nat.Properties`:
+  ```agda
+  +-0-isMonoid   : IsMonoid _+_ 0
+  *-1-isMonoid   : IsMonoid _*_ 1
+  ```
+
 Version 0.15
 ============
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Removed features
 Backwards compatible changes
 ----------------------------
 
-* In `Algebra.Structures` the algebraic structures now export left and right versions of various properties where applicable, for example:
+* The module `Algebra.Structures` can now be parameterised by equality in the same way 
+  as `Algebra.FunctionProperties`. The structures within also now export a greater selection 
+  of "left" and "right" properties. For example (where applicable):
   ```agda
   identityˡ : LeftIdentity ε _∙_
   identityʳ : RightIdentity ε _∙_

--- a/src/Algebra.agda
+++ b/src/Algebra.agda
@@ -14,7 +14,7 @@ open import Function
 open import Level
 
 ------------------------------------------------------------------------
--- Semigroups, (commutative) monoids and (abelian) groups
+-- Semigroups
 
 record Semigroup c ℓ : Set (suc (c ⊔ ℓ)) where
   infixl 7 _∙_
@@ -26,6 +26,9 @@ record Semigroup c ℓ : Set (suc (c ⊔ ℓ)) where
     isSemigroup : IsSemigroup _≈_ _∙_
 
   open IsSemigroup isSemigroup public
+
+------------------------------------------------------------------------
+-- Monoids
 
 -- A raw monoid is a monoid without any laws.
 
@@ -94,6 +97,9 @@ record IdempotentCommutativeMonoid c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open CommutativeMonoid commutativeMonoid public
     using (semigroup; rawMonoid; monoid)
+
+------------------------------------------------------------------------
+-- Groups
 
 record Group c ℓ : Set (suc (c ⊔ ℓ)) where
   infix  8 _⁻¹

--- a/src/Algebra/CommutativeMonoidSolver.agda
+++ b/src/Algebra/CommutativeMonoidSolver.agda
@@ -13,7 +13,7 @@ open import Data.Maybe as Maybe
   using (Maybe; decToMaybe; From-just; from-just)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_)
 open import Data.Nat.GeneralisedArithmetic using (fold)
-open import Data.Product using (_×_; proj₁; proj₂; uncurry)
+open import Data.Product using (_×_; uncurry)
 open import Data.Vec using (Vec; []; _∷_; lookup; replicate)
 
 open import Function using (_∘_)
@@ -106,7 +106,7 @@ empty-correct (a ∷ ρ) = empty-correct ρ
 sg-correct : ∀{n} (x : Fin n) (ρ : Env n) →  ⟦ sg x ⟧⇓ ρ ≈ lookup x ρ
 sg-correct zero (x ∷ ρ) = begin
     x ∙ ⟦ empty ⟧⇓ ρ   ≈⟨ ∙-cong refl (empty-correct ρ) ⟩
-    x ∙ ε              ≈⟨ proj₂ identity _ ⟩
+    x ∙ ε              ≈⟨ identityʳ _ ⟩
     x                  ∎
 sg-correct (suc x) (m ∷ ρ) = sg-correct x ρ
 
@@ -114,7 +114,7 @@ sg-correct (suc x) (m ∷ ρ) = sg-correct x ρ
 
 comp-correct : ∀ {n} (v w : Normal n) (ρ : Env n) →
               ⟦ v • w ⟧⇓ ρ ≈ (⟦ v ⟧⇓ ρ ∙ ⟦ w ⟧⇓ ρ)
-comp-correct [] [] ρ =  sym (proj₁ identity _)
+comp-correct [] [] ρ =  sym (identityˡ _)
 comp-correct (l ∷ v) (m ∷ w) (a ∷ ρ) = lemma l m (comp-correct v w ρ)
   where
     flip12 : ∀ a b c → a ∙ (b ∙ c) ≈ b ∙ (a ∙ c)

--- a/src/Algebra/CommutativeMonoidSolver/Example.agda
+++ b/src/Algebra/CommutativeMonoidSolver/Example.agda
@@ -6,30 +6,15 @@
 
 module Algebra.CommutativeMonoidSolver.Example where
 
-open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong₂; isEquivalence)
+open import Relation.Binary.PropositionalEquality using (_≡_)
 
-open import Data.Bool.Base using (Bool; true; false; if_then_else_; not; _∧_; _∨_)
-open import Data.Bool.Properties
+open import Data.Bool.Base using (_∨_)
+open import Data.Bool.Properties using (∨-commutativeMonoid)
 
 open import Data.Fin using (zero; suc)
 open import Data.Vec using ([]; _∷_)
 
-open import Algebra using (CommutativeMonoid)
-
-∨-cm : CommutativeMonoid _ _
-∨-cm = record
-  { Carrier = Bool
-  ; _≈_     = _≡_
-  ; _∙_     = _∨_
-  ; ε       = false
-  ; isCommutativeMonoid = record
-    { isSemigroup = ∨-isSemigroup
-    ; identityˡ = ∨-identityˡ
-    ; comm      = ∨-comm
-    }
-  }
-
-open import Algebra.CommutativeMonoidSolver ∨-cm
+open import Algebra.CommutativeMonoidSolver ∨-commutativeMonoid
 
 test : ∀ x y z → (x ∨ y) ∨ (x ∨ z) ≡ (z ∨ y) ∨ (x ∨ x)
 test a b c = let _∨_ = _⊕_ in

--- a/src/Algebra/FunctionProperties.agda
+++ b/src/Algebra/FunctionProperties.agda
@@ -4,18 +4,14 @@
 -- Properties of functions, such as associativity and commutativity
 ------------------------------------------------------------------------
 
--- These properties can (for instance) be used to define algebraic
--- structures.
-
 open import Level
 open import Relation.Binary
 open import Data.Sum
 
--- The properties are specified using the following relation as
--- "equality".
+-- The properties are parameterised by the following "equality" relation
 
 module Algebra.FunctionProperties
-         {a ℓ} {A : Set a} (_≈_ : Rel A ℓ) where
+  {a ℓ} {A : Set a} (_≈_ : Rel A ℓ) where
 
 open import Data.Product
 

--- a/src/Algebra/FunctionProperties/Consequences.agda
+++ b/src/Algebra/FunctionProperties/Consequences.agda
@@ -14,9 +14,10 @@ open Setoid S
 open import Algebra.FunctionProperties _≈_
 open import Relation.Binary.EqReasoning S
 open import Data.Sum using (inj₁; inj₂)
+open import Data.Product using (proj₁; proj₂)
 
 ------------------------------------------------------------------------
--- Transposing identity elements
+-- Existence of identity elements
 
 comm+idˡ⇒idʳ : ∀ {_•_} → Commutative _•_ →
               ∀ {e} → LeftIdentity e _•_ → RightIdentity e _•_
@@ -33,7 +34,7 @@ comm+idʳ⇒idˡ {_•_} comm {e} idʳ x = begin
   x     ∎
 
 ------------------------------------------------------------------------
--- Transposing zero elements
+-- Existence of zero elements
 
 comm+zeˡ⇒zeʳ : ∀ {_•_} → Commutative _•_ →
               ∀ {e} → LeftZero e _•_ → RightZero e _•_
@@ -49,8 +50,38 @@ comm+zeʳ⇒zeˡ {_•_} comm {e} zeʳ x = begin
   x • e ≈⟨ zeʳ x ⟩
   e     ∎
 
+assoc+distribʳ+idʳ+invʳ⇒zeˡ : ∀ {_+_ _*_ -_ 0#} →
+                            Congruent₂ _+_ → Congruent₂ _*_ →
+                            Associative _+_ → _*_ DistributesOverʳ _+_ →
+                            RightIdentity 0# _+_ → RightInverse 0# -_ _+_ →
+                            LeftZero 0# _*_
+assoc+distribʳ+idʳ+invʳ⇒zeˡ {_+_} {_*_} { -_ } {0#}
+  +-cong *-cong +-assoc distribʳ idʳ invʳ  x = begin
+   0# * x                                ≈⟨ sym (idʳ _) ⟩
+   (0# * x) + 0#                         ≈⟨ +-cong refl (sym (invʳ _)) ⟩
+   (0# * x) + ((0# * x)  + (-(0# * x)))  ≈⟨ sym (+-assoc _ _ _) ⟩
+   ((0# * x) +  (0# * x)) + (-(0# * x))  ≈⟨ +-cong (sym (distribʳ _ _ _)) refl ⟩
+   ((0# + 0#) * x) + (-(0# * x))         ≈⟨ +-cong (*-cong (idʳ _) refl) refl ⟩
+   (0# * x) + (-(0# * x))                ≈⟨ invʳ _ ⟩
+   0#                                    ∎
+
+assoc+distribˡ+idʳ+invʳ⇒zeʳ : ∀ {_+_ _*_ -_ 0#} →
+                            Congruent₂ _+_ → Congruent₂ _*_ →
+                            Associative _+_ → _*_ DistributesOverˡ _+_ →
+                            RightIdentity 0# _+_ → RightInverse 0# -_ _+_ →
+                            RightZero 0# _*_
+assoc+distribˡ+idʳ+invʳ⇒zeʳ {_+_} {_*_} { -_ } {0#}
+  +-cong *-cong +-assoc distribˡ idʳ invʳ  x = begin
+    x * 0#                               ≈⟨ sym (idʳ _) ⟩
+    (x * 0#) + 0#                        ≈⟨ +-cong refl (sym (invʳ _)) ⟩
+    (x * 0#) + ((x * 0#) + (-(x * 0#)))  ≈⟨ sym (+-assoc _ _ _) ⟩
+    ((x * 0#) + (x * 0#)) + (-(x * 0#))  ≈⟨ +-cong (sym (distribˡ _ _ _)) refl ⟩
+    (x * (0# + 0#)) + (-(x * 0#))        ≈⟨ +-cong (*-cong refl (idʳ _)) refl ⟩
+    ((x * 0#) + (-(x * 0#)))             ≈⟨ invʳ _ ⟩
+    0#                                   ∎
+
 ------------------------------------------------------------------------
--- Transposing inverse elements
+-- Existence of inverses
 
 comm+invˡ⇒invʳ : ∀ {e _⁻¹ _•_} → Commutative _•_ →
                 LeftInverse e _⁻¹ _•_ → RightInverse e _⁻¹ _•_
@@ -67,7 +98,36 @@ comm+invʳ⇒invˡ {e} {_⁻¹} {_•_} comm invʳ x = begin
   e          ∎
 
 ------------------------------------------------------------------------
--- Transposing distributivity
+-- Uniqueness of inverses
+
+assoc+id+invʳ⇒invˡ-unique : ∀ {_•_ _⁻¹ ε} →
+                           Congruent₂ _•_ → Associative _•_ →
+                           Identity ε _•_ → RightInverse ε _⁻¹ _•_ →
+                           ∀ x y → (x • y) ≈ ε → x ≈ (y ⁻¹)
+assoc+id+invʳ⇒invˡ-unique {_•_} {_⁻¹} {ε} cong assoc id invʳ x y eq =
+  begin
+    x                ≈⟨ sym (proj₂ id x) ⟩
+    x • ε            ≈⟨ cong refl (sym (invʳ y)) ⟩
+    x • (y • (y ⁻¹)) ≈⟨ sym (assoc x y (y ⁻¹)) ⟩
+    (x • y) • (y ⁻¹) ≈⟨ cong eq refl ⟩
+    ε • (y ⁻¹)       ≈⟨ proj₁ id (y ⁻¹) ⟩
+    y ⁻¹             ∎
+
+assoc+id+invˡ⇒invʳ-unique : ∀ {_•_ _⁻¹ ε} →
+                           Congruent₂ _•_ → Associative _•_ →
+                           Identity ε _•_ → LeftInverse ε _⁻¹ _•_ →
+                           ∀ x y → (x • y) ≈ ε → y ≈ (x ⁻¹)
+assoc+id+invˡ⇒invʳ-unique {_•_} {_⁻¹} {ε} cong assoc id invˡ x y eq =
+  begin
+    y                ≈⟨ sym (proj₁ id y) ⟩
+    ε • y            ≈⟨ cong (sym (invˡ x)) refl ⟩
+    ((x ⁻¹) • x) • y ≈⟨ assoc (x ⁻¹) x y ⟩
+    (x ⁻¹) • (x • y) ≈⟨ cong refl eq ⟩
+    (x ⁻¹) • ε       ≈⟨ proj₂ id (x ⁻¹) ⟩
+    x ⁻¹             ∎
+
+------------------------------------------------------------------------
+-- Distributivity
 
 comm+distrˡ⇒distrʳ : ∀ {_•_ _◦_} → Congruent₂ _◦_ → Commutative _•_ →
                    _•_ DistributesOverˡ _◦_ → _•_ DistributesOverʳ _◦_
@@ -86,7 +146,7 @@ comm+distrʳ⇒distrˡ {_•_} {_◦_} cong comm distrˡ x y z = begin
   (x • y) ◦ (x • z) ∎
 
 ------------------------------------------------------------------------
--- Transposing cancellativity
+-- Cancellativity
 
 comm+cancelˡ⇒cancelʳ : ∀ {_•_} → Commutative _•_ →
                      LeftCancellative _•_ →  RightCancellative _•_

--- a/src/Algebra/IdempotentCommutativeMonoidSolver.agda
+++ b/src/Algebra/IdempotentCommutativeMonoidSolver.agda
@@ -13,7 +13,7 @@ open import Data.Fin using (Fin; zero; suc)
 open import Data.Maybe as Maybe
   using (Maybe; decToMaybe; From-just; from-just)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_)
-open import Data.Product using (_×_; proj₁; proj₂; uncurry)
+open import Data.Product using (_×_; uncurry)
 open import Data.Vec using (Vec; []; _∷_; lookup; replicate)
 
 open import Function using (_∘_)
@@ -107,7 +107,7 @@ empty-correct (a ∷ ρ) = empty-correct ρ
 sg-correct : ∀{n} (x : Fin n) (ρ : Env n) →  ⟦ sg x ⟧⇓ ρ ≈ lookup x ρ
 sg-correct zero (x ∷ ρ) = begin
     x ∙ ⟦ empty ⟧⇓ ρ   ≈⟨ ∙-cong refl (empty-correct ρ) ⟩
-    x ∙ ε              ≈⟨ proj₂ identity _ ⟩
+    x ∙ ε              ≈⟨ identityʳ _ ⟩
     x                  ∎
 sg-correct (suc x) (m ∷ ρ) = sg-correct x ρ
 
@@ -132,7 +132,7 @@ distr a b c = begin
 
 comp-correct : ∀ {n} (v w : Normal n) (ρ : Env n) →
               ⟦ v • w ⟧⇓ ρ ≈ (⟦ v ⟧⇓ ρ ∙ ⟦ w ⟧⇓ ρ)
-comp-correct [] [] ρ = sym (proj₁ identity _)
+comp-correct [] [] ρ = sym (identityˡ _)
 comp-correct (true ∷ v) (true ∷ w) (a ∷ ρ) =
   trans (∙-cong refl (comp-correct v w ρ)) (distr _ _ _)
 comp-correct (true ∷ v) (false ∷ w) (a ∷ ρ) =

--- a/src/Algebra/IdempotentCommutativeMonoidSolver/Example.agda
+++ b/src/Algebra/IdempotentCommutativeMonoidSolver/Example.agda
@@ -7,33 +7,16 @@
 
 module Algebra.IdempotentCommutativeMonoidSolver.Example where
 
-open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong₂; isEquivalence)
+open import Relation.Binary.PropositionalEquality using (_≡_)
 
-open import Data.Bool.Base using (Bool; true; false; _∧_; _∨_)
-open import Data.Bool.Properties
+open import Data.Bool.Base using (_∨_)
+open import Data.Bool.Properties using (∨-idempotentCommutativeMonoid)
 
 open import Data.Fin using (zero; suc)
 open import Data.Vec using ([]; _∷_)
 
-open import Algebra using (IdempotentCommutativeMonoid)
-
-∨-icm : IdempotentCommutativeMonoid _ _
-∨-icm = record
-  { Carrier = Bool
-  ; _≈_     = _≡_
-  ; _∙_     = _∨_
-  ; ε       = false
-  ; isIdempotentCommutativeMonoid = record
-    { isCommutativeMonoid = record
-      { isSemigroup = ∨-isSemigroup
-      ; identityˡ   = ∨-identityˡ
-      ; comm       = ∨-comm
-      }
-   ; idem = ∨-idem
-   }
- }
-
-open import Algebra.IdempotentCommutativeMonoidSolver ∨-icm
+open import Algebra.IdempotentCommutativeMonoidSolver
+  ∨-idempotentCommutativeMonoid
 
 test : ∀ x y z → (x ∨ y) ∨ (x ∨ z) ≡ (z ∨ y) ∨ x
 test a b c = let _∨_ = _⊕_ in

--- a/src/Algebra/Monoid-solver.agda
+++ b/src/Algebra/Monoid-solver.agda
@@ -80,7 +80,7 @@ normalise (e₁ ⊕ e₂) = normalise e₁ ++ normalise e₂
 homomorphic : ∀ {n} (nf₁ nf₂ : Normal n) (ρ : Env n) →
               ⟦ nf₁ ++ nf₂ ⟧⇓ ρ ≈ (⟦ nf₁ ⟧⇓ ρ ∙ ⟦ nf₂ ⟧⇓ ρ)
 homomorphic [] nf₂ ρ = begin
-  ⟦ nf₂ ⟧⇓ ρ      ≈⟨ sym $ proj₁ identity _ ⟩
+  ⟦ nf₂ ⟧⇓ ρ      ≈⟨ sym $ identityˡ _ ⟩
   ε ∙ ⟦ nf₂ ⟧⇓ ρ  ∎
 homomorphic (x ∷ nf₁) nf₂ ρ = begin
   lookup x ρ ∙ ⟦ nf₁ ++ nf₂ ⟧⇓ ρ          ≈⟨ ∙-cong refl (homomorphic nf₁ nf₂ ρ) ⟩
@@ -92,7 +92,7 @@ homomorphic (x ∷ nf₁) nf₂ ρ = begin
 normalise-correct :
   ∀ {n} (e : Expr n) (ρ : Env n) → ⟦ normalise e ⟧⇓ ρ ≈ ⟦ e ⟧ ρ
 normalise-correct (var x) ρ = begin
-  lookup x ρ ∙ ε  ≈⟨ proj₂ identity _ ⟩
+  lookup x ρ ∙ ε  ≈⟨ identityʳ _ ⟩
   lookup x ρ      ∎
 normalise-correct id ρ = begin
   ε  ∎

--- a/src/Algebra/Morphism.agda
+++ b/src/Algebra/Morphism.agda
@@ -11,7 +11,6 @@ open import Algebra
 open import Algebra.FunctionProperties
 import Algebra.Properties.Group as GroupP
 open import Function
-open import Data.Product
 open import Level
 import Relation.Binary.EqReasoning as EqR
 
@@ -131,7 +130,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
     ⁻¹-homo : Homomorphic₁ ⟦_⟧ F._⁻¹ T._⁻¹
     ⁻¹-homo x = let open EqR T.setoid in T.uniqueˡ-⁻¹ ⟦ x F.⁻¹ ⟧ ⟦ x ⟧ $ begin
       ⟦ x F.⁻¹ ⟧ T.∙ ⟦ x ⟧ ≈⟨ T.sym (∙-homo (x F.⁻¹) x) ⟩
-      ⟦ x F.⁻¹ F.∙ x ⟧     ≈⟨ ⟦⟧-cong (proj₁ F.inverse x) ⟩
+      ⟦ x F.⁻¹ F.∙ x ⟧     ≈⟨ ⟦⟧-cong (F.inverseˡ x) ⟩
       ⟦ F.ε ⟧              ≈⟨ ε-homo ⟩
       T.ε ∎
 

--- a/src/Algebra/Operations.agda
+++ b/src/Algebra/Operations.agda
@@ -53,7 +53,7 @@ x ^ suc n = x * x ^ n
 
 1+×′ : ∀ n x → suc n ×′ x ≈ x + n ×′ x
 1+×′ 0 x = begin
-  x       ≈⟨ sym $ Σ.proj₂ +-identity x ⟩
+  x       ≈⟨ sym $ +-identityʳ x ⟩
   x + 0#  ∎
 1+×′ (suc n) x = begin
   x + suc n ×′ x  ≡⟨⟩
@@ -73,7 +73,7 @@ x ^ suc n = x * x ^ n
 
 ×-homo-+ : ∀ c m n → (m ℕ+ n) × c ≈ m × c + n × c
 ×-homo-+ c 0 n = begin
-  n × c       ≈⟨ sym $ Σ.proj₁ +-identity (n × c) ⟩
+  n × c       ≈⟨ sym $ +-identityˡ (n × c) ⟩
   0# + n × c  ∎
 ×-homo-+ c (suc m) n = begin
   c + (m ℕ+ n) × c     ≈⟨ +-cong refl (×-homo-+ c m n) ⟩
@@ -98,8 +98,8 @@ x ^ suc n = x * x ^ n
 ×1-homo-* (suc m) n = begin
   (n ℕ+ m ℕ* n) × 1#                   ≈⟨ ×-homo-+ 1# n (m ℕ* n) ⟩
   n × 1# + (m ℕ* n) × 1#               ≈⟨ +-cong refl (×1-homo-* m n) ⟩
-  n × 1# + (m × 1#) * (n × 1#)         ≈⟨ sym $ +-cong (Σ.proj₁ *-identity (n × 1#)) refl ⟩
-  1# * (n × 1#) + (m × 1#) * (n × 1#)  ≈⟨ sym $ Σ.proj₂ distrib (n × 1#) 1# (m × 1#) ⟩
+  n × 1# + (m × 1#) * (n × 1#)         ≈⟨ sym $ +-cong (*-identityˡ (n × 1#)) refl ⟩
+  1# * (n × 1#) + (m × 1#) * (n × 1#)  ≈⟨ sym $ distribʳ (n × 1#) 1# (m × 1#) ⟩
   (1# + m × 1#) * (n × 1#)             ∎
 
 -- _×′ 1# is homomorphic with respect to _ℕ*_/_*_.
@@ -119,7 +119,7 @@ x ^ suc n = x * x ^ n
   n′ × x   ≈⟨ ×-congʳ n′ x≈x′ ⟩
   n′ × x′  ∎
   where
-  ×-congʳ : ∀ n → (_×_ n) Preserves _≈_ ⟶ _≈_
+  ×-congʳ : ∀ n → (n ×_) Preserves _≈_ ⟶ _≈_
   ×-congʳ 0       x≈x′ = refl
   ×-congʳ (suc n) x≈x′ = x≈x′ ⟨ +-cong ⟩ ×-congʳ n x≈x′
 
@@ -140,6 +140,6 @@ x ^ suc n = x * x ^ n
   x  ^ n'  ≈⟨ ^-congˡ n' x≈x' ⟩
   x' ^ n'  ∎
   where
-  ^-congˡ : ∀ n → (λ x → x ^ n) Preserves _≈_ ⟶ _≈_
+  ^-congˡ : ∀ n → (_^ n) Preserves _≈_ ⟶ _≈_
   ^-congˡ zero    x≈x' = refl
   ^-congˡ (suc n) x≈x' = x≈x' ⟨ *-cong ⟩ ^-congˡ n x≈x'

--- a/src/Algebra/Properties/AbelianGroup.agda
+++ b/src/Algebra/Properties/AbelianGroup.agda
@@ -10,7 +10,6 @@ module Algebra.Properties.AbelianGroup
          {g₁ g₂} (G : AbelianGroup g₁ g₂) where
 
 import Algebra.Properties.Group as GP
-open import Data.Product
 open import Function
 import Relation.Binary.EqReasoning as EqR
 
@@ -20,25 +19,28 @@ open EqR setoid
 open GP group public
 
 private
-  lemma : ∀ x y → x ∙ y ∙ x ⁻¹ ≈ y
-  lemma x y = begin
+  lemma₁ : ∀ x y → x ∙ y ∙ x ⁻¹ ≈ y
+  lemma₁ x y = begin
     x ∙ y ∙ x ⁻¹    ≈⟨ comm _ _ ⟨ ∙-cong ⟩ refl ⟩
     y ∙ x ∙ x ⁻¹    ≈⟨ assoc _ _ _ ⟩
-    y ∙ (x ∙ x ⁻¹)  ≈⟨ refl ⟨ ∙-cong ⟩ proj₂ inverse _ ⟩
-    y ∙ ε           ≈⟨ proj₂ identity _ ⟩
+    y ∙ (x ∙ x ⁻¹)  ≈⟨ refl ⟨ ∙-cong ⟩ inverseʳ _ ⟩
+    y ∙ ε           ≈⟨ identityʳ _ ⟩
     y               ∎
+
+  lemma₂ : ∀ x y → x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹) ≈ y ⁻¹
+  lemma₂ x y = begin
+    x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹)  ≈⟨ sym $ assoc _ _ _ ⟩
+    x ∙ (y ∙ (x ∙ y) ⁻¹) ∙ y ⁻¹  ≈⟨ sym $ assoc _ _ _ ⟨ ∙-cong ⟩ refl ⟩
+    x ∙ y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹    ≈⟨ inverseʳ _ ⟨ ∙-cong ⟩ refl ⟩
+    ε ∙ y ⁻¹                     ≈⟨ identityˡ _ ⟩
+    y ⁻¹                         ∎
 
 ⁻¹-∙-comm : ∀ x y → x ⁻¹ ∙ y ⁻¹ ≈ (x ∙ y) ⁻¹
 ⁻¹-∙-comm x y = begin
   x ⁻¹ ∙ y ⁻¹                         ≈⟨ comm _ _ ⟩
-  y ⁻¹ ∙ x ⁻¹                         ≈⟨ sym $ lem ⟨ ∙-cong ⟩ refl ⟩
-  x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹) ∙ x ⁻¹  ≈⟨ lemma _ _ ⟩
-  y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹               ≈⟨ lemma _ _ ⟩
+  y ⁻¹ ∙ x ⁻¹                         ≈⟨ sym $ (lemma₂ x y) ⟨ ∙-cong ⟩ refl ⟩
+  x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹) ∙ x ⁻¹  ≈⟨ lemma₁ _ _ ⟩
+  y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹               ≈⟨ lemma₁ _ _ ⟩
   (x ∙ y) ⁻¹                          ∎
   where
-  lem = begin
-    x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹)  ≈⟨ sym $ assoc _ _ _ ⟩
-    x ∙ (y ∙ (x ∙ y) ⁻¹) ∙ y ⁻¹  ≈⟨ sym $ assoc _ _ _ ⟨ ∙-cong ⟩ refl ⟩
-    x ∙ y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹    ≈⟨ proj₂ inverse _ ⟨ ∙-cong ⟩ refl ⟩
-    ε ∙ y ⁻¹                     ≈⟨ proj₁ identity _ ⟩
-    y ⁻¹                         ∎
+

--- a/src/Algebra/Properties/BooleanAlgebra.agda
+++ b/src/Algebra/Properties/BooleanAlgebra.agda
@@ -16,7 +16,7 @@ private
   open module DL = Algebra.Properties.DistributiveLattice
                      distributiveLattice public
     hiding (replace-equality)
-open import Algebra.Structures
+open import Algebra.Structures _≈_
 open import Algebra.FunctionProperties _≈_
 open import Algebra.FunctionProperties.Consequences
   record {isEquivalence = isEquivalence}
@@ -45,7 +45,7 @@ open import Data.Product
 ------------------------------------------------------------------------
 -- The dual construction is also a boolean algebra
 
-∧-∨-isBooleanAlgebra : IsBooleanAlgebra _≈_ _∧_ _∨_ ¬_ ⊥ ⊤
+∧-∨-isBooleanAlgebra : IsBooleanAlgebra _∧_ _∨_ ¬_ ⊥ ⊤
 ∧-∨-isBooleanAlgebra = record
   { isDistributiveLattice = ∧-∨-isDistributiveLattice
   ; ∨-complementʳ         = ∧-complementʳ
@@ -117,47 +117,47 @@ open import Data.Product
 ∨-zero : Zero ⊤ _∨_
 ∨-zero = ∨-zeroˡ , ∨-zeroʳ
 
-∨-isSemigroup : IsSemigroup _≈_ _∨_
+∨-isSemigroup : IsSemigroup _∨_
 ∨-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ∨-assoc
   ; ∙-cong        = ∨-cong
   }
 
-∧-isSemigroup : IsSemigroup _≈_ _∧_
+∧-isSemigroup : IsSemigroup _∧_
 ∧-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ∧-assoc
   ; ∙-cong        = ∧-cong
   }
 
-∨-⊥-isMonoid : IsMonoid _≈_ _∨_ ⊥
+∨-⊥-isMonoid : IsMonoid _∨_ ⊥
 ∨-⊥-isMonoid = record
   { isSemigroup = ∨-isSemigroup
   ; identity    = ∨-identity
   }
 
-∧-⊤-isMonoid : IsMonoid _≈_ _∧_ ⊤
+∧-⊤-isMonoid : IsMonoid _∧_ ⊤
 ∧-⊤-isMonoid = record
   { isSemigroup = ∧-isSemigroup
   ; identity    = ∧-identity
   }
 
-∨-⊥-isCommutativeMonoid : IsCommutativeMonoid _≈_ _∨_ ⊥
+∨-⊥-isCommutativeMonoid : IsCommutativeMonoid _∨_ ⊥
 ∨-⊥-isCommutativeMonoid = record
   { isSemigroup = ∨-isSemigroup
   ; identityˡ = ∨-identityˡ
   ; comm      = ∨-comm
   }
 
-∧-⊤-isCommutativeMonoid : IsCommutativeMonoid _≈_ _∧_ ⊤
+∧-⊤-isCommutativeMonoid : IsCommutativeMonoid _∧_ ⊤
 ∧-⊤-isCommutativeMonoid = record
   { isSemigroup = ∧-isSemigroup
   ; identityˡ = ∧-identityˡ
   ; comm      = ∧-comm
   }
 
-∨-∧-isCommutativeSemiring : IsCommutativeSemiring _≈_ _∨_ _∧_ ⊥ ⊤
+∨-∧-isCommutativeSemiring : IsCommutativeSemiring _∨_ _∧_ ⊥ ⊤
 ∨-∧-isCommutativeSemiring = record
   { +-isCommutativeMonoid = ∨-⊥-isCommutativeMonoid
   ; *-isCommutativeMonoid = ∧-⊤-isCommutativeMonoid
@@ -174,7 +174,7 @@ open import Data.Product
   ; isCommutativeSemiring = ∨-∧-isCommutativeSemiring
   }
 
-∧-∨-isCommutativeSemiring : IsCommutativeSemiring _≈_ _∧_ _∨_ ⊤ ⊥
+∧-∨-isCommutativeSemiring : IsCommutativeSemiring _∧_ _∨_ ⊤ ⊥
 ∧-∨-isCommutativeSemiring = record
   { +-isCommutativeMonoid = ∧-⊤-isCommutativeMonoid
   ; *-isCommutativeMonoid = ∨-⊥-isCommutativeMonoid
@@ -314,7 +314,7 @@ module XorRing
   ⊕-¬-distribˡ : ∀ x y → ¬ (x ⊕ y) ≈ ¬ x ⊕ y
   ⊕-¬-distribˡ x y = begin
     ¬ (x ⊕ y)                              ≈⟨ ¬-cong $ ⊕-def _ _ ⟩
-    ¬ ((x ∨ y) ∧ (¬ (x ∧ y)))              ≈⟨ ¬-cong (proj₂ ∧-∨-distrib _ _ _) ⟩
+    ¬ ((x ∨ y) ∧ (¬ (x ∧ y)))              ≈⟨ ¬-cong (∧-∨-distribʳ _ _ _) ⟩
     ¬ ((x ∧ ¬ (x ∧ y)) ∨ (y ∧ ¬ (x ∧ y)))  ≈⟨ ¬-cong $
                                                 refl ⟨ ∨-cong ⟩
                                                   (refl ⟨ ∧-cong ⟩
@@ -330,7 +330,7 @@ module XorRing
     lem : ∀ x y → x ∧ ¬ (x ∧ y) ≈ x ∧ ¬ y
     lem x y = begin
       x ∧ ¬ (x ∧ y)          ≈⟨ refl ⟨ ∧-cong ⟩ deMorgan₁ _ _ ⟩
-      x ∧ (¬ x ∨ ¬ y)        ≈⟨ proj₁ ∧-∨-distrib _ _ _ ⟩
+      x ∧ (¬ x ∨ ¬ y)        ≈⟨ ∧-∨-distribˡ _ _ _ ⟩
       (x ∧ ¬ x) ∨ (x ∧ ¬ y)  ≈⟨ ∧-complementʳ _ ⟨ ∨-cong ⟩ refl ⟩
       ⊥ ∨ (x ∧ ¬ y)          ≈⟨ ∨-identityˡ _ ⟩
       x ∧ ¬ y                ∎
@@ -388,7 +388,7 @@ module XorRing
     (¬ y ∨ ¬ z))               ≈⟨ lem₃ ⟨ ∨-cong ⟩ refl ⟩
     ((x ∧ (y ∨ z)) ∧ ¬ x) ∨
     ((x ∧ (y ∨ z)) ∧
-    (¬ y ∨ ¬ z))               ≈⟨ sym $ proj₁ ∧-∨-distrib _ _ _ ⟩
+    (¬ y ∨ ¬ z))               ≈⟨ sym $ ∧-∨-distribˡ _ _ _ ⟩
     (x ∧ (y ∨ z)) ∧
     (¬ x ∨ (¬ y ∨ ¬ z))        ≈⟨  refl ⟨ ∧-cong ⟩
                                   (refl ⟨ ∨-cong ⟩ sym (deMorgan₁ _ _)) ⟩
@@ -397,7 +397,7 @@ module XorRing
     (x ∧ (y ∨ z)) ∧
     ¬ (x ∧ (y ∧ z))            ≈⟨ helper refl lem₁ ⟩
     (x ∧ (y ∨ z)) ∧
-    ¬ ((x ∧ y) ∧ (x ∧ z))      ≈⟨ proj₁ ∧-∨-distrib _ _ _ ⟨ ∧-cong ⟩
+    ¬ ((x ∧ y) ∧ (x ∧ z))      ≈⟨ ∧-∨-distribˡ _ _ _ ⟨ ∧-cong ⟩
                                       refl ⟩
     ((x ∧ y) ∨ (x ∧ z)) ∧
     ¬ ((x ∧ y) ∧ (x ∧ z))      ≈⟨ sym $ ⊕-def _ _ ⟩
@@ -436,10 +436,10 @@ module XorRing
              ((x ∨ u) ∧ (y ∨ u)) ∧
              ((x ∨ v) ∧ (y ∨ v))
     lemma₂ x y u v = begin
-        (x ∧ y) ∨ (u ∧ v)              ≈⟨ proj₁ ∨-∧-distrib _ _ _ ⟩
-        ((x ∧ y) ∨ u) ∧ ((x ∧ y) ∨ v)  ≈⟨ proj₂ ∨-∧-distrib _ _ _
+        (x ∧ y) ∨ (u ∧ v)              ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
+        ((x ∧ y) ∨ u) ∧ ((x ∧ y) ∨ v)  ≈⟨ ∨-∧-distribʳ _ _ _
                                             ⟨ ∧-cong ⟩
-                                          proj₂ ∨-∧-distrib _ _ _ ⟩
+                                          ∨-∧-distribʳ _ _ _ ⟩
         ((x ∨ u) ∧ (y ∨ u)) ∧
         ((x ∨ v) ∧ (y ∨ v))            ∎
 
@@ -465,7 +465,7 @@ module XorRing
     (x ⊕ y) ⊕ z                                ∎
     where
     lem₁ = begin
-      ((x ∨ y) ∨ z) ∧ ((¬ x ∨ ¬ y) ∨ z)  ≈⟨ sym $ proj₂ ∨-∧-distrib _ _ _ ⟩
+      ((x ∨ y) ∨ z) ∧ ((¬ x ∨ ¬ y) ∨ z)  ≈⟨ sym $ ∨-∧-distribʳ _ _ _ ⟩
       ((x ∨ y) ∧ (¬ x ∨ ¬ y)) ∨ z        ≈⟨ (refl ⟨ ∧-cong ⟩ sym (deMorgan₁ _ _))
                                                   ⟨ ∨-cong ⟩ refl ⟩
       ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ z          ∎
@@ -483,7 +483,7 @@ module XorRing
       ¬ ((x ∨ y) ∧ ¬ (x ∧ y))            ∎
 
     lem₂ = begin
-      ((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)  ≈⟨ sym $ proj₂ ∨-∧-distrib _ _ _ ⟩
+      ((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)  ≈⟨ sym $ ∨-∧-distribʳ _ _ _ ⟩
       ((x ∨ ¬ y) ∧ (¬ x ∨ y)) ∨ ¬ z          ≈⟨ lem₂' ⟨ ∨-cong ⟩ refl ⟩
       ¬ ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ ¬ z          ≈⟨ sym $ deMorgan₁ _ _ ⟩
       ¬ (((x ∨ y) ∧ ¬ (x ∧ y)) ∧ z)          ∎
@@ -491,7 +491,7 @@ module XorRing
     lem₃ = begin
       x ∨ ((y ∨ z) ∧ ¬ (y ∧ z))          ≈⟨ refl ⟨ ∨-cong ⟩
                                               (refl ⟨ ∧-cong ⟩ deMorgan₁ _ _) ⟩
-      x ∨ ((y ∨ z) ∧ (¬ y ∨ ¬ z))        ≈⟨ proj₁ ∨-∧-distrib _ _ _ ⟩
+      x ∨ ((y ∨ z) ∧ (¬ y ∨ ¬ z))        ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
       (x ∨ (y ∨ z)) ∧ (x ∨ (¬ y ∨ ¬ z))  ≈⟨ sym (∨-assoc _ _ _) ⟨ ∧-cong ⟩
                                             sym (∨-assoc _ _ _) ⟩
       ((x ∨ y) ∨ z) ∧ ((x ∨ ¬ y) ∨ ¬ z)  ∎
@@ -511,7 +511,7 @@ module XorRing
     lem₄ = begin
       ¬ (x ∧ ((y ∨ z) ∧ ¬ (y ∧ z)))  ≈⟨ deMorgan₁ _ _ ⟩
       ¬ x ∨ ¬ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈⟨ refl ⟨ ∨-cong ⟩ lem₄' ⟩
-      ¬ x ∨ ((y ∨ ¬ z) ∧ (¬ y ∨ z))  ≈⟨ proj₁ ∨-∧-distrib _ _ _ ⟩
+      ¬ x ∨ ((y ∨ ¬ z) ∧ (¬ y ∨ z))  ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
       (¬ x ∨ (y     ∨ ¬ z)) ∧
       (¬ x ∨ (¬ y ∨ z))              ≈⟨ sym (∨-assoc _ _ _) ⟨ ∧-cong ⟩
                                         sym (∨-assoc _ _ _) ⟩
@@ -530,40 +530,40 @@ module XorRing
       ((¬ x ∨ ¬ y) ∨ z) ∧
       (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ∎
 
-  ⊕-isSemigroup : IsSemigroup _≈_ _⊕_
+  ⊕-isSemigroup : IsSemigroup _⊕_
   ⊕-isSemigroup = record
     { isEquivalence = isEquivalence
     ; assoc         = ⊕-assoc
     ; ∙-cong        = ⊕-cong
     }
 
-  ⊕-⊥-isMonoid : IsMonoid _≈_ _⊕_ ⊥
+  ⊕-⊥-isMonoid : IsMonoid _⊕_ ⊥
   ⊕-⊥-isMonoid = record
     { isSemigroup = ⊕-isSemigroup
     ; identity    = ⊕-identity
     }
 
-  ⊕-⊥-isGroup : IsGroup _≈_ _⊕_ ⊥ id
+  ⊕-⊥-isGroup : IsGroup _⊕_ ⊥ id
   ⊕-⊥-isGroup = record
     { isMonoid = ⊕-⊥-isMonoid
     ; inverse  = ⊕-inverse
     ; ⁻¹-cong  = id
     }
 
-  ⊕-⊥-isAbelianGroup : IsAbelianGroup _≈_ _⊕_ ⊥ id
+  ⊕-⊥-isAbelianGroup : IsAbelianGroup _⊕_ ⊥ id
   ⊕-⊥-isAbelianGroup = record
     { isGroup = ⊕-⊥-isGroup
     ; comm    = ⊕-comm
     }
 
-  ⊕-∧-isRing : IsRing _≈_ _⊕_ _∧_ id ⊥ ⊤
+  ⊕-∧-isRing : IsRing _⊕_ _∧_ id ⊥ ⊤
   ⊕-∧-isRing = record
     { +-isAbelianGroup = ⊕-⊥-isAbelianGroup
     ; *-isMonoid = ∧-⊤-isMonoid
     ; distrib = ∧-distrib-⊕
     }
 
-  isCommutativeRing : IsCommutativeRing _≈_ _⊕_ _∧_ id ⊥ ⊤
+  isCommutativeRing : IsCommutativeRing _⊕_ _∧_ id ⊥ ⊤
   isCommutativeRing = record
     { isRing = ⊕-∧-isRing
     ; *-comm = ∧-comm

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -16,26 +16,26 @@ open import Data.Product
 
 ⁻¹-involutive : ∀ x → x ⁻¹ ⁻¹ ≈ x
 ⁻¹-involutive x = begin
-  x ⁻¹ ⁻¹               ≈⟨ sym $ proj₂ identity _ ⟩
-  x ⁻¹ ⁻¹ ∙ ε           ≈⟨ refl ⟨ ∙-cong ⟩ sym (proj₁ inverse _) ⟩
+  x ⁻¹ ⁻¹               ≈⟨ sym $ identityʳ _ ⟩
+  x ⁻¹ ⁻¹ ∙ ε           ≈⟨ refl ⟨ ∙-cong ⟩ sym (inverseˡ _) ⟩
   x ⁻¹ ⁻¹ ∙ (x ⁻¹ ∙ x)  ≈⟨ sym $ assoc _ _ _ ⟩
-  x ⁻¹ ⁻¹ ∙ x ⁻¹ ∙ x    ≈⟨ proj₁ inverse _ ⟨ ∙-cong ⟩ refl ⟩
-  ε ∙ x                 ≈⟨ proj₁ identity _ ⟩
+  x ⁻¹ ⁻¹ ∙ x ⁻¹ ∙ x    ≈⟨ inverseˡ _ ⟨ ∙-cong ⟩ refl ⟩
+  ε ∙ x                 ≈⟨ identityˡ _ ⟩
   x                     ∎
 
 private
 
   left-helper : ∀ x y → x ≈ (x ∙ y) ∙ y ⁻¹
   left-helper x y = begin
-    x              ≈⟨ sym (proj₂ identity x) ⟩
-    x ∙ ε          ≈⟨ refl ⟨ ∙-cong ⟩ sym (proj₂ inverse y) ⟩
+    x              ≈⟨ sym (identityʳ x) ⟩
+    x ∙ ε          ≈⟨ refl ⟨ ∙-cong ⟩ sym (inverseʳ y) ⟩
     x ∙ (y ∙ y ⁻¹) ≈⟨ sym (assoc x y (y ⁻¹)) ⟩
     (x ∙ y) ∙ y ⁻¹ ∎
 
   right-helper : ∀ x y → y ≈ x ⁻¹ ∙ (x ∙ y)
   right-helper x y = begin
-    y              ≈⟨ sym (proj₁ identity y) ⟩
-    ε          ∙ y ≈⟨ sym (proj₁ inverse x) ⟨ ∙-cong ⟩ refl ⟩
+    y              ≈⟨ sym (identityˡ y) ⟩
+    ε          ∙ y ≈⟨ sym (inverseˡ x) ⟨ ∙-cong ⟩ refl ⟩
     (x ⁻¹ ∙ x) ∙ y ≈⟨ assoc (x ⁻¹) x y ⟩
     x ⁻¹ ∙ (x ∙ y) ∎
 
@@ -43,14 +43,14 @@ left-identity-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
 left-identity-unique x y eq = begin
   x              ≈⟨ left-helper x y ⟩
   (x ∙ y) ∙ y ⁻¹ ≈⟨ eq ⟨ ∙-cong ⟩ refl ⟩
-       y  ∙ y ⁻¹ ≈⟨ proj₂ inverse y ⟩
+       y  ∙ y ⁻¹ ≈⟨ inverseʳ y ⟩
   ε              ∎
 
 right-identity-unique : ∀ x y → x ∙ y ≈ x → y ≈ ε
 right-identity-unique x y eq = begin
   y              ≈⟨ right-helper x y ⟩
   x ⁻¹ ∙ (x ∙ y) ≈⟨ refl ⟨ ∙-cong ⟩ eq ⟩
-  x ⁻¹ ∙  x      ≈⟨ proj₁ inverse x ⟩
+  x ⁻¹ ∙  x      ≈⟨ inverseˡ x ⟩
   ε              ∎
 
 identity-unique : ∀ {x} → Identity x _∙_ → x ≈ ε
@@ -60,7 +60,7 @@ left-inverse-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
 left-inverse-unique x y eq = begin
   x              ≈⟨ left-helper x y ⟩
   (x ∙ y) ∙ y ⁻¹ ≈⟨ eq ⟨ ∙-cong ⟩ refl ⟩
-       ε  ∙ y ⁻¹ ≈⟨ proj₁ identity (y ⁻¹) ⟩
+       ε  ∙ y ⁻¹ ≈⟨ identityˡ (y ⁻¹) ⟩
             y ⁻¹ ∎
 
 right-inverse-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -9,7 +9,6 @@ open import Algebra
 module Algebra.Properties.Ring {r₁ r₂} (R : Ring r₁ r₂) where
 
 import Algebra.Properties.AbelianGroup as AGP
-open import Data.Product
 open import Function
 import Relation.Binary.EqReasoning as EqR
 
@@ -28,24 +27,24 @@ open AGP +-abelianGroup public
 
 -‿*-distribˡ : ∀ x y → - x * y ≈ - (x * y)
 -‿*-distribˡ x y = begin
-  - x * y                        ≈⟨ sym $ proj₂ +-identity _ ⟩
-  - x * y + 0#                   ≈⟨ refl ⟨ +-cong ⟩ sym (proj₂ -‿inverse _) ⟩
+  - x * y                        ≈⟨ sym $ +-identityʳ _ ⟩
+  - x * y + 0#                   ≈⟨ refl ⟨ +-cong ⟩ sym (-‿inverseʳ _) ⟩
   - x * y + (x * y + - (x * y))  ≈⟨ sym $ +-assoc _ _ _  ⟩
-  - x * y + x * y + - (x * y)    ≈⟨ sym (proj₂ distrib _ _ _) ⟨ +-cong ⟩ refl ⟩
-  (- x + x) * y + - (x * y)      ≈⟨ (proj₁ -‿inverse _ ⟨ *-cong ⟩ refl)
+  - x * y + x * y + - (x * y)    ≈⟨ sym (distribʳ _ _ _) ⟨ +-cong ⟩ refl ⟩
+  (- x + x) * y + - (x * y)      ≈⟨ (-‿inverseˡ _ ⟨ *-cong ⟩ refl)
                                       ⟨ +-cong ⟩
                                     refl ⟩
-  0# * y + - (x * y)             ≈⟨ proj₁ zero _ ⟨ +-cong ⟩ refl ⟩
-  0# + - (x * y)                 ≈⟨ proj₁ +-identity _ ⟩
+  0# * y + - (x * y)             ≈⟨ zeroˡ _ ⟨ +-cong ⟩ refl ⟩
+  0# + - (x * y)                 ≈⟨ +-identityˡ _ ⟩
   - (x * y)                      ∎
 
 -‿*-distribʳ : ∀ x y → x * - y ≈ - (x * y)
 -‿*-distribʳ x y = begin
-  x * - y                        ≈⟨ sym $ proj₁ +-identity _ ⟩
-  0# + x * - y                   ≈⟨ sym (proj₁ -‿inverse _) ⟨ +-cong ⟩ refl ⟩
+  x * - y                        ≈⟨ sym $ +-identityˡ _ ⟩
+  0# + x * - y                   ≈⟨ sym (-‿inverseˡ _) ⟨ +-cong ⟩ refl ⟩
   - (x * y) + x * y + x * - y    ≈⟨ +-assoc _ _ _  ⟩
-  - (x * y) + (x * y + x * - y)  ≈⟨ refl ⟨ +-cong ⟩ sym (proj₁ distrib _ _ _)  ⟩
-  - (x * y) + x * (y + - y)      ≈⟨ refl ⟨ +-cong ⟩ (refl ⟨ *-cong ⟩ proj₂ -‿inverse _) ⟩
-  - (x * y) + x * 0#             ≈⟨ refl ⟨ +-cong ⟩ proj₂ zero _ ⟩
-  - (x * y) + 0#                 ≈⟨ proj₂ +-identity _ ⟩
+  - (x * y) + (x * y + x * - y)  ≈⟨ refl ⟨ +-cong ⟩ sym (distribˡ _ _ _)  ⟩
+  - (x * y) + x * (y + - y)      ≈⟨ refl ⟨ +-cong ⟩ (refl ⟨ *-cong ⟩ -‿inverseʳ _) ⟩
+  - (x * y) + x * 0#             ≈⟨ refl ⟨ +-cong ⟩ zeroʳ _ ⟩
+  - (x * y) + 0#                 ≈⟨ +-identityʳ _ ⟩
   - (x * y)                      ∎

--- a/src/Algebra/RingSolver/Lemmas.agda
+++ b/src/Algebra/RingSolver/Lemmas.agda
@@ -23,12 +23,11 @@ open import Algebra.Morphism
 open _-Raw-AlmostCommutative⟶_ morphism
 import Relation.Binary.EqReasoning as EqR; open EqR setoid
 open import Function
-open import Data.Product
 
 lemma₀ : ∀ a b c x →
          (a + b) * x + c ≈ a * x + (b * x + c)
 lemma₀ a b c x = begin
-  (a + b) * x + c      ≈⟨ proj₂ distrib _ _ _ ⟨ +-cong ⟩ refl ⟩
+  (a + b) * x + c      ≈⟨ distribʳ _ _ _ ⟨ +-cong ⟩ refl ⟩
   (a * x + b * x) + c  ≈⟨ +-assoc _ _ _ ⟩
   a * x + (b * x + c)  ∎
 
@@ -45,7 +44,7 @@ lemma₁ a b c d x = begin
 lemma₂ : ∀ a b c x → a * c * x + b * c ≈ (a * x + b) * c
 lemma₂ a b c x = begin
   a * c * x + b * c  ≈⟨ lem ⟨ +-cong ⟩ refl ⟩
-  a * x * c + b * c  ≈⟨ sym $ proj₂ distrib _ _ _ ⟩
+  a * x * c + b * c  ≈⟨ sym $ distribʳ _ _ _ ⟩
   (a * x + b) * c    ∎
   where
   lem = begin
@@ -57,21 +56,21 @@ lemma₂ a b c x = begin
 lemma₃ : ∀ a b c x → a * b * x + a * c ≈ a * (b * x + c)
 lemma₃ a b c x = begin
   a * b * x + a * c    ≈⟨ *-assoc _ _ _ ⟨ +-cong ⟩ refl ⟩
-  a * (b * x) + a * c  ≈⟨ sym $ proj₁ distrib _ _ _ ⟩
+  a * (b * x) + a * c  ≈⟨ sym $ distribˡ _ _ _ ⟩
   a * (b * x + c)      ∎
 
 lemma₄ : ∀ a b c d x →
          (a * c * x + (a * d + b * c)) * x + b * d ≈
          (a * x + b) * (c * x + d)
 lemma₄ a b c d x = begin
-  (a * c * x + (a * d + b * c)) * x + b * d              ≈⟨ proj₂ distrib _ _ _ ⟨ +-cong ⟩ refl ⟩
+  (a * c * x + (a * d + b * c)) * x + b * d              ≈⟨ distribʳ _ _ _ ⟨ +-cong ⟩ refl ⟩
   (a * c * x * x + (a * d + b * c) * x) + b * d          ≈⟨ refl ⟨ +-cong ⟩ ((refl ⟨ +-cong ⟩ refl) ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ refl ⟩
   (a * c * x * x + (a * d + b * c) * x) + b * d          ≈⟨ +-assoc _ _ _  ⟩
   a * c * x * x + ((a * d + b * c) * x + b * d)          ≈⟨ lem₁ ⟨ +-cong ⟩ (lem₂ ⟨ +-cong ⟩ refl) ⟩
   a * x * (c * x) + (a * x * d + b * (c * x) + b * d)    ≈⟨ refl ⟨ +-cong ⟩ +-assoc _ _ _ ⟩
   a * x * (c * x) + (a * x * d + (b * (c * x) + b * d))  ≈⟨ sym $ +-assoc _ _ _ ⟩
-  a * x * (c * x) + a * x * d + (b * (c * x) + b * d)    ≈⟨ sym $ proj₁ distrib _ _ _ ⟨ +-cong ⟩ proj₁ distrib _ _ _ ⟩
-  a * x * (c * x + d) + b * (c * x + d)                  ≈⟨ sym $ proj₂ distrib _ _ _ ⟩
+  a * x * (c * x) + a * x * d + (b * (c * x) + b * d)    ≈⟨ sym $ distribˡ _ _ _ ⟨ +-cong ⟩ distribˡ _ _ _ ⟩
+  a * x * (c * x + d) + b * (c * x + d)                  ≈⟨ sym $ distribʳ _ _ _ ⟩
   (a * x + b) * (c * x + d)                              ∎
   where
   lem₁′ = begin
@@ -86,7 +85,7 @@ lemma₄ a b c d x = begin
     a * x * (c * x)  ∎
 
   lem₂ = begin
-    (a * d + b * c) * x        ≈⟨ proj₂ distrib _ _ _ ⟩
+    (a * d + b * c) * x        ≈⟨ distribʳ _ _ _ ⟩
     a * d * x + b * c * x      ≈⟨ *-assoc _ _ _ ⟨ +-cong ⟩ *-assoc _ _ _ ⟩
     a * (d * x) + b * (c * x)  ≈⟨ (refl ⟨ *-cong ⟩ *-comm _ _) ⟨ +-cong ⟩ refl ⟩
     a * (x * d) + b * (c * x)  ≈⟨ sym $ *-assoc _ _ _ ⟨ +-cong ⟩ refl ⟩
@@ -95,19 +94,19 @@ lemma₄ a b c d x = begin
 lemma₅ : ∀ x → (0# * x + 1#) * x + 0# ≈ x
 lemma₅ x = begin
   (0# * x + 1#) * x + 0#   ≈⟨ ((zeroˡ _ ⟨ +-cong ⟩ refl) ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ refl ⟩
-  (0# + 1#) * x + 0#       ≈⟨ (proj₁ +-identity _ ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ refl ⟩
-  1# * x + 0#              ≈⟨ proj₂ +-identity _ ⟩
-  1# * x                   ≈⟨ proj₁ *-identity _ ⟩
+  (0# + 1#) * x + 0#       ≈⟨ (+-identityˡ _ ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ refl ⟩
+  1# * x + 0#              ≈⟨ +-identityʳ _ ⟩
+  1# * x                   ≈⟨ *-identityˡ _ ⟩
   x                        ∎
 
 lemma₆ : ∀ a x → 0# * x + a ≈ a
 lemma₆ a x = begin
   0# * x + a    ≈⟨ zeroˡ _ ⟨ +-cong ⟩ refl ⟩
-  0# + a        ≈⟨ proj₁ +-identity _ ⟩
+  0# + a        ≈⟨ +-identityˡ _ ⟩
   a             ∎
 
 lemma₇ : ∀ x → - 1# * x ≈ - x
 lemma₇ x = begin
   - 1# * x      ≈⟨ -‿*-distribˡ _ _ ⟩
-  - (1# * x)    ≈⟨ -‿cong (proj₁ *-identity _) ⟩
+  - (1# * x)    ≈⟨ -‿cong (*-identityˡ _) ⟩
   - x           ∎

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -5,179 +5,168 @@
 -- etc.)
 ------------------------------------------------------------------------
 
-open import Relation.Binary
+open import Relation.Binary using (Rel; Setoid; IsEquivalence)
 
-module Algebra.Structures where
+-- The properties are parameterised by the following "equality" relation
 
-import Algebra.FunctionProperties as FunctionProperties
-open import Data.Product
-open import Function
+module Algebra.Structures {a ℓ} {A : Set a} (_≈_ : Rel A ℓ) where
+
+open import Algebra.FunctionProperties _≈_
+import Algebra.FunctionProperties.Consequences as Consequences
+open import Data.Product using (_,_; proj₁; proj₂)
 open import Level using (_⊔_)
-import Relation.Binary.EqReasoning as EqR
-
-open FunctionProperties using (Op₁; Op₂)
 
 ------------------------------------------------------------------------
--- One binary operation
+-- Semigroups
 
-record IsSemigroup {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                   (∙ : Op₂ A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsSemigroup (∙ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isEquivalence : IsEquivalence ≈
+    isEquivalence : IsEquivalence _≈_
     assoc         : Associative ∙
-    ∙-cong        : ∙ Preserves₂ ≈ ⟶ ≈ ⟶ ≈
+    ∙-cong        : Congruent₂ ∙
 
   setoid : Setoid a ℓ
   setoid = record { isEquivalence = isEquivalence }
 
   open IsEquivalence isEquivalence public
 
-record IsMonoid {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                (∙ : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+------------------------------------------------------------------------
+-- Monoids
+
+record IsMonoid (∙ : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
   field
-    isSemigroup : IsSemigroup ≈ ∙
+    isSemigroup : IsSemigroup ∙
     identity    : Identity ε ∙
 
+  identityˡ : LeftIdentity ε ∙
+  identityˡ = proj₁ identity
+
+  identityʳ : RightIdentity ε ∙
+  identityʳ = proj₂ identity
+
   open IsSemigroup isSemigroup public
 
-record IsCommutativeMonoid {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                           (_∙_ : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsCommutativeMonoid (∙ : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
   field
-    isSemigroup : IsSemigroup ≈ _∙_
-    identityˡ   : LeftIdentity ε _∙_
-    comm        : Commutative _∙_
+    isSemigroup : IsSemigroup ∙
+    identityˡ   : LeftIdentity ε ∙
+    comm        : Commutative ∙
 
   open IsSemigroup isSemigroup public
 
-  identity : Identity ε _∙_
+  identityʳ : RightIdentity ε ∙
+  identityʳ = Consequences.comm+idˡ⇒idʳ setoid comm identityˡ
+
+  identity : Identity ε ∙
   identity = (identityˡ , identityʳ)
-    where
-    open EqR (record { isEquivalence = isEquivalence })
 
-    identityʳ : RightIdentity ε _∙_
-    identityʳ = λ x → begin
-      (x ∙ ε)  ≈⟨ comm x ε ⟩
-      (ε ∙ x)  ≈⟨ identityˡ x ⟩
-      x        ∎
-
-  isMonoid : IsMonoid ≈ _∙_ ε
+  isMonoid : IsMonoid ∙ ε
   isMonoid = record
     { isSemigroup = isSemigroup
     ; identity    = identity
     }
 
-record IsIdempotentCommutativeMonoid {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                                     (_∙_ : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsIdempotentCommutativeMonoid (∙ : Op₂ A)
+                                     (ε : A) : Set (a ⊔ ℓ) where
   field
-    isCommutativeMonoid : IsCommutativeMonoid ≈ _∙_ ε
-    idem                : Idempotent _∙_
+    isCommutativeMonoid : IsCommutativeMonoid ∙ ε
+    idem                : Idempotent ∙
 
   open IsCommutativeMonoid isCommutativeMonoid public
 
-record IsGroup {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-               (_∙_ : Op₂ A) (ε : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
-  infixl 7 _-_
+------------------------------------------------------------------------
+-- Groups
+
+record IsGroup (_∙_ : Op₂ A) (ε : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ) where
   field
-    isMonoid  : IsMonoid ≈ _∙_ ε
+    isMonoid  : IsMonoid _∙_ ε
     inverse   : Inverse ε _⁻¹ _∙_
-    ⁻¹-cong   : _⁻¹ Preserves ≈ ⟶ ≈
+    ⁻¹-cong   : Congruent₁ _⁻¹
 
   open IsMonoid isMonoid public
 
-  _-_ : FunctionProperties.Op₂ A
+  infixl 7 _-_
+  _-_ : Op₂ A
   x - y = x ∙ (y ⁻¹)
 
-  uniqueˡ-⁻¹ : ∀ x y → ≈ (x ∙ y) ε → ≈ x (y ⁻¹)
-  uniqueˡ-⁻¹ x y eq = let open EqR setoid in begin
-    x                ≈⟨ sym (proj₂ identity x) ⟩
-    x ∙ ε            ≈⟨ ∙-cong refl (sym (proj₂ inverse y)) ⟩
-    x ∙ (y ∙ (y ⁻¹)) ≈⟨ sym (assoc x y (y ⁻¹)) ⟩
-    (x ∙ y) ∙ (y ⁻¹) ≈⟨ ∙-cong eq refl ⟩
-    ε ∙ (y ⁻¹)       ≈⟨ proj₁ identity (y ⁻¹) ⟩
-    y ⁻¹ ∎
+  inverseˡ : LeftInverse ε _⁻¹ _∙_
+  inverseˡ = proj₁ inverse
 
-  uniqueʳ-⁻¹ : ∀ x y → ≈ (x ∙ y) ε → ≈ y (x ⁻¹)
-  uniqueʳ-⁻¹ x y eq = let open EqR setoid in begin
-    y                ≈⟨ sym (proj₁ identity y) ⟩
-    ε ∙ y            ≈⟨ ∙-cong (sym (proj₁ inverse x)) refl ⟩
-    ((x ⁻¹) ∙ x) ∙ y ≈⟨ assoc (x ⁻¹) x y ⟩
-    (x ⁻¹) ∙ (x ∙ y) ≈⟨ ∙-cong refl eq ⟩
-    (x ⁻¹) ∙ ε       ≈⟨ proj₂ identity (x ⁻¹) ⟩
-    x ⁻¹ ∎
+  inverseʳ : RightInverse ε _⁻¹ _∙_
+  inverseʳ = proj₂ inverse
 
-record IsAbelianGroup
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-         (∙ : Op₂ A) (ε : A) (⁻¹ : Op₁ A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+  uniqueˡ-⁻¹ : ∀ x y → (x ∙ y) ≈ ε → x ≈ (y ⁻¹)
+  uniqueˡ-⁻¹ = Consequences.assoc+id+invʳ⇒invˡ-unique
+                setoid ∙-cong assoc identity inverseʳ
+
+  uniqueʳ-⁻¹ : ∀ x y → (x ∙ y) ≈ ε → y ≈ (x ⁻¹)
+  uniqueʳ-⁻¹ = Consequences.assoc+id+invˡ⇒invʳ-unique
+                setoid ∙-cong assoc identity inverseˡ
+
+record IsAbelianGroup (∙ : Op₂ A)
+                      (ε : A) (⁻¹ : Op₁ A) : Set (a ⊔ ℓ) where
   field
-    isGroup : IsGroup ≈ ∙ ε ⁻¹
+    isGroup : IsGroup ∙ ε ⁻¹
     comm    : Commutative ∙
 
   open IsGroup isGroup public
 
-  isCommutativeMonoid : IsCommutativeMonoid ≈ ∙ ε
+  isCommutativeMonoid : IsCommutativeMonoid ∙ ε
   isCommutativeMonoid = record
     { isSemigroup = isSemigroup
-    ; identityˡ   = proj₁ identity
+    ; identityˡ   = identityˡ
     ; comm        = comm
     }
 
 ------------------------------------------------------------------------
--- Two binary operations
+-- Semirings
 
-record IsNearSemiring {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                      (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsNearSemiring (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
   field
-    +-isMonoid    : IsMonoid ≈ + 0#
-    *-isSemigroup : IsSemigroup ≈ *
+    +-isMonoid    : IsMonoid + 0#
+    *-isSemigroup : IsSemigroup *
     distribʳ      : * DistributesOverʳ +
     zeroˡ         : LeftZero 0# *
 
   open IsMonoid +-isMonoid public
-         renaming ( assoc       to +-assoc
-                  ; ∙-cong      to +-cong
-                  ; isSemigroup to +-isSemigroup
-                  ; identity    to +-identity
-                  )
+    renaming
+    ( assoc       to +-assoc
+    ; ∙-cong      to +-cong
+    ; isSemigroup to +-isSemigroup
+    ; identity    to +-identity
+    ; identityˡ    to +-identityˡ
+    ; identityʳ    to +-identityʳ
+    )
 
   open IsSemigroup *-isSemigroup public
-         using ()
-         renaming ( assoc    to *-assoc
-                  ; ∙-cong   to *-cong
-                  )
+    using ()
+    renaming
+    ( assoc    to *-assoc
+    ; ∙-cong   to *-cong
+    )
 
-record IsSemiringWithoutOne {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                            (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsSemiringWithoutOne (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
   field
-    +-isCommutativeMonoid : IsCommutativeMonoid ≈ + 0#
-    *-isSemigroup         : IsSemigroup ≈ *
+    +-isCommutativeMonoid : IsCommutativeMonoid + 0#
+    *-isSemigroup         : IsSemigroup *
     distrib               : * DistributesOver +
     zero                  : Zero 0# *
 
   open IsCommutativeMonoid +-isCommutativeMonoid public
-         hiding (identityˡ)
-         renaming ( assoc       to +-assoc
-                  ; ∙-cong      to +-cong
-                  ; isSemigroup to +-isSemigroup
-                  ; identity    to +-identity
-                  ; isMonoid    to +-isMonoid
-                  ; comm        to +-comm
-                  )
+    using ()
+    renaming
+    ( isMonoid    to +-isMonoid
+    ; comm        to +-comm
+    )
 
   open IsSemigroup *-isSemigroup public
-         using ()
-         renaming ( assoc       to *-assoc
-                  ; ∙-cong      to *-cong
-                  )
+    using ()
+    renaming
+    ( assoc       to *-assoc
+    ; ∙-cong      to *-cong
+    )
 
-  isNearSemiring : IsNearSemiring ≈ + * 0#
+  isNearSemiring : IsNearSemiring + * 0#
   isNearSemiring = record
     { +-isMonoid    = +-isMonoid
     ; *-isSemigroup = *-isSemigroup
@@ -185,47 +174,57 @@ record IsSemiringWithoutOne {a ℓ} {A : Set a} (≈ : Rel A ℓ)
     ; zeroˡ         = proj₁ zero
     }
 
-record IsSemiringWithoutAnnihilatingZero
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-         (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+  open IsNearSemiring isNearSemiring public
+    hiding (+-isMonoid)
+
+record IsSemiringWithoutAnnihilatingZero (+ * : Op₂ A)
+                                         (0# 1# : A) : Set (a ⊔ ℓ) where
   field
     -- Note that these structures do have an additive unit, but this
     -- unit does not necessarily annihilate multiplication.
-    +-isCommutativeMonoid : IsCommutativeMonoid ≈ + 0#
-    *-isMonoid            : IsMonoid ≈ * 1#
+    +-isCommutativeMonoid : IsCommutativeMonoid + 0#
+    *-isMonoid            : IsMonoid * 1#
     distrib               : * DistributesOver +
 
+  distribˡ : * DistributesOverˡ +
+  distribˡ = proj₁ distrib
+
+  distribʳ : * DistributesOverʳ +
+  distribʳ = proj₂ distrib
+
   open IsCommutativeMonoid +-isCommutativeMonoid public
-         hiding (identityˡ)
-         renaming ( assoc       to +-assoc
-                  ; ∙-cong      to +-cong
-                  ; isSemigroup to +-isSemigroup
-                  ; identity    to +-identity
-                  ; isMonoid    to +-isMonoid
-                  ; comm        to +-comm
-                  )
+    renaming
+    ( assoc       to +-assoc
+    ; ∙-cong      to +-cong
+    ; isSemigroup to +-isSemigroup
+    ; identity    to +-identity
+    ; identityˡ    to +-identityˡ
+    ; identityʳ    to +-identityʳ
+    ; isMonoid    to +-isMonoid
+    ; comm        to +-comm
+    )
 
   open IsMonoid *-isMonoid public
-         using ()
-         renaming ( assoc       to *-assoc
-                  ; ∙-cong      to *-cong
-                  ; isSemigroup to *-isSemigroup
-                  ; identity    to *-identity
-                  )
+    using ()
+    renaming
+    ( assoc       to *-assoc
+    ; ∙-cong      to *-cong
+    ; isSemigroup to *-isSemigroup
+    ; identity    to *-identity
+    ; identityˡ    to *-identityˡ
+    ; identityʳ    to *-identityʳ
+    )
 
-record IsSemiring {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                  (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsSemiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field
     isSemiringWithoutAnnihilatingZero :
-      IsSemiringWithoutAnnihilatingZero ≈ + * 0# 1#
+      IsSemiringWithoutAnnihilatingZero + * 0# 1#
     zero : Zero 0# *
 
   open IsSemiringWithoutAnnihilatingZero
          isSemiringWithoutAnnihilatingZero public
 
-  isSemiringWithoutOne : IsSemiringWithoutOne ≈ + * 0#
+  isSemiringWithoutOne : IsSemiringWithoutOne + * 0#
   isSemiringWithoutOne = record
     { +-isCommutativeMonoid = +-isCommutativeMonoid
     ; *-isSemigroup         = *-isSemigroup
@@ -234,54 +233,42 @@ record IsSemiring {a ℓ} {A : Set a} (≈ : Rel A ℓ)
     }
 
   open IsSemiringWithoutOne isSemiringWithoutOne public
-         using (isNearSemiring)
+    using (isNearSemiring)
 
 record IsCommutativeSemiringWithoutOne
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
          (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
   field
-    isSemiringWithoutOne : IsSemiringWithoutOne ≈ + * 0#
+    isSemiringWithoutOne : IsSemiringWithoutOne + * 0#
     *-comm               : Commutative *
 
   open IsSemiringWithoutOne isSemiringWithoutOne public
 
-record IsCommutativeSemiring
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-         (_+_ _*_ : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsCommutativeSemiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field
-    +-isCommutativeMonoid : IsCommutativeMonoid ≈ _+_ 0#
-    *-isCommutativeMonoid : IsCommutativeMonoid ≈ _*_ 1#
-    distribʳ              : _*_ DistributesOverʳ _+_
-    zeroˡ                 : LeftZero 0# _*_
+    +-isCommutativeMonoid : IsCommutativeMonoid + 0#
+    *-isCommutativeMonoid : IsCommutativeMonoid * 1#
+    distribʳ              : * DistributesOverʳ +
+    zeroˡ                 : LeftZero 0# *
 
   private
     module +-CM = IsCommutativeMonoid +-isCommutativeMonoid
     open module *-CM = IsCommutativeMonoid *-isCommutativeMonoid public
            using () renaming (comm to *-comm)
-  open EqR (record { isEquivalence = +-CM.isEquivalence })
 
-  distrib : _*_ DistributesOver _+_
+  distribˡ : * DistributesOverˡ +
+  distribˡ = Consequences.comm+distrʳ⇒distrˡ
+              +-CM.setoid +-CM.∙-cong *-comm distribʳ
+
+  distrib : * DistributesOver +
   distrib = (distribˡ , distribʳ)
-    where
-    distribˡ : _*_ DistributesOverˡ _+_
-    distribˡ x y z = begin
-      (x * (y + z))        ≈⟨ *-comm x (y + z) ⟩
-      ((y + z) * x)        ≈⟨ distribʳ x y z ⟩
-      ((y * x) + (z * x))  ≈⟨ *-comm y x ⟨ +-CM.∙-cong ⟩ *-comm z x ⟩
-      ((x * y) + (x * z))  ∎
 
-  zero : Zero 0# _*_
+  zeroʳ : RightZero 0# *
+  zeroʳ = Consequences.comm+zeˡ⇒zeʳ +-CM.setoid *-comm zeroˡ
+
+  zero : Zero 0# *
   zero = (zeroˡ , zeroʳ)
-    where
-    zeroʳ : RightZero 0# _*_
-    zeroʳ x = begin
-      (x * 0#)  ≈⟨ *-comm x 0# ⟩
-      (0# * x)  ≈⟨ zeroˡ x ⟩
-      0#        ∎
 
-  isSemiring : IsSemiring ≈ _+_ _*_ 0# 1#
+  isSemiring : IsSemiring + * 0# 1#
   isSemiring = record
     { isSemiringWithoutAnnihilatingZero = record
       { +-isCommutativeMonoid = +-isCommutativeMonoid
@@ -292,83 +279,73 @@ record IsCommutativeSemiring
     }
 
   open IsSemiring isSemiring public
-         hiding (distrib; zero; +-isCommutativeMonoid)
+         hiding (distrib; distribʳ; distribˡ; zero; +-isCommutativeMonoid)
 
   isCommutativeSemiringWithoutOne :
-    IsCommutativeSemiringWithoutOne ≈ _+_ _*_ 0#
+    IsCommutativeSemiringWithoutOne + * 0#
   isCommutativeSemiringWithoutOne = record
     { isSemiringWithoutOne = isSemiringWithoutOne
     ; *-comm               = *-CM.comm
     }
 
-record IsRing
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-         (_+_ _*_ : Op₂ A) (-_ : Op₁ A) (0# 1# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+------------------------------------------------------------------------
+-- Rings
+
+record IsRing (+ * : Op₂ A) (-_ : Op₁ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field
-    +-isAbelianGroup : IsAbelianGroup ≈ _+_ 0# -_
-    *-isMonoid       : IsMonoid ≈ _*_ 1#
-    distrib          : _*_ DistributesOver _+_
+    +-isAbelianGroup : IsAbelianGroup + 0# -_
+    *-isMonoid       : IsMonoid * 1#
+    distrib          : * DistributesOver +
 
   open IsAbelianGroup +-isAbelianGroup public
-         renaming ( assoc               to +-assoc
-                  ; ∙-cong              to +-cong
-                  ; isSemigroup         to +-isSemigroup
-                  ; identity            to +-identity
-                  ; isMonoid            to +-isMonoid
-                  ; inverse             to -‿inverse
-                  ; ⁻¹-cong             to -‿cong
-                  ; isGroup             to +-isGroup
-                  ; comm                to +-comm
-                  ; isCommutativeMonoid to +-isCommutativeMonoid
-                  )
+    renaming
+    ( assoc               to +-assoc
+    ; ∙-cong              to +-cong
+    ; isSemigroup         to +-isSemigroup
+    ; identity            to +-identity
+    ; identityˡ           to +-identityˡ
+    ; identityʳ           to +-identityʳ
+    ; isMonoid            to +-isMonoid
+    ; inverse             to -‿inverse
+    ; inverseˡ            to -‿inverseˡ
+    ; inverseʳ            to -‿inverseʳ
+    ; ⁻¹-cong             to -‿cong
+    ; isGroup             to +-isGroup
+    ; comm                to +-comm
+    ; isCommutativeMonoid to +-isCommutativeMonoid
+    )
 
   open IsMonoid *-isMonoid public
-         using ()
-         renaming ( assoc       to *-assoc
-                  ; ∙-cong      to *-cong
-                  ; isSemigroup to *-isSemigroup
-                  ; identity    to *-identity
-                  )
+    using ()
+    renaming
+    ( assoc       to *-assoc
+    ; ∙-cong      to *-cong
+    ; isSemigroup to *-isSemigroup
+    ; identity    to *-identity
+    ; identityˡ   to *-identityˡ
+    ; identityʳ   to *-identityʳ
+    )
 
-  zero : Zero 0# _*_
+  zeroˡ : LeftZero 0# *
+  zeroˡ = Consequences.assoc+distribʳ+idʳ+invʳ⇒zeˡ setoid
+           +-cong *-cong +-assoc (proj₂ distrib) +-identityʳ -‿inverseʳ
+
+  zeroʳ : RightZero 0# *
+  zeroʳ = Consequences.assoc+distribˡ+idʳ+invʳ⇒zeʳ setoid
+           +-cong *-cong +-assoc (proj₁ distrib) +-identityʳ -‿inverseʳ
+
+  zero : Zero 0# *
   zero = (zeroˡ , zeroʳ)
-    where
-    open EqR (record { isEquivalence = isEquivalence })
-
-    zeroˡ : LeftZero 0# _*_
-    zeroˡ x = begin
-        (0# * x)                                ≈⟨ sym $ proj₂ +-identity _ ⟩
-       ((0# * x) +            0#)               ≈⟨ refl ⟨ +-cong ⟩ sym (proj₂ -‿inverse _) ⟩
-       ((0# * x) + ((0# * x)  + (- (0# * x))))  ≈⟨ sym $ +-assoc _ _ _ ⟩
-      (((0# * x) +  (0# * x)) + (- (0# * x)))   ≈⟨ sym (proj₂ distrib _ _ _) ⟨ +-cong ⟩ refl ⟩
-             (((0# + 0#) * x) + (- (0# * x)))   ≈⟨ (proj₂ +-identity _ ⟨ *-cong ⟩ refl)
-                                                     ⟨ +-cong ⟩
-                                                   refl ⟩
-                    ((0# * x) + (- (0# * x)))   ≈⟨ proj₂ -‿inverse _ ⟩
-                             0#                 ∎
-
-    zeroʳ : RightZero 0# _*_
-    zeroʳ x = begin
-      (x * 0#)                                ≈⟨ sym $ proj₂ +-identity _ ⟩
-      ((x * 0#) + 0#)                         ≈⟨ refl ⟨ +-cong ⟩ sym (proj₂ -‿inverse _) ⟩
-      ((x * 0#) + ((x * 0#) + (- (x * 0#))))  ≈⟨ sym $ +-assoc _ _ _ ⟩
-      (((x * 0#) + (x * 0#)) + (- (x * 0#)))  ≈⟨ sym (proj₁ distrib _ _ _) ⟨ +-cong ⟩ refl ⟩
-      ((x * (0# + 0#)) + (- (x * 0#)))        ≈⟨ (refl ⟨ *-cong ⟩ proj₂ +-identity _)
-                                                   ⟨ +-cong ⟩
-                                                 refl ⟩
-      ((x * 0#) + (- (x * 0#)))               ≈⟨ proj₂ -‿inverse _ ⟩
-      0#                                      ∎
 
   isSemiringWithoutAnnihilatingZero
-    : IsSemiringWithoutAnnihilatingZero ≈ _+_ _*_ 0# 1#
+    : IsSemiringWithoutAnnihilatingZero + * 0# 1#
   isSemiringWithoutAnnihilatingZero = record
     { +-isCommutativeMonoid = +-isCommutativeMonoid
     ; *-isMonoid            = *-isMonoid
     ; distrib               = distrib
     }
 
-  isSemiring : IsSemiring ≈ _+_ _*_ 0# 1#
+  isSemiring : IsSemiring + * 0# 1#
   isSemiring = record
     { isSemiringWithoutAnnihilatingZero =
         isSemiringWithoutAnnihilatingZero
@@ -376,24 +353,22 @@ record IsRing
     }
 
   open IsSemiring isSemiring public
-         using (isNearSemiring; isSemiringWithoutOne)
+    using (distribˡ; distribʳ; isNearSemiring; isSemiringWithoutOne)
 
 record IsCommutativeRing
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
          (+ * : Op₂ A) (- : Op₁ A) (0# 1# : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
   field
-    isRing : IsRing ≈ + * - 0# 1#
+    isRing : IsRing + * - 0# 1#
     *-comm : Commutative *
 
   open IsRing isRing public
 
-  isCommutativeSemiring : IsCommutativeSemiring ≈ + * 0# 1#
+  isCommutativeSemiring : IsCommutativeSemiring + * 0# 1#
   isCommutativeSemiring = record
     { +-isCommutativeMonoid = +-isCommutativeMonoid
     ; *-isCommutativeMonoid = record
       { isSemigroup = *-isSemigroup
-      ; identityˡ   = proj₁ *-identity
+      ; identityˡ   = *-identityˡ
       ; comm        = *-comm
       }
     ; distribʳ              = proj₂ distrib
@@ -401,42 +376,40 @@ record IsCommutativeRing
     }
 
   open IsCommutativeSemiring isCommutativeSemiring public
-         using ( *-isCommutativeMonoid
-               ; isCommutativeSemiringWithoutOne
-               )
+    using
+    ( *-isCommutativeMonoid
+    ; isCommutativeSemiringWithoutOne
+    )
 
-record IsLattice {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                 (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+------------------------------------------------------------------------
+-- Lattices
+
+record IsLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isEquivalence : IsEquivalence ≈
+    isEquivalence : IsEquivalence _≈_
     ∨-comm        : Commutative ∨
     ∨-assoc       : Associative ∨
-    ∨-cong        : ∨ Preserves₂ ≈ ⟶ ≈ ⟶ ≈
+    ∨-cong        : Congruent₂ ∨
     ∧-comm        : Commutative ∧
     ∧-assoc       : Associative ∧
-    ∧-cong        : ∧ Preserves₂ ≈ ⟶ ≈ ⟶ ≈
+    ∧-cong        : Congruent₂ ∧
     absorptive    : Absorptive ∨ ∧
 
   open IsEquivalence isEquivalence public
 
-record IsDistributiveLattice {a ℓ} {A : Set a} (≈ : Rel A ℓ)
-                             (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
+record IsDistributiveLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isLattice    : IsLattice ≈ ∨ ∧
+    isLattice    : IsLattice ∨ ∧
     ∨-∧-distribʳ : ∨ DistributesOverʳ ∧
 
   open IsLattice isLattice public
 
 record IsBooleanAlgebra
-         {a ℓ} {A : Set a} (≈ : Rel A ℓ)
          (∨ ∧ : Op₂ A) (¬ : Op₁ A) (⊤ ⊥ : A) : Set (a ⊔ ℓ) where
-  open FunctionProperties ≈
   field
-    isDistributiveLattice : IsDistributiveLattice ≈ ∨ ∧
+    isDistributiveLattice : IsDistributiveLattice ∨ ∧
     ∨-complementʳ         : RightInverse ⊤ ¬ ∨
     ∧-complementʳ         : RightInverse ⊥ ¬ ∧
-    ¬-cong                : ¬ Preserves ≈ ⟶ ≈
+    ¬-cong                : Congruent₁ ¬
 
   open IsDistributiveLattice isDistributiveLattice public

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -12,13 +12,13 @@ open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence
   using (_⇔_; equivalence; module Equivalence)
 open import Algebra
-open import Algebra.Structures
 import Algebra.RingSolver.Simple as Solver
 import Algebra.RingSolver.AlmostCommutativeRing as ACR
 open import Relation.Binary.PropositionalEquality
   hiding ([_]; proof-irrelevance)
 open ≡-Reasoning
 open import Algebra.FunctionProperties (_≡_ {A = Bool})
+open import Algebra.Structures (_≡_ {A = Bool})
 open import Data.Product
 open import Data.Sum
 open import Data.Empty
@@ -74,18 +74,40 @@ open import Data.Empty
 ∨-sel false y = inj₂ refl
 ∨-sel true y  = inj₁ refl
 
-∨-isSemigroup : IsSemigroup _≡_ _∨_
+∨-isSemigroup : IsSemigroup _∨_
 ∨-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ∨-assoc
   ; ∙-cong        = cong₂ _∨_
   }
 
-∨-isCommutativeMonoid : IsCommutativeMonoid _≡_ _∨_ false
+∨-semigroup : Semigroup _ _
+∨-semigroup = record
+  { isSemigroup = ∨-isSemigroup
+  }
+
+∨-isCommutativeMonoid : IsCommutativeMonoid _∨_ false
 ∨-isCommutativeMonoid = record
   { isSemigroup = ∨-isSemigroup
-  ; identityˡ   = λ _ → refl
+  ; identityˡ   = ∨-identityˡ
   ; comm        = ∨-comm
+  }
+
+∨-commutativeMonoid : CommutativeMonoid _ _
+∨-commutativeMonoid = record
+  { isCommutativeMonoid = ∨-isCommutativeMonoid
+  }
+
+∨-isIdempotentCommutativeMonoid :
+  IsIdempotentCommutativeMonoid _∨_ false
+∨-isIdempotentCommutativeMonoid = record
+    { isCommutativeMonoid = ∨-isCommutativeMonoid
+   ; idem = ∨-idem
+   }
+
+∨-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+∨-idempotentCommutativeMonoid = record
+  { isIdempotentCommutativeMonoid = ∨-isIdempotentCommutativeMonoid
   }
 
 ------------------------------------------------------------------------
@@ -159,8 +181,8 @@ open import Data.Empty
 
 ∨-distribʳ-∧ : _∨_ DistributesOverʳ _∧_
 ∨-distribʳ-∧ x y z = begin
-  (y ∧ z) ∨ x         ≡⟨ ∨-comm (y ∧ z) x ⟩
-  x ∨ (y ∧ z)         ≡⟨ ∨-distribˡ-∧ x y z ⟩
+  (y ∧ z) ∨ x        ≡⟨ ∨-comm (y ∧ z) x ⟩
+  x ∨ (y ∧ z)        ≡⟨ ∨-distribˡ-∧ x y z ⟩
   (x ∨ y) ∧ (x ∨ z)  ≡⟨ cong₂ _∧_ (∨-comm x y) (∨-comm x z) ⟩
   (y ∨ x) ∧ (z ∨ x)  ∎
 
@@ -178,27 +200,49 @@ open import Data.Empty
 ∨-∧-absorptive : Absorptive _∨_ _∧_
 ∨-∧-absorptive = ∨-abs-∧ , ∧-abs-∨
 
-∧-isSemigroup : IsSemigroup _≡_ _∧_
+∧-isSemigroup : IsSemigroup _∧_
 ∧-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ∧-assoc
   ; ∙-cong        = cong₂ _∧_
   }
 
-∧-isCommutativeMonoid : IsCommutativeMonoid _≡_ _∧_ true
+∧-semigroup : Semigroup _ _
+∧-semigroup = record
+  { isSemigroup = ∧-isSemigroup
+  }
+
+∧-isCommutativeMonoid : IsCommutativeMonoid _∧_ true
 ∧-isCommutativeMonoid = record
   { isSemigroup = ∧-isSemigroup
-  ; identityˡ   = λ _ → refl
+  ; identityˡ   = ∧-identityˡ
   ; comm        = ∧-comm
   }
 
+∧-commutativeMonoid : CommutativeMonoid _ _
+∧-commutativeMonoid = record
+  { isCommutativeMonoid = ∧-isCommutativeMonoid
+  }
+
+∧-isIdempotentCommutativeMonoid :
+  IsIdempotentCommutativeMonoid _∧_ true
+∧-isIdempotentCommutativeMonoid = record
+  { isCommutativeMonoid = ∧-isCommutativeMonoid
+  ; idem = ∧-idem
+  }
+
+∧-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+∧-idempotentCommutativeMonoid = record
+  { isIdempotentCommutativeMonoid = ∧-isIdempotentCommutativeMonoid
+  }
+
 ∨-∧-isCommutativeSemiring
-  : IsCommutativeSemiring _≡_ _∨_ _∧_ false true
+  : IsCommutativeSemiring _∨_ _∧_ false true
 ∨-∧-isCommutativeSemiring = record
   { +-isCommutativeMonoid = ∨-isCommutativeMonoid
   ; *-isCommutativeMonoid = ∧-isCommutativeMonoid
   ; distribʳ = ∧-distribʳ-∨
-  ; zeroˡ    = λ _ → refl
+  ; zeroˡ    = ∧-zeroˡ
   }
 
 ∨-∧-commutativeSemiring : CommutativeSemiring _ _
@@ -211,12 +255,12 @@ open import Data.Empty
   }
 
 ∧-∨-isCommutativeSemiring
-  : IsCommutativeSemiring _≡_ _∧_ _∨_ true false
+  : IsCommutativeSemiring _∧_ _∨_ true false
 ∧-∨-isCommutativeSemiring = record
   { +-isCommutativeMonoid = ∧-isCommutativeMonoid
   ; *-isCommutativeMonoid = ∨-isCommutativeMonoid
   ; distribʳ = ∨-distribʳ-∧
-  ; zeroˡ    = λ _ → refl
+  ; zeroˡ    = ∨-zeroˡ
   }
 
 ∧-∨-commutativeSemiring : CommutativeSemiring _ _
@@ -228,7 +272,7 @@ open import Data.Empty
   ; isCommutativeSemiring = ∧-∨-isCommutativeSemiring
   }
 
-∨-∧-isLattice : IsLattice _≡_ _∨_ _∧_
+∨-∧-isLattice : IsLattice _∨_ _∧_
 ∨-∧-isLattice = record
   { isEquivalence = isEquivalence
   ; ∨-comm        = ∨-comm
@@ -240,13 +284,23 @@ open import Data.Empty
   ; absorptive    = ∨-∧-absorptive
   }
 
-∨-∧-isDistributiveLattice : IsDistributiveLattice _≡_ _∨_ _∧_
+∨-∧-lattice : Lattice _ _
+∨-∧-lattice = record
+  { isLattice = ∨-∧-isLattice
+  }
+
+∨-∧-isDistributiveLattice : IsDistributiveLattice _∨_ _∧_
 ∨-∧-isDistributiveLattice = record
   { isLattice     = ∨-∧-isLattice
   ; ∨-∧-distribʳ = ∨-distribʳ-∧
   }
 
-∨-∧-isBooleanAlgebra : IsBooleanAlgebra _≡_ _∨_ _∧_ not true false
+∨-∧-distributiveLattice : DistributiveLattice _ _
+∨-∧-distributiveLattice = record
+  { isDistributiveLattice = ∨-∧-isDistributiveLattice
+  }
+
+∨-∧-isBooleanAlgebra : IsBooleanAlgebra _∨_ _∧_ not true false
 ∨-∧-isBooleanAlgebra = record
   { isDistributiveLattice = ∨-∧-isDistributiveLattice
   ; ∨-complementʳ = ∨-inverseʳ
@@ -256,12 +310,7 @@ open import Data.Empty
 
 ∨-∧-booleanAlgebra : BooleanAlgebra _ _
 ∨-∧-booleanAlgebra = record
-  { _∨_              = _∨_
-  ; _∧_              = _∧_
-  ; ¬_               = not
-  ; ⊤                = true
-  ; ⊥                = false
-  ; isBooleanAlgebra = ∨-∧-isBooleanAlgebra
+  { isBooleanAlgebra = ∨-∧-isBooleanAlgebra
   }
 
 ------------------------------------------------------------------------

--- a/src/Data/Fin.agda
+++ b/src/Data/Fin.agda
@@ -11,14 +11,11 @@
 module Data.Fin where
 
 open import Data.Empty using (⊥-elim)
-open import Data.Nat as Nat
+open import Data.Nat as ℕ
   using (ℕ; zero; suc; z≤n; s≤s)
-  renaming ( _+_ to _N+_; _∸_ to _N∸_
-           ; _≤_ to _N≤_; _≥_ to _N≥_; _<_ to _N<_; _≤?_ to _N≤?_)
-open import Function
-import Level
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
+open import Function using (_∘_; _on_)
+open import Level using () renaming (zero to ℓ₀)
+open import Relation.Nullary.Decidable using (True; toWitness)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; cong)
@@ -56,33 +53,33 @@ fromℕ (suc n) = suc (fromℕ n)
 
 -- fromℕ≤ {m} _ = "m".
 
-fromℕ≤ : ∀ {m n} → m N< n → Fin n
-fromℕ≤ (Nat.s≤s Nat.z≤n)       = zero
-fromℕ≤ (Nat.s≤s (Nat.s≤s m≤n)) = suc (fromℕ≤ (Nat.s≤s m≤n))
+fromℕ≤ : ∀ {m n} → m ℕ.< n → Fin n
+fromℕ≤ (s≤s z≤n)       = zero
+fromℕ≤ (s≤s (s≤s m≤n)) = suc (fromℕ≤ (s≤s m≤n))
 
 -- fromℕ≤″ m _ = "m".
 
-fromℕ≤″ : ∀ m {n} → m Nat.<″ n → Fin n
-fromℕ≤″ zero    (Nat.less-than-or-equal refl) = zero
-fromℕ≤″ (suc m) (Nat.less-than-or-equal refl) =
-  suc (fromℕ≤″ m (Nat.less-than-or-equal refl))
+fromℕ≤″ : ∀ m {n} → m ℕ.<″ n → Fin n
+fromℕ≤″ zero    (ℕ.less-than-or-equal refl) = zero
+fromℕ≤″ (suc m) (ℕ.less-than-or-equal refl) =
+  suc (fromℕ≤″ m (ℕ.less-than-or-equal refl))
 
 -- # m = "m".
 
 infix 10 #_
 
-#_ : ∀ m {n} {m<n : True (suc m N≤? n)} → Fin n
+#_ : ∀ m {n} {m<n : True (suc m ℕ.≤? n)} → Fin n
 #_ _ {m<n = m<n} = fromℕ≤ (toWitness m<n)
 
 -- raise m "n" = "m + n".
 
-raise : ∀ {m} n → Fin m → Fin (n N+ m)
+raise : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
 raise zero    i = i
 raise (suc n) i = suc (raise n i)
 
 -- reduce≥ "m + n" _ = "n".
 
-reduce≥ : ∀ {m n} (i : Fin (m N+ n)) (i≥m : toℕ i N≥ m) → Fin n
+reduce≥ : ∀ {m n} (i : Fin (m ℕ.+ n)) (i≥m : toℕ i ℕ.≥ m) → Fin n
 reduce≥ {zero}  i       i≥m       = i
 reduce≥ {suc m} zero    ()
 reduce≥ {suc m} (suc i) (s≤s i≥m) = reduce≥ i i≥m
@@ -100,7 +97,7 @@ inject!             {i = zero}   ()
 inject! {n = suc _} {i = suc _}  zero    = zero
 inject! {n = suc _} {i = suc _}  (suc j) = suc (inject! j)
 
-inject+ : ∀ {m} n → Fin m → Fin (m N+ n)
+inject+ : ∀ {m} n → Fin m → Fin (m ℕ.+ n)
 inject+ n zero    = zero
 inject+ n (suc i) = suc (inject+ n i)
 
@@ -108,9 +105,9 @@ inject₁ : ∀ {m} → Fin m → Fin (suc m)
 inject₁ zero    = zero
 inject₁ (suc i) = suc (inject₁ i)
 
-inject≤ : ∀ {m n} → Fin m → m N≤ n → Fin n
-inject≤ zero    (Nat.s≤s le) = zero
-inject≤ (suc i) (Nat.s≤s le) = suc (inject≤ i le)
+inject≤ : ∀ {m n} → Fin m → m ℕ.≤ n → Fin n
+inject≤ zero    (s≤s le) = zero
+inject≤ (suc i) (s≤s le) = suc (inject≤ i le)
 
 -- A strengthening injection into the minimal Fin fibre.
 strengthen : ∀ {n} (i : Fin n) → Fin′ (suc i)
@@ -140,7 +137,7 @@ fold′ {n = suc n} T f x (suc i)  =
 
 -- Lifts functions.
 
-lift : ∀ {m n} k → (Fin m → Fin n) → Fin (k N+ m) → Fin (k N+ n)
+lift : ∀ {m n} k → (Fin m → Fin n) → Fin (k ℕ.+ m) → Fin (k ℕ.+ n)
 lift zero    f i       = f i
 lift (suc k) f zero    = zero
 lift (suc k) f (suc i) = suc (lift k f i)
@@ -149,7 +146,7 @@ lift (suc k) f (suc i) = suc (lift k f i)
 
 infixl 6 _+_
 
-_+_ : ∀ {m n} (i : Fin m) (j : Fin n) → Fin (toℕ i N+ n)
+_+_ : ∀ {m n} (i : Fin m) (j : Fin n) → Fin (toℕ i ℕ.+ n)
 zero  + j = j
 suc i + j = suc (i + j)
 
@@ -157,7 +154,7 @@ suc i + j = suc (i + j)
 
 infixl 6 _-_
 
-_-_ : ∀ {m} (i : Fin m) (j : Fin′ (suc i)) → Fin (m N∸ toℕ j)
+_-_ : ∀ {m} (i : Fin m) (j : Fin′ (suc i)) → Fin (m ℕ.∸ toℕ j)
 i     - zero   = i
 zero  - suc ()
 suc i - suc j  = i - j
@@ -166,7 +163,7 @@ suc i - suc j  = i - j
 
 infixl 6 _ℕ-_
 
-_ℕ-_ : (n : ℕ) (j : Fin (suc n)) → Fin (suc n N∸ toℕ j)
+_ℕ-_ : (n : ℕ) (j : Fin (suc n)) → Fin (suc n ℕ.∸ toℕ j)
 n     ℕ- zero   = fromℕ n
 zero  ℕ- suc ()
 suc n ℕ- suc i  = n ℕ- i
@@ -204,23 +201,22 @@ punchIn zero    j       = suc j
 punchIn (suc i) zero    = zero
 punchIn (suc i) (suc j) = suc (punchIn i j)
 
-
 ------------------------------------------------------------------------
 -- Order relations
 
 infix 4 _≤_ _<_
 
-_≤_ : ∀ {n} → Rel (Fin n) Level.zero
-_≤_ = _N≤_ on toℕ
+_≤_ : ∀ {n} → Rel (Fin n) ℓ₀
+_≤_ = ℕ._≤_ on toℕ
 
-_≤?_ : ∀ {n} → (a : Fin n) → (b : Fin n) → Dec (a ≤ b)
-a ≤? b = toℕ a N≤? toℕ b
-
-_<_ : ∀ {n} → Rel (Fin n) Level.zero
-_<_ = _N<_ on toℕ
+_<_ : ∀ {n} → Rel (Fin n) ℓ₀
+_<_ = ℕ._<_ on toℕ
 
 data _≺_ : ℕ → ℕ → Set where
   _≻toℕ_ : ∀ n (i : Fin n) → toℕ i ≺ n
+
+_≤?_ : ∀ {n} → Decidable (_≤_ {n})
+a ≤? b = toℕ a ℕ.≤? toℕ b
 
 -- An ordering view.
 
@@ -237,7 +233,8 @@ compare zero    (suc j) = less    (suc j) zero
 compare (suc i) zero    = greater (suc i) zero
 compare (suc i) (suc j) with compare i j
 compare (suc .(inject least)) (suc .greatest) | less    greatest least =
-                                                  less    (suc greatest) (suc least)
+  less    (suc greatest) (suc least)
 compare (suc .greatest) (suc .(inject least)) | greater greatest least =
-                                                  greater (suc greatest) (suc least)
-compare (suc .i)        (suc .i)              | equal i = equal (suc i)
+  greater (suc greatest) (suc least)
+compare (suc .i)        (suc .i)              | equal i =
+  equal (suc i)

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -11,7 +11,6 @@ import Algebra.Morphism as Morphism
 import Algebra.Properties.AbelianGroup
 import Algebra.RingSolver.Simple as Solver
 import Algebra.RingSolver.AlmostCommutativeRing as ACR
-open import Algebra.Structures
 open import Data.Integer renaming (suc to sucℤ)
 open import Data.Nat
   using (ℕ; suc; zero; _∸_; s≤s; z≤n; ≤-pred)
@@ -32,6 +31,7 @@ open import Relation.Nullary.Negation using (contradiction)
 
 open import Algebra.FunctionProperties (_≡_ {A = ℤ})
 open import Algebra.FunctionProperties.Consequences (setoid ℤ)
+open import Algebra.Structures (_≡_ {A = ℤ})
 open Morphism.Definitions ℤ ℕ _≡_
 open ℕₚ.SemiringSolver
 open ≡-Reasoning
@@ -288,20 +288,20 @@ distribʳ-⊖-+-neg a b c = begin
 +-inverse : Inverse (+ 0) -_ _+_
 +-inverse = +-inverseˡ , +-inverseʳ
 
-+-isSemigroup : IsSemigroup _≡_ _+_
++-isSemigroup : IsSemigroup _+_
 +-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = +-assoc
   ; ∙-cong        = cong₂ _+_
   }
 
-+-0-isMonoid : IsMonoid _≡_ _+_ (+ 0)
++-0-isMonoid : IsMonoid _+_ (+ 0)
 +-0-isMonoid = record
   { isSemigroup = +-isSemigroup
   ; identity    = +-identity
   }
 
-+-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ (+ 0)
++-0-isCommutativeMonoid : IsCommutativeMonoid _+_ (+ 0)
 +-0-isCommutativeMonoid = record
   { isSemigroup = +-isSemigroup
   ; identityˡ   = +-identityˡ
@@ -317,14 +317,14 @@ distribʳ-⊖-+-neg a b c = begin
   ; isCommutativeMonoid = +-0-isCommutativeMonoid
   }
 
-+-0-isGroup : IsGroup _≡_ _+_ (+ 0) (-_)
++-0-isGroup : IsGroup _+_ (+ 0) (-_)
 +-0-isGroup = record
   { isMonoid = +-0-isMonoid
   ; inverse  = +-inverse
   ; ⁻¹-cong  = cong (-_)
   }
 
-+-isAbelianGroup : IsAbelianGroup _≡_ _+_ (+ 0) (-_)
++-isAbelianGroup : IsAbelianGroup _+_ (+ 0) (-_)
 +-isAbelianGroup = record
   { isGroup = +-0-isGroup
   ; comm    = +-comm
@@ -533,20 +533,20 @@ private
         | ℕₚ.*-distribʳ-∸ (suc c) b a
         = refl
 
-*-isSemigroup : IsSemigroup _ _
+*-isSemigroup : IsSemigroup _*_
 *-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = *-assoc
   ; ∙-cong        = cong₂ _*_
   }
 
-*-1-isMonoid : IsMonoid _≡_ _*_ (+ 1)
+*-1-isMonoid : IsMonoid _*_ (+ 1)
 *-1-isMonoid = record
   { isSemigroup = *-isSemigroup
   ; identity    = *-identity
   }
 
-*-1-isCommutativeMonoid : IsCommutativeMonoid _≡_ _*_ (+ 1)
+*-1-isCommutativeMonoid : IsCommutativeMonoid _*_ (+ 1)
 *-1-isCommutativeMonoid = record
   { isSemigroup = *-isSemigroup
   ; identityˡ   = *-identityˡ
@@ -562,7 +562,7 @@ private
   ; isCommutativeMonoid = *-1-isCommutativeMonoid
   }
 
-+-*-isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ (+ 0) (+ 1)
++-*-isCommutativeSemiring : IsCommutativeSemiring _+_ _*_ (+ 0) (+ 1)
 +-*-isCommutativeSemiring = record
   { +-isCommutativeMonoid = +-0-isCommutativeMonoid
   ; *-isCommutativeMonoid = *-1-isCommutativeMonoid
@@ -570,7 +570,7 @@ private
   ; zeroˡ                 = *-zeroˡ
   }
 
-+-*-isRing : IsRing _≡_ _+_ _*_ -_ (+ 0) (+ 1)
++-*-isRing : IsRing _+_ _*_ -_ (+ 0) (+ 1)
 +-*-isRing = record
   { +-isAbelianGroup = +-isAbelianGroup
   ; *-isMonoid       = *-1-isMonoid
@@ -578,7 +578,7 @@ private
                          +-*-isCommutativeSemiring
   }
 
-+-*-isCommutativeRing : IsCommutativeRing _≡_ _+_ _*_ -_ (+ 0) (+ 1)
++-*-isCommutativeRing : IsCommutativeRing _+_ _*_ -_ (+ 0) (+ 1)
 +-*-isCommutativeRing = record
   { isRing = +-*-isRing
   ; *-comm = *-comm

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -15,7 +15,6 @@ open import Function.Injection using (_↣_)
 open import Algebra
 import Algebra.RingSolver.Simple as Solver
 import Algebra.RingSolver.AlmostCommutativeRing as ACR
-open import Algebra.Structures
 open import Data.Nat as Nat
 open import Data.Product
 open import Data.Sum
@@ -28,6 +27,7 @@ open import Algebra.FunctionProperties (_≡_ {A = ℕ})
 open import Algebra.FunctionProperties
   using (LeftCancellative; RightCancellative; Cancellative)
 open import Algebra.FunctionProperties.Consequences (setoid ℕ)
+open import Algebra.Structures (_≡_ {A = ℕ})
 open import Algebra.Morphism
 open ≡-Reasoning
 
@@ -313,7 +313,7 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
   suc (n + m) ≡⟨ sym (+-suc n m) ⟩
   n + suc m   ∎
 
-+-isSemigroup : IsSemigroup _≡_ _+_
++-isSemigroup : IsSemigroup _+_
 +-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = +-assoc
@@ -323,15 +323,21 @@ s≤′s (≤′-step m≤′n) = ≤′-step (s≤′s m≤′n)
 +-semigroup : Semigroup _ _
 +-semigroup = record { isSemigroup = +-isSemigroup }
 
-+-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _+_ 0
++-0-isMonoid : IsMonoid _+_ 0
++-0-isMonoid = record
+  { isSemigroup = +-isSemigroup
+  ; identity    = +-identity
+  }
+
++-0-monoid : Monoid _ _
++-0-monoid = record { isMonoid = +-0-isMonoid }
+
++-0-isCommutativeMonoid : IsCommutativeMonoid _+_ 0
 +-0-isCommutativeMonoid = record
   { isSemigroup = +-isSemigroup
   ; identityˡ    = +-identityˡ
   ; comm        = +-comm
   }
-
-+-0-monoid : Monoid _ _
-+-0-monoid = record { isMonoid = IsCommutativeMonoid.isMonoid +-0-isCommutativeMonoid }
 
 +-0-commutativeMonoid : CommutativeMonoid _ _
 +-0-commutativeMonoid = record { isCommutativeMonoid = +-0-isCommutativeMonoid }
@@ -509,7 +515,7 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
   n * o + m * (n * o) ≡⟨⟩
   suc m * (n * o)     ∎
 
-*-isSemigroup : IsSemigroup _≡_ _*_
+*-isSemigroup : IsSemigroup _*_
 *-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = *-assoc
@@ -519,20 +525,26 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
 *-semigroup : Semigroup _ _
 *-semigroup = record { isSemigroup = *-isSemigroup }
 
-*-1-isCommutativeMonoid : IsCommutativeMonoid _≡_ _*_ 1
+*-1-isMonoid : IsMonoid _*_ 1
+*-1-isMonoid = record
+  { isSemigroup = *-isSemigroup
+  ; identity    = *-identity
+  }
+
+*-1-monoid : Monoid _ _
+*-1-monoid = record { isMonoid = *-1-isMonoid }
+
+*-1-isCommutativeMonoid : IsCommutativeMonoid _*_ 1
 *-1-isCommutativeMonoid = record
   { isSemigroup = *-isSemigroup
   ; identityˡ    = *-identityˡ
   ; comm        = *-comm
   }
 
-*-1-monoid : Monoid _ _
-*-1-monoid = record { isMonoid = IsCommutativeMonoid.isMonoid *-1-isCommutativeMonoid }
-
 *-1-commutativeMonoid : CommutativeMonoid _ _
 *-1-commutativeMonoid = record { isCommutativeMonoid = *-1-isCommutativeMonoid }
 
-*-+-isCommutativeSemiring : IsCommutativeSemiring _≡_ _+_ _*_ 0 1
+*-+-isCommutativeSemiring : IsCommutativeSemiring _+_ _*_ 0 1
 *-+-isCommutativeSemiring = record
   { +-isCommutativeMonoid = +-0-isCommutativeMonoid
   ; *-isCommutativeMonoid = *-1-isCommutativeMonoid
@@ -747,28 +759,28 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
 ⊓-⊔-absorptive : Absorptive _⊓_ _⊔_
 ⊓-⊔-absorptive = ⊓-abs-⊔ , ⊔-abs-⊓
 
-⊔-isSemigroup : IsSemigroup _≡_ _⊔_
+⊔-isSemigroup : IsSemigroup _⊔_
 ⊔-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ⊔-assoc
   ; ∙-cong        = cong₂ _⊔_
   }
 
-⊔-0-isCommutativeMonoid : IsCommutativeMonoid _≡_ _⊔_ 0
+⊔-0-isCommutativeMonoid : IsCommutativeMonoid _⊔_ 0
 ⊔-0-isCommutativeMonoid = record
   { isSemigroup = ⊔-isSemigroup
   ; identityˡ    = ⊔-identityˡ
   ; comm        = ⊔-comm
   }
 
-⊓-isSemigroup : IsSemigroup _≡_ _⊓_
+⊓-isSemigroup : IsSemigroup _⊓_
 ⊓-isSemigroup = record
   { isEquivalence = isEquivalence
   ; assoc         = ⊓-assoc
   ; ∙-cong        = cong₂ _⊓_
   }
 
-⊔-⊓-isSemiringWithoutOne : IsSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
+⊔-⊓-isSemiringWithoutOne : IsSemiringWithoutOne _⊔_ _⊓_ 0
 ⊔-⊓-isSemiringWithoutOne = record
   { +-isCommutativeMonoid = ⊔-0-isCommutativeMonoid
   ; *-isSemigroup         = ⊓-isSemigroup
@@ -777,7 +789,7 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
   }
 
 ⊔-⊓-isCommutativeSemiringWithoutOne
-  : IsCommutativeSemiringWithoutOne _≡_ _⊔_ _⊓_ 0
+  : IsCommutativeSemiringWithoutOne _⊔_ _⊓_ 0
 ⊔-⊓-isCommutativeSemiringWithoutOne = record
   { isSemiringWithoutOne = ⊔-⊓-isSemiringWithoutOne
   ; *-comm               = ⊓-comm
@@ -789,7 +801,7 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
       ⊔-⊓-isCommutativeSemiringWithoutOne
   }
 
-⊓-⊔-isLattice : IsLattice _≡_ _⊓_ _⊔_
+⊓-⊔-isLattice : IsLattice _⊓_ _⊔_
 ⊓-⊔-isLattice = record
   { isEquivalence = isEquivalence
   ; ∨-comm        = ⊓-comm
@@ -801,7 +813,7 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
   ; absorptive    = ⊓-⊔-absorptive
   }
 
-⊓-⊔-isDistributiveLattice : IsDistributiveLattice _≡_ _⊓_ _⊔_
+⊓-⊔-isDistributiveLattice : IsDistributiveLattice _⊓_ _⊔_
 ⊓-⊔-isDistributiveLattice = record
   { isLattice   = ⊓-⊔-isLattice
   ; ∨-∧-distribʳ = ⊓-distribʳ-⊔


### PR DESCRIPTION
Some changes that I've wanted to make for a long time. All 100% backwards compatible:

- You can now provide the equality as a module parameter to `Algebra.Structures`, just like `Algebra.FunctionProperties`, and so if you're only using a single equality you no longer need to mention it every time for every structure (e.g. see changes to `Data.Bool.Properties`).
- The structure records now export the left and right versions of things like `identity`, `zero`, `inverse`, `distributivity` etc. This can be used to remove the various `proj`s scattered throughout many algebraic proofs, and increases readability.
- Added a few extra missing algebraic structures to `Data.(Nat/Bool).Properties`
