### PR TITLE
fix-agda-whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,7 +224,7 @@ Backwards compatible changes
 * Added new proofs to `Data.Fin.Properties`:
   ```agda
   ¬Fin0                  : ¬ Fin 0
-  
+
   ≤-preorder             : ℕ → Preorder _ _ _
   ≤-poset                : ℕ → Poset _ _ _
   ≤-totalOrder           : ℕ → TotalOrder _ _ _


### PR DESCRIPTION
Looks like a whitespace issue snuck in on 'master'.