### PR TITLE
Adding `Data.Vec.Any` and standardising `Vec` membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Important changes since 0.16:
 Non-backwards compatible changes
 --------------------------------
 
+#### Improved consistency between `Data.(List/Vec).(Any/All)`
+
+* New module `Data.Vec.Any`
+
+* The proofs `All-universal` and `All-irrelevance` have been moved from
+  `Data.List.All.Properties` and renamed `universal` and `irrelevant` in
+  `Data.List.All`.
+  
+* The existing `tabulate` in `Data.Vec.All` has been renamed `universal`.
+  A new function `tabulate` has been added with the following type:
+  ```agda
+  tabulate : (∀ i → P (Vec.lookup i xs)) → All P {k} xs
+  ```
+
+* Added various missing functions to the modules (see `Minor additions`).
+
 Other major changes
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,38 @@ Important changes since 0.16:
 Non-backwards compatible changes
 --------------------------------
 
-#### Improved consistency between `Data.(List/Vec).(Any/All)`
+#### Improved consistency between `Data.(List/Vec).(Any/All/Membership)`
 
-* New module `Data.Vec.Any`
+* Added new module `Data.Vec.Any`.
+
+* The type `_∈_` has been moved from `Data.Vec` to the new module
+  `Data.Vec.Membership.Propositional` and has been reimplemented using
+  `Any` from `Data.Vec.Any`. In particular this means that you must now
+  pass a `refl` proof to the `here` constructor.
+
+* The proofs associated with `_∈_` have been moved from `Data.Vec.Properties`
+  to the new module  `Data.Vec.Membership.Propositional.Properties`
+  and have been renamed as follows:
+  ```agda
+  ∈-++ₗ      ↦ ∈-++⁺ˡ
+  ∈-++ᵣ      ↦ ∈-++⁺ʳ
+  ∈-map      ↦ ∈-map⁺
+  ∈-tabulate ↦ ∈-tabulate⁺
+  ∈-allFin   ↦ ∈-allFin⁺
+  ∈-allPairs ↦ ∈-allPairs⁺
+  ∈⇒List-∈   ↦ ∈-toList⁺
+  List-∈⇒∈   ↦ ∈-fromList⁺
+  ```
 
 * The proofs `All-universal` and `All-irrelevance` have been moved from
   `Data.List.All.Properties` and renamed `universal` and `irrelevant` in
   `Data.List.All`.
-  
-* The existing `tabulate` in `Data.Vec.All` has been renamed `universal`.
-  A new function `tabulate` has been added with the following type:
+
+* The existing function `tabulate` in `Data.Vec.All` has been renamed
+  `universal`. The name `tabulate` now refers to a function with following type:
   ```agda
   tabulate : (∀ i → P (Vec.lookup i xs)) → All P {k} xs
   ```
-
-* Added various missing functions to the modules (see `Minor additions`).
 
 Other major changes
 -------------------

--- a/src/Data/Fin/Dec.agda
+++ b/src/Data/Fin/Dec.agda
@@ -9,7 +9,7 @@ module Data.Fin.Dec where
 open import Function
 import Data.Bool as Bool
 open import Data.Nat.Base hiding (_<_)
-open import Data.Vec hiding (_∈_)
+open import Data.Vec
 open import Data.Vec.Relation.Equality.DecPropositional Bool._≟_
 open import Data.Fin
 open import Data.Fin.Subset

--- a/src/Data/Fin/Subset.agda
+++ b/src/Data/Fin/Subset.agda
@@ -15,7 +15,7 @@ open import Data.Fin using (Fin; zero; suc)
 open import Data.List.Base using (List; foldr; foldl)
 open import Data.Nat using (ℕ)
 open import Data.Product using (∃)
-open import Data.Vec hiding (_∈_; foldr; foldl)
+open import Data.Vec hiding (foldr; foldl)
 import Data.Vec.Relation.Pointwise.Extensional as Pointwise
 open import Relation.Nullary
 

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -20,7 +20,7 @@ open import Data.Nat.Base using (ℕ; zero; suc; z≤n; s≤s; _≤_)
 open import Data.Nat.Properties using (≤-step)
 open import Data.Product as Product using (_×_; _,_)
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
-open import Data.Vec hiding (_∈_)
+open import Data.Vec
 open import Data.Vec.Properties
 open import Function using (const; id)
 open import Function.Equivalence using (_⇔_; equivalence)

--- a/src/Data/List/All.agda
+++ b/src/Data/List/All.agda
@@ -14,7 +14,7 @@ open import Function
 open import Level
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
-open import Relation.Unary using (Decidable; Universal; _∩_; _⊆_)
+open import Relation.Unary hiding (_∈_)
 open import Relation.Binary.PropositionalEquality as P
 
 ------------------------------------------------------------------------
@@ -83,3 +83,6 @@ module _ {a p} {A : Set a} {P : A → Set p} where
   irrelevant irr []           []           = P.refl
   irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
     P.cong₂ _∷_ (irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)
+
+  satisfiable : Satisfiable (All P)
+  satisfiable = [] , []

--- a/src/Data/List/All.agda
+++ b/src/Data/List/All.agda
@@ -14,9 +14,10 @@ open import Function
 open import Level
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
-open import Relation.Unary using (Decidable; _∩_; _⊆_)
-open import Relation.Binary.PropositionalEquality
+open import Relation.Unary using (Decidable; Universal; _∩_; _⊆_)
+open import Relation.Binary.PropositionalEquality as P
 
+------------------------------------------------------------------------
 -- All P xs means that all elements in xs satisfy P.
 
 infixr 5 _∷_
@@ -25,6 +26,9 @@ data All {a p} {A : Set a}
          (P : A → Set p) : List A → Set (p ⊔ a) where
   []  : All P []
   _∷_ : ∀ {x xs} (px : P x) (pxs : All P xs) → All P (x ∷ xs)
+
+------------------------------------------------------------------------
+-- Operations on All
 
 head : ∀ {a p} {A : Set a} {P : A → Set p} {x xs} →
        All P (x ∷ xs) → P x
@@ -35,7 +39,7 @@ tail : ∀ {a p} {A : Set a} {P : A → Set p} {x xs} →
 tail (px ∷ pxs) = pxs
 
 lookup : ∀ {a p} {A : Set a} {P : A → Set p} {xs : List A} →
-         All P xs → (∀ {x : A} → x ∈ xs → P x)
+         All P xs → (∀ {x} → x ∈ xs → P x)
 lookup []         ()
 lookup (px ∷ pxs) (here refl)  = px
 lookup (px ∷ pxs) (there x∈xs) = lookup pxs x∈xs
@@ -60,9 +64,22 @@ unzip : ∀ {a p q} {A : Set a} {P : A → Set p} {Q : A → Set q} →
 unzip []           = [] , []
 unzip (pqx ∷ pqxs) = Prod.zip _∷_ _∷_ pqx (unzip pqxs)
 
-all : ∀ {a p} {A : Set a} {P : A → Set p} →
-      Decidable P → Decidable (All P)
-all p []       = yes []
-all p (x ∷ xs) with p x
-all p (x ∷ xs) | yes px = Dec.map′ (_∷_ px) tail (all p xs)
-all p (x ∷ xs) | no ¬px = no (¬px ∘ head)
+------------------------------------------------------------------------
+-- Properties of predicates preserved by All
+
+module _ {a p} {A : Set a} {P : A → Set p} where
+
+  all : Decidable P → Decidable (All P)
+  all p []       = yes []
+  all p (x ∷ xs) with p x
+  ... | yes px = Dec.map′ (px ∷_) tail (all p xs)
+  ... | no ¬px = no (¬px ∘ head)
+
+  universal : Universal P → Universal (All P)
+  universal u []       = []
+  universal u (x ∷ xs) = u x ∷ universal u xs
+
+  irrelevant : P.IrrelevantPred P → P.IrrelevantPred (All P)
+  irrelevant irr []           []           = P.refl
+  irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
+    P.cong₂ _∷_ (irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)

--- a/src/Data/List/All/Properties.agda
+++ b/src/Data/List/All/Properties.agda
@@ -29,21 +29,6 @@ open import Relation.Nullary
 open import Relation.Unary
   using (Decidable; Universal) renaming (_⊆_ to _⋐_)
 
-----------------------------------------------------------------------
--- Basic properties of All
-
-module _ {a p} {A : Set a} {P : A → Set p} where
-
-  -- When P is universal All P holds
-  All-universal : Universal P → ∀ xs → All P xs
-  All-universal u [] = []
-  All-universal u (x ∷ xs) = u x ∷ All-universal u xs
-
-  All-irrelevance : P.IrrelevantPred P → P.IrrelevantPred (All P)
-  All-irrelevance irr []           []           = P.refl
-  All-irrelevance irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
-    P.cong₂ _∷_ (irr px₁ px₂) (All-irrelevance irr pxs₁ pxs₂)
-
 ------------------------------------------------------------------------
 -- Lemmas relating Any, All and negation.
 

--- a/src/Data/List/Any.agda
+++ b/src/Data/List/Any.agda
@@ -8,12 +8,12 @@ module Data.List.Any {a} {A : Set a} where
 
 open import Data.Empty
 open import Data.Fin
-open import Data.List.Base as List using (List; []; _∷_)
+open import Data.List.Base as List using (List; []; [_]; _∷_)
 open import Data.Product as Prod using (∃; _,_)
 open import Level using (_⊔_)
 open import Relation.Nullary using (¬_; yes; no)
 import Relation.Nullary.Decidable as Dec
-open import Relation.Unary using (Decidable; _⊆_)
+open import Relation.Unary hiding (_∈_)
 
 ------------------------------------------------------------------------
 -- Any P xs means that at least one element in xs satisfies P.
@@ -55,4 +55,5 @@ module _ {p} {P : A → Set p} where
   ... | yes px = yes (here px)
   ... | no ¬px = Dec.map′ there (tail ¬px) (any P? xs)
 
-
+  satisfiable : Satisfiable P → Satisfiable (Any P)
+  satisfiable (x , Px) = [ x ] , here Px

--- a/src/Data/Vec.agda
+++ b/src/Data/Vec.agda
@@ -24,12 +24,6 @@ data Vec {a} (A : Set a) : ℕ → Set a where
   []  : Vec A zero
   _∷_ : ∀ {n} (x : A) (xs : Vec A n) → Vec A (suc n)
 
-infix 4 _∈_
-
-data _∈_ {a} {A : Set a} : A → {n : ℕ} → Vec A n → Set a where
-  here  : ∀ {n} {x}   {xs : Vec A n} → x ∈ x ∷ xs
-  there : ∀ {n} {x y} {xs : Vec A n} (x∈xs : x ∈ xs) → x ∈ y ∷ xs
-
 infix 4 _[_]=_
 
 data _[_]=_ {a} {A : Set a} :
@@ -50,6 +44,16 @@ tail (x ∷ xs) = xs
 lookup : ∀ {a n} {A : Set a} → Fin n → Vec A n → A
 lookup zero    (x ∷ xs) = x
 lookup (suc i) (x ∷ xs) = lookup i xs
+
+insert : ∀ {a n} {A : Set a} → Fin (suc n) → A → Vec A n → Vec A (suc n)
+insert zero     x xs       = x ∷ xs
+insert (suc ()) x []
+insert (suc i)  x (y ∷ xs) = y ∷ insert i x xs
+
+remove : ∀ {a n} {A : Set a} → Fin (suc n) → Vec A (suc n) → Vec A n
+remove zero     (_ ∷ xs)     = xs
+remove (suc ()) (x ∷ [])
+remove (suc i)  (x ∷ y ∷ xs) = x ∷ remove i (y ∷ xs)
 
 -- Update.
 
@@ -253,16 +257,3 @@ init .(ys ∷ʳ y) | (ys , y , refl) = ys
 last : ∀ {a n} {A : Set a} → Vec A (1 + n) → A
 last xs         with initLast xs
 last .(ys ∷ʳ y) | (ys , y , refl) = y
-
-------------------------------------------------------------------------
--- Inserting into and removing from vectors
-
-insert : ∀ {a n} {A : Set a} → Fin (suc n) → A → Vec A n → Vec A (suc n)
-insert zero x xs = x ∷ xs
-insert (suc ()) x []
-insert (suc i) x (y ∷ xs) = y ∷ insert i x xs
-
-remove : ∀ {a n} {A : Set a} → Fin (suc n) → Vec A (suc n) → Vec A n
-remove zero (_ ∷ xs) = xs
-remove (suc ()) (x ∷ [])
-remove (suc i) (x ∷ y ∷ xs) = x ∷ remove i (y ∷ xs)

--- a/src/Data/Vec/All.agda
+++ b/src/Data/Vec/All.agda
@@ -6,6 +6,7 @@
 
 module Data.Vec.All where
 
+open import Data.Nat using (zero; suc)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Product as Prod using (_,_)
 open import Data.Vec as Vec using (Vec; []; _∷_)
@@ -13,8 +14,8 @@ open import Function using (_∘_)
 open import Level using (_⊔_)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
-open import Relation.Unary using (Decidable; Universal; _∩_; _⊆_)
-open import Relation.Binary.PropositionalEquality as P using (subst) 
+open import Relation.Unary
+open import Relation.Binary.PropositionalEquality as P using (subst)
 
 ------------------------------------------------------------------------
 -- All P xs means that all elements in xs satisfy P.
@@ -46,7 +47,7 @@ lookup (suc i) (px ∷ pxs) = lookup i pxs
 tabulate : ∀ {a p} {A : Set a} {P : A → Set p} {k xs} →
            (∀ i → P (Vec.lookup i xs)) → All P {k} xs
 tabulate {xs = []}    pxs = []
-tabulate {xs = _ ∷ _} pxs = pxs zero ∷ tabulate (pxs ∘ suc) 
+tabulate {xs = _ ∷ _} pxs = pxs zero ∷ tabulate (pxs ∘ suc)
 
 map : ∀ {a p q} {A : Set a} {P : A → Set p} {Q : A → Set q} {k} →
       P ⊆ Q → All P {k} ⊆ All Q {k}
@@ -83,11 +84,15 @@ module _ {a p} {A : Set a} {P : A → Set p} where
   ... | yes px = Dec.map′ (px ∷_) tail (all P? xs)
   ... | no ¬px = no (¬px ∘ head)
 
-  universal : ∀ {k} → Universal P → Universal (All P {k})
+  universal : Universal P → ∀ {k} → Universal (All P {k})
   universal u []       = []
   universal u (x ∷ xs) = u x ∷ universal u xs
 
-  irrelevant : ∀ {k} → P.IrrelevantPred P → P.IrrelevantPred (All P {k})
+  irrelevant : P.IrrelevantPred P → ∀ {k} → P.IrrelevantPred (All P {k})
   irrelevant irr []           []           = P.refl
   irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
     P.cong₂ _∷_ (irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)
+
+  satisfiable : Satisfiable P → ∀ {k} → Satisfiable (All P {k})
+  satisfiable (x , p) {zero}  = [] , []
+  satisfiable (x , p) {suc k} = Prod.map (x ∷_) (p ∷_) (satisfiable (x , p))

--- a/src/Data/Vec/All/Properties.agda
+++ b/src/Data/Vec/All/Properties.agda
@@ -128,4 +128,3 @@ All-++⁻∘++⁺ = ++⁻∘++⁺
 
 All-concat⁺ = concat⁺
 All-concat⁻ = concat⁻
-

--- a/src/Data/Vec/Any.agda
+++ b/src/Data/Vec/Any.agda
@@ -8,12 +8,13 @@ module Data.Vec.Any {a} {A : Set a} where
 
 open import Data.Empty
 open import Data.Fin
-open import Data.Vec as Vec using (Vec; []; _∷_)
+open import Data.Nat using (zero; suc)
+open import Data.Vec as Vec using (Vec; []; [_]; _∷_)
 open import Data.Product as Prod using (∃; _,_)
 open import Level using (_⊔_)
 open import Relation.Nullary using (¬_; yes; no)
 import Relation.Nullary.Decidable as Dec
-open import Relation.Unary using (Decidable; _⊆_)
+open import Relation.Unary
 
 ------------------------------------------------------------------------
 -- Any P xs means that at least one element in xs satisfies P.
@@ -55,3 +56,7 @@ module _ {p} {P : A → Set p} where
   any P? (x ∷ xs) with P? x
   ... | yes px = yes (here px)
   ... | no ¬px = Dec.map′ there (tail ¬px) (any P? xs)
+
+  satisfiable : Satisfiable P → ∀ {n} → Satisfiable (Any P {suc n})
+  satisfiable (x , p) {zero}  = x ∷ [] , here p
+  satisfiable (x , p) {suc n} = Prod.map (x ∷_) there (satisfiable (x , p))

--- a/src/Data/Vec/Membership/Propositional.agda
+++ b/src/Data/Vec/Membership/Propositional.agda
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Membership of vectors based on propositional equality,
+-- along with some additional definitions.
+------------------------------------------------------------------------
+
+module Data.Vec.Membership.Propositional {a} {A : Set a} where
+
+open import Data.Vec using (Vec)
+open import Data.Vec.Any using (Any)
+open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Nullary using (¬_)
+
+------------------------------------------------------------------------
+-- Types
+
+infix 4 _∈_ _∉_
+
+_∈_ : A → ∀ {n} → Vec A n → Set _
+x ∈ xs = Any (x ≡_) xs
+
+_∉_ : A → ∀ {n} → Vec A n → Set _
+x ∉ xs = ¬ x ∈ xs

--- a/src/Data/Vec/Membership/Propositional/Properties.agda
+++ b/src/Data/Vec/Membership/Propositional/Properties.agda
@@ -1,0 +1,83 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of membership of vectors based on propositional equality.
+------------------------------------------------------------------------
+
+module Data.Vec.Membership.Propositional.Properties where
+
+open import Data.Fin using (Fin; zero; suc)
+open import Data.Product using (_,_)
+open import Data.Vec hiding (here; there)
+open import Data.Vec.Any using (here; there)
+open import Data.List.Any using (here; there)
+open import Data.Vec.Membership.Propositional
+import Data.List.Membership.Propositional as List
+open import Function using (_∘_; id)
+open import Relation.Binary.PropositionalEquality using (refl)
+
+------------------------------------------------------------------------
+-- map
+
+module _ {a b} {A : Set a} {B : Set b} (f : A → B) where
+
+  ∈-map⁺ : ∀ {m v} {xs : Vec A m} → v ∈ xs → f v ∈ map f xs
+  ∈-map⁺ (here refl)  = here refl
+  ∈-map⁺ (there x∈xs) = there (∈-map⁺ x∈xs)
+
+------------------------------------------------------------------------
+-- _++_
+
+module _ {a} {A : Set a} {v : A} where
+
+  ∈-++⁺ˡ : ∀ {m n} {xs : Vec A m} {ys : Vec A n} → v ∈ xs → v ∈ xs ++ ys
+  ∈-++⁺ˡ (here refl)  = here refl
+  ∈-++⁺ˡ (there x∈xs) = there (∈-++⁺ˡ x∈xs)
+
+  ∈-++⁺ʳ : ∀ {m n} (xs : Vec A m) {ys : Vec A n} → v ∈ ys → v ∈ xs ++ ys
+  ∈-++⁺ʳ []       x∈ys = x∈ys
+  ∈-++⁺ʳ (x ∷ xs) x∈ys = there (∈-++⁺ʳ xs x∈ys)
+
+------------------------------------------------------------------------
+-- tabulate
+
+module _ {a} {A : Set a} where
+
+  ∈-tabulate⁺ : ∀ {n} (f : Fin n → A) i → f i ∈ tabulate f
+  ∈-tabulate⁺ f zero    = here refl
+  ∈-tabulate⁺ f (suc i) = there (∈-tabulate⁺ (f ∘ suc) i)
+
+------------------------------------------------------------------------
+-- allFin
+
+∈-allFin⁺ : ∀ {n} (i : Fin n) → i ∈ allFin n
+∈-allFin⁺ = ∈-tabulate⁺ id
+
+------------------------------------------------------------------------
+-- allPairs
+
+module _ {a b} {A : Set a} {B : Set b} where
+
+  ∈-allPairs⁺ : ∀ {m n x y} {xs : Vec A m} {ys : Vec B n} →
+               x ∈ xs → y ∈ ys → (x , y) ∈ allPairs xs ys
+  ∈-allPairs⁺ {xs = x ∷ xs} (here refl) = ∈-++⁺ˡ ∘ ∈-map⁺ (x ,_)
+  ∈-allPairs⁺ {xs = x ∷ _} (there x∈xs) =
+    ∈-++⁺ʳ (map (x ,_) _) ∘ ∈-allPairs⁺ x∈xs
+
+------------------------------------------------------------------------
+-- toList
+
+module _ {a} {A : Set a} {v : A} where
+
+  ∈-toList⁺ : ∀ {n} {xs : Vec A n} → v ∈ xs → v List.∈ toList xs
+  ∈-toList⁺ (here refl) = here refl
+  ∈-toList⁺ (there x∈)  = there (∈-toList⁺ x∈)
+
+------------------------------------------------------------------------
+-- fromList
+
+module _ {a} {A : Set a} {v : A} where
+
+  ∈-fromList⁺ : ∀ {xs} → v List.∈ xs → v ∈ fromList xs
+  ∈-fromList⁺ (here refl) = here refl
+  ∈-fromList⁺ (there x∈)  = there (∈-fromList⁺ x∈)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -631,49 +631,6 @@ module _ {a} {A : Set a} where
     P.cong (x ∷_) (insert-remove i (y ∷ xs))
 
 ------------------------------------------------------------------------
--- Properties of _∈_
-
-∈-++ₗ : ∀ {a m n} {A : Set a} {x : A} {xs : Vec A m} {ys : Vec A n} →
-        x ∈ xs → x ∈ xs ++ ys
-∈-++ₗ here         = here
-∈-++ₗ (there x∈xs) = there (∈-++ₗ x∈xs)
-
-∈-++ᵣ : ∀ {a m n} {A : Set a} {x : A} (xs : Vec A m) {ys : Vec A n} →
-        x ∈ ys → x ∈ xs ++ ys
-∈-++ᵣ []       x∈ys = x∈ys
-∈-++ᵣ (x ∷ xs) x∈ys = there (∈-++ᵣ xs x∈ys)
-
-∈-map : ∀ {a b m} {A : Set a} {B : Set b} {x : A} {xs : Vec A m}
-        (f : A → B) → x ∈ xs → f x ∈ map f xs
-∈-map f here         = here
-∈-map f (there x∈xs) = there (∈-map f x∈xs)
-
-∈-tabulate : ∀ {n a} {A : Set a} (f : Fin n → A) i → f i ∈ tabulate f
-∈-tabulate f zero    = here
-∈-tabulate f (suc i) = there (∈-tabulate (f ∘ suc) i)
-
-∈-allFin : ∀ {n} (i : Fin n) → i ∈ allFin n
-∈-allFin = ∈-tabulate id
-
-∈-allPairs : ∀ {a b} {A : Set a} {B : Set b} {m n : ℕ}
-             {xs : Vec A m} {ys : Vec B n}
-             {x y} → x ∈ xs → y ∈ ys → (x , y) ∈ allPairs xs ys
-∈-allPairs {xs = x ∷ xs} {ys} here         y∈ys =
-  ∈-++ₗ (∈-map (x ,_) y∈ys)
-∈-allPairs {xs = x ∷ xs} {ys} (there x∈xs) y∈ys =
-  ∈-++ᵣ (map (x ,_) ys) (∈-allPairs x∈xs y∈ys)
-
-∈⇒List-∈ : ∀ {a} {A : Set a} {n x} {xs : Vec A n} →
-           x ∈ xs → x List.∈ toList xs
-∈⇒List-∈ here       = here P.refl
-∈⇒List-∈ (there x∈) = there (∈⇒List-∈ x∈)
-
-List-∈⇒∈ : ∀ {a} {A : Set a} {x : A} {xs} →
-           x List.∈ xs → x ∈ fromList xs
-List-∈⇒∈ (here P.refl) = here
-List-∈⇒∈ (there x∈)    = there (List-∈⇒∈ x∈)
-
-------------------------------------------------------------------------
 -- Conversion function
 
 module _ {a} {A : Set a} where


### PR DESCRIPTION
Currently the implementation of membership for vectors is much more barebones than the implementation for lists. Now that we have the structure for list membership finally sorted out, this PR implements vec membership in a similar way. This means that going forward from v1.0, we can flesh it out in a backwards compatible fashion. See CHANGELOG for full details.

As always, comments welcome.