### PR TITLE
[ new ] synonym for Level.zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,7 +482,7 @@ Other minor additions
 
 * Added new synonym to `Level`:
   ```agda
-  ℓ₀ = zero
+  0ℓ = zero
   ```
 
 * Added new module `Level.Literals` with functions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,11 @@ Other minor additions
   surjection : (∀ x → to (from x) ≡ x) → From ↠ To
   ```
 
+* Added new synonym to `Level`:
+  ```agda
+  ℓ₀ = zero
+  ```
+
 * Added new module `Level.Literals` with functions:
   ```agda
   _ℕ+_   : Nat → Level → Level

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -5,10 +5,10 @@
 -- of elements /not/ in a given list
 ------------------------------------------------------------------------
 
-import Level
+open import Level using (0ℓ)
 open import Relation.Binary
 
-module Data.List.Countdown (D : DecSetoid Level.zero Level.zero) where
+module Data.List.Countdown (D : DecSetoid 0ℓ 0ℓ) where
 
 open import Data.Empty
 open import Data.Fin using (Fin; zero; suc; punchOut)

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -6,7 +6,7 @@
 
 module Data.Nat.Base where
 
-import Level using (zero)
+open import Level using (0ℓ)
 open import Function using (_∘_)
 open import Relation.Binary
 open import Relation.Binary.Core
@@ -24,29 +24,29 @@ open import Agda.Builtin.Nat public
   renaming ( Nat to ℕ
            ; _-_ to _∸_ )
 
-data _≤_ : Rel ℕ Level.zero where
+data _≤_ : Rel ℕ 0ℓ where
   z≤n : ∀ {n}                 → zero  ≤ n
   s≤s : ∀ {m n} (m≤n : m ≤ n) → suc m ≤ suc n
 
-_<_ : Rel ℕ Level.zero
+_<_ : Rel ℕ 0ℓ
 m < n = suc m ≤ n
 
-_≥_ : Rel ℕ Level.zero
+_≥_ : Rel ℕ 0ℓ
 m ≥ n = n ≤ m
 
-_>_ : Rel ℕ Level.zero
+_>_ : Rel ℕ 0ℓ
 m > n = n < m
 
-_≰_ : Rel ℕ Level.zero
+_≰_ : Rel ℕ 0ℓ
 a ≰ b = ¬ a ≤ b
 
-_≮_ : Rel ℕ Level.zero
+_≮_ : Rel ℕ 0ℓ
 a ≮ b = ¬ a < b
 
-_≱_ : Rel ℕ Level.zero
+_≱_ : Rel ℕ 0ℓ
 a ≱ b = ¬ a ≥ b
 
-_≯_ : Rel ℕ Level.zero
+_≯_ : Rel ℕ 0ℓ
 a ≯ b = ¬ a > b
 
 -- The following, alternative definition of _≤_ is more suitable for
@@ -58,13 +58,13 @@ data _≤′_ (m : ℕ) : ℕ → Set where
   ≤′-refl :                         m ≤′ m
   ≤′-step : ∀ {n} (m≤′n : m ≤′ n) → m ≤′ suc n
 
-_<′_ : Rel ℕ Level.zero
+_<′_ : Rel ℕ 0ℓ
 m <′ n = suc m ≤′ n
 
-_≥′_ : Rel ℕ Level.zero
+_≥′_ : Rel ℕ 0ℓ
 m ≥′ n = n ≤′ m
 
-_>′_ : Rel ℕ Level.zero
+_>′_ : Rel ℕ 0ℓ
 m >′ n = n <′ m
 
 -- Another alternative definition of _≤_.
@@ -77,13 +77,13 @@ record _≤″_ (m n : ℕ) : Set where
 
 infix 4 _≤″_ _<″_ _≥″_ _>″_
 
-_<″_ : Rel ℕ Level.zero
+_<″_ : Rel ℕ 0ℓ
 m <″ n = suc m ≤″ n
 
-_≥″_ : Rel ℕ Level.zero
+_≥″_ : Rel ℕ 0ℓ
 m ≥″ n = n ≤″ m
 
-_>″_ : Rel ℕ Level.zero
+_>″_ : Rel ℕ 0ℓ
 m >″ n = n <″ m
 
 erase : ∀ {m n} → m ≤″ n → m ≤″ n
@@ -163,7 +163,7 @@ suc m ≤? suc n with m ≤? n
 -- A comparison view. Taken from "View from the left"
 -- (McBride/McKinna); details may differ.
 
-data Ordering : Rel ℕ Level.zero where
+data Ordering : Rel ℕ 0ℓ where
   less    : ∀ m k → Ordering m (suc (m + k))
   equal   : ∀ m   → Ordering m m
   greater : ∀ m k → Ordering (suc (m + k)) m

--- a/src/Data/Nat/InfinitelyOften.agda
+++ b/src/Data/Nat/InfinitelyOften.agda
@@ -6,7 +6,7 @@
 
 module Data.Nat.InfinitelyOften where
 
-import Level
+open import Level using (0ℓ)
 open import Algebra
 open import Category.Monad
 open import Data.Empty
@@ -19,7 +19,7 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
 open import Relation.Nullary.Negation
 open import Relation.Unary using (Pred; _∪_; _⊆_)
-open RawMonad (¬¬-Monad {p = Level.zero})
+open RawMonad (¬¬-Monad {p = 0ℓ})
 
 -- Only true finitely often.
 

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -357,8 +357,8 @@ A⇔B →-cong-⇔ C⇔D = Eq.equivalence
   where open Related.EquationalReasoning
 
 ¬-cong : ∀ {a b} →
-         P.Extensionality a Level.zero →
-         P.Extensionality b Level.zero →
+         P.Extensionality a 0ℓ →
+         P.Extensionality b 0ℓ →
          ∀ {k} {A : Set a} {B : Set b} →
          A ∼[ ⌊ k ⌋ ] B → (¬ A) ∼[ ⌊ k ⌋ ] (¬ B)
 ¬-cong extA extB A≈B = →-cong extA extB A≈B (⊥ ∎)

--- a/src/Level.agda
+++ b/src/Level.agda
@@ -22,5 +22,5 @@ open Lift public
 
 -- Synonyms
 
-ℓ₀ : Level
-ℓ₀ = zero
+0ℓ : Level
+0ℓ = zero

--- a/src/Level.agda
+++ b/src/Level.agda
@@ -19,3 +19,8 @@ record Lift {a} ℓ (A : Set a) : Set (a ⊔ ℓ) where
   field lower : A
 
 open Lift public
+
+-- Synonyms
+
+ℓ₀ : Level
+ℓ₀ = zero

--- a/src/Level/Literals.agda
+++ b/src/Level/Literals.agda
@@ -9,7 +9,7 @@ module Level.Literals where
 open import Agda.Builtin.Nat renaming (Nat to ℕ)
 open import Agda.Builtin.FromNat
 open import Agda.Builtin.Unit
-open import Level using (Level)
+open import Level using (Level; 0ℓ)
 
 -- Increase a Level by a number of sucs.
 
@@ -22,7 +22,7 @@ suc n ℕ+ ℓ = Level.suc (n ℕ+ ℓ)
 infix 10 #_
 
 #_ : ℕ → Level
-#_ = _ℕ+ Level.zero
+#_ = _ℕ+ 0ℓ
 
 -- Literal overloading for levels.
 


### PR DESCRIPTION
An extension to the `ℓ` naming convention for levels that's used throughout the library. In a lot of places we write `Level.zero` or `zero`. The former is verbose and requires `as Level` in the header and the latter is sometimes confusing when dealing with numeric datatypes.

Thoughts? Is `ℓ` used for anything else that I'm forgetting?

