### PR TITLE
[ new ] flipped version of <$>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,6 +314,11 @@ Other minor additions
   record RawSemiring  c ℓ : Set (suc (c ⊔ ℓ))
   ```
 
+* Added new function `Category.Functor`'s `RawFunctor`:
+  ```agda
+  _<&>_ : F A → (A → B) → F B
+  ```
+
 * Added new function to `Category.Monad.Indexed`:
   ```agda
   RawIMonadT : (T : IFun I f → IFun I f) → Set (i ⊔ suc f)

--- a/src/Category/Functor.agda
+++ b/src/Category/Functor.agda
@@ -15,12 +15,16 @@ open import Relation.Binary.PropositionalEquality
 
 record RawFunctor {ℓ} (F : Set ℓ → Set ℓ) : Set (suc ℓ) where
   infixl 4 _<$>_ _<$_
+  infixl 1 _<&>_
 
   field
     _<$>_ : ∀ {A B} → (A → B) → F A → F B
 
   _<$_ : ∀ {A B} → A → F B → F A
   x <$ y = const x <$> y
+
+  _<&>_ : ∀ {A B} → F A → (A → B) → F B
+  _<&>_ = flip _<$>_
 
 -- A functor morphism from F₁ to F₂ is an operation op such that
 -- op (F₁ f x) ≡ F₂ f (op x)


### PR DESCRIPTION
Noticed we were missing <&>. Picked the [same fixity as Haskell's](https://hackage.haskell.org/package/base-4.11.1.0/docs/Data-Functor.html#v:-60--38--62-)