### PR TITLE
[ new ] fromMusical coercions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ Non-backwards compatible changes
   Data.Stream ↦ Codata.Musical.Stream
   ```
 
+* Each new-style coinduction type comes with a `fromMusical` function converting
+  old-style coinduction values to new-style ones.
+
 * The type `Costring` and method `toCostring` have been moved from `Data.String`
   to a new module `Codata.Musical.Costring`.
 

--- a/src/Codata/Colist.agda
+++ b/src/Codata/Colist.agda
@@ -86,3 +86,14 @@ module _ {a b c} {A : Set a} {B : Set b} {C : Set c} where
  zipWith f as       []       = []
  zipWith f (a ∷ as) (b ∷ bs) =
    f a b ∷ λ where .force → zipWith f (as .force) (bs .force)
+
+
+------------------------------------------------------------------------
+-- Legacy
+
+open import Coinduction
+import Codata.Musical.Colist as M
+
+fromMusical : ∀ {a} {A : Set a} → M.Colist A → ∀ {i} → Colist A i
+fromMusical M.[]       = []
+fromMusical (x M.∷ xs) = x ∷ λ where .force → fromMusical (♭ xs)

--- a/src/Codata/Conat.agda
+++ b/src/Codata/Conat.agda
@@ -85,3 +85,14 @@ extract (suc n) = suc (extract n)
 
 ¬Finite∞ : ¬ (Finite infinity)
 ¬Finite∞ (suc p) = ¬Finite∞ p
+
+
+------------------------------------------------------------------------
+-- Legacy
+
+open import Coinduction
+import Codata.Musical.Conat as M
+
+fromMusical : M.Coℕ → ∀ {i} → Conat i
+fromMusical M.zero    = zero
+fromMusical (M.suc n) = suc λ where .force → fromMusical (♭ n)

--- a/src/Codata/Covec.agda
+++ b/src/Codata/Covec.agda
@@ -9,7 +9,7 @@ module Codata.Covec where
 open import Size
 
 open import Codata.Thunk
-open import Codata.Conat
+open import Codata.Conat as Conat hiding (fromMusical)
 open import Codata.Conat.Bisimilarity
 open import Codata.Conat.Properties
 open import Codata.Colist as Colist using (Colist ; [] ; _∷_)
@@ -71,3 +71,16 @@ module _ {a b c} {A : Set a} {B : Set b} {C : Set c} where
  zipWith f []       []       = []
  zipWith f (a ∷ as) (b ∷ bs) =
    f a b ∷ λ where .force → zipWith f (as .force) (bs .force)
+
+
+
+------------------------------------------------------------------------
+-- Legacy
+
+open import Coinduction
+import Codata.Musical.Covec as M
+
+fromMusical : ∀ {a} {A : Set a} {n} →
+              M.Covec A n → ∀ {i} → Covec A i (Conat.fromMusical n)
+fromMusical M.[]       = []
+fromMusical (x M.∷ xs) = x ∷ λ where .force → fromMusical (♭ xs)

--- a/src/Codata/Stream.agda
+++ b/src/Codata/Stream.agda
@@ -63,3 +63,14 @@ module _ {ℓ} {A : Set ℓ} where
 
  iterate : ∀ {i} → (A → A) → A → Stream A i
  iterate f a = a ∷ λ where .force → map f (iterate f a)
+
+
+
+------------------------------------------------------------------------
+-- Legacy
+
+open import Coinduction
+import Codata.Musical.Stream as M
+
+fromMusical : ∀ {a} {A : Set a} → M.Stream A → ∀ {i} → Stream A i
+fromMusical (x M.∷ xs) = x ∷ λ where .force → fromMusical (♭ xs)


### PR DESCRIPTION
This allows us to convert from old-style coinduction to new-style
one. This is particularly useful when using the legacy IO module
that produce old-style values.