### PR TITLE
Drop incorrect module qualifier in FFI binding

### DIFF
--- a/src/Data/Sum/Base.agda
+++ b/src/Data/Sum/Base.agda
@@ -19,7 +19,7 @@ data _⊎_ {a b} (A : Set a) (B : Set b) : Set (a ⊔ b) where
   inj₂ : (y : B) → A ⊎ B
 
 {-# FOREIGN GHC type AgdaEither a b c d = Either c d #-}
-{-# COMPILE GHC _⊎_ = data MAlonzo.Code.Data.Sum.AgdaEither (Left | Right) #-}
+{-# COMPILE GHC _⊎_ = data AgdaEither (Left | Right) #-}
 
 ------------------------------------------------------------------------
 -- Functions


### PR DESCRIPTION
See agda/agda#3040.

There's no need (neither in 2.5.3 or above) to qualify local names in FFI bindings, but if you do it should be with the correct module name 😁.