### PR TITLE
Give Respectsˡ/Respectsʳ more general signature (REL instead of Rel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,3 +745,9 @@ Other minor additions
   ```agda
   y≤x⇒x∧y≈y : y ≤ x → x ∧ y ≈ y
   ```
+
+* Give `_Respectsʳ_`/`_Respectsˡ_` more general type, to support heterogenous relations.
+  ```agda
+  _Respectsʳ_ : REL A B ℓ₁ → Rel B ℓ₂ → Set _
+  _Respectsˡ_ : REL A B ℓ₁ → Rel A ℓ₂ → Set _
+  ```

--- a/src/Relation/Binary/Core.agda
+++ b/src/Relation/Binary/Core.agda
@@ -131,10 +131,10 @@ Minimum _≤_ = Maximum (flip _≤_)
 _Respects_ : ∀ {a ℓ₁ ℓ₂} {A : Set a} → (A → Set ℓ₁) → Rel A ℓ₂ → Set _
 P Respects _∼_ = ∀ {x y} → x ∼ y → P x → P y
 
-_Respectsʳ_ : ∀ {a ℓ₁ ℓ₂} {A : Set a} → Rel A ℓ₁ → Rel A ℓ₂ → Set _
+_Respectsʳ_ : ∀ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} → REL A B ℓ₁ → Rel B ℓ₂ → Set _
 P Respectsʳ _∼_ = ∀ {x} → (P x) Respects _∼_
 
-_Respectsˡ_ : ∀ {a ℓ₁ ℓ₂} {A : Set a} → Rel A ℓ₁ → Rel A ℓ₂ → Set _
+_Respectsˡ_ : ∀ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} → REL A B ℓ₁ → Rel A ℓ₂ → Set _
 P Respectsˡ _∼_ = ∀ {y} → (flip P y) Respects _∼_
 
 _Respects₂_ : ∀ {a ℓ₁ ℓ₂} {A : Set a} → Rel A ℓ₁ → Rel A ℓ₂ → Set _


### PR DESCRIPTION
`_Respects*_` can be given a more general type for the ˡ or ʳ versions, to support heterogeneous relations. Of course, `_Respects₂_` still unifies these into a homogeneous relation.