### PR TITLE
[ refactor ] Data.Table

### DIFF
--- a/src/Data/Table/Base.agda
+++ b/src/Data/Table/Base.agda
@@ -21,22 +21,22 @@ module _ {a} {A : Set a} {n : ℕ} where
 
 -- A contravariant map over the indices
 
- rearrange : ∀ {m} → (Fin m → Fin n) → Table A n → Table A m
- rearrange f t = tabulate (lookup t ∘ f)
+  rearrange : ∀ {m} → (Fin m → Fin n) → Table A n → Table A m
+  rearrange f t = tabulate (lookup t ∘ f)
 
- -- List-like combinators
+-- List-like combinators
 
- head : Table A (ℕ.suc n) → A
- head t = lookup t zero
+  head : Table A (ℕ.suc n) → A
+  head t = lookup t zero
 
- tail : Table A (ℕ.suc n) → Table A n
- tail t = tabulate (lookup t ∘ suc)
+  tail : Table A (ℕ.suc n) → Table A n
+  tail t = tabulate (lookup t ∘ suc)
 
- uncons : Table A (ℕ.suc n) → A × Table A n
- uncons t = head t , tail t
+  uncons : Table A (ℕ.suc n) → A × Table A n
+  uncons t = head t , tail t
 
- toList : Table A n → List A
- toList = List.tabulate ∘ lookup
+  toList : Table A n → List A
+  toList = List.tabulate ∘ lookup
 
 fromList : ∀ {a} {A : Set a} (xs : List A) → Table A (List.length xs)
 fromList = tabulate ∘ List.lookup
@@ -45,18 +45,18 @@ module _ {a b} {A : Set a} {B : Set b} where
 
 -- Folds
 
- foldr : ∀ {n} → (A → B → B) → B → Table A n → B
- foldr {n = zero}  f z t = z
- foldr {n = suc n} f z t = f (head t) (foldr f z (tail t))
+  foldr : ∀ {n} → (A → B → B) → B → Table A n → B
+  foldr {n = zero}  f z t = z
+  foldr {n = suc n} f z t = f (head t) (foldr f z (tail t))
 
- foldl : ∀ {n} → (B → A → B) → B → Table A n → B
- foldl {n = zero}  f z t = z
- foldl {n = suc n} f z t = foldl f (f z (head t)) (tail t)
+  foldl : ∀ {n} → (B → A → B) → B → Table A n → B
+  foldl {n = zero}  f z t = z
+  foldl {n = suc n} f z t = foldl f (f z (head t)) (tail t)
 
 -- Functor
 
- map : ∀ {n} → (A → B) → Table A n → Table B n
- map f t = tabulate (f ∘ lookup t)
+  map : ∀ {n} → (A → B) → Table A n → Table B n
+  map f t = tabulate (f ∘ lookup t)
 
 -- Applicative
 


### PR DESCRIPTION
* using `head t` instead of `lookup t zero`
* defining `uncons : Table A (suc n) -> A * Table A n`
* grouping functor / applicative combinators
* using anonymous modules to clean up types

There's also the question of using `List`-style foldr and foldl rather than the
[`Vec`-style ones](https://agda.github.io/agda-stdlib/Data.Vec.html#foldr)