### PR TITLE
[ new ] add `Band` and `Semilattice` algebraic structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,12 @@ Removed features
 Backwards compatible changes
 ----------------------------
 
+* Added new records to `Algebra`:
+  ```agda
+  record Band c ℓ        : Set (suc (c ⊔ ℓ))
+  record Semilattice c ℓ : Set (suc (c ⊔ ℓ))
+  ```
+
 * The module `Algebra.Structures` can now be parameterised by equality in the same way
   as `Algebra.FunctionProperties`. The structures within also now export a greater selection
   of "left" and "right" properties. For example (where applicable):
@@ -194,6 +200,11 @@ Backwards compatible changes
   zeroʳ     : RightZero 0# _*_
   distribˡ  : _*_ DistributesOverˡ _+_
   distribʳ  : _*_ DistributesOverʳ _+_
+  ```
+  Also added the following record types:
+  ```agda
+  record IsBand        (• : Op₂ A) : Set (a ⊔ ℓ)
+  record IsSemilattice (∧ : Op₂ A) : Set (a ⊔ ℓ)
   ```
 
 * Added new functions to `Algebra.Operations.CommutativeMonoid`:
@@ -224,7 +235,7 @@ Backwards compatible changes
 * Added new proofs to `Data.Fin.Properties`:
   ```agda
   ¬Fin0                  : ¬ Fin 0
-  
+
   ≤-preorder             : ℕ → Preorder _ _ _
   ≤-poset                : ℕ → Poset _ _ _
   ≤-totalOrder           : ℕ → TotalOrder _ _ _

--- a/src/Algebra.agda
+++ b/src/Algebra.agda
@@ -27,6 +27,17 @@ record Semigroup c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open IsSemigroup isSemigroup public
 
+record Band c ℓ : Set (suc (c ⊔ ℓ)) where
+  infixl 7 _∙_
+  infix  4 _≈_
+  field
+    Carrier : Set c
+    _≈_     : Rel Carrier ℓ
+    _∙_     : Op₂ Carrier
+    isBand  : IsBand _≈_ _∙_
+
+  open IsBand isBand public
+
 ------------------------------------------------------------------------
 -- Monoids
 
@@ -425,7 +436,18 @@ record CommutativeRing c ℓ : Set (suc (c ⊔ ℓ)) where
                )
 
 ------------------------------------------------------------------------
--- (Distributive) lattices and boolean algebras
+-- Lattices and boolean algebras
+
+record Semilattice c ℓ : Set (suc (c ⊔ ℓ)) where
+  infixr 7 _∧_
+  infix  4 _≈_
+  field
+    Carrier       : Set c
+    _≈_           : Rel Carrier ℓ
+    _∧_           : Op₂ Carrier
+    isSemilattice : IsSemilattice _≈_ _∧_
+
+  open IsSemilattice isSemilattice public
 
 record Lattice c ℓ : Set (suc (c ⊔ ℓ)) where
   infixr 7 _∧_

--- a/src/Algebra.agda
+++ b/src/Algebra.agda
@@ -38,6 +38,9 @@ record Band c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open IsBand isBand public
 
+  semigroup : Semigroup c ℓ
+  semigroup = record { isSemigroup = isSemigroup }
+  
 ------------------------------------------------------------------------
 -- Monoids
 
@@ -449,6 +452,11 @@ record Semilattice c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open IsSemilattice isSemilattice public
 
+  band : Band c ℓ
+  band = record { isBand = isBand }
+
+  open Band band public using (semigroup)
+  
 record Lattice c ℓ : Set (suc (c ⊔ ℓ)) where
   infixr 7 _∧_
   infixr 6 _∨_

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -30,10 +30,10 @@ record IsSemigroup (∙ : Op₂ A) : Set (a ⊔ ℓ) where
 
   open IsEquivalence isEquivalence public
 
-record IsBand (• : Op₂ A) : Set (a ⊔ ℓ) where
+record IsBand (∙ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isSemigroup : IsSemigroup •
-    idem        : Idempotent •
+    isSemigroup : IsSemigroup ∙
+    idem        : Idempotent ∙
 
   open IsSemigroup isSemigroup public
 

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -412,7 +412,7 @@ record IsSemilattice (∧ : Op₂ A) : Set (a ⊔ ℓ) where
     isBand : IsBand ∧
     comm   : Commutative ∧
 
-  open IsBand isBand
+  open IsBand isBand public
 
 record IsLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -30,6 +30,15 @@ record IsSemigroup (∙ : Op₂ A) : Set (a ⊔ ℓ) where
 
   open IsEquivalence isEquivalence public
 
+record IsBand (• : Op₂ A) : Set (a ⊔ ℓ) where
+  field
+    isSemigroup : IsSemigroup •
+    idem        : Idempotent •
+
+  open IsSemigroup isSemigroup public
+
+-- Commutative idempotent semigroups are semilattices (see Lattices)
+
 ------------------------------------------------------------------------
 -- Monoids
 
@@ -397,6 +406,13 @@ record IsCommutativeRing
 
 ------------------------------------------------------------------------
 -- Lattices
+
+record IsSemilattice (∧ : Op₂ A) : Set (a ⊔ ℓ) where
+  field
+    isBand : IsBand ∧
+    comm   : Commutative ∧
+
+  open IsBand isBand
 
 record IsLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field


### PR DESCRIPTION
Pretty self-explanatory. Going to be used for a future pull request for left and right natural orders.

I'd dearly like to re-define `IsLattice` in terms of two `IsSemilattice`s, but backwards compatibility and all that jazz...