### PR TITLE
Added some of Haskell's Data.Maybe operations to Agda's standard library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Version TODO
 
 The library has been tested using Agda version TODO.
 
+Minor Additions
+---------------
+* Added new operations to `Data.Maybe`: `fromMaybe, listToMaybe, catMaybes`.
+  These additions could not be inserted into `Data.Maybe.Base` without
+  producing a cyclic dependency with `Data.List`.
+
 Important changes since 0.16:
 
 Non-backwards compatible changes

--- a/src/Data/Maybe.agda
+++ b/src/Data/Maybe.agda
@@ -15,6 +15,7 @@ open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
 open import Relation.Binary as B
 open import Relation.Unary as U
+open import Data.List using (List ; [] ; _∷_ ; [_])
 
 ------------------------------------------------------------------------
 -- The base type and some operations
@@ -55,6 +56,29 @@ monadPlus {f} = record
   _∣_ : {A : Set f} → Maybe A → Maybe A → Maybe A
   nothing ∣ y = y
   just x  ∣ y = just x
+
+
+------------------------------------------------------------------------
+-- Other associated operations
+
+fromMaybe : {ℓ : Level} {A : Set ℓ} (default : A) (try : Maybe A) → A
+fromMaybe def (just x) = x
+fromMaybe def nothing  = def
+
+listToMaybe : {ℓ : Level} {A : Set ℓ} → List A → Maybe A
+listToMaybe []       = nothing
+listToMaybe (x ∷ xs) = just x
+
+maybeToList : {ℓ : Level} {A : Set ℓ} → Maybe A → List A
+maybeToList (just x) = [ x ]
+maybeToList nothing  = []
+
+catMaybes : {ℓ : Level} {A : Set ℓ} → List (Maybe A) → List A
+catMaybes []             = []
+catMaybes (just x ∷ xs)  = x ∷ catMaybes xs
+catMaybes (nothing ∷ xs) = catMaybes xs
+
+-- Haskell's `Data.mapMaybe` lives as Agda's `List.mapMaybe`.
 
 ------------------------------------------------------------------------
 -- Equality


### PR DESCRIPTION
Added some of Haskell `Data.Maybe` functions with the notable exception `mapMaybe`.

Ideally Haskell's `Data.Maybe.mapMaybe` would be moved into Agda's counterpart location. Unfortunately it currently lives in `Data.List.Base`, which is a surprise to those migrating from Haskell to Agda, or the many who tend to use both frequently. Attempting to relocate it quickly, naively, resulted in cyclic dependencies.