### PR TITLE
[ level ] polymorphism in Data.Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ Non-backwards compatible changes
 * Renamed `Data.Product`'s `,_` to `-,_` to avoid conflict with the right
   section of `_,_`.
 
+* Made `Data.Container` (and associated modules) more level-polymorphic and
+  moved the core definitions to `Data.Container.Core`.
+
 Other major changes
 -------------------
 
@@ -146,6 +149,11 @@ Other minor additions
 * Added new function to `Function`:
   ```agda
   typeOf : {A : Set a} → A → Set a
+  ```
+
+* Added new result to `Function.Relation.TypeIsomorphisms`:
+  ```agda
+  ×-comm : (A × B) ↔ (B × A)
   ```
 
 * Added the following types in `Relation.Unary`:

--- a/README/Container/FreeMonad.agda
+++ b/README/Container/FreeMonad.agda
@@ -24,10 +24,10 @@ open import Relation.Binary.PropositionalEquality
 
 -- The signature of state and its (generic) operations.
 
-State : Set → Container _
+State : Set → Container _ _
 State S = ⊤ ⟶ S ⊎ S ⟶ ⊤
   where
-  _⟶_ : Set → Set → Container _
+  _⟶_ : Set → Set → Container _ _
   I ⟶ O = I ▷ λ _ → O
 
 get : ∀ {S} → State S ⋆ S
@@ -50,7 +50,7 @@ prog =
   where
   open RawMonad rawMonad
 
-runState : ∀ {S X} → State S ⋆ X → (S → X ⟨×⟩ S)
+runState : {S X : Set} → State S ⋆ X → (S → X ⟨×⟩ S)
 runState (sup (inj₁ x) _)        = λ s → x , s
 runState (sup (inj₂ (inj₁ _)) k) = λ s → runState (k s) s
 runState (sup (inj₂ (inj₂ s)) k) = λ _ → runState (k _) s

--- a/src/Data/Container/Any.agda
+++ b/src/Data/Container/Any.agda
@@ -6,6 +6,7 @@
 
 module Data.Container.Any where
 
+open import Level
 open import Algebra
 open import Data.Container as C
 open import Data.Container.Combinator
@@ -20,6 +21,8 @@ open import Function.Equivalence using (equivalence)
 open import Function.Inverse as Inv using (_↔_; module Inverse)
 open import Function.Related as Related using (Related)
 open import Function.Related.TypeIsomorphisms
+open import Relation.Unary using (Pred ; _∪_ ; _∩_)
+open import Relation.Binary using (REL)
 import Relation.Binary.HeterogeneousEquality as H
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≗_; refl)
@@ -28,235 +31,252 @@ open Related.EquationalReasoning
 private
   module ×⊎ {k ℓ} = CommutativeSemiring (×⊎-CommutativeSemiring k ℓ)
 
+module _ {s p} (C : Container s p) {x} {X : Set x} {ℓ} {P : Pred X ℓ} where
+
 -- ◇ can be expressed using _∈_.
 
-↔∈ : ∀ {c} (C : Container c) {X : Set c}
-       {P : X → Set c} {xs : ⟦ C ⟧ X} →
-     ◇ P xs ↔ (∃ λ x → x ∈ xs × P x)
-↔∈ _ {P = P} {xs} = record
-  { to         = P.→-to-⟶ to
-  ; from       = P.→-to-⟶ from
-  ; inverse-of = record
-    { left-inverse-of  = λ _ → refl
-    ; right-inverse-of = to∘from
+  ↔∈ : ∀ {xs : ⟦ C ⟧ X} → ◇ P xs ↔ (∃ λ x → x ∈ xs × P x)
+  ↔∈ {xs} = record
+    { to         = P.→-to-⟶ to
+    ; from       = P.→-to-⟶ from
+    ; inverse-of = record
+      { left-inverse-of  = λ _ → refl
+      ; right-inverse-of = to∘from
+      }
     }
-  }
-  where
-  to : ◇ P xs → ∃ λ x → x ∈ xs × P x
-  to (p , Px) = (proj₂ xs p , (p , refl) , Px)
+    where
 
-  from : (∃ λ x → x ∈ xs × P x) → ◇ P xs
-  from (.(proj₂ xs p) , (p , refl) , Px) = (p , Px)
+    to : ◇ P xs → ∃ λ x → x ∈ xs × P x
+    to (p , Px) = (proj₂ xs p , (p , refl) , Px)
 
-  to∘from : to ∘ from ≗ id
-  to∘from (.(proj₂ xs p) , (p , refl) , Px) = refl
+    from : (∃ λ x → x ∈ xs × P x) → ◇ P xs
+    from (.(proj₂ xs p) , (p , refl) , Px) = (p , Px)
 
+    to∘from : to ∘ from ≗ id
+    to∘from (.(proj₂ xs p) , (p , refl) , Px) = refl
+
+module _ {s p} {C : Container s p} {x} {X : Set x}
+         {ℓ₁ ℓ₂} {P₁ : Pred X ℓ₁} {P₂ : Pred X ℓ₂} where
 -- ◇ is a congruence for bag and set equality and related preorders.
 
-cong : ∀ {k c} {C : Container c}
-         {X : Set c} {P₁ P₂ : X → Set c} {xs₁ xs₂ : ⟦ C ⟧ X} →
-       (∀ x → Related k (P₁ x) (P₂ x)) → xs₁ ∼[ k ] xs₂ →
-       Related k (◇ P₁ xs₁) (◇ P₂ xs₂)
-cong {C = C} {P₁ = P₁} {P₂} {xs₁} {xs₂} P₁↔P₂ xs₁≈xs₂ =
-  ◇ P₁ xs₁                  ↔⟨ ↔∈ C ⟩
-  (∃ λ x → x ∈ xs₁ × P₁ x)  ∼⟨ Σ.cong Inv.id (xs₁≈xs₂ ×-cong P₁↔P₂ _) ⟩
-  (∃ λ x → x ∈ xs₂ × P₂ x)  ↔⟨ sym (↔∈ C) ⟩
-  ◇ P₂ xs₂                  ∎
+  cong : ∀ {k} {xs₁ xs₂ : ⟦ C ⟧ X} →
+         (∀ x → Related k (P₁ x) (P₂ x)) → xs₁ ∼[ k ] xs₂ →
+         Related k (◇ P₁ xs₁) (◇ P₂ xs₂)
+  cong {k} {xs₁} {xs₂} P₁↔P₂ xs₁≈xs₂ =
+    ◇ P₁ xs₁                  ↔⟨ ↔∈ C ⟩
+    (∃ λ x → x ∈ xs₁ × P₁ x)  ∼⟨ Σ.cong Inv.id (xs₁≈xs₂ ×-cong P₁↔P₂ _) ⟩
+    (∃ λ x → x ∈ xs₂ × P₂ x)  ↔⟨ sym (↔∈ C) ⟩
+    ◇ P₂ xs₂                  ∎
 
 -- Nested occurrences of ◇ can sometimes be swapped.
 
-swap : ∀ {c} {C₁ C₂ : Container c} {X Y : Set c} {P : X → Y → Set c}
-         {xs : ⟦ C₁ ⟧ X} {ys : ⟦ C₂ ⟧ Y} →
-       let ◈ : ∀ {C : Container c} {X} → ⟦ C ⟧ X → (X → Set c) → Set c
-           ◈ = λ {_} {_} → flip ◇ in
-       ◈ xs (◈ ys ∘ P) ↔ ◈ ys (◈ xs ∘ flip P)
-swap {c} {C₁} {C₂} {P = P} {xs} {ys} =
-  ◇ (λ x → ◇ (P x) ys) xs                    ↔⟨ ↔∈ C₁ ⟩
-  (∃ λ x → x ∈ xs × ◇ (P x) ys)              ↔⟨ Σ.cong Inv.id (λ {x} → Inv.id ⟨ ×⊎.*-cong {ℓ = c} ⟩ ↔∈ C₂ {P = P x}) ⟩
-  (∃ λ x → x ∈ xs × ∃ λ y → y ∈ ys × P x y)  ↔⟨ Σ.cong Inv.id (λ {x} → ∃∃↔∃∃ {A = x ∈ xs} (λ _ y → y ∈ ys × P x y)) ⟩
-  (∃₂ λ x y → x ∈ xs × y ∈ ys × P x y)       ↔⟨ ∃∃↔∃∃ (λ x y → x ∈ xs × y ∈ ys × P x y) ⟩
-  (∃₂ λ y x → x ∈ xs × y ∈ ys × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → Σ.cong Inv.id (λ {x} →
-    (x ∈ xs × y ∈ ys × P x y)                     ↔⟨ sym $ ×⊎.*-assoc _ _ _ ⟩
-    ((x ∈ xs × y ∈ ys) × P x y)                   ↔⟨ ×⊎.*-comm _ _ ⟨ ×⊎.*-cong {ℓ = c} ⟩ Inv.id ⟩
-    ((y ∈ ys × x ∈ xs) × P x y)                   ↔⟨ ×⊎.*-assoc _ _ _ ⟩
-    (y ∈ ys × x ∈ xs × P x y)                     ∎)) ⟩
-  (∃₂ λ y x → y ∈ ys × x ∈ xs × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → ∃∃↔∃∃ {B = y ∈ ys} (λ x _ → x ∈ xs × P x y)) ⟩
-  (∃ λ y → y ∈ ys × ∃ λ x → x ∈ xs × P x y)  ↔⟨ Σ.cong Inv.id (λ {y} → Inv.id ⟨ ×⊎.*-cong {ℓ = c} ⟩ sym (↔∈ C₁ {P = flip P y})) ⟩
-  (∃ λ y → y ∈ ys × ◇ (flip P y) xs)         ↔⟨ sym (↔∈ C₂) ⟩
-  ◇ (λ y → ◇ (flip P y) xs) ys               ∎
+module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s₂ p₂}
+         {x y} {X : Set x} {Y : Set y} {r} {P : REL X Y r} where
+
+  swap : {xs : ⟦ C₁ ⟧ X} {ys : ⟦ C₂ ⟧ Y} →
+         let ◈ : ∀ {s p} {C : Container s p} {x} {X : Set x} {ℓ} → ⟦ C ⟧ X → Pred X ℓ → Set (p ⊔ ℓ)
+             ◈ = λ {_} {_} → flip ◇ in
+         ◈ xs (◈ ys ∘ P) ↔ ◈ ys (◈ xs ∘ flip P)
+  swap {xs} {ys} =
+    ◇ (λ x → ◇ (P x) ys) xs                    ↔⟨ ↔∈ C₁ ⟩
+    (∃ λ x → x ∈ xs × ◇ (P x) ys)              ↔⟨ Σ.cong Inv.id $ Σ.cong Inv.id $ ↔∈ C₂ ⟩
+    (∃ λ x → x ∈ xs × ∃ λ y → y ∈ ys × P x y)  ↔⟨ Σ.cong Inv.id (λ {x} → ∃∃↔∃∃ (λ _ y → y ∈ ys × P x y)) ⟩
+    (∃₂ λ x y → x ∈ xs × y ∈ ys × P x y)       ↔⟨ ∃∃↔∃∃ (λ x y → x ∈ xs × y ∈ ys × P x y) ⟩
+    (∃₂ λ y x → x ∈ xs × y ∈ ys × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → Σ.cong Inv.id (λ {x} →
+      (x ∈ xs × y ∈ ys × P x y)                     ↔⟨ sym Σ-assoc ⟩
+      ((x ∈ xs × y ∈ ys) × P x y)                   ↔⟨ Σ.cong ×-comm Inv.id ⟩
+      ((y ∈ ys × x ∈ xs) × P x y)                   ↔⟨ Σ-assoc ⟩
+      (y ∈ ys × x ∈ xs × P x y)                     ∎)) ⟩
+    (∃₂ λ y x → y ∈ ys × x ∈ xs × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → ∃∃↔∃∃ {B = y ∈ ys} (λ x _ → x ∈ xs × P x y)) ⟩
+    (∃ λ y → y ∈ ys × ∃ λ x → x ∈ xs × P x y)  ↔⟨ Σ.cong Inv.id (Σ.cong Inv.id (sym (↔∈ C₁))) ⟩
+    (∃ λ y → y ∈ ys × ◇ (flip P y) xs)         ↔⟨ sym (↔∈ C₂) ⟩
+    ◇ (λ y → ◇ (flip P y) xs) ys               ∎
 
 -- Nested occurrences of ◇ can sometimes be flattened.
 
-flatten : ∀ {c} {C₁ C₂ : Container c} {X}
-          P (xss : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)) →
-          ◇ (◇ P) xss ↔
-          ◇ P (Inverse.from (Composition.correct C₁ C₂) ⟨$⟩ xss)
-flatten {C₁ = C₁} {C₂} {X} P xss = record
-  { to         = P.→-to-⟶ t
-  ; from       = P.→-to-⟶ f
-  ; inverse-of = record
-    { left-inverse-of  = λ _ → refl
-    ; right-inverse-of = λ _ → refl
+module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s₂ p₂}
+         {x} {X : Set x} {ℓ} (P : Pred X ℓ) where
+
+  flatten : ∀ (xss : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)) →
+            ◇ (◇ P) xss ↔
+            ◇ P (Inverse.from (Composition.correct C₁ C₂) ⟨$⟩ xss)
+  flatten xss = record
+    { to         = P.→-to-⟶ t
+    ; from       = P.→-to-⟶ f
+    ; inverse-of = record
+      { left-inverse-of  = λ _ → refl
+      ; right-inverse-of = λ _ → refl
+      }
     }
-  }
-  where
-  open Inverse
+    where
+    open Inverse
 
-  t : ◇ (◇ P) xss → ◇ P (from (Composition.correct C₁ C₂) ⟨$⟩ xss)
-  t (p₁ , p₂ , p) = ((p₁ , p₂) , p)
+    t : ◇ (◇ P) xss → ◇ P (from (Composition.correct C₁ C₂) ⟨$⟩ xss)
+    t (p₁ , p₂ , p) = ((p₁ , p₂) , p)
 
-  f : ◇ P (from (Composition.correct C₁ C₂) ⟨$⟩ xss) → ◇ (◇ P) xss
-  f ((p₁ , p₂) , p) = (p₁ , p₂ , p)
+    f : ◇ P (from (Composition.correct C₁ C₂) ⟨$⟩ xss) → ◇ (◇ P) xss
+    f ((p₁ , p₂) , p) = (p₁ , p₂ , p)
 
 -- Sums commute with ◇ (for a fixed instance of a given container).
 
-◇⊎↔⊎◇ : ∀ {c} {C : Container c} {X : Set c} {xs : ⟦ C ⟧ X}
-          {P Q : X → Set c} →
-        ◇ (λ x → P x ⊎ Q x) xs ↔ (◇ P xs ⊎ ◇ Q xs)
-◇⊎↔⊎◇ {xs = xs} {P} {Q} = record
-  { to         = P.→-to-⟶ to
-  ; from       = P.→-to-⟶ from
-  ; inverse-of = record
-    { left-inverse-of  = from∘to
-    ; right-inverse-of = [ (λ _ → refl) , (λ _ → refl) ]
+module _ {s p} {C : Container s p} {x} {X : Set x}
+         {ℓ ℓ′} {P : Pred X ℓ} {Q : Pred X ℓ′} where
+
+  ◇⊎↔⊎◇ : ∀ {xs : ⟦ C ⟧ X} → ◇ (P ∪ Q) xs ↔ (◇ P xs ⊎ ◇ Q xs)
+  ◇⊎↔⊎◇ {xs} = record
+    { to         = P.→-to-⟶ to
+    ; from       = P.→-to-⟶ from
+    ; inverse-of = record
+      { left-inverse-of  = from∘to
+      ; right-inverse-of = [ (λ _ → refl) , (λ _ → refl) ]
+      }
     }
-  }
-  where
-  to : ◇ (λ x → P x ⊎ Q x) xs → ◇ P xs ⊎ ◇ Q xs
-  to (pos , inj₁ p) = inj₁ (pos , p)
-  to (pos , inj₂ q) = inj₂ (pos , q)
+    where
+    to : ◇ (λ x → P x ⊎ Q x) xs → ◇ P xs ⊎ ◇ Q xs
+    to (pos , inj₁ p) = inj₁ (pos , p)
+    to (pos , inj₂ q) = inj₂ (pos , q)
 
-  from : ◇ P xs ⊎ ◇ Q xs → ◇ (λ x → P x ⊎ Q x) xs
-  from = [ Prod.map id inj₁ , Prod.map id inj₂ ]
+    from : ◇ P xs ⊎ ◇ Q xs → ◇ (λ x → P x ⊎ Q x) xs
+    from = [ Prod.map id inj₁ , Prod.map id inj₂ ]
 
-  from∘to : from ∘ to ≗ id
-  from∘to (pos , inj₁ p) = refl
-  from∘to (pos , inj₂ q) = refl
+    from∘to : from ∘ to ≗ id
+    from∘to (pos , inj₁ p) = refl
+    from∘to (pos , inj₂ q) = refl
 
 -- Products "commute" with ◇.
 
-×◇↔◇◇× : ∀ {c} {C₁ C₂ : Container c}
-           {X Y} {P : X → Set c} {Q : Y → Set c}
-           {xs : ⟦ C₁ ⟧ X} {ys : ⟦ C₂ ⟧ Y} →
-         ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs ↔ (◇ P xs × ◇ Q ys)
-×◇↔◇◇× {C₁ = C₁} {C₂} {P = P} {Q} {xs} {ys} = record
-  { to         = P.→-to-⟶ to
-  ; from       = P.→-to-⟶ from
-  ; inverse-of = record
-    { left-inverse-of  = λ _ → refl
-    ; right-inverse-of = λ _ → refl
-    }
-  }
-  where
-  to : ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs → ◇ P xs × ◇ Q ys
-  to (p₁ , p₂ , p , q) = ((p₁ , p) , (p₂ , q))
+module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s₂ p₂}
+         {x y} {X : Set x} {Y : Set y} {ℓ ℓ′} {P : Pred X ℓ} {Q : Pred Y ℓ′} where
 
-  from : ◇ P xs × ◇ Q ys → ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs
-  from ((p₁ , p) , (p₂ , q)) = (p₁ , p₂ , p , q)
+  ×◇↔◇◇× : ∀ {xs : ⟦ C₁ ⟧ X} {ys : ⟦ C₂ ⟧ Y} →
+           ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs ↔ (◇ P xs × ◇ Q ys)
+  ×◇↔◇◇× {xs} {ys} = record
+    { to         = P.→-to-⟶ to
+    ; from       = P.→-to-⟶ from
+    ; inverse-of = record
+      { left-inverse-of  = λ _ → refl
+      ; right-inverse-of = λ _ → refl
+      }
+    }
+    where
+    to : ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs → ◇ P xs × ◇ Q ys
+    to (p₁ , p₂ , p , q) = ((p₁ , p) , (p₂ , q))
+
+    from : ◇ P xs × ◇ Q ys → ◇ (λ x → ◇ (λ y → P x × Q y) ys) xs
+    from ((p₁ , p) , (p₂ , q)) = (p₁ , p₂ , p , q)
 
 -- map can be absorbed by the predicate.
 
-map↔∘ : ∀ {c} (C : Container c) {X Y : Set c}
-        (P : Y → Set c) {xs : ⟦ C ⟧ X} (f : X → Y) →
-        ◇ P (C.map f xs) ↔ ◇ (P ∘ f) xs
-map↔∘ _ _ _ = Inv.id
+module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
+         {ℓ} (P : Pred Y ℓ) where
+
+  map↔∘ : ∀ {xs : ⟦ C ⟧ X} (f : X → Y) → ◇ P (C.map f xs) ↔ ◇ (P ∘ f) xs
+  map↔∘ f = Inv.id
 
 -- Membership in a mapped container can be expressed without reference
 -- to map.
 
-∈map↔∈×≡ : ∀ {c} (C : Container c) {X Y : Set c} {f : X → Y}
-             {xs : ⟦ C ⟧ X} {y} →
-           y ∈ C.map f xs ↔ (∃ λ x → x ∈ xs × y ≡ f x)
-∈map↔∈×≡ {c} C {f = f} {xs} {y} =
-  y ∈ C.map f xs              ↔⟨ map↔∘ C (_≡_ y) f ⟩
-  ◇ (λ x → y ≡ f x) xs        ↔⟨ ↔∈ C ⟩
-  (∃ λ x → x ∈ xs × y ≡ f x)  ∎
+module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
+         {ℓ} (P : Pred Y ℓ) where
+
+  ∈map↔∈×≡ : ∀ {f : X → Y} {xs : ⟦ C ⟧ X} {y} →
+             y ∈ C.map f xs ↔ (∃ λ x → x ∈ xs × y ≡ f x)
+  ∈map↔∈×≡ {f = f} {xs} {y} =
+    y ∈ C.map f xs              ↔⟨ map↔∘ C (_≡_ y) f ⟩
+    ◇ (λ x → y ≡ f x) xs        ↔⟨ ↔∈ C ⟩
+    (∃ λ x → x ∈ xs × y ≡ f x)  ∎
 
 -- map is a congruence for bag and set equality and related preorders.
 
-map-cong : ∀ {k c} {C : Container c} {X Y : Set c}
-             {f₁ f₂ : X → Y} {xs₁ xs₂ : ⟦ C ⟧ X} →
-           f₁ ≗ f₂ → xs₁ ∼[ k ] xs₂ →
-           C.map f₁ xs₁ ∼[ k ] C.map f₂ xs₂
-map-cong {c = c} {C} {f₁ = f₁} {f₂} {xs₁} {xs₂} f₁≗f₂ xs₁≈xs₂ {x} =
-  x ∈ C.map f₁ xs₁        ↔⟨ map↔∘ C (_≡_ x) f₁ ⟩
-  ◇ (λ y → x ≡ f₁ y) xs₁  ∼⟨ cong {xs₁ = xs₁} {xs₂ = xs₂} (Related.↔⇒ ∘ helper) xs₁≈xs₂ ⟩
-  ◇ (λ y → x ≡ f₂ y) xs₂  ↔⟨ sym (map↔∘ C (_≡_ x) f₂) ⟩
-  x ∈ C.map f₂ xs₂        ∎
-  where
-  helper : ∀ y → (x ≡ f₁ y) ↔ (x ≡ f₂ y)
-  helper y = record
-    { to         = P.→-to-⟶ (λ x≡f₁y → P.trans x≡f₁y (        f₁≗f₂ y))
-    ; from       = P.→-to-⟶ (λ x≡f₂y → P.trans x≡f₂y (P.sym $ f₁≗f₂ y))
-    ; inverse-of = record
-      { left-inverse-of  = λ _ → P.≡-irrelevance _ _
-      ; right-inverse-of = λ _ → P.≡-irrelevance _ _
+
+module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
+         {ℓ} (P : Pred Y ℓ) where
+
+  map-cong : ∀ {k} {f₁ f₂ : X → Y} {xs₁ xs₂ : ⟦ C ⟧ X} →
+             f₁ ≗ f₂ → xs₁ ∼[ k ] xs₂ →
+             C.map f₁ xs₁ ∼[ k ] C.map f₂ xs₂
+  map-cong {f₁ = f₁} {f₂} {xs₁} {xs₂} f₁≗f₂ xs₁≈xs₂ {x} =
+    x ∈ C.map f₁ xs₁        ↔⟨ map↔∘ C (_≡_ x) f₁ ⟩
+    ◇ (λ y → x ≡ f₁ y) xs₁  ∼⟨ cong {xs₁ = xs₁} {xs₂ = xs₂} (Related.↔⇒ ∘ helper) xs₁≈xs₂ ⟩
+    ◇ (λ y → x ≡ f₂ y) xs₂  ↔⟨ sym (map↔∘ C (_≡_ x) f₂) ⟩
+    x ∈ C.map f₂ xs₂        ∎
+    where
+    helper : ∀ y → (x ≡ f₁ y) ↔ (x ≡ f₂ y)
+    helper y = record
+      { to         = P.→-to-⟶ (λ x≡f₁y → P.trans x≡f₁y (        f₁≗f₂ y))
+      ; from       = P.→-to-⟶ (λ x≡f₂y → P.trans x≡f₂y (P.sym $ f₁≗f₂ y))
+      ; inverse-of = record
+        { left-inverse-of  = λ _ → P.≡-irrelevance _ _
+        ; right-inverse-of = λ _ → P.≡-irrelevance _ _
+        }
       }
-    }
 
 -- Uses of linear morphisms can be removed.
 
-remove-linear :
-  ∀ {c} {C₁ C₂ : Container c} {X} {xs : ⟦ C₁ ⟧ X}
-  (P : X → Set c) (m : C₁ ⊸ C₂) →
-  ◇ P (⟪ m ⟫⊸ xs) ↔ ◇ P xs
-remove-linear {xs = xs} P m = record
-  { to         = P.→-to-⟶ t
-  ; from       = P.→-to-⟶ f
-  ; inverse-of = record
-    { left-inverse-of  = f∘t
-    ; right-inverse-of = t∘f
+module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s₂ p₂}
+         {x} {X : Set x} {ℓ} (P : Pred X ℓ) where
+
+  remove-linear : ∀ {xs : ⟦ C₁ ⟧ X} (m : C₁ ⊸ C₂) → ◇ P (⟪ m ⟫⊸ xs) ↔ ◇ P xs
+  remove-linear {xs} m = record
+    { to         = P.→-to-⟶ t
+    ; from       = P.→-to-⟶ f
+    ; inverse-of = record
+      { left-inverse-of  = f∘t
+      ; right-inverse-of = t∘f
+      }
     }
-  }
-  where
-  open Inverse
+    where
+    open Inverse
 
-  t : ◇ P (⟪ m ⟫⊸ xs) → ◇ P xs
-  t = Prod.map (_⟨$⟩_ (to (position⊸ m))) id
+    t : ◇ P (⟪ m ⟫⊸ xs) → ◇ P xs
+    t = Prod.map (_⟨$⟩_ (to (position⊸ m))) id
 
-  f : ◇ P xs → ◇ P (⟪ m ⟫⊸ xs)
-  f = Prod.map (_⟨$⟩_ (from (position⊸ m)))
-               (P.subst (P ∘ proj₂ xs)
-                        (P.sym $ right-inverse-of (position⊸ m) _))
+    f : ◇ P xs → ◇ P (⟪ m ⟫⊸ xs)
+    f = Prod.map (_⟨$⟩_ (from (position⊸ m)))
+                 (P.subst (P ∘ proj₂ xs)
+                          (P.sym $ right-inverse-of (position⊸ m) _))
 
-  f∘t : f ∘ t ≗ id
-  f∘t (p₂ , p) = H.≅-to-≡ $
-    H.cong₂ _,_ (H.≡-to-≅ $ left-inverse-of (position⊸ m) p₂)
-                (H.≡-subst-removable
-                  (P ∘ proj₂ xs)
-                  (P.sym (right-inverse-of (position⊸ m)
-                                           (to (position⊸ m) ⟨$⟩ p₂)))
-                  p)
+    f∘t : f ∘ t ≗ id
+    f∘t (p₂ , p) = H.≅-to-≡ $
+      H.cong₂ _,_ (H.≡-to-≅ $ left-inverse-of (position⊸ m) p₂)
+                  (H.≡-subst-removable
+                    (P ∘ proj₂ xs)
+                    (P.sym (right-inverse-of (position⊸ m)
+                                             (to (position⊸ m) ⟨$⟩ p₂)))
+                    p)
 
-  t∘f : t ∘ f ≗ id
-  t∘f (p₁ , p) = H.≅-to-≡ $
-    H.cong₂ _,_ (H.≡-to-≅ $ right-inverse-of (position⊸ m) p₁)
-                (H.≡-subst-removable
-                  (P ∘ proj₂ xs)
-                  (P.sym (right-inverse-of (position⊸ m) p₁))
-                  p)
+    t∘f : t ∘ f ≗ id
+    t∘f (p₁ , p) = H.≅-to-≡ $
+      H.cong₂ _,_ (H.≡-to-≅ $ right-inverse-of (position⊸ m) p₁)
+                  (H.≡-subst-removable
+                    (P ∘ proj₂ xs)
+                    (P.sym (right-inverse-of (position⊸ m) p₁))
+                    p)
 
 -- Linear endomorphisms are identity functions if bag equality is
 -- used.
 
-linear-identity :
-  ∀ {c} {C : Container c} {X} {xs : ⟦ C ⟧ X} (m : C ⊸ C) →
-  ⟪ m ⟫⊸ xs ∼[ bag ] xs
-linear-identity {xs = xs} m {x} =
-  x ∈ ⟪ m ⟫⊸ xs  ↔⟨ remove-linear (_≡_ x) m ⟩
-  x ∈        xs  ∎
+module _ {s p} {C : Container s p} {x} {X : Set x} where
+
+  linear-identity : ∀ {xs : ⟦ C ⟧ X} (m : C ⊸ C) → ⟪ m ⟫⊸ xs ∼[ bag ] xs
+  linear-identity {xs} m {x} =
+    x ∈ ⟪ m ⟫⊸ xs  ↔⟨ remove-linear (_≡_ x) m ⟩
+    x ∈        xs  ∎
 
 -- If join can be expressed using a linear morphism (in a certain
 -- way), then it can be absorbed by the predicate.
 
-join↔◇ : ∀ {c} {C₁ C₂ C₃ : Container c} {X}
-         P (join′ : (C₁ ⟨∘⟩ C₂) ⊸ C₃) (xss : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)) →
-         let join : ∀ {X} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₃ ⟧ X
-             join = λ {_} → ⟪ join′ ⟫⊸ ∘
-                    _⟨$⟩_ (Inverse.from (Composition.correct C₁ C₂)) in
-         ◇ P (join xss) ↔ ◇ (◇ P) xss
-join↔◇ {C₁ = C₁} {C₂} P join xss =
-  ◇ P (⟪ join ⟫⊸ xss′)  ↔⟨ remove-linear P join ⟩
-  ◇ P            xss′   ↔⟨ sym $ flatten P xss ⟩
-  ◇ (◇ P) xss           ∎
-  where xss′ = Inverse.from (Composition.correct C₁ C₂) ⟨$⟩ xss
+module _ {s₁ s₂ s₃ p₁ p₂ p₃}
+         {C₁ : Container s₁ p₁} {C₂ : Container s₂ p₂} {C₃ : Container s₃ p₃}
+         {x} {X : Set x} {ℓ} (P : Pred X ℓ) where
+
+  join↔◇ : (join′ : (C₁ ⟨∘⟩ C₂) ⊸ C₃) (xss : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)) →
+           let join : ∀ {X} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₃ ⟧ X
+               join = λ {_} → ⟪ join′ ⟫⊸ ∘
+                      _⟨$⟩_ (Inverse.from (Composition.correct C₁ C₂)) in
+           ◇ P (join xss) ↔ ◇ (◇ P) xss
+  join↔◇ join xss =
+    ◇ P (⟪ join ⟫⊸ xss′)  ↔⟨ remove-linear P join ⟩
+    ◇ P            xss′   ↔⟨ sym $ flatten P xss ⟩
+   ◇ (◇ P) xss           ∎
+    where xss′ = Inverse.from (Composition.correct C₁ C₂) ⟨$⟩ xss

--- a/src/Data/Container/Combinator.agda
+++ b/src/Data/Container/Combinator.agda
@@ -22,19 +22,19 @@ open import Relation.Binary.PropositionalEquality as P
 
 -- Identity.
 
-id : ∀ {c} → Container c
+id : ∀ {s p} → Container s p
 id = Lift ⊤ ▷ F.const (Lift ⊤)
 
 -- Constant.
 
-const : ∀ {c} → Set c → Container c
+const : ∀ {s p} → Set s → Container s p
 const X = X ▷ F.const (Lift ⊥)
 
 -- Composition.
 
 infixr 9 _∘_
 
-_∘_ : ∀ {c} → Container c → Container c → Container c
+_∘_ : ∀ {s₁ s₂ p₁ p₂} → Container s₁ p₁ → Container s₂ p₂ → Container (s₁ ⊔ s₂ ⊔ p₁) (p₁ ⊔ p₂)
 C₁ ∘ C₂ = ⟦ C₁ ⟧ (Shape C₂) ▷ ◇ (Position C₂)
 
 -- Product. (Note that, up to isomorphism, this is a special case of
@@ -42,14 +42,14 @@ C₁ ∘ C₂ = ⟦ C₁ ⟧ (Shape C₂) ▷ ◇ (Position C₂)
 
 infixr 2 _×_
 
-_×_ : ∀ {c} → Container c → Container c → Container c
+_×_ : ∀ {s₁ s₂ p₁ p₂} → Container s₁ p₁ → Container s₂ p₂ → Container (s₁ ⊔ s₂) (p₁ ⊔ p₂)
 C₁ × C₂ =
   (Shape C₁ ⟨×⟩ Shape C₂) ▷
   uncurry (λ s₁ s₂ → Position C₁ s₁ ⟨⊎⟩ Position C₂ s₂)
 
 -- Indexed product.
 
-Π : ∀ {c} {I : Set c} → (I → Container c) → Container c
+Π : ∀ {i s p} {I : Set i} → (I → Container s p) → Container (i ⊔ s) (i ⊔ p)
 Π C = (∀ i → Shape (C i)) ▷ λ s → ∃ λ i → Position (C i) (s i)
 
 -- Sum. (Note that, up to isomorphism, this is a special case of
@@ -57,12 +57,12 @@ C₁ × C₂ =
 
 infixr 1 _⊎_
 
-_⊎_ : ∀ {c} → Container c → Container c → Container c
+_⊎_ : ∀ {s₁ s₂ p} → Container s₁ p → Container s₂ p → Container (s₁ ⊔ s₂) p
 C₁ ⊎ C₂ = (Shape C₁ ⟨⊎⟩ Shape C₂) ▷ [ Position C₁ , Position C₂ ]
 
 -- Indexed sum.
 
-Σ : ∀ {c} {I : Set c} → (I → Container c) → Container c
+Σ : ∀ {i s p} {I : Set i} → (I → Container s p) → Container (i ⊔ s) p
 Σ C = (∃ λ i → Shape (C i)) ▷ λ s → Position (C (proj₁ s)) (proj₂ s)
 
 -- Constant exponentiation. (Note that this is a special case of
@@ -70,7 +70,7 @@ C₁ ⊎ C₂ = (Shape C₁ ⟨⊎⟩ Shape C₂) ▷ [ Position C₁ , Position
 
 infix 0 const[_]⟶_
 
-const[_]⟶_ : ∀ {c} → Set c → Container c → Container c
+const[_]⟶_ : ∀ {i s p} → Set i → Container s p → Container (i ⊔ s) (i ⊔ p)
 const[ X ]⟶ C = Π {I = X} (F.const C)
 
 ------------------------------------------------------------------------
@@ -82,20 +82,21 @@ const[ X ]⟶ C = Π {I = X} (F.const C)
 
 module Identity where
 
-  correct : ∀ {c} {X : Set c} → ⟦ id {c} ⟧ X ↔ F.id X
-  correct {c} = record
-    { to         = P.→-to-⟶ {a  = c} λ xs → proj₂ xs _
-    ; from       = P.→-to-⟶ {b₁ = c} λ x → (_ , λ _ → x)
+  correct : ∀ {s p x} {X : Set x} → ⟦ id {s} {p} ⟧ X ↔ F.id X
+  correct  = record
+    { to         = P.→-to-⟶ λ xs → proj₂ xs _
+    ; from       = P.→-to-⟶ λ x → (_ , λ _ → x)
     ; inverse-of = record
       { left-inverse-of  = λ _ → refl
       ; right-inverse-of = λ _ → refl
       }
     }
 
-module Constant (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
+module Constant (ext : ∀ {ℓ ℓ′} → P.Extensionality ℓ ℓ′) where
 
-  correct : ∀ {ℓ} (X : Set ℓ) {Y} → ⟦ const X ⟧ Y ↔ F.const X Y
-  correct X {Y} = record
+
+  correct : ∀ {x p y} (X : Set x) {Y : Set y} → ⟦ const {x} {p ⊔ y} X ⟧ Y ↔ F.const X Y
+  correct {x} {y} X {Y} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -103,19 +104,18 @@ module Constant (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
       ; left-inverse-of  =
           λ xs → P.cong (_,_ (proj₁ xs)) (ext (λ x → ⊥-elim (lower x)))
       }
-    }
-    where
+    } where
+
     to : ⟦ const X ⟧ Y → X
     to = proj₁
 
     from : X → ⟦ const X ⟧ Y
     from = < F.id , F.const (⊥-elim ∘′ lower) >
 
-module Composition where
+module Composition {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
-  correct : ∀ {c} (C₁ C₂ : Container c) {X : Set c} →
-            ⟦ C₁ ∘ C₂ ⟧ X ↔ (⟦ C₁ ⟧ ⟨∘⟩ ⟦ C₂ ⟧) X
-  correct C₁ C₂ {X} = record
+  correct : ∀ {x} {X : Set x} → ⟦ C₁ ∘ C₂ ⟧ X ↔ (⟦ C₁ ⟧ ⟨∘⟩ ⟦ C₂ ⟧) X
+  correct {X = X} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -130,11 +130,11 @@ module Composition where
     from : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₁ ∘ C₂ ⟧ X
     from (s , f) = ((s , proj₁ ⟨∘⟩ f) , uncurry (proj₂ ⟨∘⟩ f))
 
-module Product (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
+module Product (ext : ∀ {ℓ ℓ′} → P.Extensionality ℓ ℓ′)
+       {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
-  correct : ∀ {c} (C₁ C₂ : Container c) {X : Set c} →
-            ⟦ C₁ × C₂ ⟧ X ↔ (⟦ C₁ ⟧ X ⟨×⟩ ⟦ C₂ ⟧ X)
-  correct {c} C₁ C₂ {X} = record
+  correct : ∀ {x} {X : Set x} →  ⟦ C₁ × C₂ ⟧ X ↔ (⟦ C₁ ⟧ X ⟨×⟩ ⟦ C₂ ⟧ X)
+  correct {X = X} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -151,13 +151,12 @@ module Product (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
 
     from∘to : from ⟨∘⟩ to ≗ F.id
     from∘to (s , f) =
-      P.cong (_,_ s) (ext {ℓ = c} [ (λ _ → refl) , (λ _ → refl) ])
+      P.cong (_,_ s) (ext [ (λ _ → refl) , (λ _ → refl) ])
 
-module IndexedProduct where
+module IndexedProduct {i s p} {I : Set i} (Cᵢ : I → Container s p) where
 
-  correct : ∀ {c I} (C : I → Container c) {X : Set c} →
-            ⟦ Π C ⟧ X ↔ (∀ i → ⟦ C i ⟧ X)
-  correct {I = I} C {X} = record
+  correct : ∀ {x} {X : Set x} → ⟦ Π Cᵢ ⟧ X ↔ (∀ i → ⟦ Cᵢ i ⟧ X)
+  correct {X = X} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -166,17 +165,16 @@ module IndexedProduct where
       }
     }
     where
-    to : ⟦ Π C ⟧ X → ∀ i → ⟦ C i ⟧ X
+    to : ⟦ Π Cᵢ ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
     to (s , f) = λ i → (s i , λ p → f (i , p))
 
-    from : (∀ i → ⟦ C i ⟧ X) → ⟦ Π C ⟧ X
+    from : (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π Cᵢ ⟧ X
     from f = (proj₁ ⟨∘⟩ f , uncurry (proj₂ ⟨∘⟩ f))
 
-module Sum where
+module Sum {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
 
-  correct : ∀ {c} (C₁ C₂ : Container c) {X : Set c} →
-            ⟦ C₁ ⊎ C₂ ⟧ X ↔ (⟦ C₁ ⟧ X ⟨⊎⟩ ⟦ C₂ ⟧ X)
-  correct C₁ C₂ {X} = record
+  correct : ∀ {x} {X : Set x} → ⟦ C₁ ⊎ C₂ ⟧ X ↔ (⟦ C₁ ⟧ X ⟨⊎⟩ ⟦ C₂ ⟧ X)
+  correct {X = X} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -196,11 +194,10 @@ module Sum where
     from∘to (inj₁ s₁ , f) = refl
     from∘to (inj₂ s₂ , f) = refl
 
-module IndexedSum where
+module IndexedSum {i s p} {I : Set i} (C : I → Container s p) where
 
-  correct : ∀ {c I} (C : I → Container c) {X : Set c} →
-            ⟦ Σ C ⟧ X ↔ (∃ λ i → ⟦ C i ⟧ X)
-  correct {I = I} C {X} = record
+  correct : ∀ {x} {X : Set x} → ⟦ Σ C ⟧ X ↔ (∃ λ i → ⟦ C i ⟧ X)
+  correct {X = X} = record
     { to         = P.→-to-⟶ to
     ; from       = P.→-to-⟶ from
     ; inverse-of = record
@@ -215,8 +212,7 @@ module IndexedSum where
     from : (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ C ⟧ X
     from (i , (s , f)) = ((i , s) , f)
 
-module ConstantExponentiation where
+module ConstantExponentiation {i s p} {I : Set i} (C : Container s p) where
 
-  correct : ∀ {c X} (C : Container c) {Y : Set c} →
-            ⟦ const[ X ]⟶ C ⟧ Y ↔ (X → ⟦ C ⟧ Y)
-  correct C = IndexedProduct.correct (F.const C)
+  correct : ∀ {x} {X : Set x} → ⟦ const[ I ]⟶ C ⟧ X ↔ (I → ⟦ C ⟧ X)
+  correct = IndexedProduct.correct (F.const C)

--- a/src/Data/Container/Core.agda
+++ b/src/Data/Container/Core.agda
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Containers core
+------------------------------------------------------------------------
+
+module Data.Container.Core where
+
+open import Level
+open import Data.Product
+
+infix 5 _▷_
+record Container (s p : Level) : Set (suc (s ⊔ p)) where
+  constructor _▷_
+  field
+    Shape    : Set s
+    Position : Shape → Set p
+
+-- The semantics ("extension") of a container.
+
+⟦_⟧ : ∀ {s p ℓ} → Container s p → Set ℓ → Set (s ⊔ p ⊔ ℓ)
+⟦ S ▷ P ⟧ X = Σ[ s ∈ S ] (P s → X)

--- a/src/Data/Container/FreeMonad.agda
+++ b/src/Data/Container/FreeMonad.agda
@@ -35,21 +35,23 @@ infix  1 _⋆_
 -- up in a leaf (element of the set) -- hence the Kleene star notation
 -- (the type can be read as a regular expression).
 
-_⋆C_ : ∀ {c} → Container c → Set c → Container c
+_⋆C_ : ∀ {x s p} → Container s p → Set x → Container (s ⊔ x) p
 C ⋆C X = const X ⊎ C
 
-_⋆_ : ∀ {c} → Container c → Set c → Set c
+_⋆_ : ∀ {x s p} → Container s p → Set x → Set (x ⊔ s ⊔ p)
 C ⋆ X = μ (C ⋆C X)
 
-inn : ∀ {c} {C : Container c} {X} → ⟦ C ⟧ (C ⋆ X) → C ⋆ X
-inn (s , k) = sup (inj₂ s) k
+module _ {s p} {C : Container s p} where
 
-rawMonad : ∀ {c} {C : Container c} → RawMonad (_⋆_ C)
-rawMonad = record { return = return; _>>=_ = _>>=_ }
-  where
-  return : ∀ {c} {C : Container c} {X} → X → C ⋆ X
-  return x = sup (inj₁ x) (⊥-elim ∘ lower)
+  inn : ∀ {x} {X : Set x} → ⟦ C ⟧ (C ⋆ X) → C ⋆ X
+  inn (s , k) = sup (inj₂ s) k
 
-  _>>=_ : ∀ {c} {C : Container c} {X Y} → C ⋆ X → (X → C ⋆ Y) → C ⋆ Y
-  sup (inj₁ x) _ >>= k = k x
-  sup (inj₂ s) f >>= k = inn (s , λ p → f p >>= k)
+  rawMonad : ∀ {x} → RawMonad {s ⊔ p ⊔ x} (C ⋆_)
+  rawMonad = record { return = return; _>>=_ = _>>=_ }
+    where
+    return : ∀ {X} → X → C ⋆ X
+    return x = sup (inj₁ x) (⊥-elim ∘ lower)
+
+    _>>=_ : ∀ {X Y} → C ⋆ X → (X → C ⋆ Y) → C ⋆ Y
+    sup (inj₁ x) _ >>= k = k x
+    sup (inj₂ s) f >>= k = inn (s , λ p → f p >>= k)

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -47,6 +47,20 @@ open import Relation.Nullary.Decidable as Dec using (True)
     }
   }
 
+
+------------------------------------------------------------------------
+-- × is "commutative"
+
+×-comm : ∀ {a b} {A : Set a} {B : Set b} → (A × B) ↔ (B × A)
+×-comm = record
+  { to         = P.→-to-⟶ Prod.swap
+  ; from       = P.→-to-⟶ Prod.swap
+  ; inverse-of = record
+      { left-inverse-of  = λ _ → P.refl
+      ; right-inverse-of = λ _ → P.refl
+      }
+  }
+
 ------------------------------------------------------------------------
 -- ⊥, ⊤, _×_ and _⊎_ form a commutative semiring
 
@@ -81,14 +95,7 @@ open import Relation.Nullary.Decidable as Dec using (True)
     }
 
   comm : Commutative _×_
-  comm _ _ = record
-    { to         = P.→-to-⟶ Prod.swap
-    ; from       = P.→-to-⟶ Prod.swap
-    ; inverse-of = record
-      { left-inverse-of  = λ _ → P.refl
-      ; right-inverse-of = λ _ → P.refl
-      }
-    }
+  comm _ _ = ×-comm
 
 ⊎-CommutativeMonoid : Symmetric-kind → (ℓ : Level) →
                       CommutativeMonoid _ _


### PR DESCRIPTION
Also splitting off `Data.Container.Core` just like in the Indexed
version to prepare for the refactor of `Data.W` and `Codata.Musical.M`
to use `Container`.