### PR TITLE
Automated proof of permutation for Fin with instance resolution.

### DIFF
--- a/src/Data/Fin/Instance.agda
+++ b/src/Data/Fin/Instance.agda
@@ -1,0 +1,88 @@
+module Data.Fin.Instance where
+
+open import Data.Nat
+open import Data.Nat.Properties
+open import Data.Nat.Instance
+open import Function.Inverse
+open import Relation.Binary.PropositionalEquality
+open import Instance
+open import Data.Fin hiding (_≤_)
+open import Data.Fin.Properties hiding (≤-refl ; ≤-irrelevance ; ≤-trans ; ≤-reflexive)
+open import Data.Fin.Permutation
+
+data _InverseOfᵢ_ {k} (f g : Fin (suc k) → Fin (suc k)) : (m : ℕ) → {{m≤k : m ≤ᵢ k}} → Set where
+  instance
+    inv-zero : {{eq : f (g zero) ≡ zero }} → (f InverseOfᵢ g) zero
+    inv-suc  : ∀{a} → {{sa≤k : suc a ≤ᵢ k}} → let fn = fromℕ≤ (s≤s (≤ᵢ-to-≤ {{sa≤k}}))
+                                              in {{eq : f (g fn) ≡ fn }}
+               → let e = ≤-to-≤ᵢ (≤⇒pred≤ ≤ᵢ-to-≤)
+                 in {{ind : _InverseOfᵢ_ f g a {{e}}}} → (f InverseOfᵢ g) (suc a)
+
+
+
+_InverseOfᵢ′_ : ∀{k} (f g : Fin (suc k) → Fin (suc k)) → (m : ℕ) → m ≤ k → Set
+_InverseOfᵢ′_ f g m x = _InverseOfᵢ_ f g m {{≤-to-≤ᵢ x}}
+
+
+_invOf_at′_ : ∀{k} → (f g : Fin (suc k) → Fin (suc k)) → (m : ℕ) → (m≤k : m ≤ k)
+              → (inv : (f InverseOfᵢ′ g) k ≤-refl) → f (g (fromℕ≤ (s≤s m≤k) )) ≡ fromℕ≤ (s≤s m≤k)
+_invOf_at′_ {k} f g m m≤k x = hfun k (k ∸ m) (m∸[m∸n]≡n m≤k) ≤-refl x m≤k where
+  hfun : ∀ nk l → nk ∸ l ≡ m → (nk≤k : nk ≤ k) → (f InverseOfᵢ′ g) nk nk≤k
+      → (m≤k : m ≤ k) → f (g (fromℕ≤ (s≤s m≤k) )) ≡ fromℕ≤ (s≤s m≤k)
+  hfun zero zero refl z≤n inv-zero z≤n = it
+  hfun zero (suc l) refl z≤n inv-zero z≤n = it
+  hfun (suc nk) zero refl nklk inv-suc mlk
+    = subst (λ z → f (g (fromℕ≤ (s≤s z))) ≡ fromℕ≤ (s≤s z)) (≤-irrelevance ((≤ᵢ-to-≤ {{≤-to-≤ᵢ nklk}})) mlk) it
+  hfun (suc nk) (suc l) neq (s≤s nklk) (inv-suc {{sa≤k}} {{ind = ind}}) mlk
+    = hfun nk l neq (≤-step nklk) w mlk where
+      w = subst (λ z → (f InverseOfᵢ′ g) nk z) (≤-irrelevance (≤-trans (≤-step (≤-reflexive refl))
+                                                              (s≤s (≤ᵢ-to-≤ {{≤-to-≤ᵢ nklk}}))) (≤-step nklk)) ind
+
+
+
+_invOf_at_ : ∀{k} → (f g : Fin (suc k) → Fin (suc k)) → (m : ℕ) → {{m≤k : m ≤ᵢ k}}
+             → {{inv : (f InverseOfᵢ′ g) k ≤-refl}}
+             → f (g (fromℕ≤ (s≤s (≤ᵢ-to-≤ {{m≤k}})) )) ≡ fromℕ≤ (s≤s (≤ᵢ-to-≤ {{m≤k}}))
+f invOf g at m = (f invOf g at′ m) ≤ᵢ-to-≤ it
+
+
+
+open _InverseOf_
+
+invOfᵢ-to-invOf : ∀{k} → (f g : Fin (suc k) → Fin (suc k))
+               → {{inv : (f InverseOfᵢ′ g) k ≤-refl}} → {{inv′ : (g InverseOfᵢ′ f) k ≤-refl}}
+               → (→-to-⟶ f) InverseOf (→-to-⟶ g)
+left-inverse-of (invOfᵢ-to-invOf f g) x
+  = subst (λ z → f (g z) ≡ z) (fromℕ≤-toℕ x _) ((f invOf g at′ toℕ x) (toℕ≤pred[n] x) it)  
+right-inverse-of (invOfᵢ-to-invOf f g) x
+  = subst (λ z → g (f z) ≡ z) (fromℕ≤-toℕ x _) ((g invOf f at′ toℕ x) (toℕ≤pred[n] x) it)
+
+
+
+permutationᵢ : ∀ {k} (f g : Fin (suc k) → Fin (suc k))
+               → {{inv : (f InverseOfᵢ′ g) k ≤-refl}} → {{inv′ : (g InverseOfᵢ′ f) k ≤-refl}}
+               → Permutation′ (suc k)
+permutationᵢ f g = record
+  { to         = →-to-⟶ f
+  ; from       = →-to-⟶ g
+  ; inverse-of = invOfᵢ-to-invOf g f
+  }
+
+
+-- Example
+--
+-- g : Fin 3 → Fin 3
+-- g zero = suc zero
+-- g (suc zero) = suc (suc zero)
+-- g (suc (suc zero)) = zero
+-- g (suc (suc (suc ())))
+
+-- f : Fin 3 → Fin 3
+-- f zero = suc (suc zero)
+-- f (suc zero) = zero
+-- f (suc (suc zero)) = suc zero
+-- f (suc (suc (suc ())))
+
+
+-- perm : Permutation′ 3
+-- perm = permutationᵢ f g

--- a/src/Data/Fin/Instance.agda
+++ b/src/Data/Fin/Instance.agda
@@ -1,3 +1,10 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Use of Instance arguments with regard to Fin.
+------------------------------------------------------------------------
+
+
 module Data.Fin.Instance where
 
 open import Data.Nat
@@ -53,7 +60,7 @@ invOfᵢ-to-invOf : ∀{k} → (f g : Fin (suc k) → Fin (suc k))
                → {{inv : (f InverseOfᵢ′ g) k ≤-refl}} → {{inv′ : (g InverseOfᵢ′ f) k ≤-refl}}
                → (→-to-⟶ f) InverseOf (→-to-⟶ g)
 left-inverse-of (invOfᵢ-to-invOf f g) x
-  = subst (λ z → f (g z) ≡ z) (fromℕ≤-toℕ x _) ((f invOf g at′ toℕ x) (toℕ≤pred[n] x) it)  
+  = subst (λ z → f (g z) ≡ z) (fromℕ≤-toℕ x _) ((f invOf g at′ toℕ x) (toℕ≤pred[n] x) it)
 right-inverse-of (invOfᵢ-to-invOf f g) x
   = subst (λ z → g (f z) ≡ z) (fromℕ≤-toℕ x _) ((g invOf f at′ toℕ x) (toℕ≤pred[n] x) it)
 

--- a/src/Data/Fin/Instance/Permutation.agda
+++ b/src/Data/Fin/Instance/Permutation.agda
@@ -1,11 +1,11 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Use of Instance arguments with regard to Fin.
+-- Automated proof of permutation on concrete functions f , g
 ------------------------------------------------------------------------
 
 
-module Data.Fin.Instance where
+module Data.Fin.Instance.Permutation where
 
 open import Data.Nat
 open import Data.Nat.Properties
@@ -22,7 +22,7 @@ data _InverseOfᵢ_ {k} (f g : Fin (suc k) → Fin (suc k)) : (m : ℕ) → {{m�
     inv-zero : {{eq : f (g zero) ≡ zero }} → (f InverseOfᵢ g) zero
     inv-suc  : ∀{a} → {{sa≤k : suc a ≤ᵢ k}} → let fn = fromℕ≤ (s≤s (≤ᵢ-to-≤ {{sa≤k}}))
                                               in {{eq : f (g fn) ≡ fn }}
-               → let e = ≤-to-≤ᵢ (≤⇒pred≤ ≤ᵢ-to-≤)
+               → let e = ≤-to-≤ᵢ (≤⇒pred≤ (≤ᵢ-to-≤ {{sa≤k}}))
                  in {{ind : _InverseOfᵢ_ f g a {{e}}}} → (f InverseOfᵢ g) (suc a)
 
 

--- a/src/Data/Nat/Instance.agda
+++ b/src/Data/Nat/Instance.agda
@@ -1,3 +1,10 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Use of Instance arguments with regard to Nat.
+------------------------------------------------------------------------
+
+
 module Data.Nat.Instance where
 
 open import Data.Nat
@@ -10,12 +17,11 @@ data _≤ᵢ_ : Rel ℕ 0ℓ where
     s≤s : ∀ {m n} {{m≤n : m ≤ᵢ n}} → suc m ≤ᵢ suc n
 
 
-≤ᵢ-to-≤ : ∀{a b} → {{rl : a ≤ᵢ b}} → a ≤ b 
+≤ᵢ-to-≤ : ∀{a b} → {{rl : a ≤ᵢ b}} → a ≤ b
 ≤ᵢ-to-≤ {{z≤n}} = z≤n
 ≤ᵢ-to-≤ {{s≤s}} = s≤s ≤ᵢ-to-≤
 
 ≤-to-≤ᵢ : ∀{a b} → a ≤ b → a ≤ᵢ b
 ≤-to-≤ᵢ z≤n = z≤n
 ≤-to-≤ᵢ (s≤s x) = s≤s {{≤-to-≤ᵢ x}}
-
 

--- a/src/Data/Nat/Instance.agda
+++ b/src/Data/Nat/Instance.agda
@@ -1,0 +1,21 @@
+module Data.Nat.Instance where
+
+open import Data.Nat
+open import Relation.Binary
+open import Level hiding (zero ; suc)
+
+data _≤ᵢ_ : Rel ℕ 0ℓ where
+  instance
+    z≤n : ∀ {n}                   → zero  ≤ᵢ n
+    s≤s : ∀ {m n} {{m≤n : m ≤ᵢ n}} → suc m ≤ᵢ suc n
+
+
+≤ᵢ-to-≤ : ∀{a b} → {{rl : a ≤ᵢ b}} → a ≤ b 
+≤ᵢ-to-≤ {{z≤n}} = z≤n
+≤ᵢ-to-≤ {{s≤s}} = s≤s ≤ᵢ-to-≤
+
+≤-to-≤ᵢ : ∀{a b} → a ≤ b → a ≤ᵢ b
+≤-to-≤ᵢ z≤n = z≤n
+≤-to-≤ᵢ (s≤s x) = s≤s {{≤-to-≤ᵢ x}}
+
+

--- a/src/Instance.agda
+++ b/src/Instance.agda
@@ -1,0 +1,10 @@
+module Instance where
+
+
+it : ∀ {a} {A : Set a} {{x : A}} → A
+it {{x}} = x
+{-# INLINE it #-}
+
+asInstance : ∀ {a b} {A : Set a} {B : A → Set b} (x : A) → (∀ {{x}} → B x) → B x
+asInstance x f = f {{x}}
+{-# INLINE asInstance #-}

--- a/src/Instance.agda
+++ b/src/Instance.agda
@@ -1,3 +1,10 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Helper function with regard to Instance arguments.
+------------------------------------------------------------------------
+
+
 module Instance where
 
 


### PR DESCRIPTION
There might be a way to simplify this. For now, it works.

After this, I will automate the proof for equality up to permutation for the ```Data.Table``` structure.

Since ```List``` and ```Vec``` construct a Table structure , this will also define an equality for them up to permutation.