### PR TITLE
Added thunk-syntax to mimic syntax for products etc

### DIFF
--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -27,6 +27,14 @@ Thunk^R : ∀ {f g r} {F : Size → Set f} {G : Size → Set g}
 Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
 
 ------------------------------------------------------------------------
+-- Syntax
+
+Thunk-syntax : ∀ {ℓ} → (Size → Set ℓ) → Size → Set ℓ
+Thunk-syntax = Thunk
+
+syntax Thunk-syntax (λ i → e) j = Thunk[ i < j ] e
+
+------------------------------------------------------------------------
 -- Basic functions.
 
 -- Thunk is a functor

--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -32,7 +32,7 @@ Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
 Thunk-syntax : ∀ {ℓ} → (Size → Set ℓ) → Size → Set ℓ
 Thunk-syntax = Thunk
 
-syntax Thunk-syntax (λ i → e) j = Thunk[ i < j ] e
+syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
 
 ------------------------------------------------------------------------
 -- Basic functions.


### PR DESCRIPTION
This adds a syntax declaration for `Thunk`s. It mimics the syntax declarations for `Σ`. I found myself using a lot of sized types where the size parameter was implicit, or where it wasn't the last parameter, and this syntax would make things a little easier to read. Take this example of a coinductive non-empty list:

With syntax:
```agda
record NonEmpty {i : Size} {a} (A : Set a) : Set a where
  coinductive
  field
    head : A
    tail : Maybe (Thunk[ j < i ] NonEmpty {j} A)
```

Without syntax:
```agda
record NonEmpty {i : Size} {a} (A : Set a) : Set a where
  coinductive
  field
    head : A
    tail : Maybe (Thunk (λ j → NonEmpty {j} A) i)
```