### PR TITLE
[ new ] combinators for pointwise setoids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -667,6 +667,14 @@ Other minor additions
   toDec   : P ⊎ ¬ P → Dec P
   ```
 
+* Added new functions to `Data.Sum.Relation.Pointwise`:
+  ```agda
+  inj₁ₛ : A ⟶ (A ⊎ₛ B)
+  inj₂ₛ : B ⟶ (A ⊎ₛ B)
+  [_,_]ₛ : (A ⟶ C) → (B ⟶ C) → (A ⊎ₛ B) ⟶ C
+  swapₛ : (A ⊎ₛ B) ⟶ (B ⊎ₛ A)
+  ```
+
 * Added new function to `Data.These`:
   ```agda
   fromSum : A ⊎ B → These A B

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -635,6 +635,14 @@ Other minor additions
   m≢0⇒suc[pred[m]]≡m : m ≢ 0 → suc (pred m) ≡ m
   ```
 
+* Added new functions to `Data.Product.Relation.Pointwise.NonDependent`:
+  ```agda
+  <_,_>ₛ : A ⟶ B → A ⟶ C → A ⟶ (B ×ₛ C)
+  proj₁ₛ : (A ×ₛ B) ⟶ A
+  proj₂ₛ : (A ×ₛ B) ⟶ B
+  swapₛ : (A ×ₛ B) ⟶ (B ×ₛ A)
+  ```
+
 * Added new functions to `Data.Rational`:
   ```agda
   norm-mkℚ : (n : ℤ) (d : ℕ) → d ≢0 → ℚ

--- a/src/Data/Product/Relation/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Pointwise/NonDependent.agda
@@ -255,7 +255,7 @@ module _ {a b} {A : Set a} {B : Set b} where
 
 <_,_>ₛ : ∀ {a₁ a₂ b₁ b₂ c₁ c₂}
   {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} {C : Setoid c₁ c₂} →
-  A ⟶ B → A ⟶ C → A ⟶ (B ×ₛ C)
+  (A ⟶ B) → (A ⟶ C) → A ⟶ (B ×ₛ C)
 < f , g >ₛ = record
   { _⟨$⟩_ = < f ⟨$⟩_ , g ⟨$⟩_ >
   ; cong = < F.cong f , F.cong g >
@@ -272,7 +272,7 @@ proj₂ₛ = record { _⟨$⟩_ = proj₂ ; cong = proj₂ }
 _×-⟶_ : ∀ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
   {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
   {C : Setoid c₁ c₂} {D : Setoid d₁ d₂} →
-  A ⟶ B → C ⟶ D → (A ×ₛ C) ⟶ (B ×ₛ D)
+  (A ⟶ B) → (C ⟶ D) → (A ×ₛ C) ⟶ (B ×ₛ D)
 _×-⟶_ {A = A} {B} {C} {D} f g = record
   { _⟨$⟩_ = fg
   ; cong  = fg-cong

--- a/src/Data/Product/Relation/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Pointwise/NonDependent.agda
@@ -253,6 +253,22 @@ module _ {a b} {A : Set a} {B : Set b} where
 ------------------------------------------------------------------------
 -- Some properties related to "relatedness"
 
+<_,_>ₛ : ∀ {a₁ a₂ b₁ b₂ c₁ c₂}
+  {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} {C : Setoid c₁ c₂} →
+  A ⟶ B → A ⟶ C → A ⟶ (B ×ₛ C)
+< f , g >ₛ = record
+  { _⟨$⟩_ = < f ⟨$⟩_ , g ⟨$⟩_ >
+  ; cong = < F.cong f , F.cong g >
+  }
+
+proj₁ₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+         (A ×ₛ B) ⟶ A
+proj₁ₛ = record { _⟨$⟩_ = proj₁ ; cong = proj₁ }
+
+proj₂ₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+         (A ×ₛ B) ⟶ B
+proj₂ₛ = record { _⟨$⟩_ = proj₂ ; cong = proj₂ }
+
 _×-⟶_ : ∀ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
   {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
   {C : Setoid c₁ c₂} {D : Setoid d₁ d₂} →
@@ -269,6 +285,10 @@ _×-⟶_ {A = A} {B} {C} {D} f g = record
 
   fg-cong : _≈AC_ =[ fg ]⇒ _≈BD_
   fg-cong (_∼₁_ , _∼₂_) = (F.cong f _∼₁_ , F.cong g _∼₂_)
+
+swapₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+        (A ×ₛ B) ⟶ (B ×ₛ A)
+swapₛ = < proj₂ₛ , proj₁ₛ >ₛ
 
 module _ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
   {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}

--- a/src/Data/Sum/Relation/Pointwise.agda
+++ b/src/Data/Sum/Relation/Pointwise.agda
@@ -238,6 +238,25 @@ _⊎-≟_ : ∀ {a b} {A : Set a} {B : Set b} →
 ------------------------------------------------------------------------
 -- Setoid "relatedness"
 
+inj₁ₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+        A ⟶ (A ⊎ₛ B)
+inj₁ₛ = record { _⟨$⟩_ = inj₁ ; cong = ₁∼₁ }
+
+inj₂ₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+        B ⟶ (A ⊎ₛ B)
+inj₂ₛ = record { _⟨$⟩_ = inj₂ ; cong = ₂∼₂ }
+
+[_,_]ₛ : ∀ {a₁ a₂ b₁ b₂ c₁ c₂}
+         {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} {C : Setoid c₁ c₂} →
+         (A ⟶ C) → (B ⟶ C) → (A ⊎ₛ B) ⟶ C
+[ f , g ]ₛ = record
+  { _⟨$⟩_ = [ f ⟨$⟩_ , g ⟨$⟩_ ]
+  ; cong = λ where
+    (₁∼₂ ())
+    (₁∼₁ x∼₁y) → F.cong f x∼₁y
+    (₂∼₂ x∼₂y) → F.cong g x∼₂y
+  }
+
 module _ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
          {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
          {C : Setoid c₁ c₂} {D : Setoid d₁ d₂}
@@ -258,6 +277,10 @@ module _ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
     fg-cong (₁∼₂ ())
     fg-cong (₁∼₁ x∼₁y) = ₁∼₁ $ F.cong f x∼₁y
     fg-cong (₂∼₂ x∼₂y) = ₂∼₂ $ F.cong g x∼₂y
+
+swapₛ : ∀ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} →
+        (A ⊎ₛ B) ⟶ (B ⊎ₛ A)
+swapₛ = [ inj₂ₛ , inj₁ₛ ]ₛ
 
 module _ {a₁ a₂ b₁ b₂ c₁ c₂ d₁ d₂}
          {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}


### PR DESCRIPTION
Adding some combinators I happened to need when using the × setoid. `_×-⟶_` could also be changed to be written in the combinator style if wanted (and maybe `mapₛ` would be a better name).