### PR TITLE
[ refactor ] deprecated im≡jm+n⇒[i∸j]m≡n and i∸k∸j+j∸k≡i+j∸k in Data.Nat.Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,7 +282,13 @@ anticipated any time soon, they may eventually be removed in some future release
   nonZeroDivisor-lemma
   ```
 
-* In `Function.Related`
+* In `Data.Nat.Properties`:
+  ```agda
+  i∸k∸j+j∸k≡i+j∸k
+  im≡jm+n⇒[i∸j]m≡n
+  ```
+
+* In `Function.Related`:
   ```agda
   preorder              ↦ R-preorder
   setoid                ↦ SR-setoid

--- a/src/Data/Nat/Coprimality.agda
+++ b/src/Data/Nat/Coprimality.agda
@@ -8,27 +8,25 @@ module Data.Nat.Coprimality where
 
 open import Data.Empty
 open import Data.Fin using (toℕ; fromℕ≤)
-open import Data.Fin.Properties as FinProp
+open import Data.Fin.Properties using (toℕ-fromℕ≤)
 open import Data.Nat
-open import Data.Nat.Primality
-import Data.Nat.Properties as NatProp
-open import Data.Nat.Divisibility as Div
+open import Data.Nat.Divisibility
 open import Data.Nat.GCD
 open import Data.Nat.GCD.Lemmas
+open import Data.Nat.Primality
+open import Data.Nat.Properties
 open import Data.Product as Prod
 open import Function
-open import Relation.Binary.PropositionalEquality as PropEq
-  using (_≡_; _≢_; refl)
+open import Level using (0ℓ)
+open import Relation.Binary.PropositionalEquality as P
+  using (_≡_; _≢_; refl; cong; subst; module ≡-Reasoning)
 open import Relation.Nullary
 open import Relation.Binary
-open import Algebra
-private
-  module P  = Poset Div.poset
 
 -- Coprime m n is inhabited iff m and n are coprime (relatively
 -- prime), i.e. if their only common divisor is 1.
 
-Coprime : (m n : ℕ) → Set
+Coprime : Rel ℕ 0ℓ
 Coprime m n = ∀ {i} → i ∣ m × i ∣ n → i ≡ 1
 
 -- Coprime numbers have 1 as their gcd.
@@ -37,15 +35,14 @@ coprime-gcd : ∀ {m n} → Coprime m n → GCD m n 1
 coprime-gcd {m} {n} c = GCD.is (1∣ m , 1∣ n) greatest
   where
   greatest : ∀ {d} → d ∣ m × d ∣ n → d ∣ 1
-  greatest      cd with c cd
-  greatest .{1} cd | refl = 1∣ 1
+  greatest cd with c cd
+  ... | refl = 1∣ 1
 
 -- If two numbers have 1 as their gcd, then they are coprime.
 
 gcd-coprime : ∀ {m n} → GCD m n 1 → Coprime m n
 gcd-coprime g cd with GCD.greatest g cd
-gcd-coprime g cd | divides q eq =
-  NatProp.i*j≡1⇒j≡1 q _ (PropEq.sym eq)
+... | divides q eq = i*j≡1⇒j≡1 q _ (P.sym eq)
 
 -- Coprime is decidable.
 
@@ -59,12 +56,12 @@ private
 coprime? : Decidable Coprime
 coprime? i j with gcd i j
 ... | (0           , g) = no  (0≢1  ∘ GCD.unique g ∘ coprime-gcd)
-... | (1           , g) = yes (λ {i} → gcd-coprime g {i})
+... | (1           , g) = yes (gcd-coprime g)
 ... | (suc (suc d) , g) = no  (2+≢1 ∘ GCD.unique g ∘ coprime-gcd)
 
 -- The coprimality relation is symmetric.
 
-sym : ∀ {m n} → Coprime m n → Coprime n m
+sym : Symmetric Coprime
 sym c = c ∘ swap
 
 -- Everything is coprime to 1.
@@ -75,7 +72,7 @@ sym c = c ∘ swap
 -- Nothing except for 1 is coprime to 0.
 
 0-coprimeTo-1 : ∀ {m} → Coprime 0 m → m ≡ 1
-0-coprimeTo-1 {m} c = c (m ∣0 , P.refl)
+0-coprimeTo-1 {m} c = c (m ∣0 , ∣-refl)
 
 -- If m and n are coprime, then n + m and n are also coprime.
 
@@ -125,9 +122,8 @@ data GCD′ : ℕ → ℕ → ℕ → Set where
 gcd-gcd′ : ∀ {d m n} → GCD m n d → GCD′ m n d
 gcd-gcd′         g with GCD.commonDivisor g
 gcd-gcd′ {zero}  g | (divides q₁ refl , divides q₂ refl)
-                     with q₁ * 0 | NatProp.*-comm 0 q₁
-                        | q₂ * 0 | NatProp.*-comm 0 q₂
-...                  | .0 | refl | .0 | refl = gcd-* 1 1 (1-coprimeTo 1)
+  with q₁ * 0 | *-comm 0 q₁ | q₂ * 0 | *-comm 0 q₂
+... | .0 | refl | .0 | refl = gcd-* 1 1 (1-coprimeTo 1)
 gcd-gcd′ {suc d} g | (divides q₁ refl , divides q₂ refl) =
   gcd-* q₁ q₂ (Bézout-coprime (Bézout.identity g))
 
@@ -149,11 +145,11 @@ prime⇒coprime 1             () _ _  _     _
 prime⇒coprime (suc (suc m)) _  0 () _     _
 prime⇒coprime (suc (suc m)) _  _ _  _ {1} _                       = refl
 prime⇒coprime (suc (suc m)) p  _ _  _ {0} (divides q 2+m≡q*0 , _) =
-  ⊥-elim $ NatProp.i+1+j≢i 0 (begin
+  ⊥-elim $ i+1+j≢i 0 (begin
     2 + m  ≡⟨ 2+m≡q*0 ⟩
-    q * 0  ≡⟨ proj₂ NatProp.*-zero q ⟩
+    q * 0  ≡⟨ *-zeroʳ q ⟩
     0      ∎)
-  where open PropEq.≡-Reasoning
+  where open ≡-Reasoning
 prime⇒coprime (suc (suc m)) p (suc n) _ 1+n<2+m {suc (suc i)}
               (2+i∣2+m , 2+i∣1+n) =
   ⊥-elim (p _ 2+i′∣2+m)
@@ -163,10 +159,9 @@ prime⇒coprime (suc (suc m)) p (suc n) _ 1+n<2+m {suc (suc i)}
     3 + i  ≤⟨ s≤s (∣⇒≤ 2+i∣1+n) ⟩
     2 + n  ≤⟨ 1+n<2+m ⟩
     2 + m  ∎)
-    where open NatProp.≤-Reasoning
+    where open ≤-Reasoning
 
   2+i′∣2+m : 2 + toℕ (fromℕ≤ i<m) ∣ 2 + m
-  2+i′∣2+m = PropEq.subst
-    (λ j → j ∣ 2 + m)
-    (PropEq.sym (PropEq.cong (_+_ 2) (FinProp.toℕ-fromℕ≤ i<m)))
+  2+i′∣2+m = subst (_∣ 2 + m)
+    (P.sym (cong (2 +_) (toℕ-fromℕ≤ i<m)))
     2+i∣2+m

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -7,17 +7,17 @@
 module Data.Nat.GCD where
 
 open import Data.Nat
-open import Data.Nat.Divisibility as Div
-open import Relation.Binary
-private module P = Poset Div.poset
+open import Data.Nat.Divisibility
+open import Data.Nat.GCD.Lemmas
+open import Data.Nat.Properties using (+-suc)
 open import Data.Product
-open import Relation.Binary.PropositionalEquality as PropEq using (_≡_; subst)
-open import Relation.Nullary using (Dec; yes; no)
+open import Function
 open import Induction
 open import Induction.Nat using (<′-Rec; <′-recBuilder)
 open import Induction.Lexicographic
-open import Function
-open import Data.Nat.GCD.Lemmas
+open import Relation.Binary
+open import Relation.Binary.PropositionalEquality as P using (_≡_; subst)
+open import Relation.Nullary using (Dec; yes; no)
 
 ------------------------------------------------------------------------
 -- Greatest common divisor
@@ -42,7 +42,7 @@ module GCD where
   -- The gcd is unique.
 
   unique : ∀ {d₁ d₂ m n} → GCD m n d₁ → GCD m n d₂ → d₁ ≡ d₂
-  unique d₁ d₂ = P.antisym (GCD.greatest d₂ (GCD.commonDivisor d₁))
+  unique d₁ d₂ = ∣-antisym (GCD.greatest d₂ (GCD.commonDivisor d₁))
                            (GCD.greatest d₁ (GCD.commonDivisor d₂))
 
   -- The gcd relation is "symmetric".
@@ -53,12 +53,12 @@ module GCD where
   -- The gcd relation is "reflexive".
 
   refl : ∀ {n} → GCD n n n
-  refl = is (P.refl , P.refl) proj₁
+  refl = is (∣-refl , ∣-refl) proj₁
 
   -- The GCD of 0 and n is n.
 
   base : ∀ {n} → GCD 0 n n
-  base {n} = is (n ∣0 , P.refl) proj₂
+  base {n} = is (n ∣0 , ∣-refl) proj₂
 
   -- If d is the gcd of n and k, then it is also the gcd of n and
   -- n + k.
@@ -99,10 +99,10 @@ module Bézout where
     sym (-+ x y eq) = +- y x eq
 
     refl : ∀ {d} → Identity d d d
-    refl = -+ 0 1 PropEq.refl
+    refl = -+ 0 1 P.refl
 
     base : ∀ {d} → Identity d 0 d
-    base = -+ 0 1 PropEq.refl
+    base = -+ 0 1 P.refl
 
     private
       infixl 7 _⊕_
@@ -143,7 +143,7 @@ module Bézout where
 
     stepˡ : ∀ {n k} → Lemma n (suc k) → Lemma n (suc (n + k))
     stepˡ {n} {k} (result d g b) =
-      PropEq.subst (Lemma n) (lem₀ n k) $
+      subst (Lemma n) (+-suc n k) $
         result d (GCD.step g) (Identity.step b)
 
     stepʳ : ∀ {n k} → Lemma (suc k) n → Lemma (suc (n + k)) n
@@ -176,19 +176,19 @@ module Bézout where
 
   identity : ∀ {m n d} → GCD m n d → Identity d m n
   identity {m} {n} g with lemma m n
-  identity g | result d g′ b with GCD.unique g g′
-  identity g | result d g′ b | PropEq.refl = b
+  ... | result d g′ b with GCD.unique g g′
+  ...   | P.refl = b
 
 -- Calculates the gcd of the arguments.
 
 gcd : (m n : ℕ) → ∃ λ d → GCD m n d
 gcd m n with Bézout.lemma m n
-gcd m n | Bézout.result d g _ = (d , g)
+... | Bézout.result d g _ = (d , g)
 
 -- gcd as a proposition is decidable
 
 gcd? : (m n d : ℕ) → Dec (GCD m n d)
 gcd? m n d with gcd m n
 ... | d′ , p with d′ ≟ d
-... | no ¬g = no (λ p′ → ¬g (GCD.unique p p′))
-... | yes g = yes (subst (GCD m n) g p)
+...   | no ¬g = no (¬g ∘ GCD.unique p)
+...   | yes g = yes (subst (GCD m n) g p)

--- a/src/Data/Nat/GCD/Lemmas.agda
+++ b/src/Data/Nat/GCD/Lemmas.agda
@@ -15,7 +15,25 @@ open import Relation.Binary.PropositionalEquality
 open +-*-Solver
 open ≡-Reasoning
 
-lem₀ = solve 2 (λ n k → n :+ (con 1 :+ k)  :=  con 1 :+ n :+ k) refl
+private
+  distrib-comm : ∀ x k n → x * k + x * n ≡ x * (n + k)
+  distrib-comm =
+    solve 3 (λ x k n → x :* k :+ x :* n  :=  x :* (n :+ k)) refl
+
+  distrib-comm₂ : ∀ d x k n → d + x * (n + k) ≡ d + x * k + x * n
+  distrib-comm₂ =
+    solve 4 (λ d x k n → d :+ x :* (n :+ k) :=  d :+ x :* k :+ x :* n) refl
+
+-- Other properties
+-- TODO: Can this proof be simplified? An automatic solver which can
+-- handle ∸ would be nice...
+lem₀ : ∀ i j m n → i * m ≡ j * m + n → (i ∸ j) * m ≡ n
+lem₀ i j m n eq = begin
+  (i ∸ j) * m            ≡⟨ *-distribʳ-∸ m i j ⟩
+  (i * m) ∸ (j * m)      ≡⟨ cong (_∸ j * m) eq ⟩
+  (j * m + n) ∸ (j * m)  ≡⟨ cong (_∸ j * m) (+-comm (j * m) n) ⟩
+  (n + j * m) ∸ (j * m)  ≡⟨ m+n∸n≡m n (j * m) ⟩
+  n                      ∎
 
 lem₁ : ∀ i j → 2 + i ≤′ 2 + j + i
 lem₁ i j = ≤⇒≤′ $ s≤s $ s≤s $ n≤m+n j i
@@ -23,9 +41,7 @@ lem₁ i j = ≤⇒≤′ $ s≤s $ s≤s $ n≤m+n j i
 lem₂ : ∀ d x {k n} →
        d + x * k ≡ x * n → d + x * (n + k) ≡ 2 * x * n
 lem₂ d x {k} {n} eq = begin
-  d + x * (n + k)    ≡⟨ solve 4 (λ d x n k → d :+ x :* (n :+ k)
-                                         :=  d :+ x :* k :+ x :* n)
-                                refl d x n k ⟩
+  d + x * (n + k)    ≡⟨ distrib-comm₂ d x k n ⟩
   d + x * k + x * n  ≡⟨ cong₂ _+_ eq refl ⟩
   x * n + x * n      ≡⟨ solve 3 (λ x n k → x :* n :+ x :* n
                                        :=  con 2 :* x :* n)
@@ -36,10 +52,8 @@ lem₃ : ∀ d x {i k n} →
        d + (1 + x + i) * k ≡ x * n →
        d + (1 + x + i) * (n + k) ≡ (1 + 2 * x + i) * n
 lem₃ d x {i} {k} {n} eq = begin
-  d + y * (n + k)      ≡⟨ solve 4 (λ d y n k → d :+ y :* (n :+ k)
-                                           :=  (d :+ y :* k) :+ y :* n)
-                                  refl d y n k ⟩
-  (d + y * k) + y * n  ≡⟨ cong₂ _+_ eq refl ⟩
+  d + y * (n + k)      ≡⟨ distrib-comm₂ d y k n ⟩
+  d + y * k + y * n    ≡⟨ cong₂ _+_ eq refl ⟩
   x * n + y * n        ≡⟨ solve 3 (λ x n i → x :* n :+ (con 1 :+ x :+ i) :* n
                                          :=  (con 1 :+ con 2 :* x :+ i) :* n)
                                   refl x n i ⟩
@@ -50,18 +64,12 @@ lem₄ : ∀ d y {k i} n →
        d + y * k ≡ (1 + y + i) * n →
        d + y * (n + k) ≡ (1 + 2 * y + i) * n
 lem₄ d y {k} {i} n eq = begin
-  d + y * (n + k)          ≡⟨ solve 4 (λ d y n k → d :+ y :* (n :+ k)
-                                               :=  d :+ y :* k :+ y :* n)
-                                      refl d y n k ⟩
+  d + y * (n + k)          ≡⟨ distrib-comm₂ d y k n ⟩
   d + y * k + y * n        ≡⟨ cong₂ _+_ eq refl ⟩
   (1 + y + i) * n + y * n  ≡⟨ solve 3 (λ y i n → (con 1 :+ y :+ i) :* n :+ y :* n
                                              :=  (con 1 :+ con 2 :* y :+ i) :* n)
                                       refl y i n ⟩
   (1 + 2 * y + i) * n      ∎
-
-private
-  distrib-comm =
-    solve 3 (λ x k n → x :* k :+ x :* n  :=  x :* (n :+ k)) refl
 
 lem₅ : ∀ d x {n k} →
        d + x * n ≡ x * k →
@@ -101,13 +109,13 @@ lem₈ : ∀ {i j k q} x y →
        1 + y * j ≡ x * i → j * k ≡ q * i →
        k ≡ (x * k ∸ y * q) * i
 lem₈ {i} {j} {k} {q} x y eq eq′ =
-  sym (im≡jm+n⇒[i∸j]m≡n (x * k) (y * q) i k lemma)
+  sym (lem₀ (x * k) (y * q) i k lemma)
   where
   lemma = begin
     x * k * i        ≡⟨ solve 3 (λ x k i → x :* k :* i
                                        :=  x :* i :* k)
                                 refl x k i ⟩
-    x * i * k        ≡⟨ cong (λ n → n * k) (sym eq) ⟩
+    x * i * k        ≡⟨ cong (_* k) (sym eq) ⟩
     (1 + y * j) * k  ≡⟨ solve 3 (λ y j k → (con 1 :+ y :* j) :* k
                                        :=  y :* (j :* k) :+ k)
                                 refl y j k ⟩
@@ -121,7 +129,7 @@ lem₉ : ∀ {i j k q} x y →
        1 + x * i ≡ y * j → j * k ≡ q * i →
        k ≡ (y * q ∸ x * k) * i
 lem₉ {i} {j} {k} {q} x y eq eq′ =
-  sym (im≡jm+n⇒[i∸j]m≡n (y * q) (x * k) i k lemma)
+  sym (lem₀ (y * q) (x * k) i k lemma)
   where
   lem   = solve 3 (λ a b c → a :* b :* c  :=  b :* c :* a) refl
   lemma = begin
@@ -139,7 +147,7 @@ lem₁₀ : ∀ {a′} b c {d} e f → let a = suc a′ in
         d ≡ 1
 lem₁₀ {a′} b c {d} e f eq =
   i*j≡1⇒j≡1 (e * f ∸ b * c) d
-    (im≡jm+n⇒[i∸j]m≡n (e * f) (b * c) d 1
+    (lem₀ (e * f) (b * c) d 1
        (*-cancelʳ-≡ (e * f * d) (b * c * d + 1) (begin
           e * f * d * a        ≡⟨ solve 4 (λ e f d a → e :* f :* d :* a
                                                    :=  e :* (f :* d :* a))
@@ -155,18 +163,14 @@ lem₁₁ : ∀ {i j m n k d} x y →
        1 + y * j ≡ x * i → i * k ≡ m * d → j * k ≡ n * d →
        k ≡ (x * m ∸ y * n) * d
 lem₁₁ {i} {j} {m} {n} {k} {d} x y eq eq₁ eq₂ =
-  sym (im≡jm+n⇒[i∸j]m≡n (x * m) (y * n) d k lemma)
-  where
-  assoc = solve 3 (λ x y z → x :* y :* z  :=  x :* (y :* z)) refl
-
-  lemma = begin
-    x * m * d        ≡⟨ assoc x m d ⟩
-    x * (m * d)      ≡⟨ cong (_*_ x) (sym eq₁) ⟩
-    x * (i * k)      ≡⟨ sym (assoc x i k) ⟩
+  sym (lem₀ (x * m) (y * n) d k (begin
+    x * m * d        ≡⟨ *-assoc x m d ⟩
+    x * (m * d)      ≡⟨ cong (x *_) (sym eq₁) ⟩
+    x * (i * k)      ≡⟨ sym (*-assoc x i k) ⟩
     x * i * k        ≡⟨ cong₂ _*_ (sym eq) refl ⟩
     (1 + y * j) * k  ≡⟨ solve 3 (λ y j k → (con 1 :+ y :* j) :* k
                                        :=  y :* (j :* k) :+ k)
                                 refl y j k ⟩
     y * (j * k) + k  ≡⟨ cong (λ p → y * p + k) eq₂ ⟩
-    y * (n * d) + k  ≡⟨ cong₂ _+_ (sym $ assoc y n d) refl ⟩
-    y * n * d + k    ∎
+    y * (n * d) + k  ≡⟨ cong₂ _+_ (sym $ *-assoc y n d) refl ⟩
+    y * n * d + k    ∎))

--- a/src/Data/Nat/InfinitelyOften.agda
+++ b/src/Data/Nat/InfinitelyOften.agda
@@ -6,18 +6,17 @@
 
 module Data.Nat.InfinitelyOften where
 
+open import Category.Monad using (RawMonad)
 open import Level using (0ℓ)
-open import Algebra
-open import Category.Monad
-open import Data.Empty
-open import Function
+open import Data.Empty using (⊥-elim)
 open import Data.Nat
 open import Data.Nat.Properties
 open import Data.Product as Prod hiding (map)
 open import Data.Sum hiding (map)
+open import Function
 open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary
-open import Relation.Nullary.Negation
+open import Relation.Nullary using (¬_)
+open import Relation.Nullary.Negation using (¬¬-Monad; call/cc)
 open import Relation.Unary using (Pred; _∪_; _⊆_)
 open RawMonad (¬¬-Monad {p = 0ℓ})
 
@@ -25,6 +24,11 @@ open RawMonad (¬¬-Monad {p = 0ℓ})
 
 Fin : ∀ {ℓ} → Pred ℕ ℓ → Set ℓ
 Fin P = ∃ λ i → ∀ j → i ≤ j → ¬ P j
+
+-- A non-constructive definition of "true infinitely often".
+
+Inf : ∀ {ℓ} → Pred ℕ ℓ → Set ℓ
+Inf P = ¬ Fin P
 
 -- Fin is preserved by binary sums.
 
@@ -43,11 +47,6 @@ _∪-Fin_ {P = P} {Q} (i , ¬p) (j , ¬q) = (i ⊔ j , helper)
     j ⊔ i  ≡⟨ ⊔-comm j i ⟩
     i ⊔ j  ≤⟨ i⊔j≤k ⟩
     k      ∎) q
-
--- A non-constructive definition of "true infinitely often".
-
-Inf : ∀ {ℓ} → Pred ℕ ℓ → Set ℓ
-Inf P = ¬ Fin P
 
 -- Inf commutes with binary sums (in the double-negation monad).
 

--- a/src/Data/Nat/Primality.agda
+++ b/src/Data/Nat/Primality.agda
@@ -6,22 +6,22 @@
 
 module Data.Nat.Primality where
 
-open import Data.Empty
-open import Data.Fin as Fin hiding (_+_)
+open import Data.Empty using (⊥)
+open import Data.Fin using (Fin; toℕ)
 open import Data.Fin.Properties using (all?)
-open import Data.Nat
-open import Data.Nat.Divisibility
-open import Relation.Nullary
-open import Relation.Nullary.Decidable
-open import Relation.Nullary.Negation
-open import Relation.Unary
+open import Data.Nat using (ℕ; suc; _+_)
+open import Data.Nat.Divisibility using (_∤_; _∣?_)
+open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (from-yes)
+open import Relation.Nullary.Negation using (¬?)
+open import Relation.Unary using (Decidable)
 
 -- Definition of primality.
 
 Prime : ℕ → Set
 Prime 0             = ⊥
 Prime 1             = ⊥
-Prime (suc (suc n)) = (i : Fin n) → ¬ (2 + Fin.toℕ i ∣ 2 + n)
+Prime (suc (suc n)) = (i : Fin n) → 2 + toℕ i ∤ 2 + n
 
 -- Decision procedure for primality.
 

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1106,29 +1106,6 @@ m⊓n+n∸m≡n (suc m) (suc n) = cong suc $ m⊓n+n∸m≡n m n
 ∸-distribʳ-⊔ (suc x) (suc y) zero    = sym (⊔-identityʳ (y ∸ x))
 ∸-distribʳ-⊔ (suc x) (suc y) (suc z) = ∸-distribʳ-⊔ x y z
 
--- Other properties
--- TODO: Can this proof be simplified? An automatic solver which can
--- handle ∸ would be nice...
-i∸k∸j+j∸k≡i+j∸k : ∀ i j k → i ∸ (k ∸ j) + (j ∸ k) ≡ i + j ∸ k
-i∸k∸j+j∸k≡i+j∸k zero    j k    = cong (_+ (j ∸ k)) (0∸n≡0 (k ∸ j))
-i∸k∸j+j∸k≡i+j∸k (suc i) j zero = cong (λ x → suc i ∸ x + j) (0∸n≡0 j)
-i∸k∸j+j∸k≡i+j∸k (suc i) zero (suc k) = begin
-  i ∸ k + 0  ≡⟨ +-identityʳ _ ⟩
-  i ∸ k      ≡⟨ cong (_∸ k) (sym (+-identityʳ _)) ⟩
-  i + 0 ∸ k  ∎
-i∸k∸j+j∸k≡i+j∸k (suc i) (suc j) (suc k) = begin
-  suc i ∸ (k ∸ j) + (j ∸ k) ≡⟨ i∸k∸j+j∸k≡i+j∸k (suc i) j k ⟩
-  suc i + j ∸ k             ≡⟨ cong (_∸ k) (sym (+-suc i j)) ⟩
-  i + suc j ∸ k             ∎
-
-im≡jm+n⇒[i∸j]m≡n : ∀ i j m n → i * m ≡ j * m + n → (i ∸ j) * m ≡ n
-im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
-  (i ∸ j) * m            ≡⟨ *-distribʳ-∸ m i j ⟩
-  (i * m) ∸ (j * m)      ≡⟨ cong (_∸ j * m) eq ⟩
-  (j * m + n) ∸ (j * m)  ≡⟨ cong (_∸ j * m) (+-comm (j * m) n) ⟩
-  (n + j * m) ∸ (j * m)  ≡⟨ m+n∸n≡m n (j * m) ⟩
-  n                      ∎
-
 ------------------------------------------------------------------------
 -- Properties of ⌊_/2⌋
 
@@ -1282,4 +1259,31 @@ Please use i+1+j≰i instead."
 {-# WARNING_ON_USAGE ≤-steps
 "Warning: ≤-steps was deprecated in v0.15.
 Please use ≤-stepsˡ instead."
+#-}
+
+-- Version 0.17
+
+i∸k∸j+j∸k≡i+j∸k : ∀ i j k → i ∸ (k ∸ j) + (j ∸ k) ≡ i + j ∸ k
+i∸k∸j+j∸k≡i+j∸k zero    j k    = cong (_+ (j ∸ k)) (0∸n≡0 (k ∸ j))
+i∸k∸j+j∸k≡i+j∸k (suc i) j zero = cong (λ x → suc i ∸ x + j) (0∸n≡0 j)
+i∸k∸j+j∸k≡i+j∸k (suc i) zero (suc k) = begin
+  i ∸ k + 0  ≡⟨ +-identityʳ _ ⟩
+  i ∸ k      ≡⟨ cong (_∸ k) (sym (+-identityʳ _)) ⟩
+  i + 0 ∸ k  ∎
+i∸k∸j+j∸k≡i+j∸k (suc i) (suc j) (suc k) = begin
+  suc i ∸ (k ∸ j) + (j ∸ k) ≡⟨ i∸k∸j+j∸k≡i+j∸k (suc i) j k ⟩
+  suc i + j ∸ k             ≡⟨ cong (_∸ k) (sym (+-suc i j)) ⟩
+  i + suc j ∸ k             ∎
+{-# WARNING_ON_USAGE i∸k∸j+j∸k≡i+j∸k
+"Warning: i∸k∸j+j∸k≡i+j∸k was deprecated in v0.17."
+#-}
+im≡jm+n⇒[i∸j]m≡n : ∀ i j m n → i * m ≡ j * m + n → (i ∸ j) * m ≡ n
+im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
+  (i ∸ j) * m            ≡⟨ *-distribʳ-∸ m i j ⟩
+  (i * m) ∸ (j * m)      ≡⟨ cong (_∸ j * m) eq ⟩
+  (j * m + n) ∸ (j * m)  ≡⟨ cong (_∸ j * m) (+-comm (j * m) n) ⟩
+  (n + j * m) ∸ (j * m)  ≡⟨ m+n∸n≡m n (j * m) ⟩
+  n                      ∎
+{-# WARNING_ON_USAGE im≡jm+n⇒[i∸j]m≡n
+"Warning: im≡jm+n⇒[i∸j]m≡n was deprecated in v0.17."
 #-}


### PR DESCRIPTION
Various tidying up of proofs. The only major change is to deprecate `im≡jm+n⇒[i∸j]m≡n` and `i∸k∸j+j∸k≡i+j∸k` in `Data.Nat.Properties`. Both of them are far too specific to have in `Data.Nat.Properties`. The latter was never used in the library, the former only used in `Data.Nat.GCD.Lemmas` which is full of similarly specific proofs.