### PR TITLE
[ fix #485 ] Deprecated the name `irrelevance` in favour of `irrelevant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,7 +354,7 @@ Deprecated features
   ≅-heterogeneous-irrelevanceʳ ↦ ≅-heterogeneous-irrelevantʳ
   ```
 
-* In `Relation.Binary.PropositionalEquality`:
+* In `Relation.Binary.PropositionalEquality.WithK`:
   ```agda
   ≡-irrelevance ↦ ≡-irrelevant
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,9 +304,28 @@ Other major changes
 Deprecated features
 -------------------
 
+* In `Data.Bool.Properties`:
+  ```agda
+  T-irrelevance ↦ T-irrelevant
+  ```
+
+* In `Data.Fin.Properties`:
+  ```agda
+  ≤-irrelevance ↦ ≤-irrelevant
+  <-irrelevance ↦ <-irrelevant
+  ```
+
 * In `Data.Integer.Properties`:
   ```agda
-  ≰→> ↦ ≰⇒>
+  ≰→>           ↦ ≰⇒>
+  ≤-irrelevance ↦ ≤-irrelevant
+  <-irrelevance ↦ <-irrelevant
+  ```
+
+* In `Data.Nat.Properties`:
+  ```agda
+  ≤-irrelevance ↦ ≤-irrelevant
+  <-irrelevance ↦ <-irrelevant
   ```
 
 * In `Data.Rational`:
@@ -316,6 +335,29 @@ Deprecated features
   ≡⇒≃
   ```
   (moved to `Data.Rational.Properties`)
+
+* In `Data.Rational.Properties`:
+  ```agda
+  ≤-irrelevance ↦ ≤-irrelevant
+  ```
+
+* In `Data.Vec.Properties.WithK`:
+  ```agda
+  []=-irrelevance ↦ []=-irrelevant
+  ```
+
+* In `Relation.Binary.HeterogeneousEquality`:
+  ```agda
+  ≅-irrelevance                ↦ ≅-irrelevant
+  ≅-heterogeneous-irrelevance  ↦ ≅-heterogeneous-irrelevant
+  ≅-heterogeneous-irrelevanceˡ ↦ ≅-heterogeneous-irrelevantˡ
+  ≅-heterogeneous-irrelevanceʳ ↦ ≅-heterogeneous-irrelevantʳ
+  ```
+
+* In `Relation.Binary.PropositionalEquality`:
+  ```agda
+  ≡-irrelevance ↦ ≡-irrelevant
+  ```
 
 Other minor additions
 ---------------------

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -449,9 +449,9 @@ T-∨ {true}  {b₂}    = equivalence inj₁ (const _)
 T-∨ {false} {true}  = equivalence inj₂ (const _)
 T-∨ {false} {false} = equivalence inj₁ [ id , id ]
 
-T-irrelevance : Irrelevant T
-T-irrelevance {true}  _  _  = refl
-T-irrelevance {false} () ()
+T-irrelevant : Irrelevant T
+T-irrelevant {true}  _  _  = refl
+T-irrelevant {false} () ()
 
 push-function-into-if :
   ∀ {a b} {A : Set a} {B : Set b} (f : A → B) x {y z} →
@@ -572,8 +572,16 @@ commutativeRing-xor-∧     = xor-∧-commutativeRing
 "Warning: commutativeRing-xor-∧ was deprecated in v0.15.
 Please use xor-∧-commutativeRing instead."
 #-}
-proof-irrelevance = T-irrelevance
+proof-irrelevance = T-irrelevant
 {-# WARNING_ON_USAGE proof-irrelevance
 "Warning: proof-irrelevance was deprecated in v0.15.
-Please use T-irrelevance instead."
+Please use T-irrelevant instead."
+#-}
+
+-- Version 0.18
+
+T-irrelevance = T-irrelevant
+{-# WARNING_ON_USAGE T-irrelevance
+"Warning: T-irrelevance was deprecated in v0.18.
+Please use T-irrelevant instead."
 #-}

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -237,8 +237,8 @@ m <? n = suc (toℕ m) ℕ.≤? toℕ n
   }
 
 -- Other properties
-≤-irrelevance : ∀ {n} → Irrelevant (_≤_ {n})
-≤-irrelevance = ℕₚ.≤-irrelevance
+≤-irrelevant : ∀ {n} → Irrelevant (_≤_ {n})
+≤-irrelevant = ℕₚ.≤-irrelevant
 
 ------------------------------------------------------------------------
 -- Properties of _<_
@@ -297,8 +297,8 @@ m <? n = suc (toℕ m) ℕ.≤? toℕ n
   }
 
 -- Other properties
-<-irrelevance : ∀ {n} → Irrelevant (_<_ {n})
-<-irrelevance = ℕₚ.<-irrelevance
+<-irrelevant : ∀ {n} → Irrelevant (_<_ {n})
+<-irrelevant = ℕₚ.<-irrelevant
 
 <⇒≢ : ∀ {n} {i j : Fin n} → i < j → i ≢ j
 <⇒≢ i<i refl = ℕₚ.n≮n _ i<i
@@ -639,4 +639,17 @@ Please use toℕ-inject≤ instead."
 {-# WARNING_ON_USAGE ≤+≢⇒<
 "Warning: ≤+≢⇒< was deprecated in v0.17.
 Please use ≤∧≢⇒< instead."
+#-}
+
+-- Version 0.18
+
+≤-irrelevance = ≤-irrelevant
+{-# WARNING_ON_USAGE ≤-irrelevance
+"Warning: ≤-irrelevance was deprecated in v0.18.
+Please use ≤-irrelevant instead."
+#-}
+<-irrelevance = <-irrelevant
+{-# WARNING_ON_USAGE <-irrelevance
+"Warning: <-irrelevance was deprecated in v0.18.
+Please use <-irrelevant instead."
 #-}

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -1210,10 +1210,10 @@ m≤n⇒0≤n-m {m} {n} m≤n = begin
 n≤1+n : ∀ n → n ≤ (+ 1) + n
 n≤1+n n = ≤-step ≤-refl
 
-≤-irrelevance : Irrelevant _≤_
-≤-irrelevance -≤+       -≤+         = refl
-≤-irrelevance (-≤- n≤m₁) (-≤- n≤m₂) = cong -≤- (ℕₚ.≤-irrelevance n≤m₁ n≤m₂)
-≤-irrelevance (+≤+ n≤m₁) (+≤+ n≤m₂) = cong +≤+ (ℕₚ.≤-irrelevance n≤m₁ n≤m₂)
+≤-irrelevant : Irrelevant _≤_
+≤-irrelevant -≤+       -≤+         = refl
+≤-irrelevant (-≤- n≤m₁) (-≤- n≤m₂) = cong -≤- (ℕₚ.≤-irrelevant n≤m₁ n≤m₂)
+≤-irrelevant (+≤+ n≤m₁) (+≤+ n≤m₂) = cong +≤+ (ℕₚ.≤-irrelevant n≤m₁ n≤m₂)
 
 ------------------------------------------------------------------------
 -- Properties _<_
@@ -1320,8 +1320,8 @@ n≮n { -[1+ suc n ]} (-≤- n<n) =  contradiction n<n ℕₚ.1+n≰n
 ... | yes m≤n  = -≤- m≤n
 ... | no  m≰n' = contradiction (-≤- (ℕₚ.≰⇒> m≰n')) m≰n
 
-<-irrelevance : Irrelevant _<_
-<-irrelevance = ≤-irrelevance
+<-irrelevant : Irrelevant _<_
+<-irrelevant = ≤-irrelevant
 
 +-monoˡ-< : ∀ n → (_+ n) Preserves _<_ ⟶ _<_
 +-monoˡ-< n {i} {j} i<j
@@ -1441,4 +1441,14 @@ Please use +-cancelˡ-⊖ instead."
 {-# WARNING_ON_USAGE ≰→>
 "Warning: ≰→> was deprecated in v0.18.
 Please use ≰⇒> instead."
+#-}
+≤-irrelevance = ≤-irrelevant
+{-# WARNING_ON_USAGE ≤-irrelevance
+"Warning: ≤-irrelevance was deprecated in v0.18.
+Please use ≤-irrelevant instead."
+#-}
+<-irrelevance = <-irrelevant
+{-# WARNING_ON_USAGE <-irrelevance
+"Warning: <-irrelevance was deprecated in v0.18.
+Please use <-irrelevant instead."
 #-}

--- a/src/Data/List/First/Properties.agda
+++ b/src/Data/List/First/Properties.agda
@@ -70,12 +70,12 @@ module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
   unique-index p⇒¬q (px ∷ _) [ qx ]   = ⊥-elim (p⇒¬q px qx)
   unique-index p⇒¬q (_ ∷ f₁) (_ ∷ f₂) = P.cong suc (unique-index p⇒¬q f₁ f₂)
 
-  irrelevance : P ⊆ ∁ Q → Irrelevant P → Irrelevant Q → Irrelevant (First P Q)
-  irrelevance p⇒¬q p-irr q-irr [ qx₁ ]    [ qx₂ ]    = P.cong [_] (q-irr qx₁ qx₂)
-  irrelevance p⇒¬q p-irr q-irr [ qx₁ ]    (px₂ ∷ f₂) = ⊥-elim (p⇒¬q px₂ qx₁)
-  irrelevance p⇒¬q p-irr q-irr (px₁ ∷ f₁) [ qx₂ ]    = ⊥-elim (p⇒¬q px₁ qx₂)
-  irrelevance p⇒¬q p-irr q-irr (px₁ ∷ f₁) (px₂ ∷ f₂) =
-    P.cong₂ _∷_ (p-irr px₁ px₂) (irrelevance p⇒¬q p-irr q-irr f₁ f₂)
+  irrelevant : P ⊆ ∁ Q → Irrelevant P → Irrelevant Q → Irrelevant (First P Q)
+  irrelevant p⇒¬q p-irr q-irr [ qx₁ ]    [ qx₂ ]    = P.cong [_] (q-irr qx₁ qx₂)
+  irrelevant p⇒¬q p-irr q-irr [ qx₁ ]    (px₂ ∷ f₂) = ⊥-elim (p⇒¬q px₂ qx₁)
+  irrelevant p⇒¬q p-irr q-irr (px₁ ∷ f₁) [ qx₂ ]    = ⊥-elim (p⇒¬q px₁ qx₂)
+  irrelevant p⇒¬q p-irr q-irr (px₁ ∷ f₁) (px₂ ∷ f₂) =
+    P.cong₂ _∷_ (p-irr px₁ px₂) (irrelevant p⇒¬q p-irr q-irr f₁ f₂)
 
 ------------------------------------------------------------------------
 -- Decidability

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -156,9 +156,9 @@ _≥?_ = flip _≤?_
 s≤s-injective : ∀ {m n} {p q : m ≤ n} → s≤s p ≡ s≤s q → p ≡ q
 s≤s-injective refl = refl
 
-≤-irrelevance : Irrelevant _≤_
-≤-irrelevance z≤n        z≤n        = refl
-≤-irrelevance (s≤s m≤n₁) (s≤s m≤n₂) = cong s≤s (≤-irrelevance m≤n₁ m≤n₂)
+≤-irrelevant : Irrelevant _≤_
+≤-irrelevant z≤n        z≤n        = refl
+≤-irrelevant (s≤s m≤n₁) (s≤s m≤n₂) = cong s≤s (≤-irrelevant m≤n₁ m≤n₂)
 
 ≤-step : ∀ {m n} → m ≤ n → m ≤ 1 + n
 ≤-step z≤n       = z≤n
@@ -239,8 +239,8 @@ _>?_ = flip _<?_
   }
 
 -- Other properties of _<_
-<-irrelevance : Irrelevant _<_
-<-irrelevance = ≤-irrelevance
+<-irrelevant : Irrelevant _<_
+<-irrelevant = ≤-irrelevant
 
 <⇒≤pred : ∀ {m n} → m < n → m ≤ pred n
 <⇒≤pred (s≤s le) = le
@@ -1618,4 +1618,17 @@ im≡jm+n⇒[i∸j]m≡n i j m n eq = begin
 {-# WARNING_ON_USAGE ≤+≢⇒<
 "Warning: ≤+≢⇒< was deprecated in v0.17.
 Please use ≤∧≢⇒< instead."
+#-}
+
+-- Version 0.18
+
+≤-irrelevance = ≤-irrelevant
+{-# WARNING_ON_USAGE ≤-irrelevance
+"Warning: ≤-irrelevance was deprecated in v0.18.
+Please use ≤-irrelevant instead."
+#-}
+<-irrelevance = <-irrelevant
+{-# WARNING_ON_USAGE <-irrelevance
+"Warning: <-irrelevance was deprecated in v0.18.
+Please use <-irrelevant instead."
 #-}

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -148,5 +148,19 @@ p ≤? q with (↥ p ℤ.* ↧ q) ℤ.≤? (↥ q ℤ.* ↧ p)
   ; isDecTotalOrder = ≤-isDecTotalOrder
   }
 
-≤-irrelevance : Irrelevant _≤_
-≤-irrelevance (*≤* x₁) (*≤* x₂) = cong *≤* (ℤ.≤-irrelevance x₁ x₂)
+≤-irrelevant : Irrelevant _≤_
+≤-irrelevant (*≤* x₁) (*≤* x₂) = cong *≤* (ℤ.≤-irrelevant x₁ x₂)
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 0.18
+
+≤-irrelevance = ≤-irrelevant
+{-# WARNING_ON_USAGE ≤-irrelevance
+"Warning: ≤-irrelevance was deprecated in v0.18.
+Please use ≤-irrelevant instead."
+#-}

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -53,7 +53,7 @@ module _ {a} {A : Set a} where
   []=-injective here          here          = refl
   []=-injective (there xsᵢ≡x) (there xsᵢ≡y) = []=-injective xsᵢ≡x xsᵢ≡y
 
-  -- See also Data.Vec.Properties.WithK.[]=-irrelevance.
+  -- See also Data.Vec.Properties.WithK.[]=-irrelevant.
 
 ------------------------------------------------------------------------
 -- lookup

--- a/src/Data/Vec/Properties/WithK.agda
+++ b/src/Data/Vec/Properties/WithK.agda
@@ -20,11 +20,11 @@ open import Relation.Binary.HeterogeneousEquality as H using (_≅_; refl)
 
 module _ {a} {A : Set a} where
 
-  []=-irrelevance : ∀ {n} {xs : Vec A n} {i x} →
+  []=-irrelevant : ∀ {n} {xs : Vec A n} {i x} →
                     (p q : xs [ i ]= x) → p ≡ q
-  []=-irrelevance here            here             = refl
-  []=-irrelevance (there xs[i]=x) (there xs[i]=x') =
-    P.cong there ([]=-irrelevance xs[i]=x xs[i]=x')
+  []=-irrelevant here            here             = refl
+  []=-irrelevant (there xs[i]=x) (there xs[i]=x') =
+    P.cong there ([]=-irrelevant xs[i]=x xs[i]=x')
 
 ------------------------------------------------------------------------
 -- _++_
@@ -60,3 +60,17 @@ foldl-cong : ∀ {a b} {A : Set a}
              foldl B f d xs ≅ foldl C g e xs
 foldl-cong _   d≅e []       = d≅e
 foldl-cong f≅g d≅e (x ∷ xs) = foldl-cong f≅g (f≅g d≅e) xs
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 0.18
+
+[]=-irrelevance = []=-irrelevant
+{-# WARNING_ON_USAGE []=-irrelevance
+"Warning: []=-irrelevance was deprecated in v0.18.
+Please use []=-irrelevant instead."
+#-}

--- a/src/Relation/Binary/HeterogeneousEquality.agda
+++ b/src/Relation/Binary/HeterogeneousEquality.agda
@@ -139,19 +139,19 @@ icong-≡-subst-removable _ refl _ _ = refl
 ------------------------------------------------------------------------
 --Proof irrelevance
 
-≅-irrelevance : ∀ {ℓ} {A B : Set ℓ} → Irrelevant ((A → B → Set ℓ) ∋ λ a → a ≅_)
-≅-irrelevance refl refl = refl
+≅-irrelevant : ∀ {ℓ} {A B : Set ℓ} → Irrelevant ((A → B → Set ℓ) ∋ λ a → a ≅_)
+≅-irrelevant refl refl = refl
 
 module _ {ℓ} {A₁ A₂ A₃ A₄ : Set ℓ} {a₁ : A₁} {a₂ : A₂} {a₃ : A₃} {a₄ : A₄} where
 
- ≅-heterogeneous-irrelevance : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₂ ≅ a₃ → p ≅ q
- ≅-heterogeneous-irrelevance refl refl refl = refl
+ ≅-heterogeneous-irrelevant : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₂ ≅ a₃ → p ≅ q
+ ≅-heterogeneous-irrelevant refl refl refl = refl
 
- ≅-heterogeneous-irrelevanceˡ : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₁ ≅ a₃ → p ≅ q
- ≅-heterogeneous-irrelevanceˡ refl refl refl = refl
+ ≅-heterogeneous-irrelevantˡ : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₁ ≅ a₃ → p ≅ q
+ ≅-heterogeneous-irrelevantˡ refl refl refl = refl
 
- ≅-heterogeneous-irrelevanceʳ : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₂ ≅ a₄ → p ≅ q
- ≅-heterogeneous-irrelevanceʳ refl refl refl = refl
+ ≅-heterogeneous-irrelevantʳ : (p : a₁ ≅ a₂) (q : a₃ ≅ a₄) → a₂ ≅ a₄ → p ≅ q
+ ≅-heterogeneous-irrelevantʳ refl refl refl = refl
 
 ------------------------------------------------------------------------
 -- Structures
@@ -316,8 +316,31 @@ inspect f x = [ refl ]
 
 -- Version 0.15
 
-proof-irrelevance = ≅-irrelevance
+proof-irrelevance = ≅-irrelevant
 {-# WARNING_ON_USAGE proof-irrelevance
 "Warning: proof-irrelevance was deprecated in v0.15.
-Please use ≅-irrelevance instead."
+Please use ≅-irrelevant instead."
+#-}
+
+-- Version 0.18
+
+≅-irrelevance = ≅-irrelevant
+{-# WARNING_ON_USAGE ≅-irrelevance
+"Warning: ≅-irrelevance was deprecated in v0.18.
+Please use ≅-irrelevant instead."
+#-}
+≅-heterogeneous-irrelevance = ≅-heterogeneous-irrelevant
+{-# WARNING_ON_USAGE ≅-heterogeneous-irrelevance
+"Warning: ≅-heterogeneous-irrelevance was deprecated in v0.18.
+Please use ≅-heterogeneous-irrelevant instead."
+#-}
+≅-heterogeneous-irrelevanceˡ = ≅-heterogeneous-irrelevantˡ
+{-# WARNING_ON_USAGE ≅-heterogeneous-irrelevanceˡ
+"Warning: ≅-heterogeneous-irrelevanceˡ was deprecated in v0.18.
+Please use ≅-heterogeneous-irrelevantˡ instead."
+#-}
+≅-heterogeneous-irrelevanceʳ = ≅-heterogeneous-irrelevantʳ
+{-# WARNING_ON_USAGE ≅-heterogeneous-irrelevanceʳ
+"Warning: ≅-heterogeneous-irrelevanceʳ was deprecated in v0.18.
+Please use ≅-heterogeneous-irrelevantʳ instead."
 #-}

--- a/src/Relation/Binary/HeterogeneousEquality/Quotients.agda
+++ b/src/Relation/Binary/HeterogeneousEquality/Quotients.agda
@@ -50,7 +50,7 @@ module Properties {c ℓ} {S : Setoid c ℓ} (Qu : Quotient S) where
        g (abs x)          ∎
 
      liftf≅g-ext : ∀ {a a′} → a ≈ a′ → liftf≅g a ≅ liftf≅g a′
-     liftf≅g-ext eq = ≅-heterogeneous-irrelevanceˡ _ _
+     liftf≅g-ext eq = ≅-heterogeneous-irrelevantˡ _ _
                     $ cong (lift B f p) (compat-abs eq)
 
    lift-ext : {g : ∀ a → B′ (abs a)} {p′ : compat B′ g} → (∀ x → f x ≅ g x) →

--- a/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
+++ b/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
@@ -102,7 +102,7 @@ module Integers (quot : Quotients L.zero L.zero) where
                      $ λ {a} {b} {c} p p′ → compat-abs (+²-cong {a} {b} {c} p p′)
 
     +ℤ-identityʳ : ∀ i → i +ℤ zeroℤ ≅ i
-    +ℤ-identityʳ = lift _ eq (≅-heterogeneous-irrelevanceʳ _ _ ∘ compat-abs) where
+    +ℤ-identityʳ = lift _ eq (≅-heterogeneous-irrelevantʳ _ _ ∘ compat-abs) where
 
       eq : ∀ a → abs a +ℤ zeroℤ ≅ abs a
       eq a = begin
@@ -115,7 +115,7 @@ module Integers (quot : Quotients L.zero L.zero) where
     +²-identityˡ i = refl
 
     +ℤ-identityˡ : (i : ℤ)  → zeroℤ +ℤ i ≅ i
-    +ℤ-identityˡ = lift _ eq (≅-heterogeneous-irrelevanceʳ _ _ ∘ compat-abs) where
+    +ℤ-identityˡ = lift _ eq (≅-heterogeneous-irrelevantʳ _ _ ∘ compat-abs) where
 
       eq : ∀ a → zeroℤ +ℤ abs a ≅ abs a
       eq a = begin
@@ -143,6 +143,6 @@ module Integers (quot : Quotients L.zero L.zero) where
         abs i +ℤ (abs j +ℤ abs k) ∎
 
       compat₃ : ∀ {a a′ b b′ c c′} → a ∼ a′ → b ∼ b′ → c ∼ c′ → eq a b c ≅ eq a′ b′ c′
-      compat₃ p q r = ≅-heterogeneous-irrelevanceˡ _ _
+      compat₃ p q r = ≅-heterogeneous-irrelevantˡ _ _
                     $ cong₂ _+ℤ_ (cong₂ _+ℤ_ (compat-abs p) (compat-abs q))
                     $ compat-abs r

--- a/src/Relation/Binary/PropositionalEquality/WithK.agda
+++ b/src/Relation/Binary/PropositionalEquality/WithK.agda
@@ -15,5 +15,19 @@ open import Relation.Binary.PropositionalEquality
 ------------------------------------------------------------------------
 -- Proof irrelevance
 
-≡-irrelevance : ∀ {a} {A : Set a} → Irrelevant (_≡_ {A = A})
-≡-irrelevance refl refl = refl
+≡-irrelevant : ∀ {a} {A : Set a} → Irrelevant (_≡_ {A = A})
+≡-irrelevant refl refl = refl
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 0.18
+
+≡-irrelevance = ≡-irrelevant
+{-# WARNING_ON_USAGE ≡-irrelevance
+"Warning: ≡-irrelevance was deprecated in v0.18.
+Please use ≡-irrelevant instead."
+#-}


### PR DESCRIPTION
Fix #485