### PR TITLE
Add some type annotations to module parameters in response to fix of Agda/#1063

### DIFF
--- a/src/Algebra/FunctionProperties/Consequences.agda
+++ b/src/Algebra/FunctionProperties/Consequences.agda
@@ -72,7 +72,7 @@ module _ {_•_ : Op₂ A} (comm : Commutative _•_) {e : A} where
 ------------------------------------------------------------------------
 -- Group-like structures
 
-module _ {_•_ : Op₂ A} {_⁻¹ : Op₁ A} {e} (comm : Commutative _•_) where
+module _ {_•_ : Op₂ A} {_⁻¹ : Op₁ A} {e : A} (comm : Commutative _•_) where
 
   comm+invˡ⇒invʳ : LeftInverse e _⁻¹ _•_ → RightInverse e _⁻¹ _•_
   comm+invˡ⇒invʳ invˡ x = begin
@@ -86,7 +86,7 @@ module _ {_•_ : Op₂ A} {_⁻¹ : Op₁ A} {e} (comm : Commutative _•_) whe
     x • (x ⁻¹) ≈⟨ invʳ x ⟩
     e          ∎
 
-module _ {_•_ : Op₂ A} {_⁻¹ : Op₁ A} {e} (cong : Congruent₂ _•_) where
+module _ {_•_ : Op₂ A} {_⁻¹ : Op₁ A} {e : A} (cong : Congruent₂ _•_) where
 
   assoc+id+invʳ⇒invˡ-unique : Associative _•_ →
                               Identity e _•_ → RightInverse e _⁻¹ _•_ →

--- a/src/Algebra/FunctionProperties/Consequences/Propositional.agda
+++ b/src/Algebra/FunctionProperties/Consequences/Propositional.agda
@@ -37,7 +37,7 @@ open FP⇒ public
 ------------------------------------------------------------------------
 -- Group-like structures
 
-module _ {_•_ _⁻¹ ε} where
+module _ {_•_ : A → A → A} {_⁻¹ : A → A} {ε : A} where
 
   assoc+id+invʳ⇒invˡ-unique : Associative _•_ → Identity ε _•_ →
                               RightInverse ε _⁻¹ _•_ →
@@ -52,7 +52,7 @@ module _ {_•_ _⁻¹ ε} where
 ------------------------------------------------------------------------
 -- Ring-like structures
 
-module _ {_+_ _*_ -_ 0#} where
+module _ {_+_ _*_ : A → A → A} { -_ : A → A} {0# : A} where
 
   assoc+distribʳ+idʳ+invʳ⇒zeˡ : Associative _+_ → _*_ DistributesOverʳ _+_ →
                                 RightIdentity 0# _+_ → RightInverse 0# -_ _+_ →

--- a/src/Algebra/Properties/CommutativeMonoid.agda
+++ b/src/Algebra/Properties/CommutativeMonoid.agda
@@ -44,7 +44,7 @@ open CommutativeMonoid M
 open import Algebra.FunctionProperties _≈_
 open import Relation.Binary.EqReasoning setoid
 
-module _ {n} where
+module _ {n : ℕ} where
   open B.Setoid (TE.setoid setoid n) public
     using ()
     renaming (_≈_ to _≋_)

--- a/src/Category/Monad/Partiality.agda
+++ b/src/Category/Monad/Partiality.agda
@@ -16,7 +16,7 @@ open import Data.Product as Prod hiding (map)
 open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Function
 open import Function.Equivalence using (_⇔_; equivalence)
-open import Level using (_⊔_)
+open import Level using (Level; _⊔_)
 open import Relation.Binary as B hiding (Rel)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
@@ -559,7 +559,7 @@ module _ {ℓ} {A B : Set ℓ} {_∼_ : B → B → Set ℓ} where
 -- The monad can be awkward to use, due to the limitations of guarded
 -- coinduction. The following code provides a (limited) workaround.
 
-module Workaround {a} where
+module Workaround {a : Level} where
 
   infixl 1 _>>=_
 
@@ -628,7 +628,7 @@ module Workaround {a} where
 ------------------------------------------------------------------------
 -- An alternative, but equivalent, formulation of equality/ordering
 
-module AlternativeEquality {a ℓ} where
+module AlternativeEquality {a ℓ : Level} where
 
   private
 

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -26,14 +26,14 @@ open import Data.Sum as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Inverse as Inv using (_↔_; _↔̇_; Inverse; inverse)
-open import Level using (_⊔_)
+open import Level using (Level; _⊔_)
 open import Relation.Binary
 import Relation.Binary.Construct.FromRel as Ind
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
 open import Relation.Nullary.Negation
 
-module ¬¬Monad {p} where
+module ¬¬Monad {p : Level} where
   open RawMonad (¬¬-Monad {p}) public
 open ¬¬Monad  -- we don't want the RawMonad content to be opened publicly
 

--- a/src/Data/Container/Indexed.agda
+++ b/src/Data/Container/Indexed.agda
@@ -104,7 +104,7 @@ module _ {i₁ i₂ o₁ o₂}
 
 -- Degenerate cases where no reindexing is performed.
 
-module _ {i o c r} {I : Set i} {O : Set o} where
+module _ {i o c r : _} {I : Set i} {O : Set o} where
 
   _⇒_ : B.Rel (Container I O c r) _
   C₁ ⇒ C₂ = C₁ ⇒[ ⟨id⟩ / ⟨id⟩ ] C₂
@@ -125,7 +125,7 @@ module _ {i o c r} {I : Set i} {O : Set o} where
 ⟪ m ⟫ X (c , k) = command m c , λ r₂ →
   P.subst X (coherent m) (k (response m r₂))
 
-module PlainMorphism {i o c r} {I : Set i} {O : Set o} where
+module PlainMorphism {i o c r : _} {I : Set i} {O : Set o} where
 
   -- Identity.
 

--- a/src/Data/Container/Indexed/WithK.agda
+++ b/src/Data/Container/Indexed/WithK.agda
@@ -92,7 +92,7 @@ module Map where
 ------------------------------------------------------------------------
 -- Plain morphisms
 
-module PlainMorphism {i o c r} {I : Set i} {O : Set o} where
+module PlainMorphism {i o c r : _} {I : Set i} {O : Set o} where
 
   open Data.Container.Indexed.PlainMorphism
 

--- a/src/Data/Fin/Substitution/Example.agda
+++ b/src/Data/Fin/Substitution/Example.agda
@@ -14,6 +14,7 @@ open import Data.Fin.Substitution.Lemmas
 open import Data.Nat
 open import Data.Fin using (Fin)
 open import Data.Vec
+import Level
 open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; refl; sym; cong; cong₂)
 open PropEq.≡-Reasoning
@@ -71,7 +72,7 @@ tmLemmas = record
   ; /✶-↑✶     = Lemma./✶-↑✶
   }
   where
-  module Lemma {T₁ T₂} {lift₁ : Lift T₁ Tm} {lift₂ : Lift T₂ Tm} where
+  module Lemma {T₁ T₂} {lift₁ : Lift {Level.zero} T₁ Tm} {lift₂ : Lift {Level.zero} T₂ Tm} where
 
     open Lifted lift₁ using () renaming (_↑✶_ to _↑✶₁_; _/✶_ to _/✶₁_)
     open Lifted lift₂ using () renaming (_↑✶_ to _↑✶₂_; _/✶_ to _/✶₂_)

--- a/src/Data/Graph/Acyclic.agda
+++ b/src/Data/Graph/Acyclic.agda
@@ -27,6 +27,7 @@ open import Data.Vec as Vec using (Vec; []; _∷_)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Function
 open import Induction.Nat using (<′-rec; <′-Rec)
+open import Level using (Level)
 open import Relation.Nullary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 
@@ -84,7 +85,7 @@ private
 ------------------------------------------------------------------------
 -- Higher-order functions
 
-module _ {ℓ e} {N : Set ℓ} {E : Set e} {t} where
+module _ {ℓ e} {N : Set ℓ} {E : Set e} {t : Level} where
 
 -- "Fold right".
 

--- a/src/Data/List/Any.agda
+++ b/src/Data/List/Any.agda
@@ -29,7 +29,7 @@ data Any {p} (P : A → Set p) : List A → Set (a ⊔ p) where
 ------------------------------------------------------------------------
 -- Operations on Any
 
-module _ {p} {P : A → Set p} {x xs} where
+module _ {p} {P : A → Set p} {x : A} {xs : List A} where
 
   head : ¬ Any P xs → Any P (x ∷ xs) → P x
   head ¬pxs (here px)   = px
@@ -53,7 +53,7 @@ satisfied : ∀ {p} {P : A → Set p} {xs} → Any P xs → ∃ P
 satisfied (here px) = _ , px
 satisfied (there pxs) = satisfied pxs
 
-module _ {p} {P : A → Set p} {x xs} where
+module _ {p} {P : A → Set p} {x : A} {xs : List A} where
 
   toSum : Any P (x ∷ xs) → P x ⊎ Any P xs
   toSum (here px)   = inj₁ px

--- a/src/Data/List/Any/Properties.agda
+++ b/src/Data/List/Any/Properties.agda
@@ -83,7 +83,7 @@ module _ {a p} {A : Set a} {P : A → Set p} where
 ------------------------------------------------------------------------
 -- Any is a congruence
 
-module _ {a k p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
+module _ {a} {k : Related.Kind} {p q : _} {A : Set a} {P : Pred A p} {Q : Pred A q} where
 
   Any-cong : ∀ {xs ys : List A} →
              (∀ x → Related k (P x) (Q x)) →
@@ -522,7 +522,7 @@ module _ {a p} {A : Set a} {P : A → Set p} where
 ------------------------------------------------------------------------
 -- _∷_
 
-module _ {a p} {A : Set a} where
+module _ {a p : _} {A : Set a} where
 
   ∷↔ : ∀ (P : Pred A p) {x xs} → (P x ⊎ Any P xs) ↔ Any P (x ∷ xs)
   ∷↔ P {x} {xs} =

--- a/src/Data/List/Relation/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/BagAndSetEquality.agda
@@ -105,7 +105,7 @@ module ⊆-Reasoning where
 ------------------------------------------------------------------------
 -- _∷_
 
-module _ {a k} {A : Set a} {x y : A} {xs ys} where
+module _ {a} {k : Kind} {A : Set a} {x y : A} {xs ys : List A} where
 
   ∷-cong : x ≡ y → xs ∼[ k ] ys → x ∷ xs ∼[ k ] y ∷ ys
   ∷-cong refl xs≈ys {y} =
@@ -118,7 +118,7 @@ module _ {a k} {A : Set a} {x y : A} {xs ys} where
 ------------------------------------------------------------------------
 -- map
 
-module _ {ℓ k} {A B : Set ℓ} {f g : A → B} {xs ys} where
+module _ {ℓ} {k : Kind} {A B : Set ℓ} {f g : A → B} {xs ys : List A} where
 
   map-cong : f ≗ g → xs ∼[ k ] ys → map f xs ∼[ k ] map g ys
   map-cong f≗g xs≈ys {x} =
@@ -142,7 +142,7 @@ module _ {ℓ k} {A B : Set ℓ} {f g : A → B} {xs ys} where
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {a k} {A : Set a} {xs₁ xs₂ ys₁ ys₂ : List A} where
+module _ {a} {k : Kind} {A : Set a} {xs₁ xs₂ ys₁ ys₂ : List A} where
 
   ++-cong : xs₁ ∼[ k ] xs₂ → ys₁ ∼[ k ] ys₂ →
             xs₁ ++ ys₁ ∼[ k ] xs₂ ++ ys₂
@@ -156,7 +156,7 @@ module _ {a k} {A : Set a} {xs₁ xs₂ ys₁ ys₂ : List A} where
 ------------------------------------------------------------------------
 -- concat
 
-module _ {a k} {A : Set a} {xss yss : List (List A)} where
+module _ {a} {k : Kind} {A : Set a} {xss yss : List (List A)} where
 
   concat-cong : xss ∼[ k ] yss → concat xss ∼[ k ] concat yss
   concat-cong xss≈yss {x} =
@@ -169,7 +169,7 @@ module _ {a k} {A : Set a} {xss yss : List (List A)} where
 ------------------------------------------------------------------------
 -- _>>=_
 
-module _ {ℓ k} {A B : Set ℓ} {xs ys} {f g : A → List B} where
+module _ {ℓ} {k : Kind} {A B : Set ℓ} {xs ys : List A} {f g : A → List B} where
 
   >>=-cong : xs ∼[ k ] ys → (∀ x → f x ∼[ k ] g x) →
              (xs >>= f) ∼[ k ] (ys >>= g)
@@ -183,7 +183,7 @@ module _ {ℓ k} {A B : Set ℓ} {xs ys} {f g : A → List B} where
 ------------------------------------------------------------------------
 -- _⊛_
 
-module _ {ℓ k} {A B : Set ℓ} {fs gs : List (A → B)} {xs ys} where
+module _ {ℓ} {k : Kind} {A B : Set ℓ} {fs gs : List (A → B)} {xs ys : List A} where
 
   ⊛-cong : fs ∼[ k ] gs → xs ∼[ k ] ys → (fs ⊛ xs) ∼[ k ] (gs ⊛ ys)
   ⊛-cong fs≈gs xs≈ys =
@@ -195,7 +195,7 @@ module _ {ℓ k} {A B : Set ℓ} {fs gs : List (A → B)} {xs ys} where
 ------------------------------------------------------------------------
 -- _⊗_
 
-module _ {ℓ k} {A B : Set ℓ} {xs₁ xs₂ : List A} {ys₁ ys₂ : List B} where
+module _ {ℓ} {k : Kind} {A B : Set ℓ} {xs₁ xs₂ : List A} {ys₁ ys₂ : List B} where
 
   ⊗-cong : xs₁ ∼[ k ] xs₂ → ys₁ ∼[ k ] ys₂ →
            (xs₁ ⊗ ys₁) ∼[ k ] (xs₂ ⊗ ys₂)

--- a/src/Data/List/Relation/Lex/NonStrict.agda
+++ b/src/Data/List/Relation/Lex/NonStrict.agda
@@ -32,7 +32,7 @@ open import Data.List.Relation.Lex.Core as Core public
 ------------------------------------------------------------------------
 -- Strict lexicographic ordering.
 
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
+module _ {a ℓ₁ ℓ₂ : _} {A : Set a} where
 
   Lex-< : (_≈_ : Rel A ℓ₁) (_≼_ : Rel A ℓ₂) → Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
   Lex-< _≈_ _≼_ = Core.Lex ⊥ _≈_ (Conv._<_ _≈_ _≼_)
@@ -108,7 +108,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 ------------------------------------------------------------------------
 -- Non-strict lexicographic ordering.
 
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
+module _ {a ℓ₁ ℓ₂ : _} {A : Set a} where
 
   Lex-≤ : (_≈_ : Rel A ℓ₁) (_≼_ : Rel A ℓ₂) → Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
   Lex-≤ _≈_ _≼_ = Core.Lex ⊤ _≈_ (Conv._<_ _≈_ _≼_)

--- a/src/Data/List/Relation/Lex/Strict.agda
+++ b/src/Data/List/Relation/Lex/Strict.agda
@@ -30,7 +30,7 @@ open import Data.List.Relation.Lex.Core as Core public
 ----------------------------------------------------------------------
 -- Strict lexicographic ordering.
 
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
+module _ {a ℓ₁ ℓ₂ : _} {A : Set a} where
 
   Lex-< : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
           Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
@@ -133,7 +133,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 ----------------------------------------------------------------------
 -- Non-strict lexicographic ordering.
 
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
+module _ {a ℓ₁ ℓ₂ : _} {A : Set a} where
 
   Lex-≤ : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
           Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)

--- a/src/Data/List/Relation/Prefix/Heterogeneous.agda
+++ b/src/Data/List/Relation/Prefix/Heterogeneous.agda
@@ -23,7 +23,7 @@ module _ {a b r} {A : Set a} {B : Set b} (R : REL A B r) where
   data PrefixView (as : List A) : List B → Set (a ⊔ b ⊔ r) where
     _++_ : ∀ {cs} → Pointwise R as cs → ∀ ds → PrefixView as (cs List.++ ds)
 
-module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} {a b as bs} where
+module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} {a : A} {b : B} {as : List A} {bs : List B} where
 
   head : Prefix R (a ∷ as) (b ∷ bs) → R a b
   head (r ∷ rs) = r

--- a/src/Data/List/Relation/Sublist/Propositional/Solver.agda
+++ b/src/Data/List/Relation/Sublist/Propositional/Solver.agda
@@ -43,7 +43,7 @@ data TList {a} (n : ℕ) (A : Set a) : Set a where
 RList : ∀ {a} n → Set a → Set a
 RList n A = List (Item n A)
 
-module _ {n a} {A : Set a} where
+module _ {n : ℕ} {a} {A : Set a} where
 
 -- Semantics
   ⟦_⟧I : Item n A → Vec (List A) n → List A

--- a/src/Data/List/Relation/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Subset/Propositional/Properties.agda
@@ -89,7 +89,7 @@ module _ {a p} {A : Set a} {P : A → Set p} {xs ys : List A} where
 ------------------------------------------------------------------------
 -- map
 
-module _ {a b} {A : Set a} {B : Set b} (f : A → B) {xs ys} where
+module _ {a b} {A : Set a} {B : Set b} (f : A → B) {xs ys : List A} where
 
   map-mono : xs ⊆ ys → map f xs ⊆ map f ys
   map-mono xs⊆ys =
@@ -122,7 +122,7 @@ module _ {a} {A : Set a} {xss yss : List (List A)} where
 ------------------------------------------------------------------------
 -- _>>=_
 
-module _ {ℓ} {A B : Set ℓ} (f g : A → List B) {xs ys} where
+module _ {ℓ} {A B : Set ℓ} (f g : A → List B) {xs ys : List A} where
 
   >>=-mono : xs ⊆ ys → (∀ {x} → f x ⊆ g x) → (xs >>= f) ⊆ (ys >>= g)
   >>=-mono xs⊆ys f⊆g =
@@ -155,7 +155,7 @@ module _ {ℓ} {A B : Set ℓ} {xs₁ ys₁ : List A} {xs₂ ys₂ : List B} whe
 ------------------------------------------------------------------------
 -- any
 
-module _ {a} {A : Set a} (p : A → Bool) {xs ys} where
+module _ {a} {A : Set a} (p : A → Bool) {xs ys : List A} where
 
   any-mono : xs ⊆ ys → T (any p xs) → T (any p ys)
   any-mono xs⊆ys =

--- a/src/Data/Product/Relation/Lex/NonStrict.agda
+++ b/src/Data/Product/Relation/Lex/NonStrict.agda
@@ -13,6 +13,7 @@ module Data.Product.Relation.Lex.NonStrict where
 
 open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum using (inj₁; inj₂)
+open import Level using (Level)
 open import Relation.Binary
 open import Relation.Binary.Consequences
 import Relation.Binary.Construct.NonStrictToStrict as Conv
@@ -20,7 +21,7 @@ open import Data.Product.Relation.Pointwise.NonDependent as Pointwise
   using (Pointwise)
 import Data.Product.Relation.Lex.Strict as Strict
 
-module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
+module _ {a₁ a₂ ℓ₁ ℓ₂ : _} {A₁ : Set a₁} {A₂ : Set a₂} where
 
 ------------------------------------------------------------------------
 -- A lexicographic ordering over products
@@ -151,7 +152,7 @@ module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
 ------------------------------------------------------------------------
 -- "Packages" can also be combined.
 
-module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level} where
 
   ×-poset : Poset ℓ₁ ℓ₂ _ → Poset ℓ₃ ℓ₄ _ → Poset _ _ _
   ×-poset p₁ p₂ = record

--- a/src/Data/Product/Relation/Lex/Strict.agda
+++ b/src/Data/Product/Relation/Lex/Strict.agda
@@ -24,7 +24,7 @@ open import Relation.Nullary.Sum
 open import Relation.Binary
 open import Relation.Binary.Consequences
 
-module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
+module _ {a₁ a₂ ℓ₁ ℓ₂ : _} {A₁ : Set a₁} {A₂ : Set a₂} where
 
 ------------------------------------------------------------------------
 -- A lexicographic ordering over products
@@ -231,7 +231,7 @@ module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
 ------------------------------------------------------------------------
 -- "Packages" can also be combined.
 
-module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level} where
 
   ×-preorder : Preorder ℓ₁ ℓ₂ _ → Preorder ℓ₃ ℓ₄ _ → Preorder _ _ _
   ×-preorder p₁ p₂ = record

--- a/src/Data/Product/Relation/Pointwise/Dependent.agda
+++ b/src/Data/Product/Relation/Pointwise/Dependent.agda
@@ -129,7 +129,7 @@ private
   fg-cong (P.refl , ∼) = (P.refl , F.cong g ∼)
 
 
-module _ {a₁ a₂ b₁ b₁′ b₂ b₂′} {A₁ : Set a₁} {A₂ : Set a₂} where
+module _ {a₁ a₂ b₁ b₁′ b₂ b₂′ : _} {A₁ : Set a₁} {A₂ : Set a₂} where
 
   equivalence : {B₁ : IndexedSetoid A₁ b₁ b₁′} {B₂ : IndexedSetoid A₂ b₂ b₂′}
     (A₁⇔A₂ : A₁ ⇔ A₂) →

--- a/src/Data/Product/Relation/Pointwise/Dependent/WithK.agda
+++ b/src/Data/Product/Relation/Pointwise/Dependent/WithK.agda
@@ -50,7 +50,7 @@ module _ {a b} {A : Set a} {B : A → Set b} where
 ------------------------------------------------------------------------
 -- Properties related to "relatedness"
 
-module _ {a₁ a₂ b₁ b₁′ b₂ b₂′} {A₁ : Set a₁} {A₂ : Set a₂} where
+module _ {a₁ a₂ b₁ b₁′ b₂ b₂′ : _} {A₁ : Set a₁} {A₂ : Set a₂} where
 
   inverse : {B₁ : IndexedSetoid A₁ b₁ b₁′} (B₂ : IndexedSetoid A₂ b₂ b₂′) →
     (A₁↔A₂ : A₁ ↔ A₂) →

--- a/src/Data/Product/Relation/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Pointwise/NonDependent.agda
@@ -25,11 +25,12 @@ open import Function.Related
 open import Function.Surjection as Surj
   using (Surjection; _↠_; module Surjection)
 import Relation.Nullary.Decidable as Dec
+open import Level using (Level)
 open import Relation.Nullary.Product
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 
-module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
+module _ {a₁ a₂ ℓ₁ ℓ₂ : Level} {A₁ : Set a₁} {A₂ : Set a₂} where
 
 ------------------------------------------------------------------------
 -- Pointwise lifting
@@ -183,7 +184,7 @@ module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
 ------------------------------------------------------------------------
 -- "Packages" can also be combined.
 
-module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄} where
+module _ {ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level} where
 
   ×-preorder : Preorder ℓ₁ ℓ₂ _ → Preorder ℓ₃ ℓ₄ _ → Preorder _ _ _
   ×-preorder p₁ p₂ = record

--- a/src/Data/Sum/Relation/LeftOrder.agda
+++ b/src/Data/Sum/Relation/LeftOrder.agda
@@ -174,7 +174,7 @@ module _ {a₁ a₂} {A₁ : Set a₁} {A₂ : Set a₂} where
 ------------------------------------------------------------------------
 -- "Packages" can also be combined.
 
-module _ {a b c d e f} where
+module _ {a b c d e f : Level} where
 
   ⊎-<-preorder : Preorder a b c →
                  Preorder d e f →

--- a/src/Data/Sum/Relation/Pointwise.agda
+++ b/src/Data/Sum/Relation/Pointwise.agda
@@ -25,6 +25,7 @@ open import Function.LeftInverse as LeftInv
 open import Function.Related
 open import Function.Surjection as Surj
   using (Surjection; _↠_; module Surjection)
+open import Level using (Level)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
 open import Relation.Binary
@@ -169,7 +170,7 @@ module _ {a₁ a₂} {A₁ : Set a₁} {A₂ : Set a₂} where
 ------------------------------------------------------------------------
 -- "Packages" can also be combined.
 
-module _ {a b c d} where
+module _ {a b c d : Level} where
 
   ⊎-setoid : Setoid a b → Setoid c d → Setoid _ _
   ⊎-setoid s₁ s₂ = record
@@ -188,7 +189,7 @@ module _ {a b c d} where
   _⊎ₛ_ : Setoid a b → Setoid c d → Setoid _ _
   _⊎ₛ_ = ⊎-setoid
 
-module _ {a b c d e f} where
+module _ {a b c d e f : Level} where
 
   ⊎-preorder : Preorder a b c → Preorder d e f → Preorder _ _ _
   ⊎-preorder p₁ p₂ = record

--- a/src/Data/Table/Properties.agda
+++ b/src/Data/Table/Properties.agda
@@ -12,7 +12,7 @@ open import Data.Table
 open import Data.Table.Relation.Equality
 
 open import Data.Bool using (true; false; if_then_else_)
-open import Data.Nat using (zero; suc)
+open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥-elim)
 open import Data.Fin using (Fin; suc; zero; _≟_; punchIn)
 import Data.Fin.Properties as FP
@@ -98,7 +98,7 @@ module _ {a} {A : Set a} where
 ------------------------------------------------------------------------
 -- There exists an isomorphism between tables and vectors.
 
-module _ {a n} {A : Set a} where
+module _ {a} {n : ℕ} {A : Set a} where
 
   ↔Vec : Inverse (≡-setoid A n) (P.setoid (Vec A n))
   ↔Vec = record

--- a/src/Data/Table/Relation/Equality.agda
+++ b/src/Data/Table/Relation/Equality.agda
@@ -30,6 +30,6 @@ setoid S n = record
 ≡-setoid : ∀ {a} → Set a → ℕ → Setoid _ _
 ≡-setoid A = setoid (P.setoid A)
 
-module _ {a} {A : Set a} {n} where
+module _ {a} {A : Set a} {n : ℕ} where
   open Setoid (≡-setoid A n) public
     using () renaming (_≈_ to _≗_)

--- a/src/Data/Vec/All/Properties.agda
+++ b/src/Data/Vec/All/Properties.agda
@@ -10,6 +10,7 @@ module Data.Vec.All.Properties where
 
 open import Data.List using ([]; _∷_)
 open import Data.List.All as List using ([]; _∷_)
+open import Data.Nat using (ℕ)
 open import Data.Product as Prod using (_×_; _,_; uncurry; uncurry′)
 open import Data.Vec as Vec
 open import Data.Vec.All as All using (All; []; _∷_)
@@ -43,7 +44,7 @@ module _ {a b p q} {A : Set a} {B : Set b} {f : A → B}
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {a n p} {A : Set a} {P : Pred A p} where
+module _ {a} {n : ℕ} {p} {A : Set a} {P : Pred A p} where
 
   ++⁺ : ∀ {m} {xs : Vec A m} {ys : Vec A n} →
         All P xs → All P ys → All P (xs ++ ys)
@@ -84,7 +85,7 @@ module _ {a n p} {A : Set a} {P : Pred A p} where
 ------------------------------------------------------------------------
 -- concat
 
-module _ {a m p} {A : Set a} {P : Pred A p} where
+module _ {a} {m : ℕ} {p} {A : Set a} {P : Pred A p} where
 
   concat⁺ : ∀ {n} {xss : Vec (Vec A m) n} →
             All (All P) xss → All P (concat xss)

--- a/src/Data/Vec/Any.agda
+++ b/src/Data/Vec/Any.agda
@@ -30,7 +30,7 @@ data Any {p} (P : A → Set p) : ∀ {n} → Vec A n → Set (a ⊔ p) where
 ------------------------------------------------------------------------
 -- Operations on Any
 
-module _ {p} {P : A → Set p} {n x} {xs : Vec A n} where
+module _ {p} {P : A → Set p} {n} {x : A} {xs : Vec A n} where
 
 -- If the tail does not satisfy the predicate, then the head will.
 

--- a/src/Data/Vec/Categorical.agda
+++ b/src/Data/Vec/Categorical.agda
@@ -6,17 +6,19 @@
 
 {-# OPTIONS --without-K #-}
 
-module Data.Vec.Categorical {a n} where
-
 open import Category.Applicative using (RawApplicative)
 open import Category.Applicative.Indexed using (Morphism)
 open import Category.Functor as Fun using (RawFunctor)
 import Function.Identity.Categorical as Id
 open import Category.Monad using (RawMonad)
 open import Data.Fin using (Fin)
+open import Data.Nat using (ℕ)
 open import Data.Vec as Vec hiding (_⊛_)
 open import Data.Vec.Properties
 open import Function
+open import Level
+
+module Data.Vec.Categorical {a : Level} {n : ℕ} where
 
 ------------------------------------------------------------------------
 -- Functor and applicative

--- a/src/Function/Identity/Categorical.agda
+++ b/src/Function/Identity/Categorical.agda
@@ -6,13 +6,14 @@
 
 {-# OPTIONS --without-K #-}
 
-module Function.Identity.Categorical {ℓ} where
-
 open import Category.Functor
 open import Category.Applicative
 open import Category.Monad
 open import Category.Comonad
 open import Function
+open import Level
+
+module Function.Identity.Categorical {ℓ : Level} where
 
 Identity : Set ℓ → Set ℓ
 Identity A = A

--- a/src/Induction/Nat.agda
+++ b/src/Induction/Nat.agda
@@ -17,7 +17,7 @@ open import Data.Product
 open import Data.Unit
 open import Induction
 open import Induction.WellFounded as WF
-open import Level using (Lift)
+open import Level using (Level; Lift)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Unary
 
@@ -66,7 +66,7 @@ mutual
   <′-wellFounded′ (suc n) .n ≤′-refl       = <′-wellFounded n
   <′-wellFounded′ (suc n)  m (≤′-step m<n) = <′-wellFounded′ n m m<n
 
-module _ {ℓ} where
+module _ {ℓ : Level} where
   open WF.All <′-wellFounded ℓ public
     renaming ( wfRecBuilder to <′-recBuilder
              ; wfRec        to <′-rec
@@ -82,7 +82,7 @@ module _ {ℓ} where
 <-wellFounded : WellFounded _<_
 <-wellFounded = Subrelation.wellFounded ≤⇒≤′ <′-wellFounded
 
-module _ {ℓ} where
+module _ {ℓ : Level} where
   open WF.All <-wellFounded ℓ public
     renaming ( wfRecBuilder to <-recBuilder
              ; wfRec        to <-rec
@@ -98,7 +98,7 @@ module _ {ℓ} where
 ≺-wellFounded : WellFounded _≺_
 ≺-wellFounded = Subrelation.wellFounded ≺⇒<′ <′-wellFounded
 
-module _ {ℓ} where
+module _ {ℓ : Level} where
   open WF.All ≺-wellFounded ℓ public
     renaming ( wfRecBuilder to ≺-recBuilder
              ; wfRec        to ≺-rec

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -45,7 +45,7 @@ Please use WellFounded instead."
 ------------------------------------------------------------------------
 -- Well-founded induction for the subset of accessible elements:
 
-module Some {a lt} {A : Set a} {_<_ : Rel A lt} {ℓ} where
+module Some {a lt} {A : Set a} {_<_ : Rel A lt} {ℓ : Level} where
 
   wfRecBuilder : SubsetRecursorBuilder (Acc _<_) (WfRec _<_ {ℓ = ℓ})
   wfRecBuilder P f x (acc rs) = λ y y<x →
@@ -65,7 +65,7 @@ module Some {a lt} {A : Set a} {_<_ : Rel A lt} {ℓ} where
 -- accessible:
 
 module All {a lt} {A : Set a} {_<_ : Rel A lt}
-           (wf : WellFounded _<_) ℓ where
+           (wf : WellFounded _<_) (ℓ : Level) where
 
   wfRecBuilder : RecursorBuilder (WfRec _<_ {ℓ = ℓ})
   wfRecBuilder P f x = Some.wfRecBuilder P f x (wf x)

--- a/src/Relation/Binary/Construct/Always.agda
+++ b/src/Relation/Binary/Construct/Always.agda
@@ -11,7 +11,7 @@ module Relation.Binary.Construct.Always where
 open import Relation.Binary
 open import Relation.Binary.Construct.Constant using (Const)
 open import Data.Unit using (⊤; tt)
-open import Level using (Lift; lift)
+open import Level using (Level; Lift; lift)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -22,7 +22,7 @@ Always = Const (Lift _ ⊤)
 ------------------------------------------------------------------------
 -- Properties
 
-module _ {a} (A : Set a) ℓ where
+module _ {a} (A : Set a) (ℓ : Level) where
 
   refl : Reflexive {ℓ = ℓ} {A} Always
   refl = lift tt

--- a/src/Relation/Binary/Construct/Closure/Equivalence.agda
+++ b/src/Relation/Binary/Construct/Closure/Equivalence.agda
@@ -52,7 +52,7 @@ module _ {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) where
 ------------------------------------------------------------------------
 -- Operations
 
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
+module _ {a ℓ₁ ℓ₂ : _} {A : Set a} where
 
   -- A generalised variant of map which allows the index type to change.
 

--- a/src/Relation/Binary/Construct/Closure/ReflexiveTransitive/Properties/WithK.agda
+++ b/src/Relation/Binary/Construct/Closure/ReflexiveTransitive/Properties/WithK.agda
@@ -12,6 +12,7 @@ module
   where
 
 open import Function
+open import Level using (Level)
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.ReflexiveTransitive
 open import Relation.Binary.PropositionalEquality
@@ -19,7 +20,7 @@ open import Relation.Binary.PropositionalEquality
 ------------------------------------------------------------------------
 -- Equality
 
-module _ {i t} {I : Set i} {T : Rel I t} {i j k} {x y : T i j} {xs ys}
+module _ {i t} {I : Set i} {T : Rel I t} {i j k} {x y : T i j} {xs ys : Star T j k}
   where
 
   ◅-injectiveˡ : (Star T i k ∋ x ◅ xs) ≡ y ◅ ys → x ≡ y

--- a/src/Relation/Binary/Construct/Closure/Symmetric.agda
+++ b/src/Relation/Binary/Construct/Closure/Symmetric.agda
@@ -19,7 +19,7 @@ open Sum public using () renaming (inj₁ to fwd; inj₂ to bwd)
 SymClosure : ∀ {a ℓ} {A : Set a} → Rel A ℓ → Rel A ℓ
 SymClosure _∼_ a b = a ∼ b ⊎ b ∼ a
 
-module _ {a ℓ} {A : Set a} where
+module _ {a ℓ : _} {A : Set a} where
 
   -- Symmetric closures are symmetric.
 

--- a/src/Relation/Binary/Construct/Converse.agda
+++ b/src/Relation/Binary/Construct/Converse.agda
@@ -14,6 +14,7 @@ module Relation.Binary.Construct.Converse where
 
 open import Function
 open import Data.Product
+open import Level using (Level)
 
 ------------------------------------------------------------------------
 -- Properties
@@ -143,7 +144,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {≈ : Rel A ℓ₁} {∼ : Rel A ℓ₂}
     }
     where module O = IsStrictTotalOrder O
 
-module _ {a ℓ} where
+module _ {a ℓ : Level} where
 
   setoid : Setoid a ℓ → Setoid a ℓ
   setoid S = record
@@ -157,7 +158,7 @@ module _ {a ℓ} where
     }
     where module S = DecSetoid S
 
-module _ {a ℓ₁ ℓ₂} where
+module _ {a ℓ₁ ℓ₂ : Level} where
 
   preorder : Preorder a ℓ₁ ℓ₂ → Preorder a ℓ₁ ℓ₂
   preorder O = record

--- a/src/Relation/Binary/Construct/Flip.agda
+++ b/src/Relation/Binary/Construct/Flip.agda
@@ -14,6 +14,7 @@ module Relation.Binary.Construct.Flip where
 
 open import Function
 open import Data.Product
+open import Level using (Level)
 
 ------------------------------------------------------------------------
 -- Properties
@@ -142,7 +143,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {≈ : Rel A ℓ₁} {∼ : Rel A ℓ₂}
     ; compare       = trichotomous ≈ ∼ O.compare
     } where module O = IsStrictTotalOrder O
 
-module _ {a ℓ} where
+module _ {a ℓ : Level} where
 
   setoid : Setoid a ℓ → Setoid a ℓ
   setoid S = record
@@ -158,7 +159,7 @@ module _ {a ℓ} where
     }
     where module S = DecSetoid S
 
-module _ {a ℓ₁ ℓ₂} where
+module _ {a ℓ₁ ℓ₂ : Level} where
 
   preorder : Preorder a ℓ₁ ℓ₂ → Preorder a ℓ₁ ℓ₂
   preorder O = record

--- a/src/Relation/Binary/Indexed/Heterogeneous/Construct/At.agda
+++ b/src/Relation/Binary/Indexed/Heterogeneous/Construct/At.agda
@@ -40,7 +40,7 @@ module _ {a i} {I : Set i} {A : I → Set a} where
 ------------------------------------------------------------------------
 -- Packages
 
-module _ {a i} {I : Set i} where
+module _ {a i : _} {I : Set i} where
 
   setoid : ∀ {ℓ} → IndexedSetoid I a ℓ → I → Setoid a ℓ
   setoid S index = record
@@ -62,7 +62,7 @@ module _ {a i} {I : Set i} where
 ------------------------------------------------------------------------
 -- Some useful shorthand infix notation
 
-module _ {a i} {I : Set i} where
+module _ {a i : _} {I : Set i} where
 
   _atₛ_ : ∀ {ℓ} → IndexedSetoid I a ℓ → I → Setoid a ℓ
   _atₛ_ = setoid

--- a/src/Relation/Unary/Properties.agda
+++ b/src/Relation/Unary/Properties.agda
@@ -50,7 +50,7 @@ module _ {a} {A : Set a} where
 ----------------------------------------------------------------------
 -- Subset properties
 
-module _ {a ℓ} {A : Set a} where
+module _ {a ℓ : _} {A : Set a} where
 
   ∅-⊆ : (P : Pred A ℓ) → ∅ ⊆ P
   ∅-⊆ P ()


### PR DESCRIPTION
My proposed fix to agda/agda#1063 (see https://github.com/agda/agda/pull/3427) requires some additional type annotations on module parameters. This patch updates the standard library with all the new required annotations.