### PR TITLE
Make test in Function.Related.TypeIsmorphisms more polymorphic

### DIFF
--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -303,7 +303,7 @@ private
 
   -- A test of the solver above.
 
-  test : (A B C : Set) →
+  test : {ℓ : Level} (A B C : Set ℓ) →
          (Lift ⊤ × A × (B ⊎ C)) ↔ (A × B ⊎ C × (Lift ⊥ ⊎ A))
   test = solve 3 (λ A B C → con 1 :* (A :* (B :+ C)) :=
                             A :* B :+ C :* (con 0 :+ A))


### PR DESCRIPTION
in level, just to show that it doesn't matter. Overkill, but why not? Still part of #295.