### PR TITLE
Deprivatising `Function.Related`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -301,7 +301,9 @@ anticipated any time soon, they may eventually be removed in some future release
   ```
 * In `Function.Related`
   ```agda
-  preorder ↦ ↔-preorder
+  preorder              ↦ R-preorder
+  setoid                ↦ SR-setoid
+  EquationReasoning.sym ↦ SR-sym
   ```
 
 * In `Function.Related.TypeIsomorphisms`:
@@ -519,6 +521,17 @@ Other minor additions
 * Added new function to `Function.LeftInverse`:
   ```agda
   leftInverse : (∀ x → from (to x) ≡ x) → From ↞ To
+  ```
+
+* Added new proofs to `Function.Related`:
+  ```agda
+  R-refl       : Reflexive (Related k {ℓ})
+  R-reflexive  : _≡_ ⇒ Related k {ℓ}
+  R-trans      : Trans (Related k) (Related k) (Related k)
+  R-isPreorder : IsPreorder _↔_ (Related k)
+
+  SR-sym           : Sym (Related ⌊ k ⌋) (Related ⌊ k ⌋)
+  SR-isEquivalence : IsEquivalence (Related ⌊ k ⌋)
   ```
 
 * Added new proofs to `Function.Related.TypeIsomorphisms`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,13 +525,13 @@ Other minor additions
 
 * Added new proofs to `Function.Related`:
   ```agda
-  R-refl       : Reflexive (Related k {ℓ})
-  R-reflexive  : _≡_ ⇒ Related k {ℓ}
-  R-trans      : Trans (Related k) (Related k) (Related k)
-  R-isPreorder : IsPreorder _↔_ (Related k)
+  K-refl       : Reflexive (Related k)
+  K-reflexive  : _≡_ ⇒ Related k
+  K-trans      : Trans (Related k) (Related k) (Related k)
+  K-isPreorder : IsPreorder _↔_ (Related k)
 
-  SR-sym           : Sym (Related ⌊ k ⌋) (Related ⌊ k ⌋)
-  SR-isEquivalence : IsEquivalence (Related ⌊ k ⌋)
+  SK-sym           : Sym (Related ⌊ k ⌋) (Related ⌊ k ⌋)
+  SK-isEquivalence : IsEquivalence (Related ⌊ k ⌋)
   ```
 
 * Added new proofs to `Function.Related.TypeIsomorphisms`:

--- a/src/Data/Container/Any.agda
+++ b/src/Data/Container/Any.agda
@@ -19,7 +19,7 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence using (equivalence)
 open import Function.Inverse as Inv using (_↔_; inverse; module Inverse)
-open import Function.Related as Related using (Related)
+open import Function.Related as Related using (Related; SK-sym)
 open import Function.Related.TypeIsomorphisms
 open import Relation.Unary using (Pred ; _∪_ ; _∩_)
 open import Relation.Binary using (REL)
@@ -58,7 +58,7 @@ module _ {s p} {C : Container s p} {x} {X : Set x}
   cong {k} {xs₁} {xs₂} P₁↔P₂ xs₁≈xs₂ =
     ◇ P₁ xs₁                  ↔⟨ ↔∈ C ⟩
     (∃ λ x → x ∈ xs₁ × P₁ x)  ∼⟨ Σ.cong Inv.id (xs₁≈xs₂ ×-cong P₁↔P₂ _) ⟩
-    (∃ λ x → x ∈ xs₂ × P₂ x)  ↔⟨ sym (↔∈ C) ⟩
+    (∃ λ x → x ∈ xs₂ × P₂ x)  ↔⟨ SK-sym (↔∈ C) ⟩
     ◇ P₂ xs₂                  ∎
 
 -- Nested occurrences of ◇ can sometimes be swapped.
@@ -76,13 +76,13 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
     (∃ λ x → x ∈ xs × ∃ λ y → y ∈ ys × P x y)  ↔⟨ Σ.cong Inv.id (λ {x} → ∃∃↔∃∃ (λ _ y → y ∈ ys × P x y)) ⟩
     (∃₂ λ x y → x ∈ xs × y ∈ ys × P x y)       ↔⟨ ∃∃↔∃∃ (λ x y → x ∈ xs × y ∈ ys × P x y) ⟩
     (∃₂ λ y x → x ∈ xs × y ∈ ys × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → Σ.cong Inv.id (λ {x} →
-      (x ∈ xs × y ∈ ys × P x y)                     ↔⟨ sym Σ-assoc ⟩
+      (x ∈ xs × y ∈ ys × P x y)                     ↔⟨ SK-sym Σ-assoc ⟩
       ((x ∈ xs × y ∈ ys) × P x y)                   ↔⟨ Σ.cong (×-comm _ _) Inv.id ⟩
       ((y ∈ ys × x ∈ xs) × P x y)                   ↔⟨ Σ-assoc ⟩
       (y ∈ ys × x ∈ xs × P x y)                     ∎)) ⟩
     (∃₂ λ y x → y ∈ ys × x ∈ xs × P x y)       ↔⟨ Σ.cong Inv.id (λ {y} → ∃∃↔∃∃ {B = y ∈ ys} (λ x _ → x ∈ xs × P x y)) ⟩
-    (∃ λ y → y ∈ ys × ∃ λ x → x ∈ xs × P x y)  ↔⟨ Σ.cong Inv.id (Σ.cong Inv.id (sym (↔∈ C₁))) ⟩
-    (∃ λ y → y ∈ ys × ◇ (flip P y) xs)         ↔⟨ sym (↔∈ C₂) ⟩
+    (∃ λ y → y ∈ ys × ∃ λ x → x ∈ xs × P x y)  ↔⟨ Σ.cong Inv.id (Σ.cong Inv.id (SK-sym (↔∈ C₁))) ⟩
+    (∃ λ y → y ∈ ys × ◇ (flip P y) xs)         ↔⟨ SK-sym (↔∈ C₂) ⟩
     ◇ (λ y → ◇ (flip P y) xs) ys               ∎
 
 -- Nested occurrences of ◇ can sometimes be flattened.
@@ -172,7 +172,7 @@ module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
   map-cong {f₁ = f₁} {f₂} {xs₁} {xs₂} f₁≗f₂ xs₁≈xs₂ {x} =
     x ∈ C.map f₁ xs₁        ↔⟨ map↔∘ C (_≡_ x) f₁ ⟩
     ◇ (λ y → x ≡ f₁ y) xs₁  ∼⟨ cong {xs₁ = xs₁} {xs₂ = xs₂} (Related.↔⇒ ∘ helper) xs₁≈xs₂ ⟩
-    ◇ (λ y → x ≡ f₂ y) xs₂  ↔⟨ sym (map↔∘ C (_≡_ x) f₂) ⟩
+    ◇ (λ y → x ≡ f₂ y) xs₂  ↔⟨ SK-sym (map↔∘ C (_≡_ x) f₂) ⟩
     x ∈ C.map f₂ xs₂        ∎
     where
     helper : ∀ y → (x ≡ f₁ y) ↔ (x ≡ f₂ y)
@@ -244,6 +244,6 @@ module _ {s₁ s₂ s₃ p₁ p₂ p₃}
            ◇ P (join xss) ↔ ◇ (◇ P) xss
   join↔◇ join xss =
     ◇ P (⟪ join ⟫⊸ xss′)  ↔⟨ remove-linear P join ⟩
-    ◇ P            xss′   ↔⟨ sym $ flatten P xss ⟩
+    ◇ P            xss′   ↔⟨ SK-sym $ flatten P xss ⟩
     ◇ (◇ P) xss           ∎
     where xss′ = Inverse.from (Composition.correct C₁ C₂) ⟨$⟩ xss

--- a/src/Data/List/Any/Properties.agda
+++ b/src/Data/List/Any/Properties.agda
@@ -36,7 +36,7 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence using (_⇔_; equivalence; Equivalence)
 open import Function.Inverse as Inv using (_↔_; inverse; Inverse)
-open import Function.Related as Related using (Related)
+open import Function.Related as Related using (Related; SK-sym)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; refl; inspect)
@@ -87,7 +87,7 @@ module _ {a k p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
              Preorder._∼_ (Related.InducedPreorder₂ k {A = A} _∈_) xs ys →
              Related k (Any P xs) (Any Q ys)
   Any-cong {xs} {ys} P↔Q xs≈ys =
-    Any P xs                ↔⟨ sym Any↔ ⟩
+    Any P xs                ↔⟨ SK-sym Any↔ ⟩
     (∃ λ x → x ∈ xs × P x)  ∼⟨ Σ.cong Inv.id (xs≈ys ×-cong P↔Q _) ⟩
     (∃ λ x → x ∈ ys × Q x)  ↔⟨ Any↔ ⟩
     Any Q ys                ∎

--- a/src/Data/List/Relation/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/BagAndSetEquality.agda
@@ -24,7 +24,7 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 import Function.Equivalence as FE
 open import Function.Inverse as Inv using (_↔_; Inverse; inverse)
-open import Function.Related as Related using (↔⇒; ⌊_⌋; ⌊_⌋→; ⇒→)
+open import Function.Related as Related using (↔⇒; ⌊_⌋; ⌊_⌋→; ⇒→; SK-sym)
 open import Function.Related.TypeIsomorphisms
 open import Relation.Binary
 import Relation.Binary.EqReasoning as EqR
@@ -98,7 +98,7 @@ module _ {a k} {A : Set a} {x y : A} {xs ys} where
 
   ∷-cong : x ≡ y → xs ∼[ k ] ys → x ∷ xs ∼[ k ] y ∷ ys
   ∷-cong refl xs≈ys {y} =
-    y ∈ x ∷ xs        ↔⟨ sym $ ∷↔ (y ≡_) ⟩
+    y ∈ x ∷ xs        ↔⟨ SK-sym $ ∷↔ (y ≡_) ⟩
     (y ≡ x ⊎ y ∈ xs)  ∼⟨ (y ≡ x ∎) ⊎-cong xs≈ys ⟩
     (y ≡ x ⊎ y ∈ ys)  ↔⟨ ∷↔ (y ≡_) ⟩
     y ∈ x ∷ ys        ∎
@@ -111,7 +111,7 @@ module _ {ℓ k} {A B : Set ℓ} {f g : A → B} {xs ys} where
 
   map-cong : f ≗ g → xs ∼[ k ] ys → map f xs ∼[ k ] map g ys
   map-cong f≗g xs≈ys {x} =
-    x ∈ map f xs            ↔⟨ sym $ map↔ ⟩
+    x ∈ map f xs            ↔⟨ SK-sym $ map↔ ⟩
     Any (λ y → x ≡ f y) xs  ∼⟨ Any-cong (↔⇒ ∘ helper) xs≈ys ⟩
     Any (λ y → x ≡ g y) ys  ↔⟨ map↔ ⟩
     x ∈ map g ys            ∎
@@ -136,7 +136,7 @@ module _ {a k} {A : Set a} {xs₁ xs₂ ys₁ ys₂ : List A} where
   ++-cong : xs₁ ∼[ k ] xs₂ → ys₁ ∼[ k ] ys₂ →
             xs₁ ++ ys₁ ∼[ k ] xs₂ ++ ys₂
   ++-cong xs₁≈xs₂ ys₁≈ys₂ {x} =
-    x ∈ xs₁ ++ ys₁       ↔⟨ sym $ ++↔ ⟩
+    x ∈ xs₁ ++ ys₁       ↔⟨ SK-sym $ ++↔ ⟩
     (x ∈ xs₁ ⊎ x ∈ ys₁)  ∼⟨ xs₁≈xs₂ ⊎-cong ys₁≈ys₂ ⟩
     (x ∈ xs₂ ⊎ x ∈ ys₂)  ↔⟨ ++↔ ⟩
     x ∈ xs₂ ++ ys₂       ∎
@@ -149,7 +149,7 @@ module _ {a k} {A : Set a} {xss yss : List (List A)} where
 
   concat-cong : xss ∼[ k ] yss → concat xss ∼[ k ] concat yss
   concat-cong xss≈yss {x} =
-    x ∈ concat xss         ↔⟨ sym concat↔ ⟩
+    x ∈ concat xss        ↔⟨ SK-sym concat↔ ⟩
     Any (Any (x ≡_)) xss  ∼⟨ Any-cong (λ _ → _ ∎) xss≈yss ⟩
     Any (Any (x ≡_)) yss  ↔⟨ concat↔ ⟩
     x ∈ concat yss         ∎
@@ -163,7 +163,7 @@ module _ {ℓ k} {A B : Set ℓ} {xs ys} {f g : A → List B} where
   >>=-cong : xs ∼[ k ] ys → (∀ x → f x ∼[ k ] g x) →
              (xs >>= f) ∼[ k ] (ys >>= g)
   >>=-cong xs≈ys f≈g {x} =
-    x ∈ (xs >>= f)          ↔⟨ sym >>=↔ ⟩
+    x ∈ (xs >>= f)          ↔⟨ SK-sym >>=↔ ⟩
     Any (λ y → x ∈ f y) xs  ∼⟨ Any-cong (λ x → f≈g x) xs≈ys ⟩
     Any (λ y → x ∈ g y) ys  ↔⟨ >>=↔ ⟩
     x ∈ (ys >>= g)          ∎
@@ -243,9 +243,9 @@ empty-unique {xs = _ ∷ _} ∷∼[] with ⇒→ ∷∼[] (here refl)
   ∀ {ℓ} {A B : Set ℓ} (xs : List A) {f g : A → List B} →
   (xs >>= λ x → f x ++ g x) ∼[ bag ] (xs >>= f) ++ (xs >>= g)
 >>=-left-distributive {ℓ} xs {f} {g} {y} =
-  y ∈ (xs >>= λ x → f x ++ g x)                      ↔⟨ sym $ >>=↔ ⟩
-  Any (λ x → y ∈ f x ++ g x) xs                      ↔⟨ sym (Any-cong (λ _ → ++↔) (_ ∎)) ⟩
-  Any (λ x → y ∈ f x ⊎ y ∈ g x) xs                   ↔⟨ sym $ ⊎↔ ⟩
+  y ∈ (xs >>= λ x → f x ++ g x)                      ↔⟨ SK-sym $ >>=↔ ⟩
+  Any (λ x → y ∈ f x ++ g x) xs                      ↔⟨ SK-sym (Any-cong (λ _ → ++↔) (_ ∎)) ⟩
+  Any (λ x → y ∈ f x ⊎ y ∈ g x) xs                   ↔⟨ SK-sym $ ⊎↔ ⟩
   (Any (λ x → y ∈ f x) xs ⊎ Any (λ x → y ∈ g x) xs)  ↔⟨ >>=↔ ⟨ _⊎-cong_ ⟩ >>=↔ ⟩
   (y ∈ (xs >>= f) ⊎ y ∈ (xs >>= g))                  ↔⟨ ++↔ ⟩
   y ∈ (xs >>= f) ++ (xs >>= g)                       ∎

--- a/src/Data/Product/Relation/Pointwise/Dependent.agda
+++ b/src/Data/Product/Relation/Pointwise/Dependent.agda
@@ -398,7 +398,7 @@ private
     B₁ (Inverse.from A₁↔A₂ ⟨$⟩ x)
       ∼⟨ eq ⟩
     B₂ (Inverse.to A₁↔A₂ ⟨$⟩ (Inverse.from A₁↔A₂ ⟨$⟩ x))
-      ↔⟨ B.Setoid.reflexive (Related.setoid Related.bijection _)
+      ↔⟨ Related.K-reflexive
          (P.cong B₂ $ Inverse.right-inverse-of A₁↔A₂ x) ⟩
     B₂ x
       ∎

--- a/src/Data/Product/Relation/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Pointwise/NonDependent.agda
@@ -20,7 +20,7 @@ open import Function.Inverse as Inv
   using (Inverse; _↔_; module Inverse)
 open import Function.LeftInverse as LeftInv
   using (LeftInverse; _↞_; _LeftInverseOf_; module LeftInverse)
-open import Function.Related hiding (isEquivalence)
+open import Function.Related
 open import Function.Surjection as Surj
   using (Surjection; _↠_; module Surjection)
 import Relation.Nullary.Decidable as Dec

--- a/src/Data/Sum/Relation/Pointwise.agda
+++ b/src/Data/Sum/Relation/Pointwise.agda
@@ -20,7 +20,7 @@ open import Function.Inverse as Inv
   using (Inverse; _↔_; module Inverse)
 open import Function.LeftInverse as LeftInv
   using (LeftInverse; _↞_; module LeftInverse)
-open import Function.Related hiding (isEquivalence)
+open import Function.Related
 open import Function.Surjection as Surj
   using (Surjection; _↠_; module Surjection)
 open import Relation.Nullary

--- a/src/Function/Related.agda
+++ b/src/Function/Related.agda
@@ -246,49 +246,72 @@ reverse {surjection}          = Surjection.right-inverse
 reverse {bijection}           = Inv.sym
 
 ------------------------------------------------------------------------
+-- For a fixed universe level every kind is a preorder and each
+-- symmetric kind is an equivalence
+
+K-refl : ∀ {k ℓ} → Reflexive (Related k {ℓ})
+K-refl {implication}         = id
+K-refl {reverse-implication} = lam id
+K-refl {equivalence}         = Eq.id
+K-refl {injection}           = Inj.id
+K-refl {reverse-injection}   = lam Inj.id
+K-refl {left-inverse}        = LeftInv.id
+K-refl {surjection}          = Surj.id
+K-refl {bijection}           = Inv.id
+
+K-reflexive : ∀ {k ℓ} → _≡_ ⇒ Related k {ℓ}
+K-reflexive P.refl = K-refl
+
+K-trans : ∀ {k ℓ₁ ℓ₂ ℓ₃} → Trans (Related k {ℓ₁} {ℓ₂})
+                                (Related k {ℓ₂} {ℓ₃})
+                                (Related k {ℓ₁} {ℓ₃})
+K-trans {implication}         = flip _∘′_
+K-trans {reverse-implication} = λ f g → lam (app-← f ∘ app-← g)
+K-trans {equivalence}         = flip Eq._∘_
+K-trans {injection}           = flip Inj._∘_
+K-trans {reverse-injection}   = λ f g → lam (Inj._∘_ (app-↢ f) (app-↢ g))
+K-trans {left-inverse}        = flip LeftInv._∘_
+K-trans {surjection}          = flip Surj._∘_
+K-trans {bijection}           = flip Inv._∘_
+
+SK-sym : ∀ {k ℓ₁ ℓ₂} → Sym (Related ⌊ k ⌋ {ℓ₁} {ℓ₂})
+                          (Related ⌊ k ⌋ {ℓ₂} {ℓ₁})
+SK-sym {equivalence} = Eq.sym
+SK-sym {bijection}   = Inv.sym
+
+SK-isEquivalence : ∀ k ℓ → IsEquivalence {ℓ = ℓ} (Related ⌊ k ⌋)
+SK-isEquivalence k ℓ = record
+  { refl  = K-refl
+  ; sym   = SK-sym
+  ; trans = K-trans
+  }
+
+SK-setoid : Symmetric-kind → (ℓ : Level) → Setoid _ _
+SK-setoid k ℓ = record { isEquivalence = SK-isEquivalence k ℓ }
+
+K-isPreorder : ∀ k ℓ → IsPreorder _↔_ (Related k)
+K-isPreorder k ℓ = record
+    { isEquivalence = SK-isEquivalence bijection ℓ
+    ; reflexive     = ↔⇒
+    ; trans         = K-trans
+    }
+
+K-preorder : Kind → (ℓ : Level) → Preorder _ _ _
+K-preorder k ℓ = record { isPreorder = K-isPreorder k ℓ }
+
+------------------------------------------------------------------------
 -- Equational reasoning
 
 -- Equational reasoning for related things.
 
 module EquationalReasoning where
 
-  private
-
-    refl : ∀ {k ℓ} → Reflexive (Related k {ℓ})
-    refl {implication}         = id
-    refl {reverse-implication} = lam id
-    refl {equivalence}         = Eq.id
-    refl {injection}           = Inj.id
-    refl {reverse-injection}   = lam Inj.id
-    refl {left-inverse}        = LeftInv.id
-    refl {surjection}          = Surj.id
-    refl {bijection}           = Inv.id
-
-    trans : ∀ {k ℓ₁ ℓ₂ ℓ₃} →
-            Trans (Related k {ℓ₁} {ℓ₂})
-                  (Related k {ℓ₂} {ℓ₃})
-                  (Related k {ℓ₁} {ℓ₃})
-    trans {implication}         = flip _∘′_
-    trans {reverse-implication} = λ f g → lam (app-← f ∘ app-← g)
-    trans {equivalence}         = flip Eq._∘_
-    trans {injection}           = flip Inj._∘_
-    trans {reverse-injection}   = λ f g → lam (Inj._∘_ (app-↢ f) (app-↢ g))
-    trans {left-inverse}        = flip LeftInv._∘_
-    trans {surjection}          = flip Surj._∘_
-    trans {bijection}           = flip Inv._∘_
-
-  sym : ∀ {k ℓ₁ ℓ₂} →
-        Sym (Related ⌊ k ⌋ {ℓ₁} {ℓ₂})
-            (Related ⌊ k ⌋ {ℓ₂} {ℓ₁})
-  sym {equivalence} = Eq.sym
-  sym {bijection}   = Inv.sym
-
   infix  3 _∎
   infixr 2 _∼⟨_⟩_ _↔⟨_⟩_ _↔⟨⟩_ _≡⟨_⟩_
 
   _∼⟨_⟩_ : ∀ {k x y z} (X : Set x) {Y : Set y} {Z : Set z} →
            X ∼[ k ] Y → Y ∼[ k ] Z → X ∼[ k ] Z
-  _ ∼⟨ X↝Y ⟩ Y↝Z = trans X↝Y Y↝Z
+  _ ∼⟨ X↝Y ⟩ Y↝Z = K-trans X↝Y Y↝Z
 
   -- Isomorphisms can be combined with any other kind of relatedness.
 
@@ -305,37 +328,9 @@ module EquationalReasoning where
   X ≡⟨ X≡Y ⟩ Y⇔Z = X ∼⟨ ≡⇒ X≡Y ⟩ Y⇔Z
 
   _∎ : ∀ {k x} (X : Set x) → X ∼[ k ] X
-  X ∎ = refl
-
--- For a symmetric kind and a fixed universe level we can construct a
--- setoid.
-
-isEquivalence : ∀ k ℓ → IsEquivalence {ℓ = ℓ} (Related ⌊ k ⌋)
-isEquivalence k ℓ = record
-  { refl  = _ ∎
-  ; sym   = sym
-  ; trans = _ ∼⟨_⟩_
-  } where open EquationalReasoning
-
-setoid : Symmetric-kind → (ℓ : Level) → Setoid _ _
-setoid k ℓ = record { isEquivalence = isEquivalence k ℓ }
-
--- For an arbitrary kind and a fixed universe level we can construct a
--- preorder.
-
-↔-isPreorder : ∀ k ℓ → IsPreorder _↔_ (Related k)
-↔-isPreorder k ℓ = record
-    { isEquivalence = isEquivalence bijection ℓ
-    ; reflexive     = ↔⇒
-    ; trans         = _∼⟨_⟩_ _
-    }  where open EquationalReasoning
-
-↔-preorder : Kind → (ℓ : Level) → Preorder _ _ _
-↔-preorder k ℓ = record { isPreorder = ↔-isPreorder k ℓ }
+  X ∎ = K-refl
 
 ------------------------------------------------------------------------
--- Some induced relations
-
 -- Every unary relation induces a preorder and, for symmetric kinds,
 -- an equivalence. (No claim is made that these relations are unique.)
 
@@ -346,24 +341,29 @@ InducedRelation₁ k S = λ x y → S x ∼[ k ] S y
 InducedPreorder₁ : Kind → ∀ {a s} {A : Set a} →
                    (A → Set s) → Preorder _ _ _
 InducedPreorder₁ k S = record
-  { _≈_        = P._≡_
+  { _≈_        = _≡_
   ; _∼_        = InducedRelation₁ k S
   ; isPreorder = record
     { isEquivalence = P.isEquivalence
     ; reflexive     = reflexive ∘
-                      Setoid.reflexive (setoid bijection _) ∘
+                      K-reflexive ∘
                       P.cong S
-    ; trans         = trans
+    ; trans         = K-trans
     }
-  } where open Preorder (↔-preorder _ _)
+  } where open Preorder (K-preorder _ _)
 
 InducedEquivalence₁ : Symmetric-kind → ∀ {a s} {A : Set a} →
                       (A → Set s) → Setoid _ _
 InducedEquivalence₁ k S = record
   { _≈_           = InducedRelation₁ ⌊ k ⌋ S
-  ; isEquivalence = record {refl = refl; sym = sym; trans = trans}
-  } where open Setoid (setoid _ _)
+  ; isEquivalence = record
+    { refl  = K-refl
+    ; sym   = SK-sym
+    ; trans = K-trans
+    }
+  }
 
+------------------------------------------------------------------------
 -- Every binary relation induces a preorder and, for symmetric kinds,
 -- an equivalence. (No claim is made that these relations are unique.)
 
@@ -374,18 +374,18 @@ InducedRelation₂ k _S_ = λ x y → ∀ {z} → (z S x) ∼[ k ] (z S y)
 InducedPreorder₂ : Kind → ∀ {a b s} {A : Set a} {B : Set b} →
                    (A → B → Set s) → Preorder _ _ _
 InducedPreorder₂ k _S_ = record
-  { _≈_        = P._≡_
+  { _≈_        = _≡_
   ; _∼_        = InducedRelation₂ k _S_
   ; isPreorder = record
     { isEquivalence = P.isEquivalence
     ; reflexive     = λ x≡y {z} →
                         reflexive $
-                        Setoid.reflexive (setoid bijection _) $
+                        K-reflexive $
                         P.cong (_S_ z) x≡y
 
-    ; trans         = λ i↝j j↝k → trans i↝j j↝k
+    ; trans         = λ i↝j j↝k → K-trans i↝j j↝k
     }
-  } where open Preorder (↔-preorder _ _)
+  } where open Preorder (K-preorder _ _)
 
 InducedEquivalence₂ : Symmetric-kind →
                       ∀ {a b s} {A : Set a} {B : Set b} →
@@ -397,8 +397,7 @@ InducedEquivalence₂ k _S_ = record
     ; sym   = λ i↝j → sym i↝j
     ; trans = λ i↝j j↝k → trans i↝j j↝k
     }
-  } where open Setoid (setoid _ _)
-
+  } where open Setoid (SK-setoid _ _)
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
@@ -408,8 +407,13 @@ InducedEquivalence₂ k _S_ = record
 
 -- Version 0.17
 
-preorder = ↔-preorder
+preorder = K-preorder
 {-# WARNING_ON_USAGE preorder
 "Warning: preorder was deprecated in v0.17.
-Please use ↔-preorder instead."
+Please use K-preorder instead."
+#-}
+setoid = SK-setoid
+{-# WARNING_ON_USAGE setoid
+"Warning: setoid was deprecated in v0.17.
+Please use SK-setoid instead."
 #-}

--- a/src/Function/Related.agda
+++ b/src/Function/Related.agda
@@ -330,6 +330,12 @@ module EquationalReasoning where
   _∎ : ∀ {k x} (X : Set x) → X ∼[ k ] X
   X ∎ = K-refl
 
+  sym = SK-sym
+  {-# WARNING_ON_USAGE sym
+  "Warning: EquationalReasoning.sym was deprecated in v0.17.
+  Please use SK-sym instead."
+  #-}
+
 ------------------------------------------------------------------------
 -- Every unary relation induces a preorder and, for symmetric kinds,
 -- an equivalence. (No claim is made that these relations are unique.)

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -130,7 +130,7 @@ open import Relation.Nullary.Decidable as Dec using (True)
 
 ×-isSemigroup : ∀ k ℓ → IsSemigroup {Level.suc ℓ} (Related ⌊ k ⌋) _×_
 ×-isSemigroup k ℓ = record
-  { isEquivalence = isEquivalence k ℓ
+  { isEquivalence = SK-isEquivalence k ℓ
   ; assoc         = λ _ _ _ → ↔⇒ Σ-assoc
   ; ∙-cong        = _×-cong_
   }
@@ -167,7 +167,7 @@ open import Relation.Nullary.Decidable as Dec using (True)
 
 ⊎-isSemigroup : ∀ k ℓ → IsSemigroup {Level.suc ℓ} (Related ⌊ k ⌋) _⊎_
 ⊎-isSemigroup k ℓ = record
-  { isEquivalence = isEquivalence k ℓ
+  { isEquivalence = SK-isEquivalence k ℓ
   ; assoc         = λ A B C → ↔⇒ (⊎-assoc ℓ A B C)
   ; ∙-cong        = _⊎-cong_
   }
@@ -409,13 +409,13 @@ Related-cong :
   ∀ {k a b c d} {A : Set a} {B : Set b} {C : Set c} {D : Set d} →
   A ∼[ ⌊ k ⌋ ] B → C ∼[ ⌊ k ⌋ ] D → (A ∼[ ⌊ k ⌋ ] C) ⇔ (B ∼[ ⌊ k ⌋ ] D)
 Related-cong {A = A} {B} {C} {D} A≈B C≈D =
-  Eq.equivalence (λ A≈C → B  ∼⟨ sym A≈B ⟩
+  Eq.equivalence (λ A≈C → B  ∼⟨ SK-sym A≈B ⟩
                           A  ∼⟨ A≈C ⟩
                           C  ∼⟨ C≈D ⟩
                           D  ∎)
                  (λ B≈D → A  ∼⟨ A≈B ⟩
                           B  ∼⟨ B≈D ⟩
-                          D  ∼⟨ sym C≈D ⟩
+                          D  ∼⟨ SK-sym C≈D ⟩
                           C  ∎)
   where open Related.EquationalReasoning
 


### PR DESCRIPTION
Some of the proofs in `Function.Related` that are needed to finish off #400 are currently hidden in private scope. This makes them public and attempts to come with a consistent naming scheme. The `K` stands for `Kind` and `SK` for `SymmetricKind`. 

@gallais I changed your `↔-preorder` as `_↔_` is actually the equivalence relation, not the preorder relation and therefore I think the new name is more consistent with the rest of the library.

Feel free to suggest alternative names. I also considering `Kˢ` instead of `SK` and am undecided about which is better.