### PR TITLE
Relax decidability module parameter of Algebra.Solver.Ring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ Splitting up `Data.Maybe` into the standard hierarchy.
   Algebra.Solver.Ring.NaturalCoefficients
   ```
 
+* Added `_:×_` operator to `Algebra.Solver.Ring`.
+
 * Created a module `Algebra.Solver.Ring.NaturalCoefficients.Default` that
   instantiates the solver for any `CommutativeSemiring`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Splitting up `Data.Maybe` into the standard hierarchy.
   Eq-isDecEquivalence ↦ isDecEquivalence
   ```
 
+#### Other
+
+* Moved `_≟_` from `Data.Bool.Base` to `Data.Bool.Properties`. Backwards
+  compatibility has been (nearly completely) preserved by having `Data.Bool`
+  publicly re-export `_≟_`.
+
+
 Other major changes
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,12 +43,24 @@ Splitting up `Data.Maybe` into the standard hierarchy.
   Eq-isDecEquivalence ↦ isDecEquivalence
   ```
 
+#### Refactoring of ring solvers
+
+* In the ring solvers below, the `Decidable` module parameter was replaced by a
+  strictly weaker parameter `Relation.Binary.Core.WeaklyDecidable`, which makes
+  the ring solvers more versatile.
+  ```
+  Algebra.Solver.Ring
+  Algebra.Solver.Ring.NaturalCoefficients
+  ```
+
+* Created a module `Algebra.Solver.Ring.NaturalCoefficients.Default` that
+  instantiates the solver for any `CommutativeSemiring`.
+
 #### Other
 
 * Moved `_≟_` from `Data.Bool.Base` to `Data.Bool.Properties`. Backwards
   compatibility has been (nearly completely) preserved by having `Data.Bool`
   publicly re-export `_≟_`.
-
 
 Other major changes
 -------------------

--- a/src/Algebra/Solver/IdempotentCommutativeMonoid.agda
+++ b/src/Algebra/Solver/IdempotentCommutativeMonoid.agda
@@ -8,7 +8,7 @@
 
 open import Algebra
 
-open import Data.Bool.Base as Bool using (Bool; true; false; if_then_else_; _∨_)
+open import Data.Bool as Bool using (Bool; true; false; if_then_else_; _∨_)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Maybe as Maybe
   using (Maybe; decToMaybe; From-just; from-just)

--- a/src/Algebra/Solver/Ring.agda
+++ b/src/Algebra/Solver/Ring.agda
@@ -44,7 +44,7 @@ open import Function
 open import Level using (_⊔_)
 
 infix  9 :-_ -H_ -N_
-infixr 9 _:^_ _^N_
+infixr 9 _:×_ _:^_ _^N_
 infix  8 _*x+_ _*x+HN_ _*x+H_
 infixl 8 _:*_ _*N_ _*H_ _*NH_ _*HN_
 infixl 7 _:+_ _:-_ _+H_ _+N_
@@ -76,6 +76,10 @@ _:*_ = op [*]
 
 _:-_ : ∀ {n} → Polynomial n → Polynomial n → Polynomial n
 x :- y = x :+ :- y
+
+_:×_ : ∀ {n} → ℕ → Polynomial n → Polynomial n
+zero :× p = con C.0#
+suc m :× p = p :+ m :× p
 
 -- Semantics.
 

--- a/src/Algebra/Solver/Ring.agda
+++ b/src/Algebra/Solver/Ring.agda
@@ -11,15 +11,14 @@
 
 open import Algebra
 open import Algebra.Solver.Ring.AlmostCommutativeRing
-
-open import Relation.Binary
+open import Relation.Binary.Core using (WeaklyDecidable)
 
 module Algebra.Solver.Ring
   {r₁ r₂ r₃}
   (Coeff : RawRing r₁)               -- Coefficient "ring".
   (R : AlmostCommutativeRing r₂ r₃)  -- Main "ring".
   (morphism : Coeff -Raw-AlmostCommutative⟶ R)
-  (_coeff≟_ : Decidable (Induced-equivalence morphism))
+  (_coeff≟_ : WeaklyDecidable (Induced-equivalence morphism))
   where
 
 open import Algebra.Solver.Ring.Lemmas Coeff R morphism
@@ -40,6 +39,7 @@ import Relation.Binary.Reflection as Reflection
 open import Data.Nat.Base using (ℕ; suc; zero)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Vec using (Vec; []; _∷_; lookup)
+open import Data.Maybe.Base using (just; nothing)
 open import Function
 open import Level using (_⊔_)
 
@@ -161,24 +161,24 @@ mutual
 
 mutual
 
-  -- Equality is decidable.
+  -- Equality is weakly decidable.
 
-  _≟H_ : ∀ {n} → Decidable (_≈H_ {n = n})
-  ∅           ≟H ∅           = yes ∅
-  ∅           ≟H (_ *x+ _)   = no λ()
-  (_ *x+ _)   ≟H ∅           = no λ()
+  _≟H_ : ∀ {n} → WeaklyDecidable (_≈H_ {n = n})
+  ∅           ≟H ∅           = just ∅
+  ∅           ≟H (_ *x+ _)   = nothing
+  (_ *x+ _)   ≟H ∅           = nothing
   (p₁ *x+ c₁) ≟H (p₂ *x+ c₂) with p₁ ≟H p₂ | c₁ ≟N c₂
-  ... | yes p₁≈p₂ | yes c₁≈c₂ = yes (p₁≈p₂ *x+ c₁≈c₂)
-  ... | _         | no  c₁≉c₂ = no  λ { (_ *x+ c₁≈c₂) → c₁≉c₂ c₁≈c₂ }
-  ... | no  p₁≉p₂ | _         = no  λ { (p₁≈p₂ *x+ _) → p₁≉p₂ p₁≈p₂ }
+  ... | just p₁≈p₂ | just c₁≈c₂ = just (p₁≈p₂ *x+ c₁≈c₂)
+  ... | _          | nothing    = nothing
+  ... | nothing    | _          = nothing
 
-  _≟N_ : ∀ {n} → Decidable (_≈N_ {n = n})
+  _≟N_ : ∀ {n} → WeaklyDecidable (_≈N_ {n = n})
   con c₁ ≟N con c₂ with c₁ coeff≟ c₂
-  ... | yes c₁≈c₂ = yes (con c₁≈c₂)
-  ... | no  c₁≉c₂ = no  λ { (con c₁≈c₂) → c₁≉c₂ c₁≈c₂}
+  ... | just c₁≈c₂ = just (con c₁≈c₂)
+  ... | nothing    = nothing
   poly p₁ ≟N poly p₂ with p₁ ≟H p₂
-  ... | yes p₁≈p₂ = yes (poly p₁≈p₂)
-  ... | no  p₁≉p₂ = no  λ { (poly p₁≈p₂) → p₁≉p₂ p₁≈p₂ }
+  ... | just p₁≈p₂ = just (poly p₁≈p₂)
+  ... | nothing    = nothing
 
 mutual
 
@@ -226,8 +226,8 @@ mutual
 _*x+HN_ : ∀ {n} → HNF (suc n) → Normal n → HNF (suc n)
 (p *x+ c′) *x+HN c = (p *x+ c′) *x+ c
 ∅          *x+HN c with c ≟N 0N
-... | yes c≈0 = ∅
-... | no  c≉0 = ∅ *x+ c
+... | just c≈0 = ∅
+... | nothing  = ∅ *x+ c
 
 mutual
 
@@ -254,14 +254,14 @@ mutual
   _*NH_ : ∀ {n} → Normal n → HNF (suc n) → HNF (suc n)
   c *NH ∅          = ∅
   c *NH (p *x+ c′) with c ≟N 0N
-  ... | yes c≈0 = ∅
-  ... | no  c≉0 = (c *NH p) *x+ (c *N c′)
+  ... | just c≈0 = ∅
+  ... | nothing  = (c *NH p) *x+ (c *N c′)
 
   _*HN_ : ∀ {n} → HNF (suc n) → Normal n → HNF (suc n)
   ∅          *HN c = ∅
   (p *x+ c′) *HN c with c ≟N 0N
-  ... | yes c≈0 = ∅
-  ... | no  c≉0 = (p *HN c) *x+ (c′ *N c)
+  ... | just c≈0 = ∅
+  ... | nothing  = (p *HN c) *x+ (c′ *N c)
 
   _*H_ : ∀ {n} → HNF (suc n) → HNF (suc n) → HNF (suc n)
   ∅           *H _           = ∅
@@ -342,17 +342,17 @@ normalise (:- t)         = -N normalise t
             ∀ ρ → ⟦ p *x+HN c ⟧H ρ ≈ ⟦ p *x+ c ⟧H ρ
 *x+HN≈*x+ (p *x+ c′) c ρ       = refl
 *x+HN≈*x+ ∅          c (x ∷ ρ) with c ≟N 0N
-... | yes c≈0 = begin
+... | just c≈0 = begin
   0#                 ≈⟨ 0≈⟦0⟧ c≈0 ρ ⟩
   ⟦ c ⟧N ρ           ≈⟨ sym $ lemma₆ _ _ ⟩
   0# * x + ⟦ c ⟧N ρ  ∎
-... | no c≉0 = refl
+... | nothing = refl
 
 ∅*x+HN-homo : ∀ {n} (c : Normal n) x ρ →
               ⟦ ∅ *x+HN c ⟧H (x ∷ ρ) ≈ ⟦ c ⟧N ρ
 ∅*x+HN-homo c x ρ with c ≟N 0N
-... | yes c≈0 = 0≈⟦0⟧ c≈0 ρ
-... | no  c≉0 = lemma₆ _ _
+... | just c≈0 = 0≈⟦0⟧ c≈0 ρ
+... | nothing = lemma₆ _ _
 
 mutual
 
@@ -396,11 +396,11 @@ mutual
     ⟦ c *NH p ⟧H (x ∷ ρ) ≈ ⟦ c ⟧N ρ * ⟦ p ⟧H (x ∷ ρ)
   *NH-homo c ∅          x ρ = sym (*-zeroʳ _)
   *NH-homo c (p *x+ c′) x ρ with c ≟N 0N
-  ... | yes c≈0 = begin
+  ... | just c≈0 = begin
     0#                                            ≈⟨ sym (*-zeroˡ _) ⟩
     0# * (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ)         ≈⟨ 0≈⟦0⟧ c≈0 ρ ⟨ *-cong ⟩ refl ⟩
     ⟦ c ⟧N ρ  * (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ)  ∎
-  ... | no c≉0 = begin
+  ... | nothing = begin
     ⟦ c *NH p ⟧H (x ∷ ρ) * x + ⟦ c *N c′ ⟧N ρ                 ≈⟨ (*NH-homo c p x ρ ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ *N-homo c c′ ρ ⟩
     (⟦ c ⟧N ρ * ⟦ p ⟧H (x ∷ ρ)) * x + (⟦ c ⟧N ρ * ⟦ c′ ⟧N ρ)  ≈⟨ lemma₃ _ _ _ _ ⟩
     ⟦ c ⟧N ρ * (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ)               ∎
@@ -410,11 +410,11 @@ mutual
     ⟦ p *HN c ⟧H (x ∷ ρ) ≈ ⟦ p ⟧H (x ∷ ρ) * ⟦ c ⟧N ρ
   *HN-homo ∅          c x ρ = sym (*-zeroˡ _)
   *HN-homo (p *x+ c′) c x ρ with c ≟N 0N
-  ... | yes c≈0 = begin
+  ... | just c≈0 = begin
     0#                                           ≈⟨ sym (*-zeroʳ _) ⟩
     (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ) * 0#        ≈⟨ refl ⟨ *-cong ⟩ 0≈⟦0⟧ c≈0 ρ ⟩
     (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ) * ⟦ c ⟧N ρ  ∎
-  ... | no c≉0 = begin
+  ... | nothing = begin
     ⟦ p *HN c ⟧H (x ∷ ρ) * x + ⟦ c′ *N c ⟧N ρ                 ≈⟨ (*HN-homo p c x ρ ⟨ *-cong ⟩ refl) ⟨ +-cong ⟩ *N-homo c′ c ρ ⟩
     (⟦ p ⟧H (x ∷ ρ) * ⟦ c ⟧N ρ) * x + (⟦ c′ ⟧N ρ * ⟦ c ⟧N ρ)  ≈⟨ lemma₂ _ _ _ _ ⟩
     (⟦ p ⟧H (x ∷ ρ) * x + ⟦ c′ ⟧N ρ) * ⟦ c ⟧N ρ               ∎

--- a/src/Algebra/Solver/Ring/NaturalCoefficients.agda
+++ b/src/Algebra/Solver/Ring/NaturalCoefficients.agda
@@ -7,14 +7,14 @@
 
 open import Algebra
 import Algebra.Operations.Semiring as SemiringOps
-open import Relation.Nullary
+open import Data.Maybe.Base using (Maybe; just; nothing; map)
 
 module Algebra.Solver.Ring.NaturalCoefficients
          {r₁ r₂}
          (R : CommutativeSemiring r₁ r₂)
          (dec : let open CommutativeSemiring R
                     open SemiringOps semiring in
-                ∀ m n → Dec (m × 1# ≈ n × 1#)) where
+                ∀ m n → Maybe (m × 1# ≈ n × 1#)) where
 
 import Algebra.Solver.Ring
 open import Algebra.Solver.Ring.AlmostCommutativeRing
@@ -22,7 +22,6 @@ open import Data.Nat.Base as ℕ
 open import Data.Product using (module Σ)
 open import Function
 import Relation.Binary.EqReasoning
-import Relation.Nullary.Decidable as Dec
 
 open CommutativeSemiring R
 open SemiringOps semiring
@@ -60,8 +59,8 @@ private
 
   -- Equality of certain expressions can be decided.
 
-  dec′ : ∀ m n → Dec (m ×′ 1# ≈ n ×′ 1#)
-  dec′ m n = Dec.map′ to from (dec m n)
+  dec′ : ∀ m n → Maybe (m ×′ 1# ≈ n ×′ 1#)
+  dec′ m n = map to (dec m n)
     where
     to : m × 1# ≈ n × 1# → m ×′ 1# ≈ n ×′ 1#
     to m≈n = begin
@@ -69,13 +68,6 @@ private
       m ×  1#  ≈⟨ m≈n ⟩
       n ×  1#  ≈⟨ ×≈×′ n 1# ⟩
       n ×′ 1#  ∎
-
-    from : m ×′ 1# ≈ n ×′ 1# → m × 1# ≈ n × 1#
-    from m≈n = begin
-      m ×  1#  ≈⟨ ×≈×′ m 1# ⟩
-      m ×′ 1#  ≈⟨ m≈n ⟩
-      n ×′ 1#  ≈⟨ sym $ ×≈×′ n 1# ⟩
-      n ×  1#  ∎
 
 -- The instantiation.
 

--- a/src/Algebra/Solver/Ring/NaturalCoefficients/Default.agda
+++ b/src/Algebra/Solver/Ring/NaturalCoefficients/Default.agda
@@ -1,0 +1,30 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Instantiates the natural coefficients ring solver, using coefficient
+-- equality induced by ℕ.
+--
+-- This is sufficient for proving equalities that are independent of the
+-- characteristic.  In particular, this is enough for equalities in rings of
+-- characteristic 0.
+------------------------------------------------------------------------
+
+open import Algebra
+
+module Algebra.Solver.Ring.NaturalCoefficients.Default
+         {r₁ r₂} (R : CommutativeSemiring r₁ r₂) where
+
+import Algebra.Operations.Semiring as SemiringOps
+open import Data.Maybe.Base using (Maybe; map)
+open import Data.Nat using (_≟_)
+open import Relation.Binary.Consequences using (dec⟶weaklyDec)
+import Relation.Binary.PropositionalEquality as P
+
+open CommutativeSemiring R
+open SemiringOps semiring
+
+private
+  dec : ∀ m n → Maybe (m × 1# ≈ n × 1#)
+  dec m n = map (λ { P.refl → refl }) (dec⟶weaklyDec _≟_ m n)
+
+open import Algebra.Solver.Ring.NaturalCoefficients R dec public

--- a/src/Algebra/Solver/Ring/Simple.agda
+++ b/src/Algebra/Solver/Ring/Simple.agda
@@ -7,6 +7,7 @@
 
 open import Algebra.Solver.Ring.AlmostCommutativeRing
 open import Relation.Binary
+open import Relation.Binary.Consequences using (dec⟶weaklyDec)
 
 module Algebra.Solver.Ring.Simple
          {r₁ r₂} (R : AlmostCommutativeRing r₁ r₂)
@@ -15,4 +16,4 @@ module Algebra.Solver.Ring.Simple
 
 open AlmostCommutativeRing R
 import Algebra.Solver.Ring as RS
-open RS rawRing R (-raw-almostCommutative⟶ R) _≟_ public
+open RS rawRing R (-raw-almostCommutative⟶ R) (dec⟶weaklyDec _≟_) public

--- a/src/Data/Bool.agda
+++ b/src/Data/Bool.agda
@@ -17,6 +17,12 @@ open import Relation.Binary.PropositionalEquality as PropEq
 open import Data.Bool.Base public
 
 ------------------------------------------------------------------------
+-- Publicly re-export queries
+
+open import Data.Bool.Properties public
+  using (_≟_)
+
+------------------------------------------------------------------------
 -- Some properties
 
 decSetoid : DecSetoid _ _

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -8,8 +8,6 @@ module Data.Bool.Base where
 open import Data.Unit.Base using (⊤)
 open import Data.Empty
 open import Relation.Nullary
-open import Relation.Binary.Core
-open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 
 infixr 6 _∧_
 infixr 5 _∨_ _xor_
@@ -49,14 +47,3 @@ false ∨ b = b
 _xor_ : Bool → Bool → Bool
 true  xor b = not b
 false xor b = b
-
-------------------------------------------------------------------------
--- Queries
-
-infix 4 _≟_
-
-_≟_ : Decidable {A = Bool} _≡_
-true  ≟ true  = yes refl
-false ≟ false = yes refl
-true  ≟ false = no λ()
-false ≟ true  = no λ()

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -7,7 +7,7 @@
 module Data.Bool.Properties where
 
 open import Algebra
-open import Data.Bool
+open import Data.Bool.Base
 open import Data.Empty
 open import Data.Product
 open import Data.Sum
@@ -15,13 +15,26 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence
   using (_⇔_; equivalence; module Equivalence)
+open import Relation.Binary.Core using (Decidable)
 open import Relation.Binary.PropositionalEquality
   hiding ([_]; proof-irrelevance)
+open import Relation.Nullary using (yes; no)
 open import Relation.Unary using (Irrelevant)
 
 open import Algebra.FunctionProperties (_≡_ {A = Bool})
 open import Algebra.Structures (_≡_ {A = Bool})
 open ≡-Reasoning
+
+------------------------------------------------------------------------
+-- Queries
+
+infix 4 _≟_
+
+_≟_ : Decidable {A = Bool} _≡_
+true  ≟ true  = yes refl
+false ≟ false = yes refl
+true  ≟ false = no λ()
+false ≟ true  = no λ()
 
 ------------------------------------------------------------------------
 -- Properties of _∨_

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -12,7 +12,6 @@ import Algebra.Structures as AlgebraicStructures
 import Algebra.Properties.Lattice as L
 import Algebra.Properties.DistributiveLattice as DL
 import Algebra.Properties.BooleanAlgebra as BA
-open import Data.Bool.Base using (_≟_)
 open import Data.Bool.Properties
 open import Data.Fin using (Fin; suc; zero)
 open import Data.Fin.Subset

--- a/src/Function/Related/TypeIsomorphisms/Solver.agda
+++ b/src/Function/Related/TypeIsomorphisms/Solver.agda
@@ -9,124 +9,22 @@
 module Function.Related.TypeIsomorphisms.Solver where
 
 open import Algebra using (CommutativeSemiring)
-import Algebra.Operations.Semiring as SemiringOperations
-import Algebra.Solver.Ring.NaturalCoefficients
-open import Data.Empty using (⊥; ⊥-elim)
-open import Data.Nat using (zero; suc; _≟_)
+import Algebra.Solver.Ring.NaturalCoefficients.Default
+open import Data.Empty using (⊥)
 open import Data.Product using (_×_)
-open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
-open import Data.Unit using (⊤; tt)
-open import Level using (Level; Lift; lift; lower)
-open import Function using (id; _$_; const)
-open import Function.Equality using (_⟨$⟩_)
-open import Function.Equivalence as Eq using (_⇔_; Equivalence)
-open import Function.Inverse as Inv using (_↔_; Inverse; inverse)
+open import Data.Sum using (_⊎_)
+open import Data.Unit using (⊤)
+open import Level using (Level; Lift)
+open import Function.Inverse as Inv using (_↔_)
 open import Function.Related as Related
 open import Function.Related.TypeIsomorphisms
-open import Relation.Binary
-open import Relation.Binary.PropositionalEquality as P using (_≡_)
-open import Relation.Nullary using (Dec; yes; no)
-open import Relation.Nullary.Decidable as Decidable using (True)
-
-------------------------------------------------------------------------
--- A decision procedure used by the solver below.
-
-private
-
-  coefficient-dec :
-    ∀ s ℓ →
-    let open CommutativeSemiring (×-⊎-commutativeSemiring s ℓ)
-        open SemiringOperations semiring renaming (_×_ to Times)
-    in
-
-    ∀ m n → Dec (Times m 1# ∼[ ⌊ s ⌋ ] Times n 1#)
-
-  coefficient-dec equivalence ℓ m n with m | n
-  ... | zero  | zero  = yes (Eq.equivalence id id)
-  ... | zero  | suc _ = no  (λ eq → lower (Equivalence.from eq ⟨$⟩ inj₁ _))
-  ... | suc _ | zero  = no  (λ eq → lower (Equivalence.to   eq ⟨$⟩ inj₁ _))
-  ... | suc _ | suc _ = yes (Eq.equivalence (λ _ → inj₁ _) (λ _ → inj₁ _))
-  coefficient-dec bijection ℓ m n = Decidable.map′ to (from m n) (m ≟ n)
-    where
-    open CommutativeSemiring (×-⊎-commutativeSemiring bijection ℓ)
-      using (1#; semiring)
-    open SemiringOperations semiring renaming (_×_ to Times)
-
-    to : ∀ {m n} → m ≡ n → Times m 1# ↔ Times n 1#
-    to {m} P.refl = K-refl
-
-    from : ∀ m n → Times m 1# ↔ Times n 1# → m ≡ n
-    from zero    zero    _   = P.refl
-    from zero    (suc n) 0↔+ = ⊥-elim $ lower $ Inverse.from 0↔+ ⟨$⟩ inj₁ _
-    from (suc m) zero    +↔0 = ⊥-elim $ lower $ Inverse.to   +↔0 ⟨$⟩ inj₁ _
-    from (suc m) (suc n) +↔+ = P.cong suc $ from m n (pred↔pred +↔+)
-      where
-      open P.≡-Reasoning
-
-      ↑⊤ : Set ℓ
-      ↑⊤ = Lift ℓ ⊤
-
-      inj₁≢inj₂ : ∀ {A : Set ℓ} {x : ↑⊤ ⊎ A} {y} →
-                  x ≡ inj₂ y → x ≡ inj₁ (lift tt) → ⊥
-      inj₁≢inj₂ {x = x} {y} eq₁ eq₂ =
-        P.subst [ const ⊥ , const ⊤ ] (begin
-          inj₂ y  ≡⟨ P.sym eq₁ ⟩
-          x       ≡⟨ eq₂ ⟩
-          inj₁ _  ∎)
-          _
-
-      g′ : {A B : Set ℓ}
-           (f : (↑⊤ ⊎ A) ↔ (↑⊤ ⊎ B)) (x : A) (y z : ↑⊤ ⊎ B) →
-           Inverse.to f ⟨$⟩ inj₂ x ≡ y →
-           Inverse.to f ⟨$⟩ inj₁ _ ≡ z →
-           B
-      g′ _ _ (inj₂ y)       _  _   _   = y
-      g′ _ _ (inj₁ _) (inj₂ z) _   _   = z
-      g′ f _ (inj₁ _) (inj₁ _) eq₁ eq₂ = ⊥-elim $
-        inj₁≢inj₂ (Inverse.to-from f eq₁) (Inverse.to-from f eq₂)
-
-      g : {A B : Set ℓ} → (↑⊤ ⊎ A) ↔ (↑⊤ ⊎ B) → A → B
-      g f x = g′ f x _ _ P.refl P.refl
-
-      g′∘g′ : ∀ {A B} (f : (↑⊤ ⊎ A) ↔ (↑⊤ ⊎ B))
-              x y₁ z₁ y₂ z₂ eq₁₁ eq₂₁ eq₁₂ eq₂₂ →
-              g′ (reverse f) (g′ f x y₁ z₁ eq₁₁ eq₂₁) y₂ z₂ eq₁₂ eq₂₂ ≡
-              x
-      g′∘g′ f x (inj₂ y₁) _ (inj₂ y₂) _ eq₁₁ _ eq₁₂ _ =
-        P.cong [ const y₂ , id ] (begin
-          inj₂ y₂                     ≡⟨ P.sym eq₁₂ ⟩
-          Inverse.from f ⟨$⟩ inj₂ y₁  ≡⟨ Inverse.to-from f eq₁₁ ⟩
-          inj₂ x                      ∎)
-      g′∘g′ f x (inj₁ _) (inj₂ _) (inj₁ _) (inj₂ z₂) eq₁₁ _ _ eq₂₂ =
-        P.cong [ const z₂ , id ] (begin
-          inj₂ z₂                    ≡⟨ P.sym eq₂₂ ⟩
-          Inverse.from f ⟨$⟩ inj₁ _  ≡⟨ Inverse.to-from f eq₁₁ ⟩
-          inj₂ x                     ∎)
-      g′∘g′ f _ (inj₂ y₁) _ (inj₁ _) _ eq₁₁ _ eq₁₂ _ =
-        ⊥-elim $ inj₁≢inj₂ (Inverse.to-from f eq₁₁) eq₁₂
-      g′∘g′ f _ (inj₁ _) (inj₂ z₁) (inj₂ y₂) _ _ eq₂₁ eq₁₂ _ =
-        ⊥-elim $ inj₁≢inj₂ eq₁₂ (Inverse.to-from f eq₂₁)
-      g′∘g′ f _ (inj₁ _) (inj₂ _) (inj₁ _) (inj₁ _) eq₁₁ _ _ eq₂₂ =
-        ⊥-elim $ inj₁≢inj₂ (Inverse.to-from f eq₁₁) eq₂₂
-      g′∘g′ f _ (inj₁ _) (inj₁ _) _ _ eq₁₁ eq₂₁ _ _ =
-        ⊥-elim $ inj₁≢inj₂ (Inverse.to-from f eq₁₁)
-                           (Inverse.to-from f eq₂₁)
-
-      g∘g : ∀ {A B} (f : (↑⊤ ⊎ A) ↔ (↑⊤ ⊎ B)) x →
-            g (reverse f) (g f x) ≡ x
-      g∘g f x = g′∘g′ f x _ _ _ _ P.refl P.refl P.refl P.refl
-
-      pred↔pred : {A B : Set ℓ} → (↑⊤ ⊎ A) ↔ (↑⊤ ⊎ B) → A ↔ B
-      pred↔pred X⊎↔X⊎ = inverse (g X⊎↔X⊎) (g (reverse X⊎↔X⊎))
-                                (g∘g X⊎↔X⊎) (g∘g (reverse X⊎↔X⊎))
 
 ------------------------------------------------------------------------
 -- The solver
 
 module ×-⊎-Solver (k : Symmetric-kind) {ℓ} =
-  Algebra.Solver.Ring.NaturalCoefficients
+  Algebra.Solver.Ring.NaturalCoefficients.Default
     (×-⊎-commutativeSemiring k ℓ)
-    (coefficient-dec k ℓ)
 
 ------------------------------------------------------------------------
 -- Tests

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -10,6 +10,7 @@ open import Relation.Binary.Core
 open import Relation.Nullary using (yes; no)
 open import Relation.Unary using (∁)
 open import Function using (_∘_; flip)
+open import Data.Maybe.Base using (just; nothing)
 open import Data.Sum using (inj₁; inj₂)
 open import Data.Product using (_,_)
 open import Data.Empty using (⊥-elim)
@@ -124,6 +125,13 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ�
 
 ------------------------------------------------------------------------
 -- Other proofs
+
+module _ {a b p} {A : Set a} {B : Set b} {P : REL A B p} where
+
+  dec⟶weaklyDec : Decidable P → WeaklyDecidable P
+  dec⟶weaklyDec dec x y with dec x y
+  ... | yes p = just p
+  ... | no _ = nothing
 
 module _ {a b p q} {A : Set a} {B : Set b }
          {P : REL A B p} {Q : REL A B q}

--- a/src/Relation/Binary/Core.agda
+++ b/src/Relation/Binary/Core.agda
@@ -11,6 +11,7 @@ module Relation.Binary.Core where
 
 open import Agda.Builtin.Equality using (_≡_) renaming (refl to ≡-refl)
 
+open import Data.Maybe.Base using (Maybe)
 open import Data.Product using (_×_)
 open import Data.Sum.Base using (_⊎_)
 open import Function using (_on_; flip)
@@ -138,6 +139,9 @@ Substitutive {A = A} _∼_ p = (P : A → Set p) → P Respects _∼_
 
 Decidable : ∀ {a b ℓ} {A : Set a} {B : Set b} → REL A B ℓ → Set _
 Decidable _∼_ = ∀ x y → Dec (x ∼ y)
+
+WeaklyDecidable : ∀ {a b ℓ} {A : Set a} {B : Set b} → REL A B ℓ → Set _
+WeaklyDecidable _∼_ = ∀ x y → Maybe (x ∼ y)
 
 Irrelevant : ∀ {a b ℓ} {A : Set a} {B : Set b} → REL A B ℓ → Set _
 Irrelevant _∼_ = ∀ {x y} (a : x ∼ y) (b : x ∼ y) → a ≡ b


### PR DESCRIPTION
(See #507)

This replaces the `Decidable` module parameter in `Algebra.Solver.Ring`
by a new predicate `WeaklyDecidable`. It only provides a subset of those
equality proofs that `Decidable` can provide, and does not provide
inequality proofs.

As a result, ring solvers can now be used in more general situations in
which decidable equality is not available. For this, a new module
`Algebra.Solver.Ring.NaturalCoefficients.Default` was added which
instantiates the natural coefficients solver for any
`CommutativeSemiring`, such as `×-⊎-commutativeSemiring` in
`Function.Related.TypeIsomorphisms.Solver`.

---

Any comments are appreciated. Is naming and location of the two new modules `Algebra.Solver.Ring.WeaklyDecidable` and `Algebra.Solver.Ring.NaturalCoefficients.Default` appropriate or are there better options?