### PR TITLE
[ fix #395 ] creating `Data.X.Solver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,13 +103,18 @@ Non-backwards compatible changes
   Algebra.IdempotentCommutativeMonoidSolver ↦ Algebra.Solver.IdempotentCommutativeMonoid
   ```
 
-* Renamed `Algebra.Solver.Ring.Natural-coefficients` to `Algebra.Solver.Ring.NaturalCoefficients`.
-
 * In order to avoid dependency cycles, special instances of solvers for the following
   data types have been moved from `Data.X.Properties` to new modules `Data.X.Solver`.
+  The naming conventions for these solver modules have also been standardised.
   ```agda
-  Bool, Nat, Integer, List
+  Data.Bool.Properties.RingSolver     ↦  Data.Bool.Solver.∨-∧-Solver
+  Data.Bool.Properties.XorRingSolver  ↦  Data.Bool.Solver.xor-∧-Solver
+  Data.Integer.Properties.RingSolver  ↦  Data.Integer.Solver.+-*-Solver
+  Data.List.Properties.List-solver    ↦  Data.List.Solver.++-Solver
+  Data.Nat.Properties.SemiringSolver  ↦  Data.Nat.Solver.+-*-Solver
   ```
+
+* Renamed `Algebra.Solver.Ring.Natural-coefficients` to `Algebra.Solver.Ring.NaturalCoefficients`.
 
 ### Overhaul of `Data.X.Categorical`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,24 @@ Non-backwards compatible changes
   and exports all the old names, but may be removed in some
   future version.
 
+### Rearrangement of algebraic Solvers
+
+* Standardised and moved the generic solver modules as follows:
+  ```agda
+  Algebra.RingSolver                        ↦ Algebra.Solver.Ring
+  Algebra.Monoid-solver                     ↦ Algebra.Solver.Monoid
+  Algebra.CommutativeMonoidSolver           ↦ Algebra.Solver.CommutativeMonoidx
+  Algebra.IdempotentCommutativeMonoidSolver ↦ Algebra.Solver.IdempotentCommutativeMonoid
+  ```
+
+* Renamed `Algebra.Solver.Ring.Natural-coefficients` to `Algebra.Solver.Ring.NaturalCoefficients`.
+
+* In order to avoid dependency cycles, special instances of solvers for the following
+  data types have been moved from `Data.X.Properties` to new modules `Data.X.Solver`.
+  ```agda
+  Bool, Nat, Integer, List
+  ```
+
 ### Overhaul of `Data.X.Categorical`
 
 * Created `Codata.Delay.Categorical`:

--- a/README.agda
+++ b/README.agda
@@ -125,7 +125,7 @@ import Relation.Binary.PropositionalEquality
 import Relation.Binary.PreorderReasoning
 
 -- Solver for commutative ring or semiring equalities:
-import Algebra.RingSolver
+import Algebra.Solver.Ring
 
 -- • Properties of functions, sets and relations
 

--- a/README/Integer.agda
+++ b/README/Integer.agda
@@ -57,11 +57,13 @@ ex₆ i j = begin
   i * j          ≡⟨ ℤₚ.*-comm i j ⟩
   j * i          ∎
 
--- The module RingSolver in Data.Integer.Properties contains a solver
+-- The module RingSolver in Data.Integer.Solver contains a solver
 -- for integer equalities involving variables, constants, _+_, _*_, -_
 -- and _-_.
+
+open import Data.Integer.Solver
+open RingSolver
 
 ex₇ : ∀ i j → i * - j - j * i ≡ - + 2 * i * j
 ex₇ = solve 2 (λ i j → i :* :- j :- j :* i  :=  :- con (+ 2) :* i :* j)
               P.refl
-  where open ℤₚ.RingSolver

--- a/README/Integer.agda
+++ b/README/Integer.agda
@@ -61,8 +61,8 @@ ex₆ i j = begin
 -- for integer equalities involving variables, constants, _+_, _*_, -_
 -- and _-_.
 
-open import Data.Integer.Solver
-open RingSolver
+open import Data.Integer.Solver using (module +-*-Solver)
+open +-*-Solver
 
 ex₇ : ∀ i j → i * - j - j * i ≡ - + 2 * i * j
 ex₇ = solve 2 (λ i j → i :* :- j :- j :* i  :=  :- con (+ 2) :* i :* j)

--- a/README/Nat.agda
+++ b/README/Nat.agda
@@ -42,11 +42,12 @@ ex₄ m n = begin
   m * n        ≡⟨ Nat.*-comm m n ⟩
   n * m        ∎
 
--- The module SemiringSolver in Data.Nat.Properties contains a solver
+-- The module SemiringSolver in Data.Nat.Solver contains a solver
 -- for natural number equalities involving variables, constants, _+_
 -- and _*_.
 
-open Nat.SemiringSolver
+open import Data.Nat.Solver
+open SemiringSolver
 
 ex₅ : ∀ m n → m * (n + 0) ≡ n * m
 ex₅ = solve 2 (λ m n → m :* (n :+ con 0)  :=  n :* m) refl

--- a/README/Nat.agda
+++ b/README/Nat.agda
@@ -46,8 +46,8 @@ ex₄ m n = begin
 -- for natural number equalities involving variables, constants, _+_
 -- and _*_.
 
-open import Data.Nat.Solver
-open SemiringSolver
+open import Data.Nat.Solver using (module +-*-Solver)
+open +-*-Solver
 
 ex₅ : ∀ m n → m * (n + 0) ≡ n * m
 ex₅ = solve 2 (λ m n → m :* (n :+ con 0)  :=  n :* m) refl

--- a/src/Algebra/Properties/CommutativeMonoid.agda
+++ b/src/Algebra/Properties/CommutativeMonoid.agda
@@ -9,7 +9,7 @@ open import Algebra
 module Algebra.Properties.CommutativeMonoid {g₁ g₂} (M : CommutativeMonoid g₁ g₂) where
 
 open import Algebra.Operations.CommutativeMonoid M
-open import Algebra.CommutativeMonoidSolver M
+open import Algebra.Solver.CommutativeMonoid M
 open import Relation.Binary as B using (_Preserves_⟶_)
 open import Function
 open import Function.Equality using (_⟨$⟩_)

--- a/src/Algebra/Solver/CommutativeMonoid.agda
+++ b/src/Algebra/Solver/CommutativeMonoid.agda
@@ -26,7 +26,7 @@ import Data.Vec.Relation.Pointwise.Inductive as Pointwise
 open import Relation.Binary.PropositionalEquality as P using (_≡_; decSetoid)
 open import Relation.Nullary using (Dec)
 
-module Algebra.CommutativeMonoidSolver {m₁ m₂} (M : CommutativeMonoid m₁ m₂) where
+module Algebra.Solver.CommutativeMonoid {m₁ m₂} (M : CommutativeMonoid m₁ m₂) where
 
 open CommutativeMonoid M
 open EqReasoning setoid

--- a/src/Algebra/Solver/CommutativeMonoid/Example.agda
+++ b/src/Algebra/Solver/CommutativeMonoid/Example.agda
@@ -4,7 +4,7 @@
 -- An example of how Algebra.CommutativeMonoidSolver can be used
 ------------------------------------------------------------------------
 
-module Algebra.CommutativeMonoidSolver.Example where
+module Algebra.Solver.CommutativeMonoid.Example where
 
 open import Relation.Binary.PropositionalEquality using (_≡_)
 
@@ -14,7 +14,7 @@ open import Data.Bool.Properties using (∨-commutativeMonoid)
 open import Data.Fin using (zero; suc)
 open import Data.Vec using ([]; _∷_)
 
-open import Algebra.CommutativeMonoidSolver ∨-commutativeMonoid
+open import Algebra.Solver.CommutativeMonoid ∨-commutativeMonoid
 
 test : ∀ x y z → (x ∨ y) ∨ (x ∨ z) ≡ (z ∨ y) ∨ (x ∨ x)
 test a b c = let _∨_ = _⊕_ in

--- a/src/Algebra/Solver/IdempotentCommutativeMonoid.agda
+++ b/src/Algebra/Solver/IdempotentCommutativeMonoid.agda
@@ -26,7 +26,7 @@ import Data.Vec.Relation.Pointwise.Inductive as Pointwise
 open import Relation.Binary.PropositionalEquality as P using (_≡_; decSetoid)
 open import Relation.Nullary using (Dec)
 
-module Algebra.IdempotentCommutativeMonoidSolver
+module Algebra.Solver.IdempotentCommutativeMonoid
   {m₁ m₂} (M : IdempotentCommutativeMonoid m₁ m₂) where
 
 open IdempotentCommutativeMonoid M

--- a/src/Algebra/Solver/IdempotentCommutativeMonoid/Example.agda
+++ b/src/Algebra/Solver/IdempotentCommutativeMonoid/Example.agda
@@ -5,7 +5,7 @@
 -- used
 ------------------------------------------------------------------------
 
-module Algebra.IdempotentCommutativeMonoidSolver.Example where
+module Algebra.Solver.IdempotentCommutativeMonoid.Example where
 
 open import Relation.Binary.PropositionalEquality using (_≡_)
 
@@ -15,7 +15,7 @@ open import Data.Bool.Properties using (∨-idempotentCommutativeMonoid)
 open import Data.Fin using (zero; suc)
 open import Data.Vec using ([]; _∷_)
 
-open import Algebra.IdempotentCommutativeMonoidSolver
+open import Algebra.Solver.IdempotentCommutativeMonoid
   ∨-idempotentCommutativeMonoid
 
 test : ∀ x y z → (x ∨ y) ∨ (x ∨ z) ≡ (z ∨ y) ∨ x

--- a/src/Algebra/Solver/Monoid.agda
+++ b/src/Algebra/Solver/Monoid.agda
@@ -6,7 +6,7 @@
 
 open import Algebra
 
-module Algebra.Monoid-solver {m₁ m₂} (M : Monoid m₁ m₂) where
+module Algebra.Solver.Monoid {m₁ m₂} (M : Monoid m₁ m₂) where
 
 open import Data.Fin as Fin hiding (_≟_)
 import Data.Fin.Properties as Fin

--- a/src/Algebra/Solver/Ring.agda
+++ b/src/Algebra/Solver/Ring.agda
@@ -10,11 +10,11 @@
 -- Horner normal forms are not sparse).
 
 open import Algebra
-open import Algebra.RingSolver.AlmostCommutativeRing
+open import Algebra.Solver.Ring.AlmostCommutativeRing
 
 open import Relation.Binary
 
-module Algebra.RingSolver
+module Algebra.Solver.Ring
   {r₁ r₂ r₃}
   (Coeff : RawRing r₁)               -- Coefficient "ring".
   (R : AlmostCommutativeRing r₂ r₃)  -- Main "ring".
@@ -22,7 +22,7 @@ module Algebra.RingSolver
   (_coeff≟_ : Decidable (Induced-equivalence morphism))
   where
 
-open import Algebra.RingSolver.Lemmas Coeff R morphism
+open import Algebra.Solver.Ring.Lemmas Coeff R morphism
 private module C = RawRing Coeff
 open AlmostCommutativeRing R
   renaming (zero to *-zero; zeroˡ to *-zeroˡ; zeroʳ to *-zeroʳ)

--- a/src/Algebra/Solver/Ring/AlmostCommutativeRing.agda
+++ b/src/Algebra/Solver/Ring/AlmostCommutativeRing.agda
@@ -5,7 +5,7 @@
 -- commutative rings), used by the ring solver
 ------------------------------------------------------------------------
 
-module Algebra.RingSolver.AlmostCommutativeRing where
+module Algebra.Solver.Ring.AlmostCommutativeRing where
 
 open import Relation.Binary
 open import Algebra

--- a/src/Algebra/Solver/Ring/Lemmas.agda
+++ b/src/Algebra/Solver/Ring/Lemmas.agda
@@ -7,9 +7,9 @@
 -- Note that these proofs use all "almost commutative ring" properties.
 
 open import Algebra
-open import Algebra.RingSolver.AlmostCommutativeRing
+open import Algebra.Solver.Ring.AlmostCommutativeRing
 
-module Algebra.RingSolver.Lemmas
+module Algebra.Solver.Ring.Lemmas
   {r₁ r₂ r₃}
   (coeff : RawRing r₁)
   (r : AlmostCommutativeRing r₂ r₃)

--- a/src/Algebra/Solver/Ring/NaturalCoefficients.agda
+++ b/src/Algebra/Solver/Ring/NaturalCoefficients.agda
@@ -9,15 +9,15 @@ open import Algebra
 import Algebra.Operations.Semiring as SemiringOps
 open import Relation.Nullary
 
-module Algebra.RingSolver.Natural-coefficients
+module Algebra.Solver.Ring.NaturalCoefficients
          {r₁ r₂}
          (R : CommutativeSemiring r₁ r₂)
          (dec : let open CommutativeSemiring R
                     open SemiringOps semiring in
                 ∀ m n → Dec (m × 1# ≈ n × 1#)) where
 
-import Algebra.RingSolver
-open import Algebra.RingSolver.AlmostCommutativeRing
+import Algebra.Solver.Ring
+open import Algebra.Solver.Ring.AlmostCommutativeRing
 open import Data.Nat.Base as ℕ
 open import Data.Product using (module Σ)
 open import Function
@@ -79,4 +79,4 @@ private
 
 -- The instantiation.
 
-open Algebra.RingSolver _ _ homomorphism dec′ public
+open Algebra.Solver.Ring _ _ homomorphism dec′ public

--- a/src/Algebra/Solver/Ring/Simple.agda
+++ b/src/Algebra/Solver/Ring/Simple.agda
@@ -5,14 +5,14 @@
 -- decidable equality
 ------------------------------------------------------------------------
 
-open import Algebra.RingSolver.AlmostCommutativeRing
+open import Algebra.Solver.Ring.AlmostCommutativeRing
 open import Relation.Binary
 
-module Algebra.RingSolver.Simple
+module Algebra.Solver.Ring.Simple
          {r₁ r₂} (R : AlmostCommutativeRing r₁ r₂)
          (_≟_ : Decidable (AlmostCommutativeRing._≈_ R))
          where
 
 open AlmostCommutativeRing R
-import Algebra.RingSolver as RS
+import Algebra.Solver.Ring as RS
 open RS rawRing R (-raw-almostCommutative⟶ R) _≟_ public

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -7,8 +7,6 @@
 module Data.Bool.Properties where
 
 open import Algebra
-import Algebra.RingSolver.Simple as Solver
-import Algebra.RingSolver.AlmostCommutativeRing as ACR
 open import Data.Bool
 open import Data.Empty
 open import Data.Product
@@ -381,15 +379,6 @@ push-function-into-if :
   f (if x then y else z) ≡ (if x then f y else f z)
 push-function-into-if _ true  = refl
 push-function-into-if _ false = refl
-
-------------------------------------------------------------------------
--- Modules for reasoning about boolean operations
-
-module RingSolver =
-  Solver (ACR.fromCommutativeSemiring ∨-∧-commutativeSemiring) _≟_
-
-module XorRingSolver =
-  Solver (ACR.fromCommutativeRing xor-∧-commutativeRing) _≟_
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/Bool/Solver.agda
+++ b/src/Data/Bool/Solver.agda
@@ -17,12 +17,12 @@ open import Data.Bool.Properties
 -- A module for automatically solving propositional equivalences
 -- containing _∨_ and _∧_
 
-module RingSolver =
+module ∨-∧-Solver =
   Solver (ACR.fromCommutativeSemiring ∨-∧-commutativeSemiring) _≟_
 
 ------------------------------------------------------------------------
 -- A module for automatically solving propositional equivalences
 -- containing _xor_ and _∧_
 
-module XorRingSolver =
+module xor-∧-Solver =
   Solver (ACR.fromCommutativeRing xor-∧-commutativeRing) _≟_

--- a/src/Data/Bool/Solver.agda
+++ b/src/Data/Bool/Solver.agda
@@ -1,0 +1,28 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Automatic solvers for equations over booleans
+------------------------------------------------------------------------
+
+-- See README.Nat for examples of how to use similar solvers
+
+module Data.Bool.Solver where
+
+import Algebra.Solver.Ring.Simple as Solver
+import Algebra.Solver.Ring.AlmostCommutativeRing as ACR
+open import Data.Bool using (_≟_)
+open import Data.Bool.Properties
+
+------------------------------------------------------------------------
+-- A module for automatically solving propositional equivalences
+-- containing _∨_ and _∧_
+
+module RingSolver =
+  Solver (ACR.fromCommutativeSemiring ∨-∧-commutativeSemiring) _≟_
+
+------------------------------------------------------------------------
+-- A module for automatically solving propositional equivalences
+-- containing _xor_ and _∧_
+
+module XorRingSolver =
+  Solver (ACR.fromCommutativeRing xor-∧-commutativeRing) _≟_

--- a/src/Data/BoundedVec.agda
+++ b/src/Data/BoundedVec.agda
@@ -13,7 +13,7 @@ open import Data.List.Base as List using (List)
 open import Data.Vec as Vec using (Vec)
 import Data.BoundedVec.Inefficient as Ineff
 open import Relation.Binary.PropositionalEquality
-open import Data.Nat.Properties
+open import Data.Nat.Solver
 open SemiringSolver
 
 ------------------------------------------------------------------------

--- a/src/Data/BoundedVec.agda
+++ b/src/Data/BoundedVec.agda
@@ -14,7 +14,7 @@ open import Data.Vec as Vec using (Vec)
 import Data.BoundedVec.Inefficient as Ineff
 open import Relation.Binary.PropositionalEquality
 open import Data.Nat.Solver
-open SemiringSolver
+open +-*-Solver
 
 ------------------------------------------------------------------------
 -- The type

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -8,7 +8,7 @@ module Data.Digit where
 
 open import Data.Nat using (ℕ; zero; suc; pred; _+_; _*_; _≤?_; _≤′_)
 open import Data.Nat.Properties
-open SemiringSolver
+open import Data.Nat.Solver
 open import Data.Fin as Fin using (Fin; zero; suc; toℕ)
 open import Data.Char using (Char)
 open import Data.List.Base
@@ -21,6 +21,8 @@ open import Relation.Nullary.Decidable
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
 open import Function
+
+open SemiringSolver
 
 ------------------------------------------------------------------------
 -- Digits

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -22,7 +22,7 @@ open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
 open import Function
 
-open SemiringSolver
+open +-*-Solver
 
 ------------------------------------------------------------------------
 -- Digits

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -9,8 +9,6 @@ module Data.Integer.Properties where
 open import Algebra
 import Algebra.Morphism as Morphism
 import Algebra.Properties.AbelianGroup
-import Algebra.RingSolver.Simple as Solver
-import Algebra.RingSolver.AlmostCommutativeRing as ACR
 open import Data.Integer renaming (suc to sucℤ)
 open import Data.Nat
   using (ℕ; suc; zero; _∸_; s≤s; z≤n; ≤-pred)
@@ -18,6 +16,7 @@ open import Data.Nat
   renaming (_+_ to _ℕ+_; _*_ to _ℕ*_;
     _<_ to _ℕ<_; _≥_ to _ℕ≥_; _≰_ to _ℕ≰_; _≤?_ to _ℕ≤?_)
 import Data.Nat.Properties as ℕₚ
+open import Data.Nat.Solver
 open import Data.Product using (proj₁; proj₂; _,_)
 open import Data.Sum using (inj₁; inj₂)
 open import Data.Sign as Sign using () renaming (_*_ to _𝕊*_)
@@ -33,8 +32,8 @@ open import Algebra.FunctionProperties (_≡_ {A = ℤ})
 open import Algebra.FunctionProperties.Consequences (setoid ℤ)
 open import Algebra.Structures (_≡_ {A = ℤ})
 open Morphism.Definitions ℤ ℕ _≡_
-open ℕₚ.SemiringSolver
 open ≡-Reasoning
+open SemiringSolver
 
 ------------------------------------------------------------------------
 -- Equality
@@ -420,7 +419,7 @@ private
                     := c :+ b :* (con 1 :+ c) :+
                        a :* (con 1 :+ (c :+ b :* (con 1 :+ c))))
             refl
-    where open ℕₚ.SemiringSolver
+    where open SemiringSolver
 
 *-assoc : Associative _*_
 *-assoc (+ zero) _ _ = refl
@@ -859,10 +858,6 @@ n≮n { -[1+ suc n ]} (-≤- n<n) =  contradiction n<n ℕₚ.1+n≰n
 
 ------------------------------------------------------------------------
 -- Modules for reasoning about integer number relations
-
--- A module for automatically solving propositional equivalences
-module RingSolver =
-  Solver (ACR.fromCommutativeRing +-*-commutativeRing) _≟_
 
 -- A module for reasoning about the _≤_ relation
 module ≤-Reasoning = POR ≤-poset hiding (_≈⟨_⟩_)

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -33,7 +33,7 @@ open import Algebra.FunctionProperties.Consequences (setoid ℤ)
 open import Algebra.Structures (_≡_ {A = ℤ})
 open Morphism.Definitions ℤ ℕ _≡_
 open ≡-Reasoning
-open SemiringSolver
+open +-*-Solver
 
 ------------------------------------------------------------------------
 -- Equality
@@ -419,7 +419,6 @@ private
                     := c :+ b :* (con 1 :+ c) :+
                        a :* (con 1 :+ (c :+ b :* (con 1 :+ c))))
             refl
-    where open SemiringSolver
 
 *-assoc : Associative _*_
 *-assoc (+ zero) _ _ = refl

--- a/src/Data/Integer/Solver.agda
+++ b/src/Data/Integer/Solver.agda
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Automatic solvers for equations over integers
+------------------------------------------------------------------------
+
+-- See README.Nat for examples of how to use similar solvers
+
+module Data.Integer.Solver where
+
+import Algebra.Solver.Ring.Simple as Solver
+import Algebra.Solver.Ring.AlmostCommutativeRing as ACR
+open import Data.Integer using (_≟_)
+open import Data.Integer.Properties using (+-*-commutativeRing)
+
+------------------------------------------------------------------------
+-- A module for automatically solving propositional equivalences
+-- containing _+_ and _*_
+
+-- A module for automatically solving propositional equivalences
+module RingSolver =
+  Solver (ACR.fromCommutativeRing +-*-commutativeRing) _≟_

--- a/src/Data/Integer/Solver.agda
+++ b/src/Data/Integer/Solver.agda
@@ -4,7 +4,7 @@
 -- Automatic solvers for equations over integers
 ------------------------------------------------------------------------
 
--- See README.Nat for examples of how to use similar solvers
+-- See README.Integer for examples of how to use this solver
 
 module Data.Integer.Solver where
 
@@ -18,5 +18,5 @@ open import Data.Integer.Properties using (+-*-commutativeRing)
 -- containing _+_ and _*_
 
 -- A module for automatically solving propositional equivalences
-module RingSolver =
+module +-*-Solver =
   Solver (ACR.fromCommutativeRing +-*-commutativeRing) _≟_

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -12,7 +12,6 @@ module Data.List.Properties where
 open import Algebra
 open import Algebra.Structures
 open import Algebra.FunctionProperties
-import Algebra.Monoid-solver
 open import Data.Bool.Base using (Bool; false; true; not; if_then_else_)
 open import Data.List as List
 open import Data.List.All using (All; []; _∷_)
@@ -637,13 +636,6 @@ module _ {a} {A : Set a} where
 
   ∷ʳ-injectiveʳ : ∀ {x y : A} (xs ys : List A) → xs ∷ʳ x ≡ ys ∷ʳ y → x ≡ y
   ∷ʳ-injectiveʳ xs ys eq = proj₂ (∷ʳ-injective xs ys eq)
-
-------------------------------------------------------------------------
--- Modules for reasoning about propositional equality of lists
-
--- A module for automatically solving propositional equivalences
-module List-solver {a} {A : Set a} =
-  Algebra.Monoid-solver (++-monoid A) renaming (id to nil)
 
 ------------------------------------------------------------------------
 -- DEPRECATED

--- a/src/Data/List/Solver.agda
+++ b/src/Data/List/Solver.agda
@@ -1,0 +1,19 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Automatic solvers for equations over lists
+------------------------------------------------------------------------
+
+-- See README.Nat for examples of how to use similar solvers
+
+module Data.List.Solver where
+
+open import Algebra.Solver.Monoid
+open import Data.List.Properties using (++-monoid)
+
+------------------------------------------------------------------------
+-- A module for automatically solving propositional equivalences
+-- containing _++_
+
+module List-solver {a} {A : Set a} =
+  Algebra.Solver.Monoid (++-monoid A) renaming (id to nil)

--- a/src/Data/List/Solver.agda
+++ b/src/Data/List/Solver.agda
@@ -8,12 +8,12 @@
 
 module Data.List.Solver where
 
-open import Algebra.Solver.Monoid
+import Algebra.Solver.Monoid as Solver
 open import Data.List.Properties using (++-monoid)
 
 ------------------------------------------------------------------------
 -- A module for automatically solving propositional equivalences
 -- containing _++_
 
-module List-solver {a} {A : Set a} =
-  Algebra.Solver.Monoid (++-monoid A) renaming (id to nil)
+module ++-Solver {a} {A : Set a} =
+  Solver (++-monoid A) renaming (id to nil)

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -10,6 +10,7 @@ open import Algebra
 open import Data.Nat as Nat
 open import Data.Nat.DivMod
 open import Data.Nat.Properties
+open import Data.Nat.Solver
 open import Data.Fin using (Fin; zero; suc; toℕ)
 import Data.Fin.Properties as FP
 open import Data.Product

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -23,7 +23,7 @@ import Relation.Binary.PartialOrderReasoning as PartialOrderReasoning
 open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; _≢_; refl; sym; trans; cong; cong₂; subst)
 
-open SemiringSolver
+open +-*-Solver
 
 ------------------------------------------------------------------------
 -- m ∣ n is inhabited iff m divides n. Some sources, like Hardy and

--- a/src/Data/Nat/GCD/Lemmas.agda
+++ b/src/Data/Nat/GCD/Lemmas.agda
@@ -12,7 +12,7 @@ open import Data.Nat.Solver
 open import Function
 open import Relation.Binary.PropositionalEquality
 
-open SemiringSolver
+open +-*-Solver
 open ≡-Reasoning
 
 lem₀ = solve 2 (λ n k → n :+ (con 1 :+ k)  :=  con 1 :+ n :+ k) refl

--- a/src/Data/Nat/GCD/Lemmas.agda
+++ b/src/Data/Nat/GCD/Lemmas.agda
@@ -7,16 +7,18 @@
 module Data.Nat.GCD.Lemmas where
 
 open import Data.Nat
-import Data.Nat.Properties as NatProp
-open NatProp.SemiringSolver
-open import Relation.Binary.PropositionalEquality
-open ≡-Reasoning
+open import Data.Nat.Properties
+open import Data.Nat.Solver
 open import Function
+open import Relation.Binary.PropositionalEquality
+
+open SemiringSolver
+open ≡-Reasoning
 
 lem₀ = solve 2 (λ n k → n :+ (con 1 :+ k)  :=  con 1 :+ n :+ k) refl
 
 lem₁ : ∀ i j → 2 + i ≤′ 2 + j + i
-lem₁ i j = NatProp.≤⇒≤′ $ s≤s $ s≤s $ NatProp.n≤m+n j i
+lem₁ i j = ≤⇒≤′ $ s≤s $ s≤s $ n≤m+n j i
 
 lem₂ : ∀ d x {k n} →
        d + x * k ≡ x * n → d + x * (n + k) ≡ 2 * x * n
@@ -99,7 +101,7 @@ lem₈ : ∀ {i j k q} x y →
        1 + y * j ≡ x * i → j * k ≡ q * i →
        k ≡ (x * k ∸ y * q) * i
 lem₈ {i} {j} {k} {q} x y eq eq′ =
-  sym (NatProp.im≡jm+n⇒[i∸j]m≡n (x * k) (y * q) i k lemma)
+  sym (im≡jm+n⇒[i∸j]m≡n (x * k) (y * q) i k lemma)
   where
   lemma = begin
     x * k * i        ≡⟨ solve 3 (λ x k i → x :* k :* i
@@ -119,7 +121,7 @@ lem₉ : ∀ {i j k q} x y →
        1 + x * i ≡ y * j → j * k ≡ q * i →
        k ≡ (y * q ∸ x * k) * i
 lem₉ {i} {j} {k} {q} x y eq eq′ =
-  sym (NatProp.im≡jm+n⇒[i∸j]m≡n (y * q) (x * k) i k lemma)
+  sym (im≡jm+n⇒[i∸j]m≡n (y * q) (x * k) i k lemma)
   where
   lem   = solve 3 (λ a b c → a :* b :* c  :=  b :* c :* a) refl
   lemma = begin
@@ -136,9 +138,9 @@ lem₁₀ : ∀ {a′} b c {d} e f → let a = suc a′ in
         a + b * (c * d * a) ≡ e * (f * d * a) →
         d ≡ 1
 lem₁₀ {a′} b c {d} e f eq =
-  NatProp.i*j≡1⇒j≡1 (e * f ∸ b * c) d
-    (NatProp.im≡jm+n⇒[i∸j]m≡n (e * f) (b * c) d 1
-       (NatProp.*-cancelʳ-≡ (e * f * d) (b * c * d + 1) (begin
+  i*j≡1⇒j≡1 (e * f ∸ b * c) d
+    (im≡jm+n⇒[i∸j]m≡n (e * f) (b * c) d 1
+       (*-cancelʳ-≡ (e * f * d) (b * c * d + 1) (begin
           e * f * d * a        ≡⟨ solve 4 (λ e f d a → e :* f :* d :* a
                                                    :=  e :* (f :* d :* a))
                                           refl e f d a ⟩
@@ -153,7 +155,7 @@ lem₁₁ : ∀ {i j m n k d} x y →
        1 + y * j ≡ x * i → i * k ≡ m * d → j * k ≡ n * d →
        k ≡ (x * m ∸ y * n) * d
 lem₁₁ {i} {j} {m} {n} {k} {d} x y eq eq₁ eq₂ =
-  sym (NatProp.im≡jm+n⇒[i∸j]m≡n (x * m) (y * n) d k lemma)
+  sym (im≡jm+n⇒[i∸j]m≡n (x * m) (y * n) d k lemma)
   where
   assoc = solve 3 (λ x y z → x :* y :* z  :=  x :* (y :* z)) refl
 

--- a/src/Data/Nat/LCM.agda
+++ b/src/Data/Nat/LCM.agda
@@ -19,7 +19,7 @@ open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; refl)
 open import Relation.Binary
 
-open SemiringSolver
+open +-*-Solver
 
 private
   module P  = Poset Div.poset

--- a/src/Data/Nat/LCM.agda
+++ b/src/Data/Nat/LCM.agda
@@ -6,9 +6,10 @@
 
 module Data.Nat.LCM where
 
+open import Algebra
 open import Data.Nat
-import Data.Nat.Properties as NatProp
-open NatProp.SemiringSolver
+open import Data.Nat.Properties
+open import Data.Nat.Solver
 open import Data.Nat.GCD
 open import Data.Nat.Divisibility as Div
 open import Data.Nat.Coprimality as Coprime
@@ -16,8 +17,10 @@ open import Data.Product
 open import Function
 open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; refl)
-open import Algebra
 open import Relation.Binary
+
+open SemiringSolver
+
 private
   module P  = Poset Div.poset
 
@@ -90,7 +93,7 @@ lcm .(q₁ * d) .(q₂ * d) | (d , gcd-* q₁ q₂ q₁-q₂-coprime) =
 
     q₂∣q₃ : q₂ ∣ q₃
     q₂∣q₃ = coprime-divisor (Coprime.sym q₁-q₂-coprime)
-              (divides q₄ $ NatProp.*-cancelʳ-≡ _ _ (begin
+              (divides q₄ $ *-cancelʳ-≡ _ _ (begin
                  q₁ * q₃ * d′    ≡⟨ lem₁ q₁ q₃ d′ ⟩
                  q₃ * (q₁ * d′)  ≡⟨ PropEq.sym eq₃ ⟩
                  m               ≡⟨ eq₄ ⟩

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -13,8 +13,6 @@ open import Relation.Binary
 open import Function
 open import Function.Injection using (_↣_)
 open import Algebra
-import Algebra.RingSolver.Simple as Solver
-import Algebra.RingSolver.AlmostCommutativeRing as ACR
 open import Data.Nat as Nat
 open import Data.Product
 open import Data.Sum
@@ -1162,10 +1160,6 @@ eq? inj = via-injection inj _≟_
 
 ------------------------------------------------------------------------
 -- Modules for reasoning about natural number relations
-
--- A module for automatically solving propositional equivalences
-module SemiringSolver =
-  Solver (ACR.fromCommutativeSemiring *-+-commutativeSemiring) _≟_
 
 -- A module for reasoning about the _≤_ relation
 module ≤-Reasoning where

--- a/src/Data/Nat/Solver.agda
+++ b/src/Data/Nat/Solver.agda
@@ -4,18 +4,18 @@
 -- Automatic solvers for equations over naturals
 ------------------------------------------------------------------------
 
--- See README.Nat for examples of how to use similar solvers
+-- See README.Nat for examples of how to use this solver
 
 module Data.Nat.Solver where
 
 import Algebra.Solver.Ring.Simple as Solver
 import Algebra.Solver.Ring.AlmostCommutativeRing as ACR
 open import Data.Nat using (_≟_)
-open import Data.Nat.Properties using (*-+-commutativeSemiring)
+open import Data.Nat.Properties
 
 ------------------------------------------------------------------------
 -- A module for automatically solving propositional equivalences
 -- containing _+_ and _*_
 
-module SemiringSolver =
+module +-*-Solver =
   Solver (ACR.fromCommutativeSemiring *-+-commutativeSemiring) _≟_

--- a/src/Data/Nat/Solver.agda
+++ b/src/Data/Nat/Solver.agda
@@ -1,0 +1,21 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Automatic solvers for equations over naturals
+------------------------------------------------------------------------
+
+-- See README.Nat for examples of how to use similar solvers
+
+module Data.Nat.Solver where
+
+import Algebra.Solver.Ring.Simple as Solver
+import Algebra.Solver.Ring.AlmostCommutativeRing as ACR
+open import Data.Nat using (_≟_)
+open import Data.Nat.Properties using (*-+-commutativeSemiring)
+
+------------------------------------------------------------------------
+-- A module for automatically solving propositional equivalences
+-- containing _+_ and _*_
+
+module SemiringSolver =
+  Solver (ACR.fromCommutativeSemiring *-+-commutativeSemiring) _≟_

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -10,7 +10,7 @@ module Function.Related.TypeIsomorphisms where
 open import Algebra
 import Algebra.FunctionProperties as FP
 import Algebra.Operations.Semiring as SemiringOperations
-import Algebra.RingSolver.Natural-coefficients
+import Algebra.Solver.Ring.NaturalCoefficients
 open import Algebra.Structures
 open import Data.Empty
 open import Data.Nat as Nat using (zero; suc)
@@ -273,7 +273,7 @@ private
                                 (g∘g X⊎↔X⊎) (g∘g (reverse X⊎↔X⊎))
 
 module Solver s {ℓ} =
-  Algebra.RingSolver.Natural-coefficients
+  Algebra.Solver.Ring.NaturalCoefficients
     (×⊎-CommutativeSemiring s ℓ)
     (coefficient-dec s ℓ)
 


### PR DESCRIPTION
1. Tidied up the `Solver` hierarchy, partially addressing #265 
2. Moved solvers from `Data.X.Properties` to new module `Data.X.Solver` addressing #395 
3. Came up with a meaningful naming convention for the solvers themselves (previously the naming was inconsistent and uninformative).

Comments welcome.