### PR TITLE
Some work on formalizing Suffix (re: #517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,9 @@ Splitting up `Data.Maybe` into the standard hierarchy.
 * The proofs `toList⁺` and `toList⁻` in `Data.Vec.All.Properties` have been swapped
   as they were the opposite way round to similar properties in the rest of the library.
 
+* The type of `antisymmetric` in `Data.List.Relation.Pointwise` has been modified to work
+  on heterogeneous relations.
+
 Other major changes
 -------------------
 
@@ -821,4 +824,15 @@ Other minor additions
   ```agda
   _Respectsʳ_ : REL A B ℓ₁ → Rel B ℓ₂ → Set _
   _Respectsˡ_ : REL A B ℓ₁ → Rel A ℓ₂ → Set _
+  ```
+
+* Added new proofs to `Data.List.Relation.Pointwise`:
+  ```agda
+  reverseAcc⁺ : Pointwise R a x → Pointwise R b y → Pointwise R (reverseAcc a b) (reverseAcc x y)
+  reverse⁺ : Pointwise R as bs → Pointwise R (reverse as) (reverse bs)
+  map⁺ : ∀ f g → Pointwise (λ a b → R (f a) (g b)) as bs → Pointwise R (map f as) (map g bs)
+  map⁻ : ∀ f g → Pointwise R (map f as) (map g bs) → Pointwise (λ a b → R (f a) (g b)) as bs
+  filter⁺ : Pointwise R as bs → Pointwise R (filter P? as) (filter Q? bs)
+  replicate⁺ : R a b → (n : ℕ) → Pointwise R (replicate n a) (replicate n b)
+  irrelevant : Irrelevant R → Irrelevant (Pointwise R)
   ```

--- a/src/Data/List/Relation/Suffix/Heterogeneous.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous.agda
@@ -1,0 +1,32 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- An inductive definition of the heterogeneous suffix relation
+------------------------------------------------------------------------
+
+module Data.List.Relation.Suffix.Heterogeneous where
+
+open import Level
+open import Relation.Binary using (REL; _⇒_)
+open import Data.List.Base as List using (List; []; _∷_)
+open import Data.List.Relation.Pointwise as Pointwise using (Pointwise; []; _∷_)
+
+module _ {a b r} {A : Set a} {B : Set b} (R : REL A B r) where
+
+  data Suffix : REL (List A) (List B) (a ⊔ b ⊔ r) where
+    here  : ∀ {as bs} → Pointwise R as bs → Suffix as bs
+    there : ∀ {b as bs} → Suffix as bs → Suffix as (b ∷ bs)
+
+  data SuffixView (as : List A) : List B → Set (a ⊔ b ⊔ r) where
+    _++_ : ∀ cs {ds} → Pointwise R as ds → SuffixView as (cs List.++ ds)
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
+
+  toView : ∀ {as bs} → Suffix R as bs → SuffixView R as bs
+  toView (here rs) = [] ++ rs
+  toView (there {c} suf) with toView suf
+  ... | cs ++ rs = (c ∷ cs) ++ rs
+
+  fromView : ∀ {as bs} → SuffixView R as bs → Suffix R as bs
+  fromView ([]       ++ rs) = here rs
+  fromView ((c ∷ cs) ++ rs) = there (fromView (cs ++ rs))

--- a/src/Data/List/Relation/Suffix/Heterogeneous.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous.agda
@@ -22,6 +22,18 @@ module _ {a b r} {A : Set a} {B : Set b} (R : REL A B r) where
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
+  tail : ∀ {a as bs} → Suffix R (a ∷ as) bs → Suffix R as bs
+  tail (here (_ ∷ rs)) = there (here rs)
+  tail (there x) = there (tail x)
+
+module _ {a b r s} {A : Set a} {B : Set b} {R : REL A B r} {S : REL A B s} where
+
+  map : R ⇒ S → Suffix R ⇒ Suffix S
+  map R⇒S (here rs)   = here (Pointwise.map R⇒S rs)
+  map R⇒S (there suf) = there (map R⇒S suf)
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
+
   toView : ∀ {as bs} → Suffix R as bs → SuffixView R as bs
   toView (here rs) = [] ++ rs
   toView (there {c} suf) with toView suf

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -14,7 +14,7 @@ open import Relation.Binary using (REL; Rel; Trans; Antisym; _⇒_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl; sym; subst)
 open import Data.Nat as N using (suc; _+_; _≤_; _<_)
 open import Data.List as List using (List; []; _∷_; _++_; length; filter; replicate; reverse)
-open import Data.List.Relation.Pointwise as Pw using (Pointwise; []; _∷_)
+open import Data.List.Relation.Pointwise as Pw using (Pointwise; []; _∷_; Pointwise-length)
 open import Data.List.Relation.Suffix.Heterogeneous as Suffix using (Suffix; here; there; tail)
 open import Data.List.Relation.Prefix.Heterogeneous as Prefix using (Prefix)
 import Data.Nat.Properties as ℕₚ
@@ -39,14 +39,14 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   fromPrefix {as} {bs} p with Prefix.toView p
   ... | Prefix._++_ {cs} rs ds =
     subst (Suffix R (reverse as))
-      (P.sym (Listₚ.reverse-++-commute cs ds))
+      (sym (Listₚ.reverse-++-commute cs ds))
       (Suffix.fromView (reverse ds Suffix.++ pw-reverse rs))
 
   toPrefix : ∀ {as bs} → Suffix R as bs → Prefix R (reverse as) (reverse bs)
   toPrefix {as} {bs} s with Suffix.toView s
   ... | Suffix._++_ cs {ds} rs =
     subst (Prefix R (reverse as))
-      (P.sym (Listₚ.reverse-++-commute cs ds))
+      (sym (Listₚ.reverse-++-commute cs ds))
       (Prefix.fromView (pw-reverse rs Prefix.++ reverse cs))
 
 ------------------------------------------------------------------------
@@ -55,7 +55,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} {as} where
 
   length-mono-Suffix-≤ : ∀ {bs} → Suffix R as bs → length as ≤ length bs
-  length-mono-Suffix-≤ (here rs)   = ℕₚ.≤-reflexive (Pw.Pointwise-length rs)
+  length-mono-Suffix-≤ (here rs)   = ℕₚ.≤-reflexive (Pointwise-length rs)
   length-mono-Suffix-≤ (there suf) = ℕₚ.≤-step (length-mono-Suffix-≤ suf)
 
 ------------------------------------------------------------------------
@@ -70,7 +70,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   toPointwise eq (here rs) = rs
   toPointwise eq (there suf) =
     let as≤bs = length-mono-Suffix-≤ suf
-        as>bs = ℕₚ.≤-reflexive (P.sym eq)
+        as>bs = ℕₚ.≤-reflexive (sym eq)
     in contradiction as≤bs (ℕₚ.<⇒≱ as>bs)
 
 ------------------------------------------------------------------------
@@ -111,13 +111,13 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   ++⁻ {_ ∷ _} {_}      eq suf         = ++⁻ eq (tail suf)
   ++⁻ {[]}    {[]}     eq suf         = toPointwise eq suf
   ++⁻ {[]}    {b ∷ bs} eq (there suf) = ++⁻ eq suf
-  ++⁻ {[]}    {b ∷ bs} {cs} {ds} eq (here rs) = contradiction (P.sym eq) (ℕₚ.<⇒≢ ds<cs)
+  ++⁻ {[]}    {b ∷ bs} {cs} {ds} eq (here rs) = contradiction (sym eq) (ℕₚ.<⇒≢ ds<cs)
     where
     open ℕₚ.≤-Reasoning
     ds<cs : length ds < length cs
     ds<cs = begin suc (length ds)             ≤⟨ N.s≤s (ℕₚ.n≤m+n (length bs) (length ds)) ⟩
-                  suc (length bs + length ds) ≡⟨ P.sym (Listₚ.length-++ (b ∷ bs)) ⟩
-                  length (b ∷ bs ++ ds)       ≡⟨ P.sym (Pw.Pointwise-length rs) ⟩
+                  suc (length bs + length ds) ≡⟨ sym (Listₚ.length-++ (b ∷ bs)) ⟩
+                  length (b ∷ bs ++ ds)       ≡⟨ sym (Pointwise-length rs) ⟩
                   length cs                    ∎
 
 ------------------------------------------------------------------------
@@ -137,9 +137,9 @@ module _ {a b c d r} {A : Set a} {B : Set b} {C : Set c} {D : Set d}
               Pointwise R (List.map f as) (List.map g bs) →
               Pointwise (λ a b → R (f a) (g b)) as bs
     pw-map⁻ {[]} {[]} f g [] = []
-    pw-map⁻ {[]} {b ∷ bs} f g rs with Pw.Pointwise-length rs
+    pw-map⁻ {[]} {b ∷ bs} f g rs with Pointwise-length rs
     ... | ()
-    pw-map⁻ {a ∷ as} {[]} f g rs with Pw.Pointwise-length rs
+    pw-map⁻ {a ∷ as} {[]} f g rs with Pointwise-length rs
     ... | ()
     pw-map⁻ {a ∷ as} {b ∷ bs} f g (r ∷ rs) = r ∷ pw-map⁻ f g rs
 

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -6,24 +6,44 @@
 
 module Data.List.Relation.Suffix.Heterogeneous.Properties where
 
-open import Function using (_∘_)
 open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Unary as U using (Pred)
+open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary using (REL; Rel; Trans; Antisym; _⇒_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
-open import Data.Empty using (⊥-elim)
-open import Data.Nat as N using (_≤_)
-open import Data.List as List using (List; []; _∷_; _++_; length; filter)
+open import Data.Nat as N using (suc; _+_; _≤_; _<_)
+open import Data.List as List using (List; []; _∷_; _++_; length; filter; replicate)
 open import Data.List.Relation.Pointwise as Pw using (Pointwise; []; _∷_)
 open import Data.List.Relation.Suffix.Heterogeneous using (Suffix; here; there; tail)
-import Data.Nat.Properties as Natₚ
+import Data.Nat.Properties as ℕₚ
+import Data.List.Properties as Listₚ
+
+------------------------------------------------------------------------
+-- length
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} {as} where
+
+  length-mono-Suffix-≤ : ∀ {bs} → Suffix R as bs → length as ≤ length bs
+  length-mono-Suffix-≤ (here rs)   = ℕₚ.≤-reflexive (Pw.Pointwise-length rs)
+  length-mono-Suffix-≤ (there suf) = ℕₚ.≤-step (length-mono-Suffix-≤ suf)
+
+------------------------------------------------------------------------
+-- Pointwise conversion
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   fromPointwise : Pointwise R ⇒ Suffix R
   fromPointwise = here
 
-  -- toPointwise : ∀ {as bs} → length as ≡ length bs → Suffix R as bs → Pointwise R as bs
+  toPointwise : ∀ {as bs} → length as ≡ length bs → Suffix R as bs → Pointwise R as bs
+  toPointwise eq (here rs) = rs
+  toPointwise eq (there suf) =
+    let as≤bs = length-mono-Suffix-≤ suf
+        as>bs = ℕₚ.≤-reflexive (P.sym eq)
+    in contradiction as≤bs (ℕₚ.<⇒≱ as>bs)
+
+------------------------------------------------------------------------
+-- Suffix as a partial order
 
 module _ {a b c r s t} {A : Set a} {B : Set b} {C : Set c}
          {R : REL A B r} {S : REL B C s} {T : REL A C t} where
@@ -38,15 +58,6 @@ module _ {a b c r s t} {A : Set a} {B : Set b} {C : Set c}
 --   antisym : Antisym R S E → Antisym (Suffix R) (Suffix S) (Pointwise E)
 
 ------------------------------------------------------------------------
--- length
-
-module _ {a r} {A : Set a} {R : Rel A r} {as} where
-
-  length-mono-Suffix-≤ : ∀ {bs} → Suffix R as bs → length as ≤ length bs
-  length-mono-Suffix-≤ (here rs)   = Natₚ.≤-reflexive (Pw.Pointwise-length rs)
-  length-mono-Suffix-≤ (there suf) = Natₚ.≤-step (length-mono-Suffix-≤ suf)
-
-------------------------------------------------------------------------
 -- _++_
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
@@ -56,9 +67,19 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   ++⁺ (here rs)   rs′ = here (Pw.++⁺ rs rs′)
   ++⁺ (there suf) rs′ = there (++⁺ suf rs′)
 
-  -- ++⁻ : ∀ {as bs cs ds} → Suffix R (as ++ cs) (bs ++ ds) →
-  --       length cs ≡ length ds →
-  --       Pointwise R cs ds
+  ++⁻ : ∀ {as bs cs ds} → length cs ≡ length ds →
+        Suffix R (as ++ cs) (bs ++ ds) → Pointwise R cs ds
+  ++⁻ {_ ∷ _} {_}      eq suf         = ++⁻ eq (tail suf)
+  ++⁻ {[]}    {[]}     eq suf         = toPointwise eq suf
+  ++⁻ {[]}    {b ∷ bs} eq (there suf) = ++⁻ eq suf
+  ++⁻ {[]}    {b ∷ bs} {cs} {ds} eq (here rs) = contradiction (P.sym eq) (ℕₚ.<⇒≢ ds<cs)
+    where
+    open ℕₚ.≤-Reasoning
+    ds<cs : length ds < length cs
+    ds<cs = begin suc (length ds)             ≤⟨ N.s≤s (ℕₚ.n≤m+n (length bs) (length ds)) ⟩
+                  suc (length bs + length ds) ≡⟨ P.sym (Listₚ.length-++ (b ∷ bs)) ⟩
+                  length (b ∷ bs ++ ds)       ≡⟨ P.sym (Pw.Pointwise-length rs) ⟩
+                  length cs                    ∎
 
 ------------------------------------------------------------------------
 -- map
@@ -74,15 +95,30 @@ module _ {a b c d r} {A : Set a} {B : Set b} {C : Set c} {D : Set d}
     pw-map⁺ f g []       = []
     pw-map⁺ f g (r ∷ rs) = r ∷ pw-map⁺ f g rs
 
+    pw-map⁻ : ∀ {as bs} (f : A → C) (g : B → D) →
+              Pointwise R (List.map f as) (List.map g bs) →
+              Pointwise (λ a b → R (f a) (g b)) as bs
+    pw-map⁻ {[]} {[]} f g [] = []
+    pw-map⁻ {[]} {b ∷ bs} f g rs with Pw.Pointwise-length rs
+    ... | ()
+    pw-map⁻ {a ∷ as} {[]} f g rs with Pw.Pointwise-length rs
+    ... | ()
+    pw-map⁻ {a ∷ as} {b ∷ bs} f g (r ∷ rs) = r ∷ pw-map⁻ f g rs
+
   map⁺ : ∀ {as bs} (f : A → C) (g : B → D) →
          Suffix (λ a b → R (f a) (g b)) as bs →
          Suffix R (List.map f as) (List.map g bs)
   map⁺ f g (here rs)   = here (pw-map⁺ f g rs)
   map⁺ f g (there suf) = there (map⁺ f g suf)
 
-  -- map⁻ : ∀ {as bs} → Suffix R (List.map f as) (List.map g bs)
-  --        length cs ≡ length ds →
-  --        Pointwise (λ a b → R (f a) (g b)) cs ds
+  map⁻ : ∀ {as bs} (f : A → C) (g : B → D) →
+         Suffix R (List.map f as) (List.map g bs) →
+         Suffix (λ a b → R (f a) (g b)) as bs
+  map⁻ {as} {b ∷ bs} f g (here rs) = here (pw-map⁻ f g rs)
+  map⁻ {as} {b ∷ bs} f g (there suf) = there (map⁻ f g suf)
+  map⁻ {x ∷ as} {[]} f g suf with length-mono-Suffix-≤ suf
+  ... | ()
+  map⁻ {[]} {[]} f g suf = here []
 
 ------------------------------------------------------------------------
 -- filter
@@ -97,8 +133,8 @@ module _ {a b r p q} {A : Set a} {B : Set b} {R : REL A B r}
     pw-filter⁺ []       = []
     pw-filter⁺ {a ∷ _} {b ∷ _} (r ∷ rs) with P? a | Q? b
     ... | yes p | yes q = r ∷ pw-filter⁺ rs
-    ... | yes p | no ¬q = ⊥-elim (¬q (P⇒Q r p))
-    ... | no ¬p | yes q = ⊥-elim (¬p (Q⇒P r q))
+    ... | yes p | no ¬q = contradiction (P⇒Q r p) ¬q
+    ... | no ¬p | yes q = contradiction (Q⇒P r q) ¬p
     ... | no ¬p | no ¬q = pw-filter⁺ rs
 
   filter⁺ : ∀ {as bs} → Suffix R as bs → Suffix R (filter P? as) (filter Q? bs)
@@ -108,4 +144,18 @@ module _ {a b r p q} {A : Set a} {B : Set b} {R : REL A B r}
   ... | no ¬q = filter⁺ suf
 
 ------------------------------------------------------------------------
--- TODO: take, drop
+-- replicate
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
+
+  private
+    pw-replicate : ∀ {a b} → R a b → ∀ n → Pointwise R (replicate n a) (replicate n b)
+    pw-replicate r 0       = []
+    pw-replicate r (suc n) = r ∷ pw-replicate r n
+
+  replicate⁺ : ∀ {m n a b} → m ≤ n → R a b → Suffix R (replicate m a) (replicate n b)
+  replicate⁺ {a = a} {b = b} m≤n r = repl (ℕₚ.≤⇒≤′ m≤n)
+    where
+    repl : ∀ {m n} → m N.≤′ n → Suffix R (replicate m a) (replicate n b)
+    repl N.≤′-refl       = here (pw-replicate r _)
+    repl (N.≤′-step m≤n) = there (repl m≤n)

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -35,19 +35,31 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
       foldl rs′ []       = rs′
       foldl rs′ (r ∷ rs) = foldl (r ∷ rs′) rs
 
-  fromPrefix : ∀ {as bs} → Prefix R as bs → Suffix R (reverse as) (reverse bs)
-  fromPrefix {as} {bs} p with Prefix.toView p
+  fromPrefix⁺ : ∀ {as bs} → Prefix R as bs → Suffix R (reverse as) (reverse bs)
+  fromPrefix⁺ {as} {bs} p with Prefix.toView p
   ... | Prefix._++_ {cs} rs ds =
     subst (Suffix R (reverse as))
       (sym (Listₚ.reverse-++-commute cs ds))
       (Suffix.fromView (reverse ds Suffix.++ pw-reverse rs))
 
-  toPrefix : ∀ {as bs} → Suffix R as bs → Prefix R (reverse as) (reverse bs)
-  toPrefix {as} {bs} s with Suffix.toView s
+  fromPrefix⁻ : ∀ {as bs} → Prefix R (reverse as) (reverse bs) → Suffix R as bs
+  fromPrefix⁻ pre = P.subst₂ (Suffix R)
+    (Listₚ.reverse-involutive _)
+    (Listₚ.reverse-involutive _)
+    (fromPrefix⁺ pre)
+
+  toPrefix⁺ : ∀ {as bs} → Suffix R as bs → Prefix R (reverse as) (reverse bs)
+  toPrefix⁺ {as} {bs} s with Suffix.toView s
   ... | Suffix._++_ cs {ds} rs =
     subst (Prefix R (reverse as))
       (sym (Listₚ.reverse-++-commute cs ds))
       (Prefix.fromView (pw-reverse rs Prefix.++ reverse cs))
+
+  toPrefix⁻ : ∀ {as bs} → Suffix R (reverse as) (reverse bs) → Prefix R as bs
+  toPrefix⁻ suf = P.subst₂ (Prefix R)
+    (Listₚ.reverse-involutive _)
+    (Listₚ.reverse-involutive _)
+    (toPrefix⁺ suf)
 
 ------------------------------------------------------------------------
 -- length

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -11,7 +11,7 @@ open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Unary as U using (Pred)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary using (REL; Rel; Trans; Antisym; _⇒_)
-open import Relation.Binary.PropositionalEquality as P using (_≡_; refl; subst)
+open import Relation.Binary.PropositionalEquality as P using (_≡_; refl; sym; subst)
 open import Data.Nat as N using (suc; _+_; _≤_; _<_)
 open import Data.List as List using (List; []; _∷_; _++_; length; filter; replicate; reverse)
 open import Data.List.Relation.Pointwise as Pw using (Pointwise; []; _∷_)
@@ -84,9 +84,17 @@ module _ {a b c r s t} {A : Set a} {B : Set b} {C : Set c}
   trans rs⇒t (here rs)    (there ssuf)    = there (trans rs⇒t (here rs) ssuf)
   trans rs⇒t (there rsuf) ssuf            = trans rs⇒t rsuf (tail ssuf)
 
--- module _ {a b e r s t} {A : Set a} {B : Set b}
---          {R : REL A B r} {S : REL B A s} {E : REL A B e} where
---   antisym : Antisym R S E → Antisym (Suffix R) (Suffix S) (Pointwise E)
+module _ {a b e r s} {A : Set a} {B : Set b}
+         {R : REL A B r} {S : REL B A s} {E : REL A B e} where
+
+  private
+    pw-antisym : Antisym R S E → Antisym (Pointwise R) (Pointwise S) (Pointwise E)
+    pw-antisym antisym []       []       = []
+    pw-antisym antisym (r ∷ rs) (s ∷ ss) = antisym r s ∷ pw-antisym antisym rs ss
+
+  antisym : Antisym R S E → Antisym (Suffix R) (Suffix S) (Pointwise E)
+  antisym rs⇒e rsuf ssuf = pw-antisym rs⇒e (toPointwise eq rsuf) (toPointwise (sym eq) ssuf)
+    where eq = ℕₚ.≤-antisym (length-mono-Suffix-≤ rsuf) (length-mono-Suffix-≤ ssuf)
 
 ------------------------------------------------------------------------
 -- _++_

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -1,0 +1,111 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of the heterogeneous suffix relation
+------------------------------------------------------------------------
+
+module Data.List.Relation.Suffix.Heterogeneous.Properties where
+
+open import Function using (_∘_)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Unary as U using (Pred)
+open import Relation.Binary using (REL; Rel; Trans; Antisym; _⇒_)
+open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
+open import Data.Empty using (⊥-elim)
+open import Data.Nat as N using (_≤_)
+open import Data.List as List using (List; []; _∷_; _++_; length; filter)
+open import Data.List.Relation.Pointwise as Pw using (Pointwise; []; _∷_)
+open import Data.List.Relation.Suffix.Heterogeneous using (Suffix; here; there; tail)
+import Data.Nat.Properties as Natₚ
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
+
+  fromPointwise : Pointwise R ⇒ Suffix R
+  fromPointwise = here
+
+  -- toPointwise : ∀ {as bs} → length as ≡ length bs → Suffix R as bs → Pointwise R as bs
+
+module _ {a b c r s t} {A : Set a} {B : Set b} {C : Set c}
+         {R : REL A B r} {S : REL B C s} {T : REL A C t} where
+
+  trans : Trans R S T → Trans (Suffix R) (Suffix S) (Suffix T)
+  trans rs⇒t (here rs)    (here ss)       = here (Pw.transitive rs⇒t rs ss)
+  trans rs⇒t (here rs)    (there ssuf)    = there (trans rs⇒t (here rs) ssuf)
+  trans rs⇒t (there rsuf) ssuf            = trans rs⇒t rsuf (tail ssuf)
+
+-- module _ {a b e r s t} {A : Set a} {B : Set b}
+--          {R : REL A B r} {S : REL B A s} {E : REL A B e} where
+--   antisym : Antisym R S E → Antisym (Suffix R) (Suffix S) (Pointwise E)
+
+------------------------------------------------------------------------
+-- length
+
+module _ {a r} {A : Set a} {R : Rel A r} {as} where
+
+  length-mono-Suffix-≤ : ∀ {bs} → Suffix R as bs → length as ≤ length bs
+  length-mono-Suffix-≤ (here rs)   = Natₚ.≤-reflexive (Pw.Pointwise-length rs)
+  length-mono-Suffix-≤ (there suf) = Natₚ.≤-step (length-mono-Suffix-≤ suf)
+
+------------------------------------------------------------------------
+-- _++_
+
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
+
+  ++⁺ : ∀ {as bs cs ds} → Suffix R as bs → Pointwise R cs ds →
+        Suffix R (as ++ cs) (bs ++ ds)
+  ++⁺ (here rs)   rs′ = here (Pw.++⁺ rs rs′)
+  ++⁺ (there suf) rs′ = there (++⁺ suf rs′)
+
+  -- ++⁻ : ∀ {as bs cs ds} → Suffix R (as ++ cs) (bs ++ ds) →
+  --       length cs ≡ length ds →
+  --       Pointwise R cs ds
+
+------------------------------------------------------------------------
+-- map
+
+module _ {a b c d r} {A : Set a} {B : Set b} {C : Set c} {D : Set d}
+         {R : REL C D r} where
+
+  -- TODO: move this lemma into Pointwise?
+  private
+    pw-map⁺ : ∀ {as bs} (f : A → C) (g : B → D) →
+              Pointwise (λ a b → R (f a) (g b)) as bs →
+              Pointwise R (List.map f as) (List.map g bs)
+    pw-map⁺ f g []       = []
+    pw-map⁺ f g (r ∷ rs) = r ∷ pw-map⁺ f g rs
+
+  map⁺ : ∀ {as bs} (f : A → C) (g : B → D) →
+         Suffix (λ a b → R (f a) (g b)) as bs →
+         Suffix R (List.map f as) (List.map g bs)
+  map⁺ f g (here rs)   = here (pw-map⁺ f g rs)
+  map⁺ f g (there suf) = there (map⁺ f g suf)
+
+  -- map⁻ : ∀ {as bs} → Suffix R (List.map f as) (List.map g bs)
+  --        length cs ≡ length ds →
+  --        Pointwise (λ a b → R (f a) (g b)) cs ds
+
+------------------------------------------------------------------------
+-- filter
+
+module _ {a b r p q} {A : Set a} {B : Set b} {R : REL A B r}
+         {P : Pred A p} {Q : Pred B q} (P? : U.Decidable P) (Q? : U.Decidable Q)
+         (P⇒Q : ∀ {a b} → R a b → P a → Q b) (Q⇒P : ∀ {a b} → R a b → Q b → P a)
+         where
+
+  private
+    pw-filter⁺ : ∀ {as bs} → Pointwise R as bs → Pointwise R (filter P? as) (filter Q? bs)
+    pw-filter⁺ []       = []
+    pw-filter⁺ {a ∷ _} {b ∷ _} (r ∷ rs) with P? a | Q? b
+    ... | yes p | yes q = r ∷ pw-filter⁺ rs
+    ... | yes p | no ¬q = ⊥-elim (¬q (P⇒Q r p))
+    ... | no ¬p | yes q = ⊥-elim (¬p (Q⇒P r q))
+    ... | no ¬p | no ¬q = pw-filter⁺ rs
+
+  filter⁺ : ∀ {as bs} → Suffix R as bs → Suffix R (filter P? as) (filter Q? bs)
+  filter⁺ (here rs) = here (pw-filter⁺ rs)
+  filter⁺ (there {a} suf) with Q? a
+  ... | yes q = there (filter⁺ suf)
+  ... | no ¬q = filter⁺ suf
+
+------------------------------------------------------------------------
+-- TODO: take, drop

--- a/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Suffix/Heterogeneous/Properties.agda
@@ -6,7 +6,7 @@
 
 module Data.List.Relation.Suffix.Heterogeneous.Properties where
 
-open import Function using (flip)
+open import Function using (_$_; flip)
 open import Relation.Nullary using (Dec; yes; no)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Unary as U using (Pred)
@@ -39,29 +39,23 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   fromPrefix⁺ : ∀ {as bs} → Prefix R as bs → Suffix R (reverse as) (reverse bs)
   fromPrefix⁺ {as} {bs} p with Prefix.toView p
-  ... | Prefix._++_ {cs} rs ds =
-    subst (Suffix R (reverse as))
-      (sym (Listₚ.reverse-++-commute cs ds))
-      (Suffix.fromView (reverse ds Suffix.++ pw-reverse rs))
+  ... | Prefix._++_ {cs} rs ds = subst (Suffix R (reverse as))
+                                       (sym (Listₚ.reverse-++-commute cs ds))
+                               $ Suffix.fromView (reverse ds Suffix.++ pw-reverse rs)
 
   fromPrefix⁻ : ∀ {as bs} → Prefix R (reverse as) (reverse bs) → Suffix R as bs
-  fromPrefix⁻ pre = P.subst₂ (Suffix R)
-    (Listₚ.reverse-involutive _)
-    (Listₚ.reverse-involutive _)
-    (fromPrefix⁺ pre)
+  fromPrefix⁻ pre = P.subst₂ (Suffix R) (Listₚ.reverse-involutive _) (Listₚ.reverse-involutive _)
+                  $ fromPrefix⁺ pre
 
   toPrefix⁺ : ∀ {as bs} → Suffix R as bs → Prefix R (reverse as) (reverse bs)
   toPrefix⁺ {as} {bs} s with Suffix.toView s
-  ... | Suffix._++_ cs {ds} rs =
-    subst (Prefix R (reverse as))
-      (sym (Listₚ.reverse-++-commute cs ds))
-      (Prefix.fromView (pw-reverse rs Prefix.++ reverse cs))
+  ... | Suffix._++_ cs {ds} rs = subst (Prefix R (reverse as))
+                                       (sym (Listₚ.reverse-++-commute cs ds))
+                               $ Prefix.fromView (pw-reverse rs Prefix.++ reverse cs)
 
   toPrefix⁻ : ∀ {as bs} → Suffix R (reverse as) (reverse bs) → Prefix R as bs
-  toPrefix⁻ suf = P.subst₂ (Prefix R)
-    (Listₚ.reverse-involutive _)
-    (Listₚ.reverse-involutive _)
-    (toPrefix⁺ suf)
+  toPrefix⁻ suf = P.subst₂ (Prefix R) (Listₚ.reverse-involutive _) (Listₚ.reverse-involutive _)
+                $ toPrefix⁺ suf
 
 ------------------------------------------------------------------------
 -- length
@@ -130,8 +124,8 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
     open ℕₚ.≤-Reasoning
     ds<cs : length ds < length cs
     ds<cs = begin suc (length ds)             ≤⟨ N.s≤s (ℕₚ.n≤m+n (length bs) (length ds)) ⟩
-                  suc (length bs + length ds) ≡⟨ sym (Listₚ.length-++ (b ∷ bs)) ⟩
-                  length (b ∷ bs ++ ds)       ≡⟨ sym (Pointwise-length rs) ⟩
+                  suc (length bs + length ds) ≡⟨ sym $ Listₚ.length-++ (b ∷ bs) ⟩
+                  length (b ∷ bs ++ ds)       ≡⟨ sym $ Pointwise-length rs ⟩
                   length cs                    ∎
 
 ------------------------------------------------------------------------
@@ -224,16 +218,16 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
       P.cong₂ _∷_ (R-irr r r₁) (pw-irrelevant R-irr rs rs₁)
 
   irrelevant : Irrelevant R → Irrelevant (Suffix R)
-  irrelevant R-irr (here rs)    (here rs₁)    = P.cong here (pw-irrelevant R-irr rs rs₁)
+  irrelevant R-irr (here rs)    (here rs₁)    = P.cong here $ pw-irrelevant R-irr rs rs₁
   irrelevant R-irr (here rs)    (there rsuf)  = contradiction (length-mono-Suffix-≤ rsuf)
                                                               (ℕₚ.<⇒≱ (ℕₚ.≤-reflexive (sym (Pointwise-length rs))))
   irrelevant R-irr (there rsuf) (here rs)     = contradiction (length-mono-Suffix-≤ rsuf)
                                                               (ℕₚ.<⇒≱ (ℕₚ.≤-reflexive (sym (Pointwise-length rs))))
-  irrelevant R-irr (there rsuf) (there rsuf₁) = P.cong there (irrelevant R-irr rsuf rsuf₁)
+  irrelevant R-irr (there rsuf) (there rsuf₁) = P.cong there $ irrelevant R-irr rsuf rsuf₁
 
 ------------------------------------------------------------------------
 -- Decidability
 
   suffix? : B.Decidable R → B.Decidable (Suffix R)
   suffix? R? as bs = Dec.map′ fromPrefix⁻ toPrefix⁺
-    (Prefixₚ.prefix? R? (reverse as) (reverse bs))
+                   $ Prefixₚ.prefix? R? (reverse as) (reverse bs)


### PR DESCRIPTION
Hello, new Agda contributor, so please let me know if I have made any major style violations or anything like that.

Here is an implementation of a heterogeneous `Suffix` property, to go along with `Prefix` (#522). Many of the Prefix theorems are mirrored here, except for those that don't apply easily to suffixes (e.g. `zipWith`, `inits`, ...).

Considerations before merging:
* The data constructor names `here`/`there` may not be appropriate, maybe something like `skip`/`stop` is more accurate since `here` does not refer to a single element, like in the case of `Any`.
* I've defined a number of `Pointwise` lemmas that probably deserve to be moved into the `Pointwise` module.