### PR TITLE
Added some List tabulate-lookup properties.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -995,3 +995,11 @@ Other minor additions
   replicate⁺  : R a b → Pointwise R (replicate n a) (replicate n b)
   irrelevant  : Irrelevant R → Irrelevant (Pointwise R)
   ```
+
+* Added new proofs to `Data.List.Properties`:
+  ```agda
+  length-tabulate : ∀ {n} → (f : Fin n → A) → length (tabulate f) ≡ n
+  lookup-tabulate : ∀ {n} → (f : Fin n → A) →
+                    ∀ i → let i′ = cast (sym (length-tabulate f)) i
+                          in lookup (tabulate f) i′ ≡ f i
+  ```

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -8,7 +8,7 @@
 
 module Data.List.Base where
 
-open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_; _*_)
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_; _*_ ; _≤_ ; s≤s)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 open import Data.Bool.Base as Bool
@@ -203,6 +203,12 @@ module _ {a} {A : Set a} where
   lookup [] ()
   lookup (x ∷ xs) Fin.zero    = x
   lookup (x ∷ xs) (Fin.suc i) = lookup xs i
+
+  lookup′ : ∀{n} → (xs : List A) → (rl : n ≤ length xs) → Fin n → A
+  lookup′ [] () zero
+  lookup′ (x ∷ xs) rl zero = x
+  lookup′ [] () (suc fn)
+  lookup′ (x ∷ xs) (s≤s rl) (suc fn) = lookup′ xs rl fn
 
 -- Numerical
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -204,12 +204,6 @@ module _ {a} {A : Set a} where
   lookup (x ∷ xs) Fin.zero    = x
   lookup (x ∷ xs) (Fin.suc i) = lookup xs i
 
-  lookup′ : ∀{n} → (xs : List A) → (rl : n ≤ length xs) → Fin n → A
-  lookup′ [] () zero
-  lookup′ (x ∷ xs) rl zero = x
-  lookup′ [] () (suc fn)
-  lookup′ (x ∷ xs) (s≤s rl) (suc fn) = lookup′ xs rl fn
-
 -- Numerical
 
 upTo : ℕ → List ℕ

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -33,6 +33,7 @@ open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary.Decidable using (⌊_⌋)
 open import Relation.Unary using (Pred; Decidable; ∁)
 open import Relation.Unary.Properties using (∁?)
+open import Relation.Binary.PropositionalEquality using (cong ; subst ; trans)
 
 ------------------------------------------------------------------------
 -- _∷_
@@ -574,6 +575,32 @@ module _ {a} {A : Set a} where
   tabulate-lookup : ∀ (xs : List A) → tabulate (lookup xs) ≡ xs
   tabulate-lookup []       = refl
   tabulate-lookup (x ∷ xs) = P.cong (_ ∷_) (tabulate-lookup xs)
+
+  tabulate-len : ∀ {n} → (f : Fin n → A) →
+                 length (tabulate f) ≡ n
+  tabulate-len {zero} f = refl
+  tabulate-len {suc n} f = cong suc (tabulate-len (λ z → f (suc z)))
+
+  lookup-tabulate : ∀{n} → (f : Fin n → A) →
+                    ∀ x → let x′ = subst Fin (tabulate-len f) x
+                          in f x′ ≡ lookup (tabulate f) x
+  lookup-tabulate {zero} f ()
+  lookup-tabulate {suc n} f zero with length (tabulate (f ∘ suc)) | tabulate-len (f ∘ suc)
+  ... | .n | refl = refl
+  lookup-tabulate {suc n} f (suc x) = trans q (lookup-tabulate (f ∘ suc) x) where
+    q : f (subst Fin (tabulate-len f) (suc x)) ≡ f (suc (subst Fin (tabulate-len (λ x → f (suc x))) x))
+    q with length (tabulate (f ∘ suc)) | tabulate-len (f ∘ suc)
+    q | e | refl = refl
+
+  tabulate-lookup′ : (xs : List A) → (rl : length xs ≤ length xs) →
+                     tabulate (lookup′ xs rl) ≡ xs
+  tabulate-lookup′ [] rl = refl
+  tabulate-lookup′ (x ∷ xs) (s≤s rl) = cong (x ∷_) (tabulate-lookup′ xs rl)
+
+  lookup-tabulate′ : ∀{n} → (f : Fin n → A) → (rl : n ≤ length (tabulate f)) →
+        ∀ x → f x ≡ lookup′ (tabulate f) rl x
+  lookup-tabulate′ f rl zero = refl
+  lookup-tabulate′ f (s≤s rl) (suc x) = lookup-tabulate′ (f ∘ suc) rl x
 
 module _ {a b} {A : Set a} {B : Set b} where
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -576,42 +576,16 @@ module _ {a} {A : Set a} where
   tabulate-lookup []       = refl
   tabulate-lookup (x ∷ xs) = P.cong (_ ∷_) (tabulate-lookup xs)
 
-  tabulate-len : ∀ {n} → (f : Fin n → A) →
+  length-tabulate : ∀ {n} → (f : Fin n → A) →
                  length (tabulate f) ≡ n
-  tabulate-len {zero} f = refl
-  tabulate-len {suc n} f = cong suc (tabulate-len (λ z → f (suc z)))
-
-  tabulate-len≤l : ∀{n} → (f : Fin n → A) →
-                   length (tabulate f) ≤ n
-  tabulate-len≤l {n = zero} f = z≤n
-  tabulate-len≤l {n = suc n} f = s≤s (tabulate-len≤l (λ z → f (suc z)))
-
-  tabulate-len≤r : ∀{n} → (f : Fin n → A) →
-                   n ≤ length (tabulate f)
-  tabulate-len≤r {n = zero} f = z≤n
-  tabulate-len≤r {n = suc n} f = s≤s (tabulate-len≤r (λ z → f (suc z)))
-
+  length-tabulate {zero} f = refl
+  length-tabulate {suc n} f = cong suc (length-tabulate (λ z → f (suc z)))
 
   lookup-tabulate : ∀{n} → (f : Fin n → A) →
-                    ∀ x → let x′ = subst Fin (tabulate-len f) x
-                          in f x′ ≡ lookup (tabulate f) x
-  lookup-tabulate {zero} f ()
-  lookup-tabulate {suc n} f zero with length (tabulate (f ∘ suc)) | tabulate-len (f ∘ suc)
-  ... | .n | refl = refl
-  lookup-tabulate {suc n} f (suc x) = trans q (lookup-tabulate (f ∘ suc) x) where
-    q : f (subst Fin (tabulate-len f) (suc x)) ≡ f (suc (subst Fin (tabulate-len (λ x → f (suc x))) x))
-    q with length (tabulate (f ∘ suc)) | tabulate-len (f ∘ suc)
-    q | e | refl = refl
-
-  tabulate-lookup′ : (xs : List A) → (rl : length xs ≤ length xs) →
-                     tabulate (lookup′ xs rl) ≡ xs
-  tabulate-lookup′ [] rl = refl
-  tabulate-lookup′ (x ∷ xs) (s≤s rl) = cong (x ∷_) (tabulate-lookup′ xs rl)
-
-  lookup-tabulate′ : ∀{n} → (f : Fin n → A) → (rl : n ≤ length (tabulate f)) →
-        ∀ x → f x ≡ lookup′ (tabulate f) rl x
-  lookup-tabulate′ f rl zero = refl
-  lookup-tabulate′ f (s≤s rl) (suc x) = lookup-tabulate′ (f ∘ suc) rl x
+                    ∀ i → let i′ = cast (sym (length-tabulate f)) i
+                          in lookup (tabulate f) i′ ≡ f i
+  lookup-tabulate f zero    = refl
+  lookup-tabulate f (suc i) = lookup-tabulate (f ∘ suc) i
 
 module _ {a b} {A : Set a} {B : Set b} where
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -27,13 +27,12 @@ open import Data.These as These using (These; this; that; these)
 open import Function
 import Relation.Binary.Reasoning.Setoid as EqR
 open import Relation.Binary.PropositionalEquality as P
-  using (_≡_; _≢_; _≗_; refl ; sym)
+  using (_≡_; _≢_; _≗_; refl ; sym ; cong)
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary.Decidable using (⌊_⌋)
 open import Relation.Unary using (Pred; Decidable; ∁)
 open import Relation.Unary.Properties using (∁?)
-open import Relation.Binary.PropositionalEquality using (cong ; subst ; trans)
 
 ------------------------------------------------------------------------
 -- _∷_
@@ -579,7 +578,7 @@ module _ {a} {A : Set a} where
   length-tabulate : ∀ {n} → (f : Fin n → A) →
                  length (tabulate f) ≡ n
   length-tabulate {zero} f = refl
-  length-tabulate {suc n} f = cong suc (length-tabulate (λ z → f (suc z)))
+  length-tabulate {suc n} f = P.cong suc (length-tabulate (λ z → f (suc z)))
 
   lookup-tabulate : ∀{n} → (f : Fin n → A) →
                     ∀ i → let i′ = cast (sym (length-tabulate f)) i

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -581,6 +581,17 @@ module _ {a} {A : Set a} where
   tabulate-len {zero} f = refl
   tabulate-len {suc n} f = cong suc (tabulate-len (λ z → f (suc z)))
 
+  tabulate-len≤l : ∀{n} → (f : Fin n → A) →
+                   length (tabulate f) ≤ n
+  tabulate-len≤l {n = zero} f = z≤n
+  tabulate-len≤l {n = suc n} f = s≤s (tabulate-len≤l (λ z → f (suc z)))
+
+  tabulate-len≤r : ∀{n} → (f : Fin n → A) →
+                   n ≤ length (tabulate f)
+  tabulate-len≤r {n = zero} f = z≤n
+  tabulate-len≤r {n = suc n} f = s≤s (tabulate-len≤r (λ z → f (suc z)))
+
+
   lookup-tabulate : ∀{n} → (f : Fin n → A) →
                     ∀ x → let x′ = subst Fin (tabulate-len f) x
                           in f x′ ≡ lookup (tabulate f) x


### PR DESCRIPTION
I also wrote ```lookup\'``` which removes a length type dependency that makes proofs harder.