### PR TITLE
Categorical: refactor & first batch of transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,32 @@ Non-backwards compatible changes
   tabulate : (∀ i → P (Vec.lookup i xs)) → All P {k} xs
   ```
 
+### Overhaul of `Data.X.Categorical`
+
+* Added new functions to `Data.List.Categorical`:
+  ```agda
+  functor     : RawFunctor List
+  applicative : RawApplicative List
+  monadT      : RawMonad M → RawMonad (M ∘′ List)
+  ```
+
+* Moved `monad` from `Data.List.NonEmpty` to `Data.List.NonEmpty.Categorical`
+  and added new functions:
+  ```agda
+  functor     : RawFunctor List⁺
+  applicative : RawApplicative List⁺
+  monadT      : RawMonad M → RawMonad (M ∘′ List⁺)
+  sequence    : List⁺ (M A) → M (List⁺ A)
+  mapM        : (A → M B) → List⁺ A → M (List⁺ B)
+  ```
+
+* Moved `functor`, `monadT`, `monad`, `monadZero` and `monadPlus` from
+  `Data.Maybe` to `Data.Maybe.Categorical` and added the following functions:
+  ```agda
+  sequence : Maybe (M A) → M (Maybe A)
+  mapM     : (A → M B) → Maybe A → M (Maybe B)
+  ```
+
 #### Other
 
 * The `Data.List.Relation.Sublist` directory has been moved to
@@ -154,6 +180,11 @@ Other minor additions
   ```agda
   ∈-insert : v ≈ v′ → v ∈ xs ++ [ v′ ] ++ ys
   ∈-∃++    : v ∈ xs → ∃₂ λ ys zs → ∃ λ w → v ≈ w × xs ≋ ys ++ [ w ] ++ zs
+  ```
+
+* Added new function to `Data.List.NonEmpty`:
+  ```agda
+  concatMap : (A → List⁺ B) → List⁺ A → List⁺ B
   ```
 
 * Added new function to `Data.Maybe.Base`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,28 +79,42 @@ Non-backwards compatible changes
 
 ### Overhaul of `Data.X.Categorical`
 
-* Added new functions to `Data.List.Categorical`:
+* In `Data.List.Categorical` renamed `sequence` to `sequenceM` and added
+  new functions:
   ```agda
   functor     : RawFunctor List
   applicative : RawApplicative List
   monadT      : RawMonad M → RawMonad (M ∘′ List)
+  sequenceA   : RawApplicative F → List (F A) → F (List A)
+  mapA        : RawApplicative F → (A → F B) → List A → F (List B)
+  forA        : RawApplicative F → List A → (A → F B) → F (List B)
+  forM        : RawMonad M → List A → (A → M B) → M (List B)
   ```
 
-* Moved `monad` from `Data.List.NonEmpty` to `Data.List.NonEmpty.Categorical`
-  and added new functions:
+* Created `Data.List.NonEmpty.Categorical`, moved `monad` into it
+  from `Data.List.NonEmpty` and added new functions:
   ```agda
   functor     : RawFunctor List⁺
   applicative : RawApplicative List⁺
   monadT      : RawMonad M → RawMonad (M ∘′ List⁺)
-  sequence    : List⁺ (M A) → M (List⁺ A)
-  mapM        : (A → M B) → List⁺ A → M (List⁺ B)
+  sequenceA   : RawApplicative F → List⁺ (F A) → F (List⁺ A)
+  mapA        : RawApplicative F → (A → F B) → List⁺ A → F (List⁺ B)
+  forA        : RawApplicative F → List⁺ A → (A → F B) → F (List⁺ B)
+  sequenceM   : RawMonad M → List⁺ (M A) → M (List⁺ A)
+  mapM        : RawMonad M → (A → M B) → List⁺ A → M (List⁺ B)
+  forM        : RawMonad M → List⁺ A → (A → M B) → M (List⁺ B)
   ```
 
-* Moved `functor`, `monadT`, `monad`, `monadZero` and `monadPlus` from
-  `Data.Maybe` to `Data.Maybe.Categorical` and added the following functions:
+* Created `Data.Maybe.Categorical`, moved `functor`, `monadT`, `monad`,
+  `monadZero` and `monadPlus` into it from `Data.Maybe` and added the
+  following functions:
   ```agda
-  sequence : Maybe (M A) → M (Maybe A)
-  mapM     : (A → M B) → Maybe A → M (Maybe B)
+  sequenceA : RawApplicative F → Maybe (F A) → F (Maybe A)
+  mapA      : RawApplicative F → (A → F B) → Maybe A → F (Maybe B)
+  forA      : RawApplicative F → Maybe A → (A → F B) → F (Maybe B)
+  sequenceM : RawMonad M → Maybe (M A) → M (Maybe A)
+  mapM      : RawMonad M → (A → M B) → Maybe A → M (Maybe B)
+  forM      : RawMonad M → Maybe A → (A → M B) → M (Maybe B)
   ```
 
 #### Other

--- a/src/Data/List/Categorical.agda
+++ b/src/Data/List/Categorical.agda
@@ -53,19 +53,27 @@ monadPlus = record
 ------------------------------------------------------------------------
 -- Get access to other monadic functions
 
-private
- module Monadic {m} {M : Set m → Set m} (Mon : RawMonad M) where
+module _ {f F} (App : RawApplicative {f} F) where
 
-  open RawMonad Mon
+  open RawApplicative App
 
-  sequence : ∀ {A} → List (M A) → M (List A)
-  sequence []       = return []
-  sequence (x ∷ xs) = _∷_ <$> x ⊛ sequence xs
+  sequenceA : ∀ {A} → List (F A) → F (List A)
+  sequenceA []       = pure []
+  sequenceA (x ∷ xs) = _∷_ <$> x ⊛ sequenceA xs
 
-  mapM : ∀ {a} {A : Set a} {B} → (A → M B) → List A → M (List B)
-  mapM f = sequence ∘ map f
+  mapA : ∀ {a} {A : Set a} {B} → (A → F B) → List A → F (List B)
+  mapA f = sequenceA ∘ map f
 
-open Monadic public
+  forA : ∀ {a} {A : Set a} {B} → List A → (A → F B) → F (List B)
+  forA = flip mapA
+
+module _ {m M} (Mon : RawMonad {m} M) where
+
+  private App = RawMonad.rawIApplicative Mon
+
+  sequenceM = sequenceA App
+  mapM = mapA App
+  forM = forA App
 
 ------------------------------------------------------------------------
 -- List monad transformer

--- a/src/Data/List/NonEmpty.agda
+++ b/src/Data/List/NonEmpty.agda
@@ -120,11 +120,8 @@ xs ++⁺ ys = List.foldr _∷⁺_ ys xs
 concat : ∀ {a} {A : Set a} → List⁺ (List⁺ A) → List⁺ A
 concat (xs ∷ xss) = xs ⁺++ List.concat (List.map toList xss)
 
-monad : ∀ {f} → RawMonad (List⁺ {a = f})
-monad = record
-  { return = [_]
-  ; _>>=_  = λ xs f → concat (map f xs)
-  }
+concatMap : ∀ {a b} {A : Set a} {B : Set b} → (A → List⁺ B) → List⁺ A → List⁺ B
+concatMap f = concat ∘′ map f
 
 reverse : ∀ {a} {A : Set a} → List⁺ A → List⁺ A
 reverse = lift (-,_ ∘′ Vec.reverse)

--- a/src/Data/List/NonEmpty/Categorical.agda
+++ b/src/Data/List/NonEmpty/Categorical.agda
@@ -1,0 +1,63 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- A categorical view of List⁺
+------------------------------------------------------------------------
+
+module Data.List.NonEmpty.Categorical where
+
+import Data.List.Categorical as List
+open import Data.List.NonEmpty
+open import Category.Functor
+open import Category.Applicative
+open import Category.Monad
+open import Category.Monad.Identity
+open import Function
+
+------------------------------------------------------------------------
+-- List⁺ applicative functor
+
+functor : ∀ {f} → RawFunctor {f} List⁺
+functor = record
+  { _<$>_ = map
+  }
+
+applicative : ∀ {f} → RawApplicative {f} List⁺
+applicative = record
+  { pure = [_]
+  ; _⊛_  = λ fs as → concatMap (λ f → map f as) fs
+  }
+
+------------------------------------------------------------------------
+-- List⁺ monad
+
+monad : ∀ {f} → RawMonad {f} List⁺
+monad = record
+  { return = [_]
+  ; _>>=_  = flip concatMap
+  }
+
+------------------------------------------------------------------------
+-- Get access to other monadic functions
+
+private
+ module Monadic {m} {M : Set m → Set m} (Mon : RawMonad M) where
+
+  open RawMonad Mon
+
+  sequence : ∀ {A} → List⁺ (M A) → M (List⁺ A)
+  sequence (x ∷ xs) = _∷_ <$> x ⊛ List.sequence Mon xs
+
+  mapM : ∀ {a} {A : Set a} {B} → (A → M B) → List⁺ A → M (List⁺ B)
+  mapM f = sequence ∘ map f
+
+open Monadic public
+
+------------------------------------------------------------------------
+-- List⁺ monad transformer
+
+monadT : ∀ {f M} → RawMonad {f} M → RawMonad (M ∘′ List⁺)
+monadT M = record
+  { return = pure ∘′ [_]
+  ; _>>=_  = λ mas f → mas >>= λ as → concat <$> mapM M f as
+  } where open RawMonad M

--- a/src/Data/List/NonEmpty/Categorical.agda
+++ b/src/Data/List/NonEmpty/Categorical.agda
@@ -40,18 +40,26 @@ monad = record
 ------------------------------------------------------------------------
 -- Get access to other monadic functions
 
-private
- module Monadic {m} {M : Set m → Set m} (Mon : RawMonad M) where
+module _ {f F} (App : RawApplicative {f} F) where
 
-  open RawMonad Mon
+  open RawApplicative App
 
-  sequence : ∀ {A} → List⁺ (M A) → M (List⁺ A)
-  sequence (x ∷ xs) = _∷_ <$> x ⊛ List.sequence Mon xs
+  sequenceA : ∀ {A} → List⁺ (F A) → F (List⁺ A)
+  sequenceA (x ∷ xs) = _∷_ <$> x ⊛ List.sequenceA App xs
 
-  mapM : ∀ {a} {A : Set a} {B} → (A → M B) → List⁺ A → M (List⁺ B)
-  mapM f = sequence ∘ map f
+  mapA : ∀ {a} {A : Set a} {B} → (A → F B) → List⁺ A → F (List⁺ B)
+  mapA f = sequenceA ∘ map f
 
-open Monadic public
+  forA : ∀ {a} {A : Set a} {B} → List⁺ A → (A → F B) → F (List⁺ B)
+  forA = flip mapA
+
+module _ {m M} (Mon : RawMonad {m} M) where
+
+  private App = RawMonad.rawIApplicative Mon
+
+  sequenceM = sequenceA App
+  mapM = mapA App
+  forM = forA App
 
 ------------------------------------------------------------------------
 -- List⁺ monad transformer

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -9,6 +9,7 @@ module Data.List.NonEmpty.Properties where
 open import Category.Monad
 open import Data.List as List using (List; []; _∷_; _++_)
 open import Data.List.Categorical using () renaming (monad to listMonad)
+open import Data.List.NonEmpty.Categorical using () renaming (monad to list⁺Monad)
 open import Data.List.NonEmpty as List⁺
 open import Data.List.Properties
 open import Function
@@ -20,7 +21,7 @@ private
          RawMonad {f = a} listMonad
            using () renaming (_>>=_ to _⋆>>=_)
   open module L⁺Mo {a} =
-         RawMonad {f = a} List⁺.monad
+         RawMonad {f = a} list⁺Monad
 
 η : ∀ {a} {A : Set a}
     (xs : List⁺ A) → head xs ∷ tail xs ≡ List⁺.toList xs
@@ -45,5 +46,7 @@ toList->>= : ∀ {ℓ} {A B : Set ℓ}
              (List⁺.toList xs ⋆>>= List⁺.toList ∘ f) ≡
              (List⁺.toList (xs >>= f))
 toList->>= f (x ∷ xs) = begin
-  List.concat (List.map (List⁺.toList ∘ f) (x ∷ xs))         ≡⟨ cong List.concat $ map-compose {g = List⁺.toList} {f = f} (x ∷ xs) ⟩
-  List.concat (List.map List⁺.toList (List.map f (x ∷ xs)))  ∎
+  List.concat (List.map (List⁺.toList ∘ f) (x ∷ xs))
+    ≡⟨ cong List.concat $ map-compose {g = List⁺.toList} (x ∷ xs) ⟩
+  List.concat (List.map List⁺.toList (List.map f (x ∷ xs)))
+    ∎

--- a/src/Data/Maybe.agda
+++ b/src/Data/Maybe.agda
@@ -22,41 +22,6 @@ open import Relation.Unary as U
 open import Data.Maybe.Base public
 
 ------------------------------------------------------------------------
--- Maybe monad
-
-functor : ∀ {f} → RawFunctor (Maybe {a = f})
-functor = record
-  { _<$>_ = map
-  }
-
-monadT : ∀ {f} {M : Set f → Set f} →
-         RawMonad M → RawMonad (λ A → M (Maybe A))
-monadT M = record
-  { return = M.return ∘ just
-  ; _>>=_  = λ m f → M._>>=_ m (maybe f (M.return nothing))
-  }
-  where module M = RawMonad M
-
-monad : ∀ {f} → RawMonad (Maybe {a = f})
-monad = monadT IdentityMonad
-
-monadZero : ∀ {f} → RawMonadZero (Maybe {a = f})
-monadZero = record
-  { monad = monad
-  ; ∅     = nothing
-  }
-
-monadPlus : ∀ {f} → RawMonadPlus (Maybe {a = f})
-monadPlus {f} = record
-  { monadZero = monadZero
-  ; _∣_       = _∣_
-  }
-  where
-  _∣_ : {A : Set f} → Maybe A → Maybe A → Maybe A
-  nothing ∣ y = y
-  just x  ∣ y = just x
-
-------------------------------------------------------------------------
 -- Equality
 
 data Eq {a ℓ} {A : Set a} (_≈_ : Rel A ℓ) : Rel (Maybe A) (a ⊔ ℓ) where

--- a/src/Data/Maybe/Categorical.agda
+++ b/src/Data/Maybe/Categorical.agda
@@ -1,0 +1,73 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- A categorical view of Maybe
+------------------------------------------------------------------------
+
+module Data.Maybe.Categorical where
+
+open import Data.Maybe.Base
+open import Category.Functor
+open import Category.Applicative
+open import Category.Monad
+open import Category.Monad.Identity
+open import Function
+
+------------------------------------------------------------------------
+-- Maybe applicative functor
+
+functor : ∀ {f} → RawFunctor {f} Maybe
+functor = record
+  { _<$>_ = map
+  }
+
+applicative : ∀ {f} → RawApplicative {f} Maybe
+applicative = record
+  { pure = just
+  ; _⊛_  = maybe map (const nothing)
+  }
+
+------------------------------------------------------------------------
+-- Maybe monad transformer
+
+monadT : ∀ {f M} → RawMonad {f} M → RawMonad (M ∘′ Maybe)
+monadT M = record
+  { return = M.return ∘ just
+  ; _>>=_  = λ m f → m M.>>= maybe f (M.return nothing)
+  }
+  where module M = RawMonad M
+
+------------------------------------------------------------------------
+-- Maybe monad
+
+monad : ∀ {f} → RawMonad {f} Maybe
+monad = monadT IdentityMonad
+
+monadZero : ∀ {f} → RawMonadZero {f} Maybe
+monadZero = record
+  { monad = monad
+  ; ∅     = nothing
+  }
+
+monadPlus : ∀ {f} → RawMonadPlus {f} Maybe
+monadPlus {f} = record
+  { monadZero = monadZero
+  ; _∣_       = maybe′ (const ∘ just) id
+  }
+
+------------------------------------------------------------------------
+-- Get access to other monadic functions
+
+private
+ module Monadic {m} {M : Set m → Set m} (Mon : RawMonad M) where
+
+  open RawMonad Mon
+
+  sequence : ∀ {A} → Maybe (M A) → M (Maybe A)
+  sequence nothing  = return nothing
+  sequence (just x) = just <$> x
+
+  mapM : ∀ {a} {A : Set a} {B} → (A → M B) → Maybe A → M (Maybe B)
+  mapM f = sequence ∘ map f
+
+open Monadic public

--- a/src/Data/Maybe/Categorical.agda
+++ b/src/Data/Maybe/Categorical.agda
@@ -58,16 +58,24 @@ monadPlus {f} = record
 ------------------------------------------------------------------------
 -- Get access to other monadic functions
 
-private
- module Monadic {m} {M : Set m → Set m} (Mon : RawMonad M) where
+module _ {f F} (App : RawApplicative {f} F) where
 
-  open RawMonad Mon
+  open RawApplicative App
 
-  sequence : ∀ {A} → Maybe (M A) → M (Maybe A)
-  sequence nothing  = return nothing
-  sequence (just x) = just <$> x
+  sequenceA : ∀ {A} → Maybe (F A) → F (Maybe A)
+  sequenceA nothing  = pure nothing
+  sequenceA (just x) = just <$> x
 
-  mapM : ∀ {a} {A : Set a} {B} → (A → M B) → Maybe A → M (Maybe B)
-  mapM f = sequence ∘ map f
+  mapA : ∀ {a} {A : Set a} {B} → (A → F B) → Maybe A → F (Maybe B)
+  mapA f = sequenceA ∘ map f
 
-open Monadic public
+  forA : ∀ {a} {A : Set a} {B} → Maybe A → (A → F B) → F (Maybe B)
+  forA = flip mapA
+
+module _ {m M} (Mon : RawMonad {m} M) where
+
+  private App = RawMonad.rawIApplicative Mon
+
+  sequenceM = sequenceA App
+  mapM = mapA App
+  forM = forA App


### PR DESCRIPTION
* Moving categorical stuff from `Data.Maybe` to `Data.Maybe.Categorical`
* Cleaning up `Data.List.Categorical`'s `Monadic` using an anonymous module
* Adding monad transformers for `List` and `List+`
* Simplifying the constraint on `sequence / mapM` to a mere `RawApplicative` (+ defining monadic variants)
* Throwing in `for(A/M)` because we can get nice code from them