### PR TITLE
Generic Vec membership (fix #486)

### DIFF
--- a/src/Data/Vec/Membership/DecPropositional.agda
+++ b/src/Data/Vec/Membership/DecPropositional.agda
@@ -1,0 +1,20 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Decidable propositional membership over vectors
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K #-}
+
+open import Relation.Binary using (Decidable)
+open import Relation.Binary.PropositionalEquality using (_≡_; decSetoid)
+
+module Data.Vec.Membership.DecPropositional
+  {a} {A : Set a} (_≟_ : Decidable (_≡_ {A = A})) where
+
+------------------------------------------------------------------------
+-- Re-export contents of propositional membership
+
+open import Data.Vec.Membership.Propositional {A = A} public
+open import Data.Vec.Membership.DecSetoid (decSetoid _≟_) public
+  using (_∈?_)

--- a/src/Data/Vec/Membership/DecSetoid.agda
+++ b/src/Data/Vec/Membership/DecSetoid.agda
@@ -1,0 +1,29 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Decidable setoid membership over vectors.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K #-}
+
+open import Relation.Binary using (DecSetoid)
+
+module Data.Vec.Membership.DecSetoid {c ℓ} (DS : DecSetoid c ℓ) where
+
+open import Data.Vec using (Vec)
+open import Data.Vec.Any using (any)
+open import Relation.Nullary using (Dec)
+open DecSetoid DS renaming (Carrier to A)
+
+------------------------------------------------------------------------
+-- Re-export contents of propositional membership
+
+open import Data.Vec.Membership.Setoid setoid public
+
+------------------------------------------------------------------------
+-- Other operations
+
+infix 4 _∈?_
+
+_∈?_ : ∀ x {n} (xs : Vec A n) → Dec (x ∈ xs)
+x ∈? xs = any (x ≟_) xs

--- a/src/Data/Vec/Membership/Propositional.agda
+++ b/src/Data/Vec/Membership/Propositional.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Membership of vectors based on propositional equality,
+-- Data.Vec.Any.Membership instantiated with propositional equality,
 -- along with some additional definitions.
 ------------------------------------------------------------------------
 
@@ -11,16 +11,17 @@ module Data.Vec.Membership.Propositional {a} {A : Set a} where
 
 open import Data.Vec using (Vec)
 open import Data.Vec.Any using (Any)
-open import Relation.Binary.PropositionalEquality using (_≡_)
-open import Relation.Nullary using (¬_)
+open import Relation.Binary.PropositionalEquality using (setoid; subst)
+
+import Data.Vec.Membership.Setoid as SetoidMembership
 
 ------------------------------------------------------------------------
--- Types
+-- Re-export contents of setoid membership
 
-infix 4 _∈_ _∉_
+open SetoidMembership (setoid A) public hiding (lose)
 
-_∈_ : A → ∀ {n} → Vec A n → Set _
-x ∈ xs = Any (x ≡_) xs
+------------------------------------------------------------------------
+-- Other operations
 
-_∉_ : A → ∀ {n} → Vec A n → Set _
-x ∉ xs = ¬ x ∈ xs
+lose : ∀ {p} {P : A → Set p} {x n} {xs : Vec A n} → x ∈ xs → P x → Any P xs
+lose = SetoidMembership.lose (setoid A) (subst _)

--- a/src/Data/Vec/Membership/Setoid.agda
+++ b/src/Data/Vec/Membership/Setoid.agda
@@ -1,0 +1,55 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Membership of vectors, along with some additional definitions.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K #-}
+
+open import Relation.Binary using (Setoid; _Respects_)
+
+module Data.Vec.Membership.Setoid {c ℓ} (S : Setoid c ℓ) where
+
+open import Function
+open import Data.Vec as Vec using (Vec; []; _∷_)
+open import Data.Vec.Any as Any using (Any; here; there; index)
+open import Data.Product using (∃; _×_; _,_)
+open import Relation.Nullary using (¬_)
+open import Relation.Unary using (Pred)
+
+open Setoid S renaming (Carrier to A)
+
+------------------------------------------------------------------------
+-- Definitions
+
+infix 4 _∈_ _∉_
+
+_∈_ : A → ∀ {n} → Vec A n → Set _
+x ∈ xs = Any (x ≈_) xs
+
+_∉_ : A → ∀ {n} → Vec A n → Set _
+x ∉ xs = ¬ x ∈ xs
+
+------------------------------------------------------------------------
+-- Operations
+
+mapWith∈ : ∀ {b} {B : Set b} {n}
+           (xs : Vec A n) → (∀ {x} → x ∈ xs → B) → Vec B n
+mapWith∈ []       f = []
+mapWith∈ (x ∷ xs) f = f (here refl) ∷ mapWith∈ xs (f ∘ there)
+
+_∷=_ : ∀ {n} {xs : Vec A n} {x} → x ∈ xs → A → Vec A n
+_∷=_ {xs = xs} x∈xs v = xs Vec.[ index x∈xs ]≔ v
+
+------------------------------------------------------------------------
+-- Finding and losing witnesses
+
+module _ {p} {P : Pred A p} where
+
+  find : ∀ {n} {xs : Vec A n} → Any P xs → ∃ λ x → x ∈ xs × P x
+  find (here px)   = (_ , here refl , px)
+  find (there pxs) with find pxs
+  ... | (x , x∈xs , px) = (x , there x∈xs , px)
+
+  lose : P Respects _≈_ → ∀ {x n} {xs : Vec A n} → x ∈ xs → P x → Any P xs
+  lose resp x∈xs px = Any.map (flip resp px) x∈xs


### PR DESCRIPTION
Adds the following modules:
* `Data.Vec.Membership.Setoid`
* `Data.Vec.Membership.DecSetoid`
* `Data.Vec.Membership.DecPropositional`

Refactors `Data.Vec.Membership.Propositional` to be an alias for `Data.Vec.Membership.Setoid`.  This is basically copied from `Data.List.Membership.*` with slight changed to accommodate vectors. 

**Discussion:**
I preserved the signature of `_∈_`:
```haskell
_∈_ : A → ∀ {n} → Vec A n → Set _
```
However, this forces `_∈?_` to have a more clumsy signature (I chose: `_∈?_ : ∀ x {n} (xs : Vec A n) → Dec (x ∈ xs)`). Instead it could be done by placing `{n}` first:
```haskell
_∈_ : ∀ {n} → A → Vec A n → Set _
_∈?_ : ∀ {n} → Decidable (_∈_ {n})
```
Which gives a nicer signature for `_∈?_` but induces a *technically-unnecessary* dependency in `_∈_`.