### PR TITLE
Make From-just & From-injₙ's types consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@ Non-backwards compatible changes
   ```
   and added new module `Data.List.Relation.Sublist.Inductive`.
 
+* Made the `Set` argument implicit in `Data.Maybe.Base`'s `From-just`
+  to be consistent with the definition of `Data.Sum`'s `From-injₙ`.
+
+
 Other major changes
 -------------------
 

--- a/README/Case.agda
+++ b/README/Case.agda
@@ -22,8 +22,8 @@ pred n = case n of λ
   ; (suc n) → n
   }
 
-from-just : ∀ {a} {A : Set a} (x : Maybe A) → From-just A x
-from-just x = case x return From-just _ of λ
+from-just : ∀ {a} {A : Set a} (x : Maybe A) → From-just x
+from-just x = case x return From-just of λ
   { (just x) → x
   ; nothing  → _
   }

--- a/src/Algebra/CommutativeMonoidSolver.agda
+++ b/src/Algebra/CommutativeMonoidSolver.agda
@@ -188,11 +188,9 @@ prove′ e₁ e₂ =
 
 -- This procedure can be combined with from-just.
 
-prove : ∀ n (e₁ e₂ : Expr n) →
-  From-just (∀ ρ → ⟦ e₁ ⟧ ρ ≈ ⟦ e₂ ⟧ ρ) (prove′  e₁ e₂)
+prove : ∀ n (e₁ e₂ : Expr n) → From-just (prove′ e₁ e₂)
 prove _ e₁ e₂ = from-just (prove′ e₁ e₂)
 
 -- prove : ∀ n (es : Expr n × Expr n) →
---         From-just (∀ ρ → ⟦ proj₁ es ⟧ ρ ≈ ⟦ proj₂ es ⟧ ρ)
---                   (uncurry prove′ es)
+--         From-just (uncurry prove′ es)
 -- prove _ = from-just ∘ uncurry prove′

--- a/src/Algebra/IdempotentCommutativeMonoidSolver.agda
+++ b/src/Algebra/IdempotentCommutativeMonoidSolver.agda
@@ -201,13 +201,11 @@ prove′ e₁ e₂ =
 
 -- This procedure can be combined with from-just.
 
-prove : ∀ n (e₁ e₂ : Expr n) →
-  From-just (∀ ρ → ⟦ e₁ ⟧ ρ ≈ ⟦ e₂ ⟧ ρ) (prove′  e₁ e₂)
+prove : ∀ n (e₁ e₂ : Expr n) → From-just (prove′ e₁ e₂)
 prove _ e₁ e₂ = from-just (prove′ e₁ e₂)
 
 -- prove : ∀ n (es : Expr n × Expr n) →
---         From-just (∀ ρ → ⟦ proj₁ es ⟧ ρ ≈ ⟦ proj₂ es ⟧ ρ)
---                   (uncurry prove′ es)
+--         From-just (uncurry prove′ es)
 -- prove _ = from-just ∘ uncurry prove′
 
 -- -}

--- a/src/Algebra/Monoid-solver.agda
+++ b/src/Algebra/Monoid-solver.agda
@@ -132,6 +132,5 @@ prove′ e₁ e₂ =
 -- This procedure can be combined with from-just.
 
 prove : ∀ n (es : Expr n × Expr n) →
-        From-just (∀ ρ → ⟦ proj₁ es ⟧ ρ ≈ ⟦ proj₂ es ⟧ ρ)
-                  (uncurry prove′ es)
+        From-just (uncurry prove′ es)
 prove _ = from-just ∘ uncurry prove′

--- a/src/Data/Maybe/Base.agda
+++ b/src/Data/Maybe/Base.agda
@@ -60,13 +60,15 @@ maybe′ = maybe
 -- A safe variant of "fromJust". If the value is nothing, then the
 -- return type is the unit type.
 
-From-just : ∀ {a} (A : Set a) → Maybe A → Set a
-From-just A (just _) = A
-From-just A nothing  = Lift ⊤
+module _ {a} {A : Set a} where
 
-from-just : ∀ {a} {A : Set a} (x : Maybe A) → From-just A x
-from-just (just x) = x
-from-just nothing  = _
+  From-just : Maybe A → Set a
+  From-just (just _) = A
+  From-just nothing  = Lift ⊤
+
+  from-just : (x : Maybe A) → From-just x
+  from-just (just x) = x
+  from-just nothing  = _
 
 -- Functoriality: map.
 

--- a/src/Data/Sum.agda
+++ b/src/Data/Sum.agda
@@ -20,26 +20,28 @@ open import Data.Sum.Base public
 ------------------------------------------------------------------------
 -- Additional functions
 
-isInj₁ : ∀ {a b} {A : Set a} {B : Set b} → A ⊎ B → Maybe A
-isInj₁ (inj₁ x) = just x
-isInj₁ (inj₂ y) = nothing
+module _ {a b} {A : Set a} {B : Set b} where
 
-isInj₂ : ∀ {a b} {A : Set a} {B : Set b} → A ⊎ B → Maybe B
-isInj₂ (inj₁ x) = nothing
-isInj₂ (inj₂ y) = just y
+  isInj₁ : A ⊎ B → Maybe A
+  isInj₁ (inj₁ x) = just x
+  isInj₁ (inj₂ y) = nothing
 
-From-inj₁ : ∀ {a b} {A : Set a} {B : Set b} → A ⊎ B → Set a
-From-inj₁ {A = A} (inj₁ _) = A
-From-inj₁         (inj₂ _) = Lift ⊤
+  isInj₂ : A ⊎ B → Maybe B
+  isInj₂ (inj₁ x) = nothing
+  isInj₂ (inj₂ y) = just y
 
-from-inj₁ : ∀ {a b} {A : Set a} {B : Set b} (x : A ⊎ B) → From-inj₁ x
-from-inj₁ (inj₁ x) = x
-from-inj₁ (inj₂ _) = lift tt
+  From-inj₁ : A ⊎ B → Set a
+  From-inj₁ (inj₁ _) = A
+  From-inj₁ (inj₂ _) = Lift ⊤
 
-From-inj₂ : ∀ {a b} {A : Set a} {B : Set b} → A ⊎ B → Set b
-From-inj₂         (inj₁ _) = Lift ⊤
-From-inj₂ {B = B} (inj₂ _) = B
+  from-inj₁ : (x : A ⊎ B) → From-inj₁ x
+  from-inj₁ (inj₁ x) = x
+  from-inj₁ (inj₂ _) = _
 
-from-inj₂ : ∀ {a b} {A : Set a} {B : Set b} (x : A ⊎ B) → From-inj₂ x
-from-inj₂ (inj₁ _) = lift tt
-from-inj₂ (inj₂ x) = x
+  From-inj₂ : A ⊎ B → Set b
+  From-inj₂ (inj₁ _) = Lift ⊤
+  From-inj₂ (inj₂ _) = B
+
+  from-inj₂ : (x : A ⊎ B) → From-inj₂ x
+  from-inj₂ (inj₁ _) = _
+  from-inj₂ (inj₂ x) = x


### PR DESCRIPTION
Made the `Set` argument implicit in `Data.Maybe.Base`'s `From-just`
to be consistent with the definition of `Data.Sum`'s `From-injₙ`