### PR TITLE
[ new ] useful modular arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ Other major changes
 Deprecated features
 -------------------
 
+The following deprecations have occurred as part of a drive to improve consistency across
+the library. The deprecated names still exist and therefore all existing code should still
+work, however they have been deprecated and use of any new names is encouraged. Although not
+anticipated any time soon, they may eventually be removed in some future release of the library.
+
+* In `Data.Nat.Divisibility`:
+  ```
+  nonZeroDivisor-lemma
+  ```
+
 Other minor additions
 ---------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@ Other minor additions
   ∈-∃++    : v ∈ xs → ∃₂ λ ys zs → ∃ λ w → v ≈ w × xs ≋ ys ++ [ w ] ++ zs
   ```
 
+* Added new proof to `Data.Fin.Properties`:
+  ```agda
+  toℕ-fromℕ≤″ : toℕ (fromℕ≤″ m m<n) ≡ m
+  ```
+
+* Added new operations and proofs to `Data.Nat.DivMod`:
+  ```agda
+  _%_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
+
+  a%1≡0         : a % 1 ≡ 0
+  a%n<n         : a % (suc n) < (suc n)
+  a≡a%n+[a/n]*n : a ≡ a % suc n + (a div (suc n)) * suc n
+  ```
+
 * Added new function to `Function`:
   ```agda
   typeOf : {A : Set a} → A → Set a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,13 +134,26 @@ Other minor additions
   ∈-∃++    : v ∈ xs → ∃₂ λ ys zs → ∃ λ w → v ≈ w × xs ≋ ys ++ [ w ] ++ zs
   ```
 
+* Added new proofs to `Data.Nat.Divisibility`:
+  ```agda
+  n∣m⇒m%n≡0 : suc n ∣ m → m % (suc n) ≡ 0
+  m%n≡0⇒n∣m : m % (suc n) ≡ 0 → suc n ∣ m
+  m%n≡0⇔n∣m : m % (suc n) ≡ 0 ⇔ suc n ∣ m
+  ```
+
 * Added new operations and proofs to `Data.Nat.DivMod`:
   ```agda
   _%_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
 
+  a≡a%n+[a/n]*n : a ≡ a % suc n + (a div (suc n)) * suc n
   a%1≡0         : a % 1 ≡ 0
   a%n<n         : a % (suc n) < (suc n)
-  a≡a%n+[a/n]*n : a ≡ a % suc n + (a div (suc n)) * suc n
+  n%n≡0         : suc n % suc n ≡ 0
+  a%n%n≡a%n     : a % suc n % suc n ≡ a % suc n
+  [a+n]%n≡a%n   : (a + suc n) % suc n ≡ a % suc n
+  [a+kn]%n≡a%n  : (a + k * (suc n)) % suc n ≡ a % suc n
+  kn%n≡0        : k * (suc n) % (suc n) ≡ 0
+  %-distribˡ-+  : (a + b) % suc n ≡ (a % suc n + b % suc n) % suc n
   ```
 
 * Added new functions in `Data.Table.Base`:

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -131,6 +131,13 @@ fromℕ≤≡fromℕ≤″ (s≤s z≤n)       (ℕ.less-than-or-equal refl) = r
 fromℕ≤≡fromℕ≤″ (s≤s (s≤s m<n)) (ℕ.less-than-or-equal refl) =
   cong suc (fromℕ≤≡fromℕ≤″ (s≤s m<n) (ℕ.less-than-or-equal refl))
 
+toℕ-fromℕ≤″ : ∀ {m n} (m<n : m ℕ.<″ n) → toℕ (fromℕ≤″ m m<n) ≡ m
+toℕ-fromℕ≤″ {m} {n} m<n = begin
+  toℕ (fromℕ≤″ m m<n)  ≡⟨ cong toℕ (sym (fromℕ≤≡fromℕ≤″ _ m<n)) ⟩
+  toℕ (fromℕ≤ _)       ≡⟨ toℕ-fromℕ≤ (ℕₚ.≤″⇒≤ m<n) ⟩
+  m ∎
+  where open P.≡-Reasoning
+
 ------------------------------------------------------------------------
 -- Properties of _≤_
 

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -12,7 +12,7 @@ open import Data.Fin using (Fin; toℕ; fromℕ≤″; fromℕ≤)
 open import Data.Fin.Properties using (toℕ-fromℕ≤″)
 open import Data.Nat as Nat
 open import Data.Nat.DivMod.Core
-open import Data.Nat.Properties using (≤⇒≤″)
+open import Data.Nat.Properties using (≤⇒≤″; +-assoc; +-comm; +-identityʳ)
 open import Relation.Nullary.Decidable using (False)
 open import Relation.Binary.PropositionalEquality
 import Relation.Binary.PropositionalEquality.TrustMe as TrustMe
@@ -38,7 +38,13 @@ _%_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
 (a % suc n) = mod-helper 0 n a n
 
 ------------------------------------------------------------------------
--- Proofs
+-- _div_
+
+a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
+a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
+
+------------------------------------------------------------------------
+-- _%_
 
 a%1≡0 : ∀ a → a % 1 ≡ 0
 a%1≡0 = a[modₕ]1≡0
@@ -52,22 +58,33 @@ n%n≡0 n = n[modₕ]n≡0 0 n
 a%n%n≡a%n : ∀ a n → a % suc n % suc n ≡ a % suc n
 a%n%n≡a%n a n = modₕ-absorb 0 a n
 
+[a+n]%n≡a%n : ∀ a n → (a + suc n) % suc n ≡ a % suc n
+[a+n]%n≡a%n a n = a+n[modₕ]n≡a[modₕ]n 0 a n
+
+[a+kn]%n≡a%n : ∀ a k n → (a + k * (suc n)) % suc n ≡ a % suc n
+[a+kn]%n≡a%n a zero    n = cong (_% suc n) (+-identityʳ a)
+[a+kn]%n≡a%n a (suc k) n = begin
+  (a + (m + k * m)) % m ≡⟨ cong (_% m) (sym (+-assoc a m (k * m))) ⟩
+  (a + m + k * m)   % m ≡⟨ [a+kn]%n≡a%n (a + m) k n ⟩
+  (a + m)           % m ≡⟨ [a+n]%n≡a%n a n ⟩
+  a                 % m ∎
+  where m = suc n
+
+kn%n≡0 : ∀ k n → k * (suc n) % (suc n) ≡ 0
+kn%n≡0 = [a+kn]%n≡a%n 0
+
 %-distribˡ-+ : ∀ a b n → (a + b) % suc n ≡ (a % suc n + b % suc n) % suc n
-%-distribˡ-+ a b n = {!!}
-
-[n+k]%n≡k%n : ∀ k n → (suc n + k) % suc n ≡ k % suc n
-[n+k]%n≡k%n k n = begin
-  (suc n + k) % suc n                 ≡⟨ %-distribˡ-+ (suc n) k n ⟩
-  (suc n % suc n + k % suc n) % suc n ≡⟨ cong (λ v → (v + k % suc n) % suc n) (n%n≡0 n) ⟩
-  k % suc n % suc n                   ≡⟨ a%n%n≡a%n k n ⟩
-  k % suc n                           ∎
-
-[k*n]%n≡0 : ∀ k n → k * (suc n) % (suc n) ≡ 0
-[k*n]%n≡0 zero    n = refl
-[k*n]%n≡0 (suc k) n = trans ([n+k]%n≡k%n (k * suc n) n) ([k*n]%n≡0 k n)
-
-a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
-a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
+%-distribˡ-+ a b n = begin
+  (a + b)                           % m ≡⟨ cong (λ v → (v + b) % m) (a≡a%n+[a/n]*n a n) ⟩
+  (a % m + a div m * m + b)         % m ≡⟨ cong (_% m) (+-assoc (a % m) _ b) ⟩
+  (a % m + (a div m * m + b))       % m ≡⟨ cong (λ v → (a % m + v) % m) (+-comm _ b) ⟩
+  (a % m + (b + a div m * m))       % m ≡⟨ cong (_% m) (sym (+-assoc (a % m) b _)) ⟩
+  (a % m + b + a div m * m)         % m ≡⟨ [a+kn]%n≡a%n (a % m + b) (a div m) n ⟩
+  (a % m + b)                       % m ≡⟨ cong (λ v → (a % m + v) % m) (a≡a%n+[a/n]*n b n) ⟩
+  (a % m + (b % m + (b div m) * m)) % m ≡⟨ sym (cong (_% m) (+-assoc (a % m) (b % m) _)) ⟩
+  (a % m +  b % m + (b div m) * m)  % m ≡⟨ [a+kn]%n≡a%n (a % m + b % m) (b div m) n ⟩
+  (a % m + b % m)                   % m ∎
+  where m = suc n
 
 ------------------------------------------------------------------------
 -- Certified operations (i.e. operations with proofs)

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -46,15 +46,28 @@ a%1≡0 = a[modₕ]1≡0
 a%n<n : ∀ a n → a % (suc n) < (suc n)
 a%n<n a n = s≤s (mod-lemma 0 a n)
 
-a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
-a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
+n%n≡0 : ∀ n → suc n % suc n ≡ 0
+n%n≡0 n = n[modₕ]n≡0 0 n
+
+a%n%n≡a%n : ∀ a n → a % suc n % suc n ≡ a % suc n
+a%n%n≡a%n a n = modₕ-absorb 0 a n
+
+%-distribˡ-+ : ∀ a b n → (a + b) % suc n ≡ (a % suc n + b % suc n) % suc n
+%-distribˡ-+ a b n = {!!}
 
 [n+k]%n≡k%n : ∀ k n → (suc n + k) % suc n ≡ k % suc n
-[n+k]%n≡k%n k n = {!!}
+[n+k]%n≡k%n k n = begin
+  (suc n + k) % suc n                 ≡⟨ %-distribˡ-+ (suc n) k n ⟩
+  (suc n % suc n + k % suc n) % suc n ≡⟨ cong (λ v → (v + k % suc n) % suc n) (n%n≡0 n) ⟩
+  k % suc n % suc n                   ≡⟨ a%n%n≡a%n k n ⟩
+  k % suc n                           ∎
 
 [k*n]%n≡0 : ∀ k n → k * (suc n) % (suc n) ≡ 0
 [k*n]%n≡0 zero    n = refl
 [k*n]%n≡0 (suc k) n = trans ([n+k]%n≡k%n (k * suc n) n) ([k*n]%n≡0 k n)
+
+a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
+a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
 
 ------------------------------------------------------------------------
 -- Certified operations (i.e. operations with proofs)

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -51,13 +51,13 @@ a%1≡0 : ∀ a → a % 1 ≡ 0
 a%1≡0 = a[modₕ]1≡0
 
 a%n<n : ∀ a n → a % suc n < suc n
-a%n<n a n = s≤s (mod-lemma 0 a n)
+a%n<n a n = s≤s (a[modₕ]n<n 0 a n)
 
 n%n≡0 : ∀ n → suc n % suc n ≡ 0
 n%n≡0 n = n[modₕ]n≡0 0 n
 
 a%n%n≡a%n : ∀ a n → a % suc n % suc n ≡ a % suc n
-a%n%n≡a%n a n = modₕ-absorb 0 a n
+a%n%n≡a%n a n = modₕ-idem 0 a n
 
 [a+n]%n≡a%n : ∀ a n → (a + suc n) % suc n ≡ a % suc n
 [a+n]%n≡a%n a n = a+n[modₕ]n≡a[modₕ]n 0 a n

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -6,23 +6,51 @@
 
 module Data.Nat.DivMod where
 
-open import Data.Fin as Fin using (Fin; toℕ)
-import Data.Fin.Properties as FinP
+open import Agda.Builtin.Nat using (div-helper; mod-helper)
+
+open import Data.Fin using (Fin; toℕ; fromℕ≤″; fromℕ≤)
+open import Data.Fin.Properties using (toℕ-fromℕ≤″)
 open import Data.Nat as Nat
-open import Data.Nat.Properties
-open import Relation.Nullary.Decidable
-open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Data.Nat.DivMod.Core
+open import Data.Nat.Properties using (≤⇒≤″)
+open import Relation.Nullary.Decidable using (False)
+open import Relation.Binary.PropositionalEquality
 import Relation.Binary.PropositionalEquality.TrustMe as TrustMe
   using (erase)
 
-open import Agda.Builtin.Nat using ( div-helper; mod-helper )
+open ≡-Reasoning
 
-open SemiringSolver
-open P.≡-Reasoning
-open ≤-Reasoning
-  renaming (begin_ to start_; _∎ to _□; _≡⟨_⟩_ to _≡⟨_⟩′_)
+------------------------------------------------------------------------
+-- Basic operations
 
-infixl 7 _div_ _mod_ _divMod_
+infixl 7 _div_ _%_
+
+-- Integer division
+
+_div_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
+(a div 0) {}
+(a div suc n) = div-helper 0 n a n
+
+-- Integer remainder (mod)
+
+_%_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
+(a % 0) {}
+(a % suc n) = mod-helper 0 n a n
+
+------------------------------------------------------------------------
+-- Proofs
+
+a%1≡0 : ∀ a → a % 1 ≡ 0
+a%1≡0 = a[modₕ]1≡0
+
+a%n<n : ∀ a n → a % (suc n) < (suc n)
+a%n<n a n = s≤s (mod-lemma 0 a n)
+
+a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
+a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
+
+------------------------------------------------------------------------
+-- Certified operations (i.e. operations with proofs)
 
 -- A specification of integer division.
 
@@ -33,116 +61,23 @@ record DivMod (dividend divisor : ℕ) : Set where
     remainder : Fin divisor
     property  : dividend ≡ toℕ remainder + quotient * divisor
 
--- Integer division.
+infixl 7 _mod_ _divMod_
 
-_div_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → ℕ
-(d div 0) {}
-(d div suc s) = div-helper 0 s d s
+-- Certified modulus
 
--- The remainder after integer division.
+_mod_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → Fin divisor
+(a mod 0) {}
+(a mod suc n) = fromℕ≤″ (a % suc n) (Nat.erase (≤⇒≤″ (a%n<n a n)))
 
-private
-  -- The remainder is not too large.
-
-  mod-lemma : (acc d n : ℕ) →
-              let s = acc + n in
-              mod-helper acc s d n ≤ s
-
-  mod-lemma acc zero n = start
-    acc      ≤⟨ m≤m+n acc n ⟩
-    acc + n  □
-
-  mod-lemma acc (suc d) zero = start
-    mod-helper zero (acc + 0) d (acc + 0)  ≤⟨ mod-lemma zero d (acc + 0) ⟩
-    acc + 0                                □
-
-  mod-lemma acc (suc d) (suc n) =
-    P.subst (λ x → mod-helper (suc acc) x d n ≤ x)
-            (P.sym (+-suc acc n))
-            (mod-lemma (suc acc) d n)
-
-_mod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → Fin divisor
-(d mod 0) {}
-(d mod suc s) =
-  Fin.fromℕ≤″ (mod-helper 0 s d s)
-              (Nat.erase (≤⇒≤″ (s≤s (mod-lemma 0 d s))))
-
--- Integer division with remainder.
-
-private
-
-  -- The quotient and remainder are related to the dividend and
-  -- divisor in the right way.
-
-  division-lemma :
-    (mod-acc div-acc d n : ℕ) →
-    let s = mod-acc + n in
-    mod-acc + div-acc * suc s + d
-      ≡
-    mod-helper mod-acc s d n + div-helper div-acc s d n * suc s
-
-  division-lemma mod-acc div-acc zero n = begin
-
-    mod-acc + div-acc * suc s + zero  ≡⟨ +-identityʳ _ ⟩
-
-    mod-acc + div-acc * suc s         ∎
-
-    where s = mod-acc + n
-
-  division-lemma mod-acc div-acc (suc d) zero = begin
-
-    mod-acc + div-acc * suc s + suc d                ≡⟨ solve 3
-                                                              (λ mod-acc div-acc d →
-                                                                   let s = mod-acc :+ con 0 in
-                                                                   mod-acc :+ div-acc :* (con 1 :+ s) :+ (con 1 :+ d)
-                                                                     :=
-                                                                   (con 1 :+ div-acc) :* (con 1 :+ s) :+ d)
-                                                              P.refl mod-acc div-acc d ⟩
-    suc div-acc * suc s + d                          ≡⟨ division-lemma zero (suc div-acc) d s ⟩
-
-    mod-helper zero          s      d  s    +
-    div-helper (suc div-acc) s      d  s    * suc s  ≡⟨⟩
-
-    mod-helper      mod-acc  s (suc d) zero +
-    div-helper      div-acc  s (suc d) zero * suc s  ∎
-
-    where s = mod-acc + 0
-
-  division-lemma mod-acc div-acc (suc d) (suc n) = begin
-
-    mod-acc + div-acc * suc s + suc d                   ≡⟨ solve 4
-                                                                 (λ mod-acc div-acc n d →
-                                                                      mod-acc :+ div-acc :* (con 1 :+ (mod-acc :+ (con 1 :+ n))) :+ (con 1 :+ d)
-                                                                        :=
-                                                                      con 1 :+ mod-acc :+ div-acc :* (con 2 :+ mod-acc :+ n) :+ d)
-                                                                 P.refl mod-acc div-acc n d ⟩
-    suc mod-acc + div-acc * suc s′ + d                  ≡⟨ division-lemma (suc mod-acc) div-acc d n ⟩
-
-    mod-helper (suc mod-acc) s′ d n +
-    div-helper      div-acc  s′ d n * suc s′            ≡⟨ P.cong (λ s → mod-helper (suc mod-acc) s d n +
-                                                                         div-helper div-acc s d n * suc s)
-                                                                  (P.sym (+-suc mod-acc n)) ⟩
-
-    mod-helper (suc mod-acc) s d n +
-    div-helper      div-acc  s d n * suc s              ≡⟨⟩
-
-    mod-helper      mod-acc  s (suc d) (suc n) +
-    div-helper      div-acc  s (suc d) (suc n) * suc s  ∎
-
-    where
-    s  = mod-acc + suc n
-    s′ = suc mod-acc + n
+-- Returns modulus and division result with correctness proof
 
 _divMod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} →
            DivMod dividend divisor
-(d divMod 0) {}
-(d divMod suc s) =
-  result (d div suc s) (d mod suc s) (TrustMe.erase (begin
-    d                                                        ≡⟨ division-lemma 0 0 d s ⟩
-    mod-helper 0 s d s         + div-helper 0 s d s * suc s  ≡⟨ P.cong₂ _+_ (P.sym (FinP.toℕ-fromℕ≤ lemma)) P.refl ⟩
-    toℕ (Fin.fromℕ≤    lemma)  + div-helper 0 s d s * suc s  ≡⟨ P.cong (λ n → toℕ n + div-helper 0 s d s * suc s)
-                                                                       (FinP.fromℕ≤≡fromℕ≤″ lemma _) ⟩
-    toℕ (Fin.fromℕ≤″ _ lemma′) + div-helper 0 s d s * suc s  ∎))
+(a divMod 0) {}
+(a divMod suc n) = result (a div suc n) (a mod suc n)
+  (TrustMe.erase (begin
+    a                                                ≡⟨ a≡a%n+[a/n]*n a n ⟩
+    (a % suc n)             + (a div suc n) * suc n  ≡⟨ cong₂ _+_ (sym (toℕ-fromℕ≤″ lemma′)) refl ⟩
+    toℕ (fromℕ≤″ _ lemma′) + (a div suc n) * suc n  ∎))
   where
-  lemma  = s≤s (mod-lemma 0 d s)
-  lemma′ = Nat.erase (≤⇒≤″ lemma)
+  lemma′ = Nat.erase (≤⇒≤″ (a%n<n a n))

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -49,6 +49,13 @@ a%n<n a n = s≤s (mod-lemma 0 a n)
 a≡a%n+[a/n]*n : ∀ a n → a ≡ a % suc n + (a div (suc n)) * suc n
 a≡a%n+[a/n]*n a n = division-lemma 0 0 a n
 
+[n+k]%n≡k%n : ∀ k n → (suc n + k) % suc n ≡ k % suc n
+[n+k]%n≡k%n k n = {!!}
+
+[k*n]%n≡0 : ∀ k n → k * (suc n) % (suc n) ≡ 0
+[k*n]%n≡0 zero    n = refl
+[k*n]%n≡0 (suc k) n = trans ([n+k]%n≡k%n (k * suc n) n) ([k*n]%n≡0 k n)
+
 ------------------------------------------------------------------------
 -- Certified operations (i.e. operations with proofs)
 
@@ -65,7 +72,7 @@ infixl 7 _mod_ _divMod_
 
 -- Certified modulus
 
-_mod_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → Fin divisor
+_mod_ : (dividend divisor : ℕ) {≢0 : False (divisor ≟ 0)} → Fin divisor
 (a mod 0) {}
 (a mod suc n) = fromℕ≤″ (a % suc n) (Nat.erase (≤⇒≤″ (a%n<n a n)))
 

--- a/src/Data/Nat/DivMod/Core.agda
+++ b/src/Data/Nat/DivMod/Core.agda
@@ -1,0 +1,56 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Core lemmas for division and modulus operations
+------------------------------------------------------------------------
+
+module Data.Nat.DivMod.Core where
+
+open import Agda.Builtin.Nat using ()
+  renaming (div-helper to divₕ; mod-helper to modₕ)
+
+open import Data.Nat
+open import Data.Nat.Properties
+open import Relation.Binary.PropositionalEquality
+
+open SemiringSolver
+open ≡-Reasoning
+
+-------------------------------------------------------------------------
+-- mod lemmas
+
+a[modₕ]1≡0 : ∀ a → modₕ 0 0 a 0 ≡ 0
+a[modₕ]1≡0 zero    = refl
+a[modₕ]1≡0 (suc a) = a[modₕ]1≡0 a
+
+mod-lemma : ∀ acc d n → modₕ acc (acc + n) d n ≤ acc + n
+mod-lemma acc zero    n       = m≤m+n acc n
+mod-lemma acc (suc d) zero    = mod-lemma zero d (acc + 0)
+mod-lemma acc (suc d) (suc n)
+          rewrite +-suc acc n = mod-lemma (suc acc) d n
+
+-------------------------------------------------------------------------
+-- division lemmas
+
+-- The quotient and remainder are related to the dividend and
+-- divisor in the right way.
+
+division-lemma : ∀ accᵐ accᵈ d n →
+    accᵐ + accᵈ * suc (accᵐ + n) + d ≡
+    modₕ accᵐ (accᵐ + n) d n + divₕ accᵈ (accᵐ + n) d n * suc (accᵐ + n)
+division-lemma accᵐ accᵈ zero    n    = +-identityʳ _
+division-lemma accᵐ accᵈ (suc d) zero rewrite +-identityʳ accᵐ = begin
+  accᵐ + accᵈ * suc accᵐ + suc d          ≡⟨ +-suc _ d ⟩
+  suc accᵈ * suc accᵐ + d                 ≡⟨ division-lemma zero (suc accᵈ) d accᵐ ⟩
+  modₕ 0          accᵐ d accᵐ +
+  divₕ (suc accᵈ) accᵐ d accᵐ * suc accᵐ  ≡⟨⟩
+  modₕ accᵐ accᵐ (suc d) 0 +
+  divₕ accᵈ accᵐ (suc d) 0 * suc accᵐ      ∎
+  where open ≡-Reasoning
+division-lemma accᵐ accᵈ (suc d) (suc n) rewrite +-suc accᵐ n = begin
+  accᵐ + accᵈ * (2 + accᵐ + n) + suc d             ≡⟨ +-suc _ d ⟩
+  suc (accᵐ + accᵈ * (2 + accᵐ + n) + d)           ≡⟨ division-lemma (suc accᵐ) accᵈ d n ⟩
+  modₕ (suc accᵐ) (suc (accᵐ + n)) d n +
+  divₕ accᵈ (suc (accᵐ + n)) d n * (2 + accᵐ + n)  ∎
+  where
+  open ≡-Reasoning

--- a/src/Data/Nat/DivMod/Core.agda
+++ b/src/Data/Nat/DivMod/Core.agda
@@ -18,15 +18,28 @@ open ≡-Reasoning
 -------------------------------------------------------------------------
 -- mod lemmas
 
+modₕ-skipTo0 : ∀ acc n a b → modₕ acc n (b + a) a ≡ modₕ (a + acc) n b 0
+modₕ-skipTo0 acc n zero    b = cong (λ v → modₕ acc n v 0) (+-identityʳ b)
+modₕ-skipTo0 acc n (suc a) b = begin
+  modₕ acc n (b + suc a) (suc a) ≡⟨ cong (λ v → modₕ acc n v (suc a)) (+-suc b a) ⟩
+  modₕ acc n (suc b + a) (suc a) ≡⟨⟩
+  modₕ (suc acc) n (b + a) a     ≡⟨ modₕ-skipTo0 (suc acc) n a b ⟩
+  modₕ (a + suc acc) n b 0       ≡⟨ cong (λ v → modₕ v n b 0) (+-suc a acc) ⟩
+  modₕ (suc a + acc) n b 0       ∎
+
+modₕ-skipToEnd : ∀ acc n a b → modₕ acc n a (a + b) ≡ acc + a
+modₕ-skipToEnd acc n zero    b = sym (+-identityʳ acc)
+modₕ-skipToEnd acc n (suc a) b = begin
+  modₕ (suc acc) n a (a + b) ≡⟨ modₕ-skipToEnd (suc acc) n a b ⟩
+  suc acc + a                ≡⟨ sym (+-suc acc a) ⟩
+  acc + suc a                ∎
+
 a[modₕ]1≡0 : ∀ a → modₕ 0 0 a 0 ≡ 0
 a[modₕ]1≡0 zero    = refl
 a[modₕ]1≡0 (suc a) = a[modₕ]1≡0 a
 
 n[modₕ]n≡0 : ∀ acc v → modₕ acc (acc + v) (suc v) v ≡ 0
-n[modₕ]n≡0 acc       zero    = refl
-n[modₕ]n≡0 zero      (suc v) = n[modₕ]n≡0 1 v
-n[modₕ]n≡0 (suc acc) (suc v)
-         rewrite +-suc acc v = n[modₕ]n≡0 (2 + acc) v
+n[modₕ]n≡0 acc v = modₕ-skipTo0 acc (acc + v) v 1
 
 mod-lemma : ∀ acc d n → modₕ acc (acc + n) d n ≤ acc + n
 mod-lemma acc zero    n       = m≤m+n acc n
@@ -34,54 +47,32 @@ mod-lemma acc (suc d) zero    = mod-lemma zero d (acc + 0)
 mod-lemma acc (suc d) (suc n)
           rewrite +-suc acc n = mod-lemma (suc acc) d n
 
-lemma2 : ∀ acc a n → modₕ acc (acc + a + n) a (a + n) ≡ acc + a
-lemma2 acc zero    n = sym (+-identityʳ acc)
-lemma2 acc (suc a) n rewrite +-suc acc a = lemma2 (suc acc) a n
-
 modₕ-absorb : ∀ acc a n → modₕ 0 (acc + n) (modₕ acc (acc + n) a n) (acc + n) ≡ modₕ acc (acc + n) a n
-modₕ-absorb acc zero    n       = lemma2 0 acc n
+modₕ-absorb acc zero    n       = modₕ-skipToEnd 0 (acc + n) acc n
 modₕ-absorb acc (suc a) zero    rewrite +-identityʳ acc = modₕ-absorb 0 a acc
 modₕ-absorb acc (suc a) (suc n) rewrite +-suc acc n = modₕ-absorb (suc acc) a n
 
-modₕ-distribˡ-+2 : ∀ a b n → modₕ 0 n (a + b) n ≡ modₕ 0 n (modₕ 0 n a n + modₕ 0 n b n) n
-modₕ-distribˡ-+2 (suc a) (suc b) (suc n) = {!!}
-modₕ-distribˡ-+2 (suc a) (suc b) (suc (suc n)) = {!!}
-modₕ-distribˡ-+2 (suc a) (suc b) (suc (suc (suc n))) = {!!}
-modₕ-distribˡ-+2 (suc (suc a)) (suc b) (suc n) = {!!}
-modₕ-distribˡ-+2 (suc (suc (suc a))) (suc b) (suc n) = {!!}
-
-
-lemma4 : ∀ acc → modₕ acc acc acc 0 ≡ modₕ 0 acc (acc + acc) acc
-lemma4 zero = refl
-lemma4 (suc zero) = refl
-lemma4 (suc (suc zero)) = refl
-lemma4 (suc (suc (suc acc))) = {!!}
-
-lemma5 : ∀ acc a → modₕ acc (acc + suc a) a (suc a) ≡ modₕ (suc acc) (acc + suc a) (a + acc + a) a
-lemma5 5 9 = {!!}
-
-
-lemma3 : ∀ acc b n → modₕ acc (acc + n) (acc + b) n ≡
-                     modₕ 0 (acc + n) (acc + modₕ acc (acc + n) b n) (acc + n)
-lemma3 zero      zero    zero = refl
-lemma3 (suc acc) zero    zero rewrite +-identityʳ acc = {!!}
-lemma3 acc       zero    (suc b) = {!!}
-lemma3 acc       (suc a) (suc b) = {!!}
-lemma3 6         8       13      = {!!}
-
-modₕ-distribˡ-+ : ∀ acc a b n → modₕ acc (acc + n) (a + acc + b) n ≡
-                                modₕ 0 (acc + n) (modₕ acc (acc + n) a n + modₕ acc (acc + n) b n) (acc + n)
-modₕ-distribˡ-+ acc a zero n rewrite +-identityʳ (a + acc) = begin
-  _ ≡⟨ cong (λ v → modₕ acc (acc + n) v n) (+-comm a acc) ⟩
-  _ ≡⟨ lemma3 acc a n ⟩
-  _ ≡⟨ cong (λ v → modₕ 0 (acc + n) v (acc + n)) (+-comm acc _) ⟩
-  _                                ∎
-modₕ-distribˡ-+ acc zero b n = lemma3 acc b n
-modₕ-distribˡ-+ acc (suc a) (suc b) zero = {!!}
-modₕ-distribˡ-+ acc (suc a) (suc b) (suc n) rewrite +-suc acc n = begin
-  modₕ (suc acc) (suc (acc + n)) (a + acc + suc b) n ≡⟨ cong (λ v → modₕ (suc acc) (suc acc + n) v n) {x = a + acc + suc b} {y = a + suc acc + b} {!!} ⟩
-  modₕ (suc acc) (suc (acc + n)) (a + suc acc + b) n ≡⟨ modₕ-distribˡ-+ (suc acc) a b n ⟩
-  _                               ∎
+a+n[modₕ]n≡a[modₕ]n : ∀ acc a n → modₕ acc (acc + n) (acc + a + suc n) n ≡ modₕ acc (acc + n) a n
+a+n[modₕ]n≡a[modₕ]n acc zero n rewrite +-identityʳ acc = begin
+  modₕ acc (acc + n) (acc + suc n) n   ≡⟨ cong (λ v → modₕ acc (acc + n) v n) (+-suc acc n) ⟩
+  modₕ acc (acc + n) (suc acc + n) n   ≡⟨ modₕ-skipTo0 acc (acc + n) n (suc acc) ⟩
+  modₕ (acc + n) (acc + n) (suc acc) 0 ≡⟨⟩
+  modₕ 0 (acc + n) acc (acc + n)       ≡⟨ modₕ-skipToEnd 0 (acc + n) acc n ⟩
+  acc                                  ∎
+a+n[modₕ]n≡a[modₕ]n acc (suc a) zero rewrite +-identityʳ acc = begin
+  modₕ acc acc (acc + suc a + 1)   0   ≡⟨ cong (λ v → modₕ acc acc v 0) (+-comm (acc + suc a) 1) ⟩
+  modₕ acc acc (1 + (acc + suc a)) 0   ≡⟨⟩
+  modₕ 0   acc (acc + suc a)       acc ≡⟨ cong (λ v → modₕ 0 acc v acc) (+-comm acc (suc a)) ⟩
+  modₕ 0   acc (suc a + acc)       acc ≡⟨ cong (λ v → modₕ 0 acc v acc) (sym (+-suc a acc)) ⟩
+  modₕ 0   acc (a + suc acc)       acc ≡⟨ a+n[modₕ]n≡a[modₕ]n 0 a acc ⟩
+  modₕ 0   acc a                   acc ∎
+a+n[modₕ]n≡a[modₕ]n acc (suc a) (suc n) rewrite +-suc acc n = begin
+  modₕ acc       (suc acc + n) (acc + suc a + suc (suc n)) (suc n) ≡⟨ cong (λ v → modₕ acc (suc acc + n) (v + suc (suc n)) (suc n)) (+-suc acc a) ⟩
+  modₕ acc       (suc acc + n) (suc acc + a + suc (suc n)) (suc n) ≡⟨⟩
+  modₕ (suc acc) (suc acc + n) (acc + a + (suc (suc n)))   n       ≡⟨ cong (λ v → modₕ (suc acc) (suc acc + n) v n) (sym (+-assoc (acc + a) 1 (suc n))) ⟩
+  modₕ (suc acc) (suc acc + n) (acc + a + 1 + suc n)       n       ≡⟨ cong (λ v → modₕ (suc acc) (suc acc + n) (v + suc n) n) (+-comm (acc + a) 1) ⟩
+  modₕ (suc acc) (suc acc + n) (suc acc + a + suc n)       n       ≡⟨ a+n[modₕ]n≡a[modₕ]n (suc acc) a n ⟩
+  modₕ (suc acc) (suc acc + n) a                           n       ∎
 
 -------------------------------------------------------------------------
 -- division lemmas

--- a/src/Data/Nat/DivMod/Core.agda
+++ b/src/Data/Nat/DivMod/Core.agda
@@ -13,7 +13,6 @@ open import Data.Nat
 open import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality
 
-open SemiringSolver
 open ≡-Reasoning
 
 -------------------------------------------------------------------------
@@ -23,11 +22,66 @@ a[modₕ]1≡0 : ∀ a → modₕ 0 0 a 0 ≡ 0
 a[modₕ]1≡0 zero    = refl
 a[modₕ]1≡0 (suc a) = a[modₕ]1≡0 a
 
+n[modₕ]n≡0 : ∀ acc v → modₕ acc (acc + v) (suc v) v ≡ 0
+n[modₕ]n≡0 acc       zero    = refl
+n[modₕ]n≡0 zero      (suc v) = n[modₕ]n≡0 1 v
+n[modₕ]n≡0 (suc acc) (suc v)
+         rewrite +-suc acc v = n[modₕ]n≡0 (2 + acc) v
+
 mod-lemma : ∀ acc d n → modₕ acc (acc + n) d n ≤ acc + n
 mod-lemma acc zero    n       = m≤m+n acc n
 mod-lemma acc (suc d) zero    = mod-lemma zero d (acc + 0)
 mod-lemma acc (suc d) (suc n)
           rewrite +-suc acc n = mod-lemma (suc acc) d n
+
+lemma2 : ∀ acc a n → modₕ acc (acc + a + n) a (a + n) ≡ acc + a
+lemma2 acc zero    n = sym (+-identityʳ acc)
+lemma2 acc (suc a) n rewrite +-suc acc a = lemma2 (suc acc) a n
+
+modₕ-absorb : ∀ acc a n → modₕ 0 (acc + n) (modₕ acc (acc + n) a n) (acc + n) ≡ modₕ acc (acc + n) a n
+modₕ-absorb acc zero    n       = lemma2 0 acc n
+modₕ-absorb acc (suc a) zero    rewrite +-identityʳ acc = modₕ-absorb 0 a acc
+modₕ-absorb acc (suc a) (suc n) rewrite +-suc acc n = modₕ-absorb (suc acc) a n
+
+modₕ-distribˡ-+2 : ∀ a b n → modₕ 0 n (a + b) n ≡ modₕ 0 n (modₕ 0 n a n + modₕ 0 n b n) n
+modₕ-distribˡ-+2 (suc a) (suc b) (suc n) = {!!}
+modₕ-distribˡ-+2 (suc a) (suc b) (suc (suc n)) = {!!}
+modₕ-distribˡ-+2 (suc a) (suc b) (suc (suc (suc n))) = {!!}
+modₕ-distribˡ-+2 (suc (suc a)) (suc b) (suc n) = {!!}
+modₕ-distribˡ-+2 (suc (suc (suc a))) (suc b) (suc n) = {!!}
+
+
+lemma4 : ∀ acc → modₕ acc acc acc 0 ≡ modₕ 0 acc (acc + acc) acc
+lemma4 zero = refl
+lemma4 (suc zero) = refl
+lemma4 (suc (suc zero)) = refl
+lemma4 (suc (suc (suc acc))) = {!!}
+
+lemma5 : ∀ acc a → modₕ acc (acc + suc a) a (suc a) ≡ modₕ (suc acc) (acc + suc a) (a + acc + a) a
+lemma5 5 9 = {!!}
+
+
+lemma3 : ∀ acc b n → modₕ acc (acc + n) (acc + b) n ≡
+                     modₕ 0 (acc + n) (acc + modₕ acc (acc + n) b n) (acc + n)
+lemma3 zero      zero    zero = refl
+lemma3 (suc acc) zero    zero rewrite +-identityʳ acc = {!!}
+lemma3 acc       zero    (suc b) = {!!}
+lemma3 acc       (suc a) (suc b) = {!!}
+lemma3 6         8       13      = {!!}
+
+modₕ-distribˡ-+ : ∀ acc a b n → modₕ acc (acc + n) (a + acc + b) n ≡
+                                modₕ 0 (acc + n) (modₕ acc (acc + n) a n + modₕ acc (acc + n) b n) (acc + n)
+modₕ-distribˡ-+ acc a zero n rewrite +-identityʳ (a + acc) = begin
+  _ ≡⟨ cong (λ v → modₕ acc (acc + n) v n) (+-comm a acc) ⟩
+  _ ≡⟨ lemma3 acc a n ⟩
+  _ ≡⟨ cong (λ v → modₕ 0 (acc + n) v (acc + n)) (+-comm acc _) ⟩
+  _                                ∎
+modₕ-distribˡ-+ acc zero b n = lemma3 acc b n
+modₕ-distribˡ-+ acc (suc a) (suc b) zero = {!!}
+modₕ-distribˡ-+ acc (suc a) (suc b) (suc n) rewrite +-suc acc n = begin
+  modₕ (suc acc) (suc (acc + n)) (a + acc + suc b) n ≡⟨ cong (λ v → modₕ (suc acc) (suc acc + n) v n) {x = a + acc + suc b} {y = a + suc acc + b} {!!} ⟩
+  modₕ (suc acc) (suc (acc + n)) (a + suc acc + b) n ≡⟨ modₕ-distribˡ-+ (suc acc) a b n ⟩
+  _                               ∎
 
 -------------------------------------------------------------------------
 -- division lemmas
@@ -46,11 +100,8 @@ division-lemma accᵐ accᵈ (suc d) zero rewrite +-identityʳ accᵐ = begin
   divₕ (suc accᵈ) accᵐ d accᵐ * suc accᵐ  ≡⟨⟩
   modₕ accᵐ accᵐ (suc d) 0 +
   divₕ accᵈ accᵐ (suc d) 0 * suc accᵐ      ∎
-  where open ≡-Reasoning
 division-lemma accᵐ accᵈ (suc d) (suc n) rewrite +-suc accᵐ n = begin
   accᵐ + accᵈ * (2 + accᵐ + n) + suc d             ≡⟨ +-suc _ d ⟩
   suc (accᵐ + accᵈ * (2 + accᵐ + n) + d)           ≡⟨ division-lemma (suc accᵐ) accᵈ d n ⟩
   modₕ (suc accᵐ) (suc (accᵐ + n)) d n +
   divₕ accᵈ (suc (accᵐ + n)) d n * (2 + accᵐ + n)  ∎
-  where
-  open ≡-Reasoning

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -6,20 +6,23 @@
 
 module Data.Nat.Divisibility where
 
+open import Algebra
 open import Data.Nat as Nat
-open import Data.Nat.DivMod using (_divMod_; result)
+open import Data.Nat.DivMod
 open import Data.Nat.Properties
 open import Data.Fin using (Fin; zero; suc; toℕ)
 import Data.Fin.Properties as FP
-open SemiringSolver
-open import Algebra
 open import Data.Product
+open import Function
+open import Function.Equivalence using (_⇔_)
 open import Relation.Nullary
+import Relation.Nullary.Decidable as Dec
 open import Relation.Binary
 import Relation.Binary.PartialOrderReasoning as PartialOrderReasoning
 open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; _≢_; refl; sym; trans; cong; cong₂; subst)
-open import Function
+
+open SemiringSolver
 
 ------------------------------------------------------------------------
 -- m ∣ n is inhabited iff m divides n. Some sources, like Hardy and
@@ -179,6 +182,33 @@ module _ where
       q * (i * (suc k))  ≡⟨ sym (*-assoc q i (suc k)) ⟩
       (q * i) * (suc k)  ∎))
 
+  m%n≡0⇒n∣m : ∀ m n → m % (suc n) ≡ 0 → suc n ∣ m
+  m%n≡0⇒n∣m m n eq = divides (m div (suc n)) (begin
+    m                                     ≡⟨ a≡a%n+[a/n]*n m n ⟩
+    m % (suc n) + m div (suc n) * (suc n) ≡⟨ cong₂ _+_ eq refl ⟩
+    m div (suc n) * (suc n)               ∎)
+
+  n∣m⇒m%n≡0 : ∀ m n → suc n ∣ m → m % (suc n) ≡ 0
+  n∣m⇒m%n≡0 m n (divides v eq) = begin
+    m           % (suc n) ≡⟨ cong (_% (suc n)) eq ⟩
+    (v * suc n) % (suc n) ≡⟨ [k*n]%n≡0 v n ⟩
+    0                     ∎
+
+  m%n≡0⇔n∣m : ∀ m n → m % (suc n) ≡ 0 ⇔ suc n ∣ m
+  m%n≡0⇔n∣m m n = record
+    { to   = PropEq.→-to-⟶ (m%n≡0⇒n∣m m n)
+    ; from = PropEq.→-to-⟶ (n∣m⇒m%n≡0 m n)
+    }
+
+-- Divisibility is decidable.
+
+infix 4 _∣?_
+
+_∣?_ : Decidable _∣_
+zero  ∣? zero   = yes (0 ∣0)
+zero  ∣? suc m  = no ((λ()) ∘′ 0∣⇒≡0)
+suc n ∣? m      = Dec.map (m%n≡0⇔n∣m m n) (m % (suc n) ≟ 0)
+
 -- If the remainder after division is non-zero, then the divisor does
 -- not divide the dividend.
 
@@ -204,19 +234,6 @@ nonZeroDivisor-lemma m (suc q) r r≢zero d =
   lem = solve 3 (λ m r q → r :+ (m :+ q)  :=  m :+ (r :+ q))
                 refl (suc m) (toℕ r) (q * suc m)
   d' = subst (1 + m ∣_) lem d
-
--- Divisibility is decidable.
-
-infix 4 _∣?_
-
-_∣?_ : Decidable _∣_
-zero  ∣? zero                     = yes (0 ∣0)
-zero  ∣? suc n                    = no ((λ()) ∘′ 0∣⇒≡0)
-suc m ∣? n                        with n divMod suc m
-suc m ∣? .(q * suc m)             | result q zero    refl =
-  yes $ divides q refl
-suc m ∣? .(1 + toℕ r + q * suc m) | result q (suc r) refl =
-  no $ nonZeroDivisor-lemma m q (suc r) (λ())
 
 ------------------------------------------------------------------------
 -- DEPRECATED - please use new names as continuing support for the old

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -7,7 +7,7 @@
 module Data.Nat.Divisibility where
 
 open import Data.Nat as Nat
-open import Data.Nat.DivMod
+open import Data.Nat.DivMod using (_divMod_; result)
 open import Data.Nat.Properties
 open import Data.Fin using (Fin; zero; suc; toℕ)
 import Data.Fin.Properties as FP

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -191,7 +191,7 @@ module _ where
   n∣m⇒m%n≡0 : ∀ m n → suc n ∣ m → m % (suc n) ≡ 0
   n∣m⇒m%n≡0 m n (divides v eq) = begin
     m           % (suc n) ≡⟨ cong (_% (suc n)) eq ⟩
-    (v * suc n) % (suc n) ≡⟨ [k*n]%n≡0 v n ⟩
+    (v * suc n) % (suc n) ≡⟨ kn%n≡0 v n ⟩
     0                     ∎
 
   m%n≡0⇔n∣m : ∀ m n → m % (suc n) ≡ 0 ⇔ suc n ∣ m

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -197,7 +197,6 @@ module _ where
   m%n≡0⇔n∣m : ∀ m n → m % (suc n) ≡ 0 ⇔ suc n ∣ m
   m%n≡0⇔n∣m m n = equivalence (m%n≡0⇒n∣m m n) (n∣m⇒m%n≡0 m n)
 
-
 -- Divisibility is decidable.
 
 infix 4 _∣?_
@@ -207,12 +206,19 @@ zero  ∣? zero   = yes (0 ∣0)
 zero  ∣? suc m  = no ((λ()) ∘′ 0∣⇒≡0)
 suc n ∣? m      = Dec.map (m%n≡0⇔n∣m m n) (m % (suc n) ≟ 0)
 
+------------------------------------------------------------------------
+-- DEPRECATED - please use new names as continuing support for the old
+-- names is not guaranteed.
+
+∣-+ = ∣m∣n⇒∣m+n
+∣-∸ = ∣m+n∣m⇒∣n
+∣-* = n∣m*n
+
 -- If the remainder after division is non-zero, then the divisor does
 -- not divide the dividend.
 
-nonZeroDivisor-lemma
-  : ∀ m q (r : Fin (1 + m)) → toℕ r ≢ 0 →
-    1 + m ∤ toℕ r + q * (1 + m)
+nonZeroDivisor-lemma : ∀ m q (r : Fin (1 + m)) → toℕ r ≢ 0 →
+                       1 + m ∤ toℕ r + q * (1 + m)
 nonZeroDivisor-lemma m zero r r≢zero (divides zero eq) = r≢zero $ begin
   toℕ r      ≡⟨ sym (*-identityˡ (toℕ r)) ⟩
   1 * toℕ r  ≡⟨ eq ⟩
@@ -232,11 +238,3 @@ nonZeroDivisor-lemma m (suc q) r r≢zero d =
   lem = solve 3 (λ m r q → r :+ (m :+ q)  :=  m :+ (r :+ q))
                 refl (suc m) (toℕ r) (q * suc m)
   d' = subst (1 + m ∣_) lem d
-
-------------------------------------------------------------------------
--- DEPRECATED - please use new names as continuing support for the old
--- names is not guaranteed.
-
-∣-+ = ∣m∣n⇒∣m+n
-∣-∸ = ∣m+n∣m⇒∣n
-∣-* = n∣m*n


### PR DESCRIPTION
This attempts to build a more practical modular arithmetic library than currently exists. In particular it defines a new modulus operator `_%_` which returns a `ℕ` instead of the old `_mod_` which returns a `Fin divisor`. This new operator is **much** easier to  write arithmetic expressions with and prove properties of.

This was inspired by the problems caused by `_mod_` in #143. Namely the unsafe `_mod_` pollutes a large section of the `Data.Nat` hierarchy. Consequently I've adjusted `Data.Nat.Divisibility` to use `_%_` rather than `_mod_`. This has massively cleaned up several proofs. 

Accordingly `_mod_` and `_divMod_` can now be relegated to `Data.Nat.DivMod.Unsafe` in some future PR.

Outstanding questions:
* Naming convention for proofs about `_%_`. Obviously the proofs require the use of `suc n` rather than `n`, but the names don't signal this. Is everyone okay with this? Or do people have suggestions for an alternative naming convention signalling this?
* Is everyone happy if I got rid of the very ugly `nonZeroDivisor-lemma` proof in `Data.Nat.Divisibility`. It was required for the decidability of divisibility but isn't required any more now that we're using the new `_%_`.
* I'm wondering if I should later on relegate the name `_div_` to `Data.Nat.DivMod.Unsafe` as well, and have the name `_/_` instead to better match `_%_`?

Oh and if anyone can find a way of shrinking the `mod-helper` proofs in `Data.Nat.DivMod.Core` feel free!