### PR TITLE
[ refactor ] straightening out the Algebra hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,20 +45,29 @@ Splitting up `Data.Maybe` into the standard hierarchy.
 
 #### Changes to the algebra hierarchy
 
+* Over time the algebra inheritance hierarchy has become a little
+  wonky due to poorly structured additions. This attempts to straighten
+  the hierarchy out and new policies have been put in place so that
+  the need for additional such changes will be minimised in the future.
+
 * Added `Magma` and `IsMagma` to the algebra hierarchy.
 
-* The name `RawSemigroup` in `Algebra` has been deprecated in favour of `RawMagma`.
+* The name `RawSemigroup` in `Algebra` has been deprecated in favour
+  of `RawMagma`.
 
 * The fields `isEquivalence` and `∙-cong` in `IsSemigroup` have been
   replaced with `isMagma`.
 
-* The fields `...` in `IsLattice` have been replaced with `∨-isSemilattice`
-  and `∧-isSemilattice`.
+* The fields `isEquivalence`, `∨-cong`, `∨-assoc`, `∨-comm`, `∧-cong`,
+  `∧-assoc`  and `∧-comm` in `IsLattice` have been replaced with
+  `∨-isSemilattice` and `∧-isSemilattice`.
 
-* The record `Lattice` now exports proofs of `∨-idem` and `∧-idem` directly. Therefore
-  `∨-idempotence` and `∧-idempotence` in `Algebra.Properties.Lattice` have been deprecated.
+* The record `Lattice` now exports proofs of `∨-idem` and `∧-idem` directly.
+  Therefore `∨-idempotence` and `∧-idempotence` in `Algebra.Properties.Lattice`
+  have been deprecated.
 
-* The record `BooleanAlgebra` now exports `∨-isSemigroup`, `∧-isSemigroup` directly so `Algebra.Properties.BooleanAlgebra` no longer does so.
+* The record `BooleanAlgebra` now exports `∨-isSemigroup`, `∧-isSemigroup`
+  directly  so `Algebra.Properties.BooleanAlgebra` no longer does so.
 
 #### Relaxation of ring solvers requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Splitting up `Data.Maybe` into the standard hierarchy.
 * The record `Lattice` now exports proofs of `∨-idem` and `∧-idem` directly. Therefore
   `∨-idempotence` and `∧-idempotence` in `Algebra.Properties.Lattice` have been deprecated.
 
+* The record `BooleanAlgebra` now exports `∨-isSemigroup`, `∧-isSemigroup` directly so `Algebra.Properties.BooleanAlgebra` no longer does so.
+
 #### Relaxation of ring solvers requirements
 
 * In the ring solvers below, the assumption that equality is `Decidable`
@@ -145,6 +147,23 @@ Other minor additions
   splitAt-map : splitAt n (map f xs) ≡ map (map f) (map f) (splitAt n xs)
   ```
 
+* Added new proofs to `Data.Bool.Properties`:
+  ```agda
+  ∧-isMagma       : IsMagma _∧_
+  ∨-isMagma       : IsMagma _∨_
+  ∨-isBand        : IsBand _∨_
+  ∨-isSemilattice : IsSemilattice _∨_
+  ∧-isBand        : IsBand _∧_
+  ∧-isSemilattice : IsSemilattice _∧_
+
+  ∧-magma         : Magma 0ℓ 0ℓ
+  ∨-magma         : Magma 0ℓ 0ℓ
+  ∨-band          : Band 0ℓ 0ℓ
+  ∧-band          : Band 0ℓ 0ℓ
+  ∨-semilattice   : Semilattice 0ℓ 0ℓ
+  ∧-semilattice   : Semilattice 0ℓ 0ℓ
+  ```
+
 * Added new function to `Data.Fin.Base`:
   ```agda
   cast : m ≡ n → Fin m → Fin n
@@ -153,6 +172,36 @@ Other minor additions
 * Added new proof to `Data.Fin.Properties`:
   ```agda
   toℕ-cast    : toℕ (cast eq k) ≡ toℕ k
+  ```
+
+* Added new proofs to `Data.Fin.Subset.Properties`:
+  ```agda
+  ∩-isMagma       : IsMagma _∩_
+  ∪-isMagma       : IsMagma _∪_
+  ∩-isBand        : IsBand _∩_
+  ∪-isBand        : IsBand _∪_
+  ∩-isSemilattice : IsSemilattice _∩_
+  ∪-isSemilattice : IsSemilattice _∪_
+
+  ∩-magma         : Magma _ _
+  ∪-magma         : Magma _ _
+  ∩-band          : Band _ _
+  ∪-band          : Band _ _
+  ∩-semilattice   : Semilattice _ _
+  ∪-semilattice   : Semilattice _ _
+  ```
+
+* Added new proofs to `Data.Integer.Properties`:
+  ```agda
+  +-isMagma   : IsMagma _+_
+  *-isMagma   : IsMagma _*_
+
+  +-magma     : Magma 0ℓ 0ℓ
+  *-magma     : Magma 0ℓ 0ℓ
+  +-semigroup : Semigroup 0ℓ 0ℓ
+  *-semigroup : Semigroup 0ℓ 0ℓ
+  +-0-monoid  : Monoid 0ℓ 0ℓ
+  *-1-monoid  : Monoid 0ℓ 0ℓ
   ```
 
 * Added new operations to `Data.List.All`:
@@ -204,11 +253,19 @@ Other minor additions
 
 * Added new proofs to `Data.List.Properties`:
   ```agda
-  length-%= : length (xs [ k ]%= f) ≡ length xs
-  length-∷= : length (xs [ k ]∷= v) ≡ length xs
-  map-∷=    : map f (xs [ k ]∷= v) ≡ map f xs [ cast eq k ]∷= f v
-  length-─  : length (xs ─ k) ≡ pred (length xs)
-  map-─     : map f (xs ─ k) ≡ map f xs ─ cast eq k
+  ++-isMagma : IsMagma _++_
+
+  length-%=  : length (xs [ k ]%= f) ≡ length xs
+  length-∷=  : length (xs [ k ]∷= v) ≡ length xs
+  map-∷=     : map f (xs [ k ]∷= v) ≡ map f xs [ cast eq k ]∷= f v
+  length-─   : length (xs ─ k) ≡ pred (length xs)
+  map-─      : map f (xs ─ k) ≡ map f xs ─ cast eq k
+  ```
+
+* Added new proofs to `Data.List.Relation.Permutation.Inductive.Properties`:
+  ```agda
+  ++-isMagma : IsMagma _↭_ _++_
+  ++-magma   : Magma _ _
   ```
 
 * Added new proofs to `Data.Maybe.All`:
@@ -270,7 +327,7 @@ Other minor additions
   ⊓-isBand        : IsBand _⊓_
   ⊔-isSemilattice : IsSemilattice _⊔_
   ⊓-isSemilattice : IsSemilattice _⊓_
-  
+
   +-magma       : Magma 0ℓ 0ℓ
   *-magma       : Magma 0ℓ 0ℓ
   ⊔-magma       : Magma 0ℓ 0ℓ
@@ -300,6 +357,15 @@ Other minor additions
   ```agda
   fromAny : Any P xs → ∃ λ x → x ∈ xs × P x
   toAny   : x ∈ xs → P x → Any P xs
+  ```
+
+* Added new proofs to `Function.Related.TypeIsomorphisms`:
+  ```agda
+  ×-isMagma : ∀ k ℓ → IsMagma (Related ⌊ k ⌋) _×_
+  ⊎-isMagma : ∀ k ℓ → IsMagma (Related ⌊ k ⌋) _⊎_
+
+  ⊎-magma : Symmetric-kind → (ℓ : Level) → Semigroup _ _
+  ×-magma : Symmetric-kind → (ℓ : Level) → Magma _ _
   ```
 
 * Added new proofs to `Relation.Binary.Consequences`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ Splitting up `Data.Maybe` into the standard hierarchy.
 
 * The name `RawSemigroup` in `Algebra` has been deprecated in favour of `RawMagma`.
 
+* The fields `isEquivalence` and `∙-cong` in `IsSemigroup` have been
+  replaced with `isMagma`.
+
+* The fields `...` in `IsLattice` have been replaced with `∨-isSemilattice`
+  and `∧-isSemilattice`.
+
+* The record `Lattice` now exports proofs of `∨-idem` and `∧-idem` directly. Therefore
+  `∨-idempotence` and `∧-idempotence` in `Algebra.Properties.Lattice` have been deprecated.
+
 #### Relaxation of ring solvers requirements
 
 * In the ring solvers below, the assumption that equality is `Decidable`
@@ -249,6 +258,33 @@ Other minor additions
 * Added new function to `Data.Maybe.Base`:
   ```agda
   _<∣>_     : Maybe A → Maybe A → Maybe A
+  ```
+
+* Added new proofs to `Data.Nat.Properties`:
+  ```agda
+  +-isMagma       : IsMagma _+_
+  *-isMagma       : IsMagma _*_
+  ⊔-isMagma       : IsMagma _⊔_
+  ⊓-isMagma       : IsMagma _⊓_
+  ⊔-isBand        : IsBand _⊔_
+  ⊓-isBand        : IsBand _⊓_
+  ⊔-isSemilattice : IsSemilattice _⊔_
+  ⊓-isSemilattice : IsSemilattice _⊓_
+  
+  +-magma       : Magma 0ℓ 0ℓ
+  *-magma       : Magma 0ℓ 0ℓ
+  ⊔-magma       : Magma 0ℓ 0ℓ
+  ⊓-magma       : Magma 0ℓ 0ℓ
+  ⊔-band        : Band 0ℓ 0ℓ
+  ⊓-band        : Band 0ℓ 0ℓ
+  ⊔-semilattice : Semilattice 0ℓ 0ℓ
+  ⊓-semilattice : Semilattice 0ℓ 0ℓ
+  ```
+
+* Added new proofs to `Data.Sign.Properties`:
+  ```agda
+  *-isMagma : IsMagma _*_
+  *-magma   : Magma 0ℓ 0ℓ
   ```
 
 * Added new functions to `Data.Vec.Any.Properties`:

--- a/src/Algebra.agda
+++ b/src/Algebra.agda
@@ -73,6 +73,23 @@ record Band c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open Semigroup semigroup public using (magma; rawMagma)
 
+
+record Semilattice c ℓ : Set (suc (c ⊔ ℓ)) where
+  infixr 7 _∧_
+  infix  4 _≈_
+  field
+    Carrier       : Set c
+    _≈_           : Rel Carrier ℓ
+    _∧_           : Op₂ Carrier
+    isSemilattice : IsSemilattice _≈_ _∧_
+
+  open IsSemilattice isSemilattice public
+
+  band : Band c ℓ
+  band = record { isBand = isBand }
+
+  open Band band public using (rawMagma; magma; semigroup)
+
 ------------------------------------------------------------------------
 -- Monoids
 
@@ -536,22 +553,6 @@ record CommutativeRing c ℓ : Set (suc (c ⊔ ℓ)) where
 ------------------------------------------------------------------------
 -- Lattices and boolean algebras
 
-record Semilattice c ℓ : Set (suc (c ⊔ ℓ)) where
-  infixr 7 _∧_
-  infix  4 _≈_
-  field
-    Carrier       : Set c
-    _≈_           : Rel Carrier ℓ
-    _∧_           : Op₂ Carrier
-    isSemilattice : IsSemilattice _≈_ _∧_
-
-  open IsSemilattice isSemilattice public
-
-  band : Band c ℓ
-  band = record { isBand = isBand }
-
-  open Band band public using (rawMagma; magma; semigroup)
-
 record Lattice c ℓ : Set (suc (c ⊔ ℓ)) where
   infixr 7 _∧_
   infixr 6 _∨_
@@ -565,8 +566,27 @@ record Lattice c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open IsLattice isLattice public
 
-  setoid : Setoid _ _
-  setoid = record { isEquivalence = isEquivalence }
+  ∨-semilattice : Semilattice c ℓ
+  ∨-semilattice = record { isSemilattice = ∨-isSemilattice }
+
+  open Semilattice ∨-semilattice public
+    using () renaming
+    ( rawMagma  to ∨-rawMagma
+    ; magma     to ∨-magma
+    ; semigroup to ∨-semigroup
+    ; band      to ∨-band
+    )
+
+  ∧-semilattice : Semilattice c ℓ
+  ∧-semilattice = record { isSemilattice = ∧-isSemilattice }
+
+  open Semilattice ∧-semilattice public
+    using () renaming
+    ( rawMagma  to ∧-rawMagma
+    ; magma     to ∧-magma
+    ; semigroup to ∧-semigroup
+    ; band      to ∧-band
+    )
 
 record DistributiveLattice c ℓ : Set (suc (c ⊔ ℓ)) where
   infixr 7 _∧_
@@ -584,7 +604,11 @@ record DistributiveLattice c ℓ : Set (suc (c ⊔ ℓ)) where
   lattice : Lattice _ _
   lattice = record { isLattice = isLattice }
 
-  open Lattice lattice public using (setoid)
+  open Lattice lattice public
+    using
+    ( ∧-rawMagma; ∧-magma; ∧-semigroup; ∧-band; ∧-semilattice
+    ; ∨-rawMagma; ∨-magma; ∨-semigroup; ∨-band; ∨-semilattice
+    )
 
 record BooleanAlgebra c ℓ : Set (suc (c ⊔ ℓ)) where
   infix  8 ¬_
@@ -604,12 +628,14 @@ record BooleanAlgebra c ℓ : Set (suc (c ⊔ ℓ)) where
   open IsBooleanAlgebra isBooleanAlgebra public
 
   distributiveLattice : DistributiveLattice _ _
-  distributiveLattice =
-    record { isDistributiveLattice = isDistributiveLattice }
+  distributiveLattice = record { isDistributiveLattice = isDistributiveLattice }
 
   open DistributiveLattice distributiveLattice public
-         using (setoid; lattice)
-
+    using
+    ( ∧-rawMagma; ∧-magma; ∧-semigroup; ∧-band; ∧-semilattice
+    ; ∨-rawMagma; ∨-magma; ∨-semigroup; ∨-band; ∨-semilattice
+    ; lattice
+    )
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Algebra/Properties/BooleanAlgebra.agda
+++ b/src/Algebra/Properties/BooleanAlgebra.agda
@@ -7,8 +7,8 @@
 open import Algebra
 
 module Algebra.Properties.BooleanAlgebra
-         {b₁ b₂} (B : BooleanAlgebra b₁ b₂)
-         where
+  {b₁ b₂} (B : BooleanAlgebra b₁ b₂)
+  where
 
 open BooleanAlgebra B
 import Algebra.Properties.DistributiveLattice
@@ -18,8 +18,7 @@ private
     hiding (replace-equality)
 open import Algebra.Structures _≈_
 open import Algebra.FunctionProperties _≈_
-open import Algebra.FunctionProperties.Consequences
-  record {isEquivalence = isEquivalence}
+open import Algebra.FunctionProperties.Consequences setoid
 open import Relation.Binary.EqReasoning setoid
 open import Relation.Binary
 open import Function
@@ -68,7 +67,7 @@ open import Data.Product
 ∧-identityʳ : RightIdentity ⊤ _∧_
 ∧-identityʳ x = begin
   x ∧ ⊤          ≈⟨ refl ⟨ ∧-cong ⟩ sym (∨-complementʳ _) ⟩
-  x ∧ (x ∨ ¬ x)  ≈⟨ proj₂ absorptive _ _ ⟩
+  x ∧ (x ∨ ¬ x)  ≈⟨ ∧-absorbs-∨ _ _ ⟩
   x              ∎
 
 ∧-identityˡ : LeftIdentity ⊤ _∧_
@@ -80,7 +79,7 @@ open import Data.Product
 ∨-identityʳ : RightIdentity ⊥ _∨_
 ∨-identityʳ x = begin
   x ∨ ⊥          ≈⟨ refl ⟨ ∨-cong ⟩ sym (∧-complementʳ _) ⟩
-  x ∨ x ∧ ¬ x    ≈⟨ proj₁ absorptive _ _ ⟩
+  x ∨ x ∧ ¬ x    ≈⟨ ∨-absorbs-∧ _ _ ⟩
   x              ∎
 
 ∨-identityˡ : LeftIdentity ⊥ _∨_
@@ -117,20 +116,6 @@ open import Data.Product
 ∨-zero : Zero ⊤ _∨_
 ∨-zero = ∨-zeroˡ , ∨-zeroʳ
 
-∨-isSemigroup : IsSemigroup _∨_
-∨-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = ∨-assoc
-  ; ∙-cong        = ∨-cong
-  }
-
-∧-isSemigroup : IsSemigroup _∧_
-∧-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = ∧-assoc
-  ; ∙-cong        = ∧-cong
-  }
-
 ∨-⊥-isMonoid : IsMonoid _∨_ ⊥
 ∨-⊥-isMonoid = record
   { isSemigroup = ∨-isSemigroup
@@ -146,23 +131,23 @@ open import Data.Product
 ∨-⊥-isCommutativeMonoid : IsCommutativeMonoid _∨_ ⊥
 ∨-⊥-isCommutativeMonoid = record
   { isSemigroup = ∨-isSemigroup
-  ; identityˡ = ∨-identityˡ
-  ; comm      = ∨-comm
+  ; identityˡ   = ∨-identityˡ
+  ; comm        = ∨-comm
   }
 
 ∧-⊤-isCommutativeMonoid : IsCommutativeMonoid _∧_ ⊤
 ∧-⊤-isCommutativeMonoid = record
   { isSemigroup = ∧-isSemigroup
-  ; identityˡ = ∧-identityˡ
-  ; comm      = ∧-comm
+  ; identityˡ   = ∧-identityˡ
+  ; comm        = ∧-comm
   }
 
 ∨-∧-isCommutativeSemiring : IsCommutativeSemiring _∨_ _∧_ ⊥ ⊤
 ∨-∧-isCommutativeSemiring = record
   { +-isCommutativeMonoid = ∨-⊥-isCommutativeMonoid
   ; *-isCommutativeMonoid = ∧-⊤-isCommutativeMonoid
-  ; distribʳ = proj₂ ∧-∨-distrib
-  ; zeroˡ    = ∧-zeroˡ
+  ; distribʳ              = proj₂ ∧-∨-distrib
+  ; zeroˡ                 = ∧-zeroˡ
   }
 
 ∨-∧-commutativeSemiring : CommutativeSemiring _ _
@@ -530,11 +515,16 @@ module XorRing
       ((¬ x ∨ ¬ y) ∨ z) ∧
       (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ∎
 
+  ⊕-isMagma : IsMagma _⊕_
+  ⊕-isMagma = record
+    { isEquivalence = isEquivalence
+    ; ∙-cong        = ⊕-cong
+    }
+
   ⊕-isSemigroup : IsSemigroup _⊕_
   ⊕-isSemigroup = record
-    { isEquivalence = isEquivalence
-    ; assoc         = ⊕-assoc
-    ; ∙-cong        = ⊕-cong
+    { isMagma = ⊕-isMagma
+    ; assoc   = ⊕-assoc
     }
 
   ⊕-⊥-isMonoid : IsMonoid _⊕_ ⊥

--- a/src/Algebra/Properties/BooleanAlgebra/Expression.agda
+++ b/src/Algebra/Properties/BooleanAlgebra/Expression.agda
@@ -116,38 +116,60 @@ lift n = record
   ; isBooleanAlgebra = record
     { isDistributiveLattice = record
       { isLattice = record
-        { isEquivalence = PW.isEquivalence isEquivalence
-        ; ∨-comm        = λ _ _ → ext λ i →
-                            solve i 2 (λ x y → x or y , y or x)
-                                  (∨-comm _ _) _ _
-        ; ∨-assoc       = λ _ _ _ → ext λ i →
-                            solve i 3
-                              (λ x y z → (x or y) or z , x or (y or z))
-                              (∨-assoc _ _ _) _ _ _
-        ; ∨-cong        = λ xs≈us ys≈vs → ext λ i →
-                            solve₁ i 4 (λ x y u v → x or y , u or v)
-                                   _ _ _ _
-                                   (∨-cong (Pointwise.app xs≈us i)
-                                           (Pointwise.app ys≈vs i))
-        ; ∧-comm        = λ _ _ → ext λ i →
-                            solve i 2 (λ x y → x and y , y and x)
-                                  (∧-comm _ _) _ _
-        ; ∧-assoc       = λ _ _ _ → ext λ i →
+        { ∨-isSemilattice = record
+          { isBand = record
+            { isSemigroup = record
+              { isMagma = record
+                { isEquivalence = PW.isEquivalence isEquivalence
+                ; ∙-cong        = λ xs≈us ys≈vs → ext λ i →
+                                    solve₁ i 4 (λ x y u v → x or y , u or v)
+                                      _ _ _ _
+                                      (∨-cong (Pointwise.app xs≈us i)
+                                        (Pointwise.app ys≈vs i))
+                }
+              ; assoc = λ _ _ _ → ext λ i →
+                          solve i 3
+                            (λ x y z → (x or y) or z , x or (y or z))
+                            (∨-assoc _ _ _) _ _ _
+              }
+            ; idem = λ _ → ext λ i →
+                          solve i 1
+                            (λ x → x or x , x) (∨-idem _) _
+            }
+          ; comm   = λ _ _ → ext λ i →
+                       solve i 2 (λ x y → x or y , y or x)
+                       (∨-comm _ _) _ _
+          }
+        ; ∧-isSemilattice = record
+          { isBand = record
+            { isSemigroup = record
+              { isMagma = record
+                { isEquivalence = PW.isEquivalence isEquivalence
+                ; ∙-cong        = λ xs≈ys us≈vs → ext λ i →
+                                    solve₁ i 4 (λ x y u v → x and y , u and v)
+                                      _ _ _ _
+                                      (∧-cong (Pointwise.app xs≈ys i)
+                                        (Pointwise.app us≈vs i))
+                }
+              ; assoc   = λ _ _ _ → ext λ i →
                             solve i 3
                               (λ x y z → (x and y) and z ,
                                          x and (y and z))
                               (∧-assoc _ _ _) _ _ _
-        ; ∧-cong        = λ xs≈ys us≈vs → ext λ i →
-                            solve₁ i 4 (λ x y u v → x and y , u and v)
-                                   _ _ _ _
-                                   (∧-cong (Pointwise.app xs≈ys i)
-                                           (Pointwise.app us≈vs i))
-        ; absorptive    = (λ _ _ → ext λ i →
-                             solve i 2 (λ x y → x or (x and y) , x)
-                                   (proj₁ absorptive _ _) _ _) ,
-                          (λ _ _ → ext λ i →
-                             solve i 2 (λ x y → x and (x or y) , x)
-                                   (proj₂ absorptive _ _) _ _)
+              }
+            ; idem        =  λ _ → ext λ i →
+                              solve i 1
+                                (λ x → x and x , x) (∧-idem _) _
+            }
+          ; comm   = λ _ _ → ext λ i →
+                       solve i 2 (λ x y → x and y , y and x)
+                       (∧-comm _ _) _ _
+          }
+        ; absorptive      =
+          (λ _ _ → ext λ i →
+            solve i 2 (λ x y → x or (x and y) , x) (∨-absorbs-∧ _ _) _ _) ,
+          (λ _ _ → ext λ i →
+            solve i 2 (λ x y → x and (x or y) , x) (∧-absorbs-∨ _ _) _ _)
         }
       ; ∨-∧-distribʳ = λ _ _ _ → ext λ i →
                          solve i 3

--- a/src/Algebra/Properties/DistributiveLattice.agda
+++ b/src/Algebra/Properties/DistributiveLattice.agda
@@ -22,7 +22,7 @@ open import Relation.Binary.EqReasoning setoid
 open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence using (_⇔_; module Equivalence)
-open import Data.Product
+open import Data.Product using (_,_)
 
 ∨-∧-distribˡ : _∨_ DistributesOverˡ _∧_
 ∨-∧-distribˡ x y z = begin
@@ -36,12 +36,12 @@ open import Data.Product
 
 ∧-∨-distribˡ : _∧_ DistributesOverˡ _∨_
 ∧-∨-distribˡ x y z = begin
-  x ∧ (y ∨ z)                ≈⟨ sym (proj₂ absorptive _ _) ⟨ ∧-cong ⟩ refl ⟩
+  x ∧ (y ∨ z)                ≈⟨ sym (∧-absorbs-∨ _ _) ⟨ ∧-cong ⟩ refl ⟩
   (x ∧ (x ∨ y)) ∧ (y ∨ z)    ≈⟨ (refl ⟨ ∧-cong ⟩ ∨-comm _ _) ⟨ ∧-cong ⟩ refl ⟩
   (x ∧ (y ∨ x)) ∧ (y ∨ z)    ≈⟨ ∧-assoc _ _ _ ⟩
-  x ∧ ((y ∨ x) ∧ (y ∨ z))    ≈⟨ refl ⟨ ∧-cong ⟩ sym (proj₁ ∨-∧-distrib _ _ _) ⟩
-  x ∧ (y ∨ x ∧ z)            ≈⟨ sym (proj₁ absorptive _ _) ⟨ ∧-cong ⟩ refl ⟩
-  (x ∨ x ∧ z) ∧ (y ∨ x ∧ z)  ≈⟨ sym $ proj₂ ∨-∧-distrib _ _ _ ⟩
+  x ∧ ((y ∨ x) ∧ (y ∨ z))    ≈⟨ refl ⟨ ∧-cong ⟩ sym (∨-∧-distribˡ _ _ _) ⟩
+  x ∧ (y ∨ x ∧ z)            ≈⟨ sym (∨-absorbs-∧ _ _) ⟨ ∧-cong ⟩ refl ⟩
+  (x ∨ x ∧ z) ∧ (y ∨ x ∧ z)  ≈⟨ sym $ ∨-∧-distribʳ _ _ _ ⟩
   x ∧ y ∨ x ∧ z              ∎
 
 ∧-∨-distribʳ : _∧_ DistributesOverʳ _∨_
@@ -59,7 +59,7 @@ open import Data.Product
 ∧-∨-isDistributiveLattice : IsDistributiveLattice _≈_ _∧_ _∨_
 ∧-∨-isDistributiveLattice = record
   { isLattice    = ∧-∨-isLattice
-  ; ∨-∧-distribʳ = proj₂ ∧-∨-distrib
+  ; ∨-∧-distribʳ = ∧-∨-distribʳ
   }
 
 ∧-∨-distributiveLattice : DistributiveLattice _ _

--- a/src/Algebra/Properties/Lattice.agda
+++ b/src/Algebra/Properties/Lattice.agda
@@ -10,48 +10,29 @@ module Algebra.Properties.Lattice {l₁ l₂} (L : Lattice l₁ l₂) where
 
 open Lattice L
 open import Algebra.Structures
-import Algebra.FunctionProperties as P; open P _≈_
+open import Algebra.FunctionProperties _≈_
 open import Relation.Binary
 import Relation.Binary.Lattice as R
-import Relation.Binary.EqReasoning as EqR; open EqR setoid
+open import Relation.Binary.EqReasoning  setoid
 open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence using (_⇔_; module Equivalence)
-open import Data.Product
+open import Data.Product using (_,_; swap)
 
-∧-idempotent : Idempotent _∧_
-∧-idempotent x = begin
-  x ∧ x            ≈⟨ refl ⟨ ∧-cong ⟩ sym (proj₁ absorptive _ _) ⟩
-  x ∧ (x ∨ x ∧ x)  ≈⟨ proj₂ absorptive _ _ ⟩
-  x                ∎
-
-∨-idempotent : Idempotent _∨_
-∨-idempotent x = begin
-  x ∨ x      ≈⟨ refl ⟨ ∨-cong ⟩ sym (∧-idempotent _) ⟩
-  x ∨ x ∧ x  ≈⟨ proj₁ absorptive _ _ ⟩
-  x          ∎
-
+------------------------------------------------------------------------
 -- The dual construction is also a lattice.
 
 ∧-∨-isLattice : IsLattice _≈_ _∧_ _∨_
 ∧-∨-isLattice = record
-  { isEquivalence = isEquivalence
-  ; ∨-comm        = ∧-comm
-  ; ∨-assoc       = ∧-assoc
-  ; ∨-cong        = ∧-cong
-  ; ∧-comm        = ∨-comm
-  ; ∧-assoc       = ∨-assoc
-  ; ∧-cong        = ∨-cong
-  ; absorptive    = swap absorptive
+  { ∨-isSemilattice = ∧-isSemilattice
+  ; ∧-isSemilattice = ∨-isSemilattice
+  ; absorptive      = swap absorptive
   }
 
 ∧-∨-lattice : Lattice _ _
-∧-∨-lattice = record
-  { _∧_       = _∨_
-  ; _∨_       = _∧_
-  ; isLattice = ∧-∨-isLattice
-  }
+∧-∨-lattice = record { isLattice = ∧-∨-isLattice }
 
+------------------------------------------------------------------------
 -- Every lattice can be turned into a poset.
 
 poset : Poset _ _ _
@@ -63,7 +44,7 @@ poset = record
     { isPreorder = record
       { isEquivalence = isEquivalence
       ; reflexive     = λ {i} {j} i≈j → begin
-                          i      ≈⟨ sym $ ∧-idempotent _ ⟩
+                          i      ≈⟨ sym $ ∧-idem _ ⟩
                           i ∧ i  ≈⟨ ∧-cong refl i≈j ⟩
                           i ∧ j  ∎
       ; trans         = λ {i} {j} {k} i≈i∧j j≈j∧k → begin
@@ -83,6 +64,7 @@ poset = record
 
 open Poset poset using (_≤_; isPartialOrder)
 
+------------------------------------------------------------------------
 -- Every algebraic lattice can be turned into an order-theoretic one.
 
 isOrderTheoreticLattice : R.IsLattice _≈_ _≤_ _∨_ _∧_
@@ -101,12 +83,12 @@ isOrderTheoreticLattice = record
                          z            ∎))
   ; infimum        = λ x y →
                        (begin
-                         x ∧ y        ≈⟨ ∧-cong (sym (∧-idempotent x)) refl ⟩
+                         x ∧ y        ≈⟨ ∧-cong (sym (∧-idem x)) refl ⟩
                          (x ∧ x) ∧ y  ≈⟨ ∧-assoc x x y  ⟩
                          x ∧ (x ∧ y)  ≈⟨ ∧-comm x (x ∧ y) ⟩
                          (x ∧ y) ∧ x  ∎) ,
                        (begin
-                         x ∧ y        ≈⟨ ∧-cong refl (sym (∧-idempotent y)) ⟩
+                         x ∧ y        ≈⟨ ∧-cong refl (sym (∧-idem y)) ⟩
                          x ∧ (y ∧ y)  ≈⟨ sym (∧-assoc x y y) ⟩
                          (x ∧ y) ∧ y  ∎) ,
                        (λ z z≈z∧x z≈z∧y → begin
@@ -116,27 +98,27 @@ isOrderTheoreticLattice = record
                          z ∧ (x ∧ y)  ∎)
   }
   where
-    ∧-absorbs-∨ = proj₂ absorptive
 
-    -- An alternative but equivalent interpretation of the order _≤_.
+  -- An alternative but equivalent interpretation of the order _≤_.
 
-    complete : ∀ {x y} → x ≤ y → x ∨ y ≈ y
-    complete {x} {y} x≈x∧y = begin
-      x ∨ y        ≈⟨ ∨-cong x≈x∧y refl ⟩
-      (x ∧ y) ∨ y  ≈⟨ ∨-cong (∧-comm x y) refl ⟩
-      (y ∧ x) ∨ y  ≈⟨ ∨-comm (y ∧ x) y ⟩
-      y ∨ (y ∧ x)  ≈⟨ proj₁ absorptive y x ⟩
-      y            ∎
+  complete : ∀ {x y} → x ≤ y → x ∨ y ≈ y
+  complete {x} {y} x≈x∧y = begin
+    x ∨ y        ≈⟨ ∨-cong x≈x∧y refl ⟩
+    (x ∧ y) ∨ y  ≈⟨ ∨-cong (∧-comm x y) refl ⟩
+    (y ∧ x) ∨ y  ≈⟨ ∨-comm (y ∧ x) y ⟩
+    y ∨ (y ∧ x)  ≈⟨ ∨-absorbs-∧ y x ⟩
+    y            ∎
 
-    sound : ∀ {x y} → x ∨ y ≈ y → x ≤ y
-    sound {x} {y} x∨y≈y = begin
-      x            ≈⟨ sym (∧-absorbs-∨ x y) ⟩
-      x ∧ (x ∨ y)  ≈⟨ ∧-cong refl x∨y≈y ⟩
-      x ∧ y        ∎
+  sound : ∀ {x y} → x ∨ y ≈ y → x ≤ y
+  sound {x} {y} x∨y≈y = begin
+    x            ≈⟨ sym (∧-absorbs-∨ x y) ⟩
+    x ∧ (x ∨ y)  ≈⟨ ∧-cong refl x∨y≈y ⟩
+    x ∧ y        ∎
 
 orderTheoreticLattice : R.Lattice _ _ _
 orderTheoreticLattice = record { isLattice = isOrderTheoreticLattice }
 
+------------------------------------------------------------------------
 -- One can replace the underlying equality with an equivalent one.
 
 replace-equality : {_≈′_ : Rel Carrier l₂} →
@@ -146,18 +128,60 @@ replace-equality {_≈′_} ≈⇔≈′ = record
   ; _∧_       = _∧_
   ; _∨_       = _∨_
   ; isLattice = record
-    { isEquivalence = record
-      { refl  = to ⟨$⟩ refl
-      ; sym   = λ x≈y → to ⟨$⟩ sym (from ⟨$⟩ x≈y)
-      ; trans = λ x≈y y≈z → to ⟨$⟩ trans (from ⟨$⟩ x≈y) (from ⟨$⟩ y≈z)
+    { ∨-isSemilattice = record
+      { isBand = record
+        { isSemigroup = record
+          { isMagma = record
+            { isEquivalence = isEq
+            ; ∙-cong        = λ x≈y u≈v → to ⟨$⟩ ∨-cong (from ⟨$⟩ x≈y) (from ⟨$⟩ u≈v)
+            }
+          ; assoc   = λ x y z → to ⟨$⟩ ∨-assoc x y z
+          }
+        ; idem = λ x → to ⟨$⟩ ∨-idem x
+        }
+      ; comm = λ x y → to ⟨$⟩ ∨-comm x y
       }
-    ; ∨-comm     = λ x y → to ⟨$⟩ ∨-comm x y
-    ; ∨-assoc    = λ x y z → to ⟨$⟩ ∨-assoc x y z
-    ; ∨-cong     = λ x≈y u≈v → to ⟨$⟩ ∨-cong (from ⟨$⟩ x≈y) (from ⟨$⟩ u≈v)
-    ; ∧-comm     = λ x y → to ⟨$⟩ ∧-comm x y
-    ; ∧-assoc    = λ x y z → to ⟨$⟩ ∧-assoc x y z
-    ; ∧-cong     = λ x≈y u≈v → to ⟨$⟩ ∧-cong (from ⟨$⟩ x≈y) (from ⟨$⟩ u≈v)
-    ; absorptive = (λ x y → to ⟨$⟩ proj₁ absorptive x y)
-                 , (λ x y → to ⟨$⟩ proj₂ absorptive x y)
+    ; ∧-isSemilattice = record
+      { isBand = record
+        { isSemigroup = record
+          { isMagma = record
+            { isEquivalence = isEq
+            ; ∙-cong        = λ x≈y u≈v → to ⟨$⟩ ∧-cong (from ⟨$⟩ x≈y) (from ⟨$⟩ u≈v)
+            }
+          ; assoc   = λ x y z → to ⟨$⟩ ∧-assoc x y z
+          }
+        ; idem = λ x → to ⟨$⟩ ∧-idem x
+        }
+      ; comm = λ x y → to ⟨$⟩ ∧-comm x y
+      }
+    ; absorptive      = (λ x y → to ⟨$⟩ ∨-absorbs-∧ x y)
+                      , (λ x y → to ⟨$⟩ ∧-absorbs-∨ x y)
     }
-  } where open module E {x y} = Equivalence (≈⇔≈′ {x} {y})
+  }
+  where
+  open module E {x y} = Equivalence (≈⇔≈′ {x} {y})
+
+  isEq = record
+    { refl  = to ⟨$⟩ refl
+    ; sym   = λ x≈y → to ⟨$⟩ sym (from ⟨$⟩ x≈y)
+    ; trans = λ x≈y y≈z → to ⟨$⟩ trans (from ⟨$⟩ x≈y) (from ⟨$⟩ y≈z)
+    }
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 0.18
+
+∨-idempotent = ∨-idem
+{-# WARNING_ON_USAGE ∨-idempotent
+"Warning: ∨-idempotent was deprecated in v0.14.
+Instead please use `∨-idem` from the `Lattice` record."
+#-}
+∧-idempotent = ∧-idem
+{-# WARNING_ON_USAGE ∧-idempotent
+"Warning: ∧-idempotent was deprecated in v0.14.
+Instead please use `∧-idem` from the `Lattice` record."
+#-}

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -31,19 +31,10 @@ record IsMagma (∙ : Op₂ A) : Set (a ⊔ ℓ) where
 
 record IsSemigroup (∙ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isEquivalence : IsEquivalence _≈_
-    ∙-cong        : Congruent₂ ∙
-    assoc         : Associative ∙
+    isMagma : IsMagma ∙
+    assoc   : Associative ∙
 
-  open IsEquivalence isEquivalence public
-
-  isMagma : IsMagma ∙
-  isMagma = record
-    { isEquivalence = isEquivalence
-    ; ∙-cong        = ∙-cong
-    }
-
-  open IsMagma isMagma public using (setoid)
+  open IsMagma isMagma public
 
 record IsBand (∙ : Op₂ A) : Set (a ⊔ ℓ) where
   field
@@ -52,7 +43,12 @@ record IsBand (∙ : Op₂ A) : Set (a ⊔ ℓ) where
 
   open IsSemigroup isSemigroup public
 
--- Commutative idempotent semigroups are semilattices (see Lattices)
+record IsSemilattice (∧ : Op₂ A) : Set (a ⊔ ℓ) where
+  field
+    isBand : IsBand ∧
+    comm   : Commutative ∧
+
+  open IsBand isBand public
 
 ------------------------------------------------------------------------
 -- Monoids
@@ -428,25 +424,40 @@ record IsCommutativeRing
 ------------------------------------------------------------------------
 -- Lattices
 
-record IsSemilattice (∧ : Op₂ A) : Set (a ⊔ ℓ) where
-  field
-    isBand : IsBand ∧
-    comm   : Commutative ∧
-
-  open IsBand isBand public
-
 record IsLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isEquivalence : IsEquivalence _≈_
-    ∨-comm        : Commutative ∨
-    ∨-assoc       : Associative ∨
-    ∨-cong        : Congruent₂ ∨
-    ∧-comm        : Commutative ∧
-    ∧-assoc       : Associative ∧
-    ∧-cong        : Congruent₂ ∧
-    absorptive    : Absorptive ∨ ∧
+    ∨-isSemilattice : IsSemilattice ∨
+    ∧-isSemilattice : IsSemilattice ∧
+    absorptive      : Absorptive ∨ ∧
 
-  open IsEquivalence isEquivalence public
+  ∨-absorbs-∧ : ∨ Absorbs ∧
+  ∨-absorbs-∧ = proj₁ absorptive
+
+  ∧-absorbs-∨ : ∧ Absorbs ∨
+  ∧-absorbs-∨ = proj₂ absorptive
+
+  open IsSemilattice ∨-isSemilattice public
+    renaming
+    ( ∙-cong      to ∨-cong
+    ; assoc       to ∨-assoc
+    ; comm        to ∨-comm
+    ; idem        to ∨-idem
+    ; isMagma     to ∨-isMagma
+    ; isSemigroup to ∨-isSemigroup
+    ; isBand      to ∨-isBand
+    )
+
+  open IsSemilattice ∧-isSemilattice public
+    renaming
+    ( ∙-cong      to ∧-cong
+    ; assoc       to ∧-assoc
+    ; comm        to ∧-comm
+    ; idem        to ∧-idem
+    ; isMagma     to ∧-isMagma
+    ; isSemigroup to ∧-isSemigroup
+    ; isBand      to ∧-isBand
+    )
+    hiding (refl; reflexive; sym; trans; isEquivalence; setoid)
 
 record IsDistributiveLattice (∨ ∧ : Op₂ A) : Set (a ⊔ ℓ) where
   field

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -15,6 +15,7 @@ open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence
   using (_⇔_; equivalence; module Equivalence)
+open import Level using (0ℓ)
 open import Relation.Binary.Core using (Decidable)
 open import Relation.Binary.PropositionalEquality
   hiding ([_]; proof-irrelevance)
@@ -87,16 +88,48 @@ false ≟ true  = no λ()
 ∨-sel false y = inj₂ refl
 ∨-sel true y  = inj₁ refl
 
-∨-isSemigroup : IsSemigroup _∨_
-∨-isSemigroup = record
+∨-isMagma : IsMagma _∨_
+∨-isMagma = record
   { isEquivalence = isEquivalence
-  ; assoc         = ∨-assoc
   ; ∙-cong        = cong₂ _∨_
   }
 
-∨-semigroup : Semigroup _ _
+∨-magma : Magma 0ℓ 0ℓ
+∨-magma = record
+  { isMagma = ∨-isMagma
+  }
+
+∨-isSemigroup : IsSemigroup _∨_
+∨-isSemigroup = record
+  { isMagma = ∨-isMagma
+  ; assoc   = ∨-assoc
+  }
+
+∨-semigroup : Semigroup 0ℓ 0ℓ
 ∨-semigroup = record
   { isSemigroup = ∨-isSemigroup
+  }
+
+∨-isBand : IsBand _∨_
+∨-isBand = record
+  { isSemigroup = ∨-isSemigroup
+  ; idem        = ∨-idem
+  }
+
+∨-band : Band 0ℓ 0ℓ
+∨-band = record
+  { isBand = ∨-isBand
+  }
+
+∨-isSemilattice : IsSemilattice _∨_
+∨-isSemilattice = record
+  { isBand = ∨-isBand
+  ; comm   = ∨-comm
+  }
+
+∨-semilattice : Semilattice 0ℓ 0ℓ
+∨-semilattice = record
+  { isSemilattice = ∨-isSemilattice
   }
 
 ∨-isCommutativeMonoid : IsCommutativeMonoid _∨_ false
@@ -106,7 +139,7 @@ false ≟ true  = no λ()
   ; comm        = ∨-comm
   }
 
-∨-commutativeMonoid : CommutativeMonoid _ _
+∨-commutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
 ∨-commutativeMonoid = record
   { isCommutativeMonoid = ∨-isCommutativeMonoid
   }
@@ -118,7 +151,7 @@ false ≟ true  = no λ()
    ; idem = ∨-idem
    }
 
-∨-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+∨-idempotentCommutativeMonoid : IdempotentCommutativeMonoid 0ℓ 0ℓ
 ∨-idempotentCommutativeMonoid = record
   { isIdempotentCommutativeMonoid = ∨-isIdempotentCommutativeMonoid
   }
@@ -213,16 +246,48 @@ false ≟ true  = no λ()
 ∨-∧-absorptive : Absorptive _∨_ _∧_
 ∨-∧-absorptive = ∨-abs-∧ , ∧-abs-∨
 
-∧-isSemigroup : IsSemigroup _∧_
-∧-isSemigroup = record
+∧-isMagma : IsMagma _∧_
+∧-isMagma = record
   { isEquivalence = isEquivalence
-  ; assoc         = ∧-assoc
   ; ∙-cong        = cong₂ _∧_
   }
 
-∧-semigroup : Semigroup _ _
+∧-magma : Magma 0ℓ 0ℓ
+∧-magma = record
+  { isMagma = ∧-isMagma
+  }
+
+∧-isSemigroup : IsSemigroup _∧_
+∧-isSemigroup = record
+  { isMagma = ∧-isMagma
+  ; assoc   = ∧-assoc
+  }
+
+∧-semigroup : Semigroup 0ℓ 0ℓ
 ∧-semigroup = record
   { isSemigroup = ∧-isSemigroup
+  }
+
+∧-isBand : IsBand _∧_
+∧-isBand = record
+  { isSemigroup = ∧-isSemigroup
+  ; idem        = ∧-idem
+  }
+
+∧-band : Band 0ℓ 0ℓ
+∧-band = record
+  { isBand = ∧-isBand
+  }
+
+∧-isSemilattice : IsSemilattice _∧_
+∧-isSemilattice = record
+  { isBand = ∧-isBand
+  ; comm   = ∧-comm
+  }
+
+∧-semilattice : Semilattice 0ℓ 0ℓ
+∧-semilattice = record
+  { isSemilattice = ∧-isSemilattice
   }
 
 ∧-isCommutativeMonoid : IsCommutativeMonoid _∧_ true
@@ -232,7 +297,7 @@ false ≟ true  = no λ()
   ; comm        = ∧-comm
   }
 
-∧-commutativeMonoid : CommutativeMonoid _ _
+∧-commutativeMonoid : CommutativeMonoid 0ℓ 0ℓ
 ∧-commutativeMonoid = record
   { isCommutativeMonoid = ∧-isCommutativeMonoid
   }
@@ -244,7 +309,7 @@ false ≟ true  = no λ()
   ; idem = ∧-idem
   }
 
-∧-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+∧-idempotentCommutativeMonoid : IdempotentCommutativeMonoid 0ℓ 0ℓ
 ∧-idempotentCommutativeMonoid = record
   { isIdempotentCommutativeMonoid = ∧-isIdempotentCommutativeMonoid
   }
@@ -258,7 +323,7 @@ false ≟ true  = no λ()
   ; zeroˡ    = ∧-zeroˡ
   }
 
-∨-∧-commutativeSemiring : CommutativeSemiring _ _
+∨-∧-commutativeSemiring : CommutativeSemiring 0ℓ 0ℓ
 ∨-∧-commutativeSemiring = record
   { _+_                   = _∨_
   ; _*_                   = _∧_
@@ -276,7 +341,7 @@ false ≟ true  = no λ()
   ; zeroˡ    = ∨-zeroˡ
   }
 
-∧-∨-commutativeSemiring : CommutativeSemiring _ _
+∧-∨-commutativeSemiring : CommutativeSemiring 0ℓ 0ℓ
 ∧-∨-commutativeSemiring = record
   { _+_                   = _∧_
   ; _*_                   = _∨_
@@ -287,17 +352,12 @@ false ≟ true  = no λ()
 
 ∨-∧-isLattice : IsLattice _∨_ _∧_
 ∨-∧-isLattice = record
-  { isEquivalence = isEquivalence
-  ; ∨-comm        = ∨-comm
-  ; ∨-assoc       = ∨-assoc
-  ; ∨-cong        = cong₂ _∨_
-  ; ∧-comm        = ∧-comm
-  ; ∧-assoc       = ∧-assoc
-  ; ∧-cong        = cong₂ _∧_
-  ; absorptive    = ∨-∧-absorptive
+  { ∨-isSemilattice = ∨-isSemilattice
+  ; ∧-isSemilattice = ∧-isSemilattice
+  ; absorptive      = ∨-∧-absorptive
   }
 
-∨-∧-lattice : Lattice _ _
+∨-∧-lattice : Lattice 0ℓ 0ℓ
 ∨-∧-lattice = record
   { isLattice = ∨-∧-isLattice
   }
@@ -308,7 +368,7 @@ false ≟ true  = no λ()
   ; ∨-∧-distribʳ = ∨-distribʳ-∧
   }
 
-∨-∧-distributiveLattice : DistributiveLattice _ _
+∨-∧-distributiveLattice : DistributiveLattice 0ℓ 0ℓ
 ∨-∧-distributiveLattice = record
   { isDistributiveLattice = ∨-∧-isDistributiveLattice
   }
@@ -321,7 +381,7 @@ false ≟ true  = no λ()
   ; ¬-cong        = cong not
   }
 
-∨-∧-booleanAlgebra : BooleanAlgebra _ _
+∨-∧-booleanAlgebra : BooleanAlgebra 0ℓ 0ℓ
 ∨-∧-booleanAlgebra = record
   { isBooleanAlgebra = ∨-∧-isBooleanAlgebra
   }
@@ -333,7 +393,7 @@ xor-is-ok : ∀ x y → x xor y ≡ (x ∨ y) ∧ not (x ∧ y)
 xor-is-ok true  y = refl
 xor-is-ok false y = sym (∧-identityʳ _)
 
-xor-∧-commutativeRing : CommutativeRing _ _
+xor-∧-commutativeRing : CommutativeRing 0ℓ 0ℓ
 xor-∧-commutativeRing = commutativeRing
   where
   import Algebra.Properties.BooleanAlgebra as BA

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -239,16 +239,48 @@ module _ (n : ℕ) where
 
   open AlgebraicStructures {A = Subset n} _≡_
 
+  ∩-isMagma : IsMagma _∩_
+  ∩-isMagma = record
+    { isEquivalence = isEquivalence
+    ; ∙-cong        = cong₂ _∩_
+    }
+
+  ∩-magma : Magma _ _
+  ∩-magma = record
+    { isMagma = ∩-isMagma
+    }
+
   ∩-isSemigroup : IsSemigroup _∩_
   ∩-isSemigroup = record
-    { isEquivalence = isEquivalence
-    ; assoc         = ∩-assoc
-    ; ∙-cong        = cong₂ _∩_
+    { isMagma = ∩-isMagma
+    ; assoc   = ∩-assoc
     }
 
   ∩-semigroup : Semigroup _ _
   ∩-semigroup = record
     { isSemigroup = ∩-isSemigroup
+    }
+
+  ∩-isBand : IsBand _∩_
+  ∩-isBand = record
+    { isSemigroup = ∩-isSemigroup
+    ; idem        = ∩-idem
+    }
+
+  ∩-band : Band _ _
+  ∩-band = record
+    { isBand = ∩-isBand
+    }
+
+  ∩-isSemilattice : IsSemilattice _∩_
+  ∩-isSemilattice = record
+    { isBand = ∩-isBand
+    ; comm   = ∩-comm
+    }
+
+  ∩-semilattice : Semilattice _ _
+  ∩-semilattice = record
+    { isSemilattice = ∩-isSemilattice
     }
 
   ∩-isMonoid : IsMonoid _∩_ ⊤
@@ -378,16 +410,48 @@ module _ (n : ℕ) where
 
   open AlgebraicStructures {A = Subset n} _≡_
 
+  ∪-isMagma : IsMagma _∪_
+  ∪-isMagma = record
+    { isEquivalence = isEquivalence
+    ; ∙-cong        = cong₂ _∪_
+    }
+
+  ∪-magma : Magma _ _
+  ∪-magma = record
+    { isMagma = ∪-isMagma
+    }
+
   ∪-isSemigroup : IsSemigroup _∪_
   ∪-isSemigroup = record
-    { isEquivalence = isEquivalence
-    ; assoc         = ∪-assoc
-    ; ∙-cong        = cong₂ _∪_
+    { isMagma = ∪-isMagma
+    ; assoc   = ∪-assoc
     }
 
   ∪-semigroup : Semigroup _ _
   ∪-semigroup = record
     { isSemigroup = ∪-isSemigroup
+    }
+
+  ∪-isBand : IsBand _∪_
+  ∪-isBand = record
+    { isSemigroup = ∪-isSemigroup
+    ; idem        = ∪-idem
+    }
+
+  ∪-band : Band _ _
+  ∪-band = record
+    { isBand = ∪-isBand
+    }
+
+  ∪-isSemilattice : IsSemilattice _∪_
+  ∪-isSemilattice = record
+    { isBand = ∪-isBand
+    ; comm   = ∪-comm
+    }
+
+  ∪-semilattice : Semilattice _ _
+  ∪-semilattice = record
+    { isSemilattice = ∪-isSemilattice
     }
 
   ∪-isMonoid : IsMonoid _∪_ ⊥
@@ -426,14 +490,9 @@ module _ (n : ℕ) where
 
   ∪-∩-isLattice : IsLattice _∪_ _∩_
   ∪-∩-isLattice = record
-    { isEquivalence = isEquivalence
-    ; ∨-comm        = ∪-comm
-    ; ∨-assoc       = ∪-assoc
-    ; ∨-cong        = cong₂ _∪_
-    ; ∧-comm        = ∩-comm
-    ; ∧-assoc       = ∩-assoc
-    ; ∧-cong        = cong₂ _∩_
-    ; absorptive    = ∪-abs-∩ , ∩-abs-∪
+    { ∨-isSemilattice = ∪-isSemilattice
+    ; ∧-isSemilattice = ∩-isSemilattice n
+    ; absorptive      = ∪-abs-∩ , ∩-abs-∪
     }
 
   ∪-∩-lattice : Lattice _ _

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -18,11 +18,12 @@ open import Data.Nat as ℕ
     _≤_ to _ℕ≤_; _<_ to _ℕ<_; _≥_ to _ℕ≥_; _≰_ to _ℕ≰_; _≟_ to _ℕ≟_; _≤?_ to _ℕ≤?_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Nat.Solver
-open import Data.Product using (proj₁; proj₂; _,_)
+open import Data.Product using (_,_)
 open import Data.Sum using (inj₁; inj₂)
 open import Data.Sign as Sign using () renaming (_*_ to _𝕊*_)
 import Data.Sign.Properties as 𝕊ₚ
 open import Function using (_∘_; _$_)
+open import Level using (0ℓ)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
 import Relation.Binary.PartialOrderReasoning as POR
@@ -307,17 +308,37 @@ distribʳ-⊖-+-neg a b c = begin
 +-inverse : Inverse (+ 0) -_ _+_
 +-inverse = +-inverseˡ , +-inverseʳ
 
++-isMagma : IsMagma _+_
++-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _+_
+  }
+
++-magma : Magma 0ℓ 0ℓ
++-magma = record
+  { isMagma = +-isMagma
+  }
+
 +-isSemigroup : IsSemigroup _+_
 +-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = +-assoc
-  ; ∙-cong        = cong₂ _+_
+  { isMagma = +-isMagma
+  ; assoc   = +-assoc
+  }
+
++-semigroup : Semigroup 0ℓ 0ℓ
++-semigroup = record
+  { isSemigroup = +-isSemigroup
   }
 
 +-0-isMonoid : IsMonoid _+_ (+ 0)
 +-0-isMonoid = record
   { isSemigroup = +-isSemigroup
   ; identity    = +-identity
+  }
+
++-0-monoid : Monoid 0ℓ 0ℓ
++-0-monoid = record
+  { isMonoid = +-0-isMonoid
   }
 
 +-0-isCommutativeMonoid : IsCommutativeMonoid _+_ (+ 0)
@@ -329,11 +350,7 @@ distribʳ-⊖-+-neg a b c = begin
 
 +-0-commutativeMonoid : CommutativeMonoid _ _
 +-0-commutativeMonoid = record
-  { Carrier             = ℤ
-  ; _≈_                 = _≡_
-  ; _∙_                 = _+_
-  ; ε                   = + 0
-  ; isCommutativeMonoid = +-0-isCommutativeMonoid
+  { isCommutativeMonoid = +-0-isCommutativeMonoid
   }
 
 +-0-isGroup : IsGroup _+_ (+ 0) (-_)
@@ -351,12 +368,7 @@ distribʳ-⊖-+-neg a b c = begin
 
 +-0-abelianGroup : AbelianGroup _ _
 +-0-abelianGroup = record
-  { Carrier = ℤ
-  ; _≈_ = _≡_
-  ; _∙_ = _+_
-  ; ε = + 0
-  ; _⁻¹ = -_
-  ; isAbelianGroup = +-isAbelianGroup
+  { isAbelianGroup = +-isAbelianGroup
   }
 
 -- Other properties of _+_
@@ -551,17 +563,37 @@ private
         | ℕₚ.*-distribʳ-∸ (suc c) b a
         = refl
 
+*-isMagma : IsMagma _*_
+*-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _*_
+  }
+
+*-magma : Magma 0ℓ 0ℓ
+*-magma = record
+  { isMagma = *-isMagma
+  }
+
 *-isSemigroup : IsSemigroup _*_
 *-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = *-assoc
-  ; ∙-cong        = cong₂ _*_
+  { isMagma = *-isMagma
+  ; assoc   = *-assoc
+  }
+
+*-semigroup : Semigroup 0ℓ 0ℓ
+*-semigroup = record
+  { isSemigroup = *-isSemigroup
   }
 
 *-1-isMonoid : IsMonoid _*_ (+ 1)
 *-1-isMonoid = record
   { isSemigroup = *-isSemigroup
   ; identity    = *-identity
+  }
+
+*-1-monoid : Monoid 0ℓ 0ℓ
+*-1-monoid = record
+  { isMonoid = *-1-isMonoid
   }
 
 *-1-isCommutativeMonoid : IsCommutativeMonoid _*_ (+ 1)
@@ -573,11 +605,7 @@ private
 
 *-1-commutativeMonoid : CommutativeMonoid _ _
 *-1-commutativeMonoid = record
-  { Carrier             = ℤ
-  ; _≈_                 = _≡_
-  ; _∙_                 = _*_
-  ; ε                   = + 1
-  ; isCommutativeMonoid = *-1-isCommutativeMonoid
+  { isCommutativeMonoid = *-1-isCommutativeMonoid
   }
 
 +-*-isCommutativeSemiring : IsCommutativeSemiring _+_ _*_ (+ 0) (+ 1)
@@ -861,10 +889,7 @@ n≤1+n n = ≤-step ≤-refl
 
 <-strictTotalOrder : StrictTotalOrder _ _ _
 <-strictTotalOrder = record
-  { Carrier            = ℤ
-  ; _≈_                = _≡_
-  ; _<_                = _<_
-  ; isStrictTotalOrder = <-isStrictTotalOrder
+  { isStrictTotalOrder = <-isStrictTotalOrder
   }
 
 n≮n : ∀ {n} → n ≮ n

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -10,7 +10,7 @@
 module Data.List.Properties where
 
 open import Algebra
-open import Algebra.Structures
+import Algebra.Structures as Structures
 open import Algebra.FunctionProperties
 open import Data.Bool.Base using (Bool; false; true; not; if_then_else_)
 open import Data.List as List
@@ -153,35 +153,41 @@ module _ {a} {A : Set a} where
   length-++ []       = refl
   length-++ (x ∷ xs) = P.cong suc (length-++ xs)
 
-  ++-isSemigroup : IsSemigroup {A = List A} _≡_ _++_
-  ++-isSemigroup = record
+module _ {a} {A : Set a} where
+
+  open Structures {A = List A} _≡_
+
+  ++-isMagma : IsMagma _++_
+  ++-isMagma = record
     { isEquivalence = P.isEquivalence
-    ; assoc         = ++-assoc
     ; ∙-cong        = P.cong₂ _++_
     }
 
-  ++-isMonoid : IsMonoid {A = List A} _≡_ _++_ []
+  ++-isSemigroup : IsSemigroup _++_
+  ++-isSemigroup = record
+    { isMagma = ++-isMagma
+    ; assoc   = ++-assoc
+    }
+
+  ++-isMonoid : IsMonoid _++_ []
   ++-isMonoid = record
     { isSemigroup = ++-isSemigroup
     ; identity    = ++-identity
     }
 
-++-semigroup : ∀ {a} (A : Set a) → Semigroup _ _
-++-semigroup A = record
-  { Carrier  = List A
-  ; _≈_      = _≡_
-  ; _∙_      = _++_
-  ; isSemigroup = ++-isSemigroup
-  }
+module _ {a} (A : Set a) where
 
-++-monoid : ∀ {a} (A : Set a) → Monoid _ _
-++-monoid A = record
-  { Carrier  = List A
-  ; _≈_      = _≡_
-  ; _∙_      = _++_
-  ; ε        = []
-  ; isMonoid = ++-isMonoid
-  }
+  ++-semigroup : Semigroup a a
+  ++-semigroup = record
+    { Carrier     = List A
+    ; isSemigroup = ++-isSemigroup
+    }
+
+  ++-monoid : Monoid a a
+  ++-monoid = record
+    { Carrier  = List A
+    ; isMonoid = ++-isMonoid
+    }
 
 ------------------------------------------------------------------------
 -- alignWith

--- a/src/Data/List/Relation/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/BagAndSetEquality.agda
@@ -208,10 +208,12 @@ commutativeMonoid {a} k A = record
   ; ε                   = []
   ; isCommutativeMonoid = record
     { isSemigroup = record
-      { isEquivalence = Eq.isEquivalence
+      { isMagma = record
+        { isEquivalence = Eq.isEquivalence
+        ; ∙-cong        = ++-cong
+        }
       ; assoc         = λ xs ys zs →
                           Eq.reflexive (LP.++-assoc xs ys zs)
-      ; ∙-cong        = ++-cong
       }
     ; identityˡ = λ xs {x} → x ∈ xs ∎
     ; comm      = λ xs ys {x} →

--- a/src/Data/List/Relation/Permutation/Inductive/Properties.agda
+++ b/src/Data/List/Relation/Permutation/Inductive/Properties.agda
@@ -178,11 +178,21 @@ module _ {a} {A : Set a} where
     ys ++ ([ x ] ++ xs)  ≡⟨⟩
     ys ++ (x ∷ xs)       ∎
 
+  ++-isMagma : IsMagma _↭_ _++_
+  ++-isMagma = record
+    { isEquivalence = ↭-isEquivalence
+    ; ∙-cong        = ++⁺
+    }
+
+  ++-magma : Magma _ _
+  ++-magma = record
+    { isMagma = ++-isMagma
+    }
+
   ++-isSemigroup : IsSemigroup _↭_ _++_
   ++-isSemigroup = record
-    { isEquivalence = ↭-isEquivalence
-    ; assoc         = ++-assoc
-    ; ∙-cong        = ++⁺
+    { isMagma = ++-isMagma
+    ; assoc   = ++-assoc
     }
 
   ++-semigroup : Semigroup a _

--- a/src/Data/Maybe/Properties.agda
+++ b/src/Data/Maybe/Properties.agda
@@ -7,8 +7,8 @@
 module Data.Maybe.Properties where
 
 open import Algebra
-open import Algebra.Structures
-open import Algebra.FunctionProperties
+import Algebra.Structures as Structures
+import Algebra.FunctionProperties as FunctionProperties
 open import Data.Maybe.Base
 open import Data.Maybe.All using (All; just; nothing)
 open import Data.Product using (_,_)
@@ -77,31 +77,40 @@ module _ {a b} {A : Set a} {B : Set b} where
 
 module _ {a} {A : Set a} where
 
-  <∣>-assoc : Associative {A = Maybe A} _≡_ _<∣>_
+  open FunctionProperties {A = Maybe A} _≡_
+
+  <∣>-assoc : Associative _<∣>_
   <∣>-assoc (just x) y z = refl
   <∣>-assoc nothing  y z = refl
 
-  <∣>-identityˡ : LeftIdentity {A = Maybe A} _≡_ nothing _<∣>_
+  <∣>-identityˡ : LeftIdentity nothing _<∣>_
   <∣>-identityˡ (just x) = refl
   <∣>-identityˡ nothing  = refl
 
-  <∣>-identityʳ : RightIdentity {A = Maybe A} _≡_ nothing _<∣>_
+  <∣>-identityʳ : RightIdentity nothing _<∣>_
   <∣>-identityʳ (just x) = refl
   <∣>-identityʳ nothing  = refl
 
-  <∣>-identity : Identity {A = Maybe A} _≡_ nothing _<∣>_
+  <∣>-identity : Identity nothing _<∣>_
   <∣>-identity = <∣>-identityˡ , <∣>-identityʳ
 
 module _ {a} (A : Set a) where
 
-  <∣>-isSemigroup : IsSemigroup {A = Maybe A} _≡_ _<∣>_
-  <∣>-isSemigroup = record
+  open Structures {A = Maybe A} _≡_
+
+  <∣>-isMagma : IsMagma _<∣>_
+  <∣>-isMagma = record
     { isEquivalence = isEquivalence
-    ; assoc         = <∣>-assoc
     ; ∙-cong        = cong₂ _<∣>_
     }
 
-  <∣>-isMonoid : IsMonoid {A = Maybe A} _≡_ _<∣>_ nothing
+  <∣>-isSemigroup : IsSemigroup _<∣>_
+  <∣>-isSemigroup = record
+    { isMagma = <∣>-isMagma
+    ; assoc   = <∣>-assoc
+    }
+
+  <∣>-isMonoid : IsMonoid _<∣>_ nothing
   <∣>-isMonoid = record
     { isSemigroup = <∣>-isSemigroup
     ; identity    = <∣>-identity

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -401,11 +401,21 @@ _>″?_ = flip _<″?_
   suc (n + m) ≡⟨ sym (+-suc n m) ⟩
   n + suc m   ∎
 
++-isMagma : IsMagma _+_
++-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _+_
+  }
+
++-magma : Magma 0ℓ 0ℓ
++-magma = record
+  { isMagma = +-isMagma
+  }
+
 +-isSemigroup : IsSemigroup _+_
 +-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = +-assoc
-  ; ∙-cong        = cong₂ _+_
+  { isMagma = +-isMagma
+  ; assoc   = +-assoc
   }
 
 +-semigroup : Semigroup 0ℓ 0ℓ
@@ -612,11 +622,21 @@ n≤′m+n (suc m) n = ≤′-step (n≤′m+n m n)
   n * o + m * (n * o) ≡⟨⟩
   suc m * (n * o)     ∎
 
+*-isMagma : IsMagma _*_
+*-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _*_
+  }
+
+*-magma : Magma 0ℓ 0ℓ
+*-magma = record
+  { isMagma = *-isMagma
+  }
+
 *-isSemigroup : IsSemigroup _*_
 *-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = *-assoc
-  ; ∙-cong        = cong₂ _*_
+  { isMagma = *-isMagma
+  ; assoc   = *-assoc
   }
 
 *-semigroup : Semigroup 0ℓ 0ℓ
@@ -884,16 +904,48 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
 ⊓-⊔-absorptive : Absorptive _⊓_ _⊔_
 ⊓-⊔-absorptive = ⊓-abs-⊔ , ⊔-abs-⊓
 
+⊔-isMagma : IsMagma _⊔_
+⊔-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _⊔_
+  }
+
+⊔-magma : Magma 0ℓ 0ℓ
+⊔-magma = record
+  { isMagma = ⊔-isMagma
+  }
+
 ⊔-isSemigroup : IsSemigroup _⊔_
 ⊔-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = ⊔-assoc
-  ; ∙-cong        = cong₂ _⊔_
+  { isMagma = ⊔-isMagma
+  ; assoc   = ⊔-assoc
   }
 
 ⊔-semigroup : Semigroup 0ℓ 0ℓ
 ⊔-semigroup = record
   { isSemigroup = ⊔-isSemigroup
+  }
+
+⊔-isBand : IsBand _⊔_
+⊔-isBand = record
+  { isSemigroup = ⊔-isSemigroup
+  ; idem        = ⊔-idem
+  }
+
+⊔-band : Band 0ℓ 0ℓ
+⊔-band = record
+  { isBand = ⊔-isBand
+  }
+
+⊔-isSemilattice : IsSemilattice _⊔_
+⊔-isSemilattice = record
+  { isBand = ⊔-isBand
+  ; comm   = ⊔-comm
+  }
+
+⊔-semilattice : Semilattice 0ℓ 0ℓ
+⊔-semilattice = record
+  { isSemilattice = ⊔-isSemilattice
   }
 
 ⊔-0-isCommutativeMonoid : IsCommutativeMonoid _⊔_ 0
@@ -908,16 +960,48 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
   { isCommutativeMonoid = ⊔-0-isCommutativeMonoid
   }
 
+⊓-isMagma : IsMagma _⊓_
+⊓-isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong        = cong₂ _⊓_
+  }
+
+⊓-magma : Magma 0ℓ 0ℓ
+⊓-magma = record
+  { isMagma = ⊓-isMagma
+  }
+
 ⊓-isSemigroup : IsSemigroup _⊓_
 ⊓-isSemigroup = record
-  { isEquivalence = isEquivalence
-  ; assoc         = ⊓-assoc
-  ; ∙-cong        = cong₂ _⊓_
+  { isMagma = ⊓-isMagma
+  ; assoc   = ⊓-assoc
   }
 
 ⊓-semigroup : Semigroup 0ℓ 0ℓ
 ⊓-semigroup = record
   { isSemigroup = ⊔-isSemigroup
+  }
+
+⊓-isBand : IsBand _⊓_
+⊓-isBand = record
+  { isSemigroup = ⊓-isSemigroup
+  ; idem        = ⊓-idem
+  }
+
+⊓-band : Band 0ℓ 0ℓ
+⊓-band = record
+  { isBand = ⊓-isBand
+  }
+
+⊓-isSemilattice : IsSemilattice _⊓_
+⊓-isSemilattice = record
+  { isBand = ⊓-isBand
+  ; comm   = ⊓-comm
+  }
+
+⊓-semilattice : Semilattice 0ℓ 0ℓ
+⊓-semilattice = record
+  { isSemilattice = ⊓-isSemilattice
   }
 
 ⊔-⊓-isSemiringWithoutOne : IsSemiringWithoutOne _⊔_ _⊓_ 0
@@ -943,14 +1027,9 @@ i^j≡1⇒j≡0∨i≡1 i (suc j) eq = inj₂ (i*j≡1⇒i≡1 i (i ^ j) eq)
 
 ⊓-⊔-isLattice : IsLattice _⊓_ _⊔_
 ⊓-⊔-isLattice = record
-  { isEquivalence = isEquivalence
-  ; ∨-comm        = ⊓-comm
-  ; ∨-assoc       = ⊓-assoc
-  ; ∨-cong        = cong₂ _⊓_
-  ; ∧-comm        = ⊔-comm
-  ; ∧-assoc       = ⊔-assoc
-  ; ∧-cong        = cong₂ _⊔_
-  ; absorptive    = ⊓-⊔-absorptive
+  { ∨-isSemilattice = ⊓-isSemilattice
+  ; ∧-isSemilattice = ⊔-isSemilattice
+  ; absorptive      = ⊓-⊔-absorptive
   }
 
 ⊓-⊔-lattice : Lattice 0ℓ 0ℓ

--- a/src/Data/Sign/Properties.agda
+++ b/src/Data/Sign/Properties.agda
@@ -7,13 +7,15 @@
 module Data.Sign.Properties where
 
 open import Algebra
-open import Algebra.Structures
 open import Data.Empty
-open import Function
 open import Data.Sign
 open import Data.Product using (_,_)
+open import Function
+open import Level using (0ℓ)
 open import Relation.Binary.PropositionalEquality
-open import Algebra.FunctionProperties (_≡_ {A = Sign})
+
+open import Algebra.Structures {A = Sign} _≡_
+open import Algebra.FunctionProperties {A = Sign} _≡_
 
 -- The opposite of a sign is not equal to the sign.
 
@@ -68,34 +70,37 @@ opposite-injective { + } { + } refl = refl
 *-cancel-≡ : Cancellative _*_
 *-cancel-≡ = *-cancelˡ-≡ , *-cancelʳ-≡
 
-*-isSemigroup : IsSemigroup _≡_ _*_
-*-isSemigroup = record
+*-isMagma : IsMagma _*_
+*-isMagma = record
   { isEquivalence = isEquivalence
-  ; assoc         = *-assoc
   ; ∙-cong        = cong₂ _*_
   }
 
-*-semigroup : Semigroup _ _
-*-semigroup = record
-  { Carrier     = Sign
-  ; _≈_         = _≡_
-  ; _∙_         = _*_
-  ; isSemigroup = *-isSemigroup
+*-magma : Magma 0ℓ 0ℓ
+*-magma = record
+  { isMagma = *-isMagma
   }
 
-*-isMonoid : IsMonoid _≡_ _*_ +
-*-isMonoid = record
-    { isSemigroup = *-isSemigroup
-    ; identity    = *-identity
-    }
+*-isSemigroup : IsSemigroup _*_
+*-isSemigroup = record
+  { isMagma = *-isMagma
+  ; assoc   = *-assoc
+  }
 
-*-monoid : Monoid _ _
+*-semigroup : Semigroup 0ℓ 0ℓ
+*-semigroup = record
+  { isSemigroup = *-isSemigroup
+  }
+
+*-isMonoid : IsMonoid _*_ +
+*-isMonoid = record
+  { isSemigroup = *-isSemigroup
+  ; identity    = *-identity
+  }
+
+*-monoid : Monoid 0ℓ 0ℓ
 *-monoid = record
-  { Carrier  = Sign
-  ; _≈_      = _≡_
-  ; _∙_      = _*_
-  ; ε        = +
-  ; isMonoid = *-isMonoid
+  { isMonoid = *-isMonoid
   }
 
 -- Other properties of _*_

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -125,11 +125,21 @@ open import Relation.Nullary.Decidable using (True)
 
 -- ⊤, _×_ form a commutative monoid
 
+×-isMagma : ∀ k ℓ → IsMagma {Level.suc ℓ} (Related ⌊ k ⌋) _×_
+×-isMagma k ℓ = record
+  { isEquivalence = SK-isEquivalence k ℓ
+  ; ∙-cong        = _×-cong_
+  }
+
+×-magma : Symmetric-kind → (ℓ : Level) → Magma _ _
+×-magma k ℓ = record
+  { isMagma = ×-isMagma k ℓ
+  }
+
 ×-isSemigroup : ∀ k ℓ → IsSemigroup {Level.suc ℓ} (Related ⌊ k ⌋) _×_
 ×-isSemigroup k ℓ = record
-  { isEquivalence = SK-isEquivalence k ℓ
-  ; assoc         = λ _ _ _ → ↔⇒ Σ-assoc
-  ; ∙-cong        = _×-cong_
+  { isMagma = ×-isMagma k ℓ
+  ; assoc   = λ _ _ _ → ↔⇒ Σ-assoc
   }
 
 ×-semigroup : Symmetric-kind → (ℓ : Level) → Semigroup _ _
@@ -162,11 +172,21 @@ open import Relation.Nullary.Decidable using (True)
 
 -- ⊥, _⊎_ form a commutative monoid
 
+⊎-isMagma : ∀ k ℓ → IsMagma {Level.suc ℓ} (Related ⌊ k ⌋) _⊎_
+⊎-isMagma k ℓ = record
+  { isEquivalence = SK-isEquivalence k ℓ
+  ; ∙-cong        = _⊎-cong_
+  }
+
+⊎-magma : Symmetric-kind → (ℓ : Level) → Magma _ _
+⊎-magma k ℓ = record
+  { isMagma = ⊎-isMagma k ℓ
+  }
+
 ⊎-isSemigroup : ∀ k ℓ → IsSemigroup {Level.suc ℓ} (Related ⌊ k ⌋) _⊎_
 ⊎-isSemigroup k ℓ = record
-  { isEquivalence = SK-isEquivalence k ℓ
-  ; assoc         = λ A B C → ↔⇒ (⊎-assoc ℓ A B C)
-  ; ∙-cong        = _⊎-cong_
+  { isMagma = ⊎-isMagma k ℓ
+  ; assoc   = λ A B C → ↔⇒ (⊎-assoc ℓ A B C)
   }
 
 ⊎-semigroup : Symmetric-kind → (ℓ : Level) → Semigroup _ _

--- a/src/Relation/Binary/Properties/Lattice.agda
+++ b/src/Relation/Binary/Properties/Lattice.agda
@@ -111,15 +111,36 @@ collapse₂ {x} {y} ∨≤∧ = antisym
 
 isAlgLattice : Alg.IsLattice _≈_ _∨_ _∧_
 isAlgLattice = record
-  { isEquivalence = isEquivalence
-  ; ∨-comm        = J.∨-comm
-  ; ∨-assoc       = J.∨-assoc
-  ; ∨-cong        = J.∨-cong
-  ; ∧-comm        = M.∧-comm
-  ; ∧-assoc       = M.∧-assoc
-  ; ∧-cong        = M.∧-cong
+  { ∨-isSemilattice = record
+    { isBand = record
+      { isSemigroup = record
+        { isMagma = record
+          { isEquivalence = isEquivalence
+          ; ∙-cong        = J.∨-cong
+          }
+        ; assoc = J.∨-assoc
+        }
+      ; idem = J.∨-idempotent
+      }
+    ; comm = J.∨-comm
+    }
+  ; ∧-isSemilattice = record
+    { isBand = record
+      { isSemigroup = record
+        { isMagma = record
+          { isEquivalence = isEquivalence
+          ; ∙-cong        = M.∧-cong
+          }
+        ; assoc = M.∧-assoc
+        }
+      ; idem = M.∧-idempotent
+      }
+    ; comm = M.∧-comm
+    }
   ; absorptive    = absorptive
   }
 
 algLattice : Alg.Lattice c ℓ₁
-algLattice = record { isLattice = isAlgLattice }
+algLattice = record
+  { isLattice = isAlgLattice
+  }


### PR DESCRIPTION
This "corrects" the fields for `IsSemigroup` and `IsLattice` as discussed in #456. This is a little painful but I think better to nip this in the bud in v1.0 than to leave it be and have it cause even more problems in the long term.