### PR TITLE
Update Data.List.Membership.DecPropositional.

### DIFF
--- a/src/Data/List/Membership/DecPropositional.agda
+++ b/src/Data/List/Membership/DecPropositional.agda
@@ -13,7 +13,7 @@ module Data.List.Membership.DecPropositional
 ------------------------------------------------------------------------
 -- Re-export contents of propositional membership
 
-open import Data.List.Membership.Propositional public
+open import Data.List.Membership.Propositional {A = A} public
 open import Data.List.Membership.DecSetoid (decSetoid _≟_) public
   using (_∈?_)
 


### PR DESCRIPTION
"open import Data.List.Membership.Propositional public" is not given the carrier A and thus it returns generic functions. This is now fixed.