### PR TITLE
Add injectivity proofs for `_++_` in `Data.Vec.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -390,6 +390,13 @@ Backwards compatible changes
                             f (P.subst A eq x) ≅ f x
   ```
 
+* Added new proofs to `Data.Vec.Properties`
+  ```agda
+  ++-injectiveˡ : (xs xs' : Vec A n) → xs ++ ys ≡ xs' ++ ys' → xs ≡ xs'
+  ++-injectiveʳ : (xs xs' : Vec A n) → xs ++ ys ≡ xs' ++ ys' → ys ≡ ys'
+  ++-injective  : (xs xs' : Vec A n) → xs ++ ys ≡ xs' ++ ys' → xs ≡ xs' × ys ≡ ys'
+  ```
+
 Version 0.15
 ============
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -161,6 +161,25 @@ map-[]≔ f (x ∷ xs) (suc i) = P.cong (_ ∷_) $ map-[]≔ f xs i
 ------------------------------------------------------------------------
 -- _++_
 
+module _ {a} {A : Set a} {m} {ys ys' : Vec A m} where
+
+  ++-injectiveˡ : ∀ {n} (xs xs' : Vec A n) →
+                  xs ++ ys ≡ xs' ++ ys' → xs ≡ xs'
+  ++-injectiveˡ []       []         _  = refl
+  ++-injectiveˡ (x ∷ xs) (x' ∷ xs') eq =
+    P.cong₂ _∷_ (∷-injectiveˡ eq) (++-injectiveˡ _ _ (∷-injectiveʳ eq))
+
+  ++-injectiveʳ : ∀ {n} (xs xs' : Vec A n) →
+                  xs ++ ys ≡ xs' ++ ys' → ys ≡ ys'
+  ++-injectiveʳ []       []         eq = eq
+  ++-injectiveʳ (x ∷ xs) (x' ∷ xs') eq =
+    ++-injectiveʳ xs xs' (∷-injectiveʳ eq)
+
+  ++-injective  : ∀ {n} (xs xs' : Vec A n) →
+                  xs ++ ys ≡ xs' ++ ys' → xs ≡ xs' × ys ≡ ys'
+  ++-injective xs xs' eq =
+    (++-injectiveˡ xs xs' eq , ++-injectiveʳ xs xs' eq)
+
 module _ {a} {A : Set a} where
 
   lookup-++-< : ∀ {m n} (xs : Vec A m) (ys : Vec A n) →


### PR DESCRIPTION
Concatenation is an injective function iff the length of the vectors are the same.

My last pull request was a very nice experience, so I'll try again! This time I could not find anything on the mailing list talking about this, so the only known need for these proofs are my own. Still, I think it is quite a natural thing to have in the standard library.