### PR TITLE
[ new ] try to make formatting issue from new modules clearer

### DIFF
--- a/GenerateEverything.hs
+++ b/GenerateEverything.hs
@@ -101,7 +101,7 @@ extractHeader mod = fmap (extract . lines) $ readFileUTF8 mod
     | not (delimiter d1)
     , last d1 == '\r'
     = error $ mod ++ " contains \\r, probably due to git misconfiguration; maybe set autocrf to input?"
-  extract _ = error $ mod ++ " is malformed."
+  extract _ = error $ mod ++ " is malformed. It is required to have a module header. Please see other existing files or consult HACKING.md."
 
 -- | Formats the extracted module information.
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -51,6 +51,17 @@ How to make changes
    Your proposed changes MUST pass these tests. Note that the tests require the use of a tool called
    `fix-agda-whitespace`. See the instructions at the end of this file for how to install this.
 
+   If you are creating new modules, please make sure you are having a proper header,
+   and a brief description of what the module is for, e.g.
+   ```
+   ------------------------------------------------------------------------
+   -- The Agda standard library
+   --
+   -- {PLACE YOUR BRIEF DESCRIPTION HERE}
+   ------------------------------------------------------------------------
+   ```
+
+
 ### Upload your changes
 
 8. Use the `git add` command to add the files you have changed to your proposed commit.


### PR DESCRIPTION
This PR containing ~~two~~ one fix~~es~~:

1. I find that the produced error message when forgetting to add library header is not very clear. It just says the file is malformed, but does not mention how to fix it.
2. ~~I do not find `cabal install` in the makefile is necessary. Once I forgot to work in a sandbox and it ended up copying `GenerateEverything` to be global cabal folder. Please let me know there are better fixes for that.~~
I removed changes to `GNUmakefile`.