### PR TITLE
[ fix ] inlining the map in iterate

### DIFF
--- a/src/Codata/Stream.agda
+++ b/src/Codata/Stream.agda
@@ -62,4 +62,4 @@ module _ {ℓ ℓ₁ ℓ₂} {A : Set ℓ} {B : Set ℓ₁} {C : Set ℓ₂} whe
 module _ {ℓ} {A : Set ℓ} where
 
  iterate : ∀ {i} → (A → A) → A → Stream A i
- iterate f a = a ∷ λ where .force → map f (iterate f a)
+ iterate f a = a ∷ λ where .force → iterate f (f a)


### PR DESCRIPTION
I don't know why I went with the worse version to begin with...