### PR TITLE
[ new ] Product.map for fst/snd component only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -364,6 +364,13 @@ Backwards compatible changes
   ∸-distribˡ-⊔-⊓ : x ∸ (y ⊔ z) ≡ (x ∸ y) ⊓ (x ∸ z)
   ```
 
+* Added new functions to `Data.Product`:
+
+  ```agda
+  map₁ : (A → B) → A × C → B × C
+  map₂ : (∀ {x} → B x → C x) → Σ A B → Σ A C
+  ```
+
 * Added new functions to `Data.Product.N-ary`:
   ```agda
   _∈[_]_     : A → ∀ n → A ^ n → Set a

--- a/src/Data/Product.agda
+++ b/src/Data/Product.agda
@@ -85,10 +85,18 @@ _,′_ = _,_
 < f , g > x = (f x , g x)
 
 map : ∀ {a b p q}
-        {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
+      {A : Set a} {B : Set b} {P : A → Set p} {Q : B → Set q} →
       (f : A → B) → (∀ {x} → P x → Q (f x)) →
       Σ A P → Σ B Q
 map f g (x , y) = (f x , g y)
+
+map₁ : ∀ {a b c} {A : Set a} {B : Set b} {C : Set c} →
+       (A → B) → A × C → B × C
+map₁ f = map f id
+
+map₂ : ∀ {a b c} {A : Set a} {B : A → Set b} {C : A → Set c} →
+       (∀ {x} → B x → C x) → Σ A B → Σ A C
+map₂ f = map id f
 
 zip : ∀ {a b c p q r}
         {A : Set a} {B : Set b} {C : Set c}


### PR DESCRIPTION
After seeing quite a lot of `Product.map` used with `id` in [`Data.Graph.Acyclic`](https://agda.github.io/agda-stdlib/Data.Graph.Acyclic.html),
I figured it was worth having names for these. I've used numbers as subscripts
to follow `proj₁` / `proj₂`.