### PR TITLE
[ fix #344 ] Symmetric reasoning combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,9 @@ Non-backwards compatible changes
   ```
   proves that `a < d` rather than `a ≤ d`.
 
+* New symmetric equality combinators  `_≈˘⟨_⟩_` and `_≡˘⟨_⟩_` have been added. Consequently
+  expressions of the form `x ≈⟨ sym y≈x ⟩ y` can be replaced with `x ≈˘⟨ y≈x ⟩ y`.
+
 #### Relaxation of ring solvers requirements
 
 * In the ring solvers below, the assumption that equality is `Decidable`

--- a/src/Algebra/Properties/AbelianGroup.agda
+++ b/src/Algebra/Properties/AbelianGroup.agda
@@ -35,8 +35,8 @@ private
 
   lemma₂ : ∀ x y → x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹) ≈ y ⁻¹
   lemma₂ x y = begin
-    x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹)  ≈⟨ sym $ assoc _ _ _ ⟩
-    x ∙ (y ∙ (x ∙ y) ⁻¹) ∙ y ⁻¹  ≈⟨ ∙-congˡ $ sym $ assoc _ _ _ ⟩
+    x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹)  ≈˘⟨ assoc _ _ _ ⟩
+    x ∙ (y ∙ (x ∙ y) ⁻¹) ∙ y ⁻¹  ≈˘⟨ ∙-congˡ $ assoc _ _ _ ⟩
     x ∙ y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹    ≈⟨ ∙-congˡ $ inverseʳ _ ⟩
     ε ∙ y ⁻¹                     ≈⟨ identityˡ _ ⟩
     y ⁻¹                         ∎
@@ -44,7 +44,7 @@ private
 ⁻¹-∙-comm : ∀ x y → x ⁻¹ ∙ y ⁻¹ ≈ (x ∙ y) ⁻¹
 ⁻¹-∙-comm x y = begin
   x ⁻¹ ∙ y ⁻¹                         ≈⟨ comm _ _ ⟩
-  y ⁻¹ ∙ x ⁻¹                         ≈⟨ ∙-congˡ $ sym $ (lemma₂ x y) ⟩
+  y ⁻¹ ∙ x ⁻¹                         ≈˘⟨ ∙-congˡ $ lemma₂ x y ⟩
   x ∙ (y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹) ∙ x ⁻¹  ≈⟨ lemma₁ _ _ ⟩
   y ∙ (x ∙ y) ⁻¹ ∙ y ⁻¹               ≈⟨ lemma₁ _ _ ⟩
   (x ∙ y) ⁻¹                          ∎

--- a/src/Algebra/Properties/BooleanAlgebra.agda
+++ b/src/Algebra/Properties/BooleanAlgebra.agda
@@ -93,7 +93,7 @@ open import Data.Product using (_,_)
 ∧-zeroʳ : RightZero ⊥ _∧_
 ∧-zeroʳ x = begin
   x ∧ ⊥          ≈⟨ ∧-congʳ $ sym (∧-complementʳ _) ⟩
-  x ∧  x  ∧ ¬ x  ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+  x ∧  x  ∧ ¬ x  ≈˘⟨ ∧-assoc _ _ _ ⟩
   (x ∧ x) ∧ ¬ x  ≈⟨ ∧-congˡ $ ∧-idempotent _ ⟩
   x       ∧ ¬ x  ≈⟨ ∧-complementʳ _ ⟩
   ⊥              ∎
@@ -107,7 +107,7 @@ open import Data.Product using (_,_)
 ∨-zeroʳ : ∀ x → x ∨ ⊤ ≈ ⊤
 ∨-zeroʳ x = begin
   x ∨ ⊤          ≈⟨ ∨-congʳ $ sym (∨-complementʳ _) ⟩
-  x ∨  x  ∨ ¬ x  ≈⟨ sym $ ∨-assoc _ _ _ ⟩
+  x ∨  x  ∨ ¬ x  ≈˘⟨ ∨-assoc _ _ _ ⟩
   (x ∨ x) ∨ ¬ x  ≈⟨ ∨-congˡ $ ∨-idempotent _ ⟩
   x       ∨ ¬ x  ≈⟨ ∨-complementʳ _ ⟩
   ⊤              ∎
@@ -212,12 +212,12 @@ open import Data.Product using (_,_)
 private
   lemma : ∀ x y → x ∧ y ≈ ⊥ → x ∨ y ≈ ⊤ → ¬ x ≈ y
   lemma x y x∧y=⊥ x∨y=⊤ = begin
-    ¬ x                ≈⟨ sym $ ∧-identityʳ _ ⟩
-    ¬ x ∧ ⊤            ≈⟨ ∧-congʳ $ sym x∨y=⊤ ⟩
+    ¬ x                ≈˘⟨ ∧-identityʳ _ ⟩
+    ¬ x ∧ ⊤            ≈˘⟨ ∧-congʳ x∨y=⊤ ⟩
     ¬ x ∧ (x ∨ y)      ≈⟨ ∧-∨-distribˡ _ _ _ ⟩
     ¬ x ∧ x ∨ ¬ x ∧ y  ≈⟨ ∨-congˡ $ ∧-complementˡ _ ⟩
-    ⊥ ∨ ¬ x ∧ y        ≈⟨ ∨-congˡ $ sym x∧y=⊥ ⟩
-    x ∧ y ∨ ¬ x ∧ y    ≈⟨ sym $ ∧-∨-distribʳ _ _ _ ⟩
+    ⊥ ∨ ¬ x ∧ y        ≈˘⟨ ∨-congˡ x∧y=⊥ ⟩
+    x ∧ y ∨ ¬ x ∧ y    ≈˘⟨ ∧-∨-distribʳ _ _ _ ⟩
     (x ∨ ¬ x) ∧ y      ≈⟨ ∧-congˡ $ ∨-complementʳ _ ⟩
     ⊤ ∧ y              ≈⟨ ∧-identityˡ _ ⟩
     y                  ∎
@@ -252,7 +252,7 @@ deMorgan₁ x y = lemma (x ∧ y) (¬ x ∨ ¬ y) lem₁ lem₂
     ¬ x ∨ y                ∎
 
   lem₂ = begin
-    (x ∧ y) ∨ (¬ x ∨ ¬ y)  ≈⟨ sym $ ∨-assoc _ _ _ ⟩
+    (x ∧ y) ∨ (¬ x ∨ ¬ y)  ≈˘⟨ ∨-assoc _ _ _ ⟩
     ((x ∧ y) ∨ ¬ x) ∨ ¬ y  ≈⟨ ∨-congˡ lem₃ ⟩
     (¬ x ∨ y) ∨ ¬ y        ≈⟨ ∨-assoc _ _ _ ⟩
     ¬ x ∨ (y ∨ ¬ y)        ≈⟨ ∨-congʳ $ ∨-complementʳ _ ⟩
@@ -261,9 +261,8 @@ deMorgan₁ x y = lemma (x ∧ y) (¬ x ∨ ¬ y) lem₁ lem₂
 
 deMorgan₂ : ∀ x y → ¬ (x ∨ y) ≈ ¬ x ∧ ¬ y
 deMorgan₂ x y = begin
-  ¬ (x ∨ y)          ≈⟨ ¬-cong $ sym (¬-involutive _) ⟨ ∨-cong ⟩
-                                 sym (¬-involutive _) ⟩
-  ¬ (¬ ¬ x ∨ ¬ ¬ y)  ≈⟨ ¬-cong $ sym $ deMorgan₁ _ _ ⟩
+  ¬ (x ∨ y)          ≈˘⟨ ¬-cong $ ((¬-involutive _) ⟨ ∨-cong ⟩ (¬-involutive _)) ⟩
+  ¬ (¬ ¬ x ∨ ¬ ¬ y)  ≈˘⟨ ¬-cong $ deMorgan₁ _ _ ⟩
   ¬ ¬ (¬ x ∧ ¬ y)    ≈⟨ ¬-involutive _ ⟩
   ¬ x ∧ ¬ y          ∎
 
@@ -312,14 +311,14 @@ module XorRing
     x ⊕ u                ≈⟨ ⊕-def _ _ ⟩
     (x ∨ u) ∧ ¬ (x ∧ u)  ≈⟨ helper (x≈y ⟨ ∨-cong ⟩ u≈v)
                                    (x≈y ⟨ ∧-cong ⟩ u≈v) ⟩
-    (y ∨ v) ∧ ¬ (y ∧ v)  ≈⟨ sym $ ⊕-def _ _ ⟩
+    (y ∨ v) ∧ ¬ (y ∧ v)  ≈˘⟨ ⊕-def _ _ ⟩
     y ⊕ v                ∎
 
   ⊕-comm : Commutative _⊕_
   ⊕-comm x y = begin
     x ⊕ y                ≈⟨ ⊕-def _ _ ⟩
     (x ∨ y) ∧ ¬ (x ∧ y)  ≈⟨ helper (∨-comm _ _) (∧-comm _ _) ⟩
-    (y ∨ x) ∧ ¬ (y ∧ x)  ≈⟨ sym $ ⊕-def _ _ ⟩
+    (y ∨ x) ∧ ¬ (y ∧ x)  ≈˘⟨ ⊕-def _ _ ⟩
     y ⊕ x                ∎
 
   ⊕-¬-distribˡ : ∀ x y → ¬ (x ⊕ y) ≈ ¬ x ⊕ y
@@ -331,7 +330,7 @@ module XorRing
     ¬ ((x ∧ ¬ y) ∨ (y ∧ ¬ x))              ≈⟨ deMorgan₂ _ _ ⟩
     ¬ (x ∧ ¬ y) ∧ ¬ (y ∧ ¬ x)              ≈⟨ ∧-congˡ $ deMorgan₁ _ _ ⟩
     (¬ x ∨ (¬ ¬ y)) ∧ ¬ (y ∧ ¬ x)          ≈⟨ helper (∨-congʳ $ ¬-involutive _) (∧-comm _ _) ⟩
-    (¬ x ∨ y) ∧ ¬ (¬ x ∧ y)                ≈⟨ sym $ ⊕-def _ _ ⟩
+    (¬ x ∨ y) ∧ ¬ (¬ x ∧ y)                ≈˘⟨ ⊕-def _ _ ⟩
     ¬ x ⊕ y                                ∎
     where
     lem : ∀ x y → x ∧ ¬ (x ∧ y) ≈ x ∧ ¬ y
@@ -351,7 +350,7 @@ module XorRing
 
   ⊕-annihilates-¬ : ∀ x y → x ⊕ y ≈ ¬ x ⊕ ¬ y
   ⊕-annihilates-¬ x y = begin
-    x ⊕ y        ≈⟨ sym $ ¬-involutive _ ⟩
+    x ⊕ y        ≈˘⟨ ¬-involutive _ ⟩
     ¬ ¬ (x ⊕ y)  ≈⟨ ¬-cong $ ⊕-¬-distribˡ _ _ ⟩
     ¬ (¬ x ⊕ y)  ≈⟨ ⊕-¬-distribʳ _ _ ⟩
     ¬ x ⊕ ¬ y    ∎
@@ -386,45 +385,45 @@ module XorRing
   ∧-distribˡ-⊕ : _∧_ DistributesOverˡ _⊕_
   ∧-distribˡ-⊕ x y z = begin
     x ∧ (y ⊕ z)                ≈⟨ ∧-congʳ $ ⊕-def _ _ ⟩
-    x ∧ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+    x ∧ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈˘⟨ ∧-assoc _ _ _ ⟩
     (x ∧ (y ∨ z)) ∧ ¬ (y ∧ z)  ≈⟨ ∧-congʳ $ deMorgan₁ _ _ ⟩
     (x ∧ (y ∨ z)) ∧
-    (¬ y ∨ ¬ z)                ≈⟨ sym $ ∨-identityˡ _ ⟩
+    (¬ y ∨ ¬ z)                ≈˘⟨ ∨-identityˡ _ ⟩
     ⊥ ∨
     ((x ∧ (y ∨ z)) ∧
     (¬ y ∨ ¬ z))               ≈⟨ ∨-congˡ lem₃ ⟩
     ((x ∧ (y ∨ z)) ∧ ¬ x) ∨
     ((x ∧ (y ∨ z)) ∧
-    (¬ y ∨ ¬ z))               ≈⟨ sym $ ∧-∨-distribˡ _ _ _ ⟩
+    (¬ y ∨ ¬ z))               ≈˘⟨ ∧-∨-distribˡ _ _ _ ⟩
     (x ∧ (y ∨ z)) ∧
-    (¬ x ∨ (¬ y ∨ ¬ z))        ≈⟨ ∧-congʳ $ ∨-congʳ $ sym (deMorgan₁ _ _) ⟩
+    (¬ x ∨ (¬ y ∨ ¬ z))        ≈˘⟨ ∧-congʳ $ ∨-congʳ (deMorgan₁ _ _) ⟩
     (x ∧ (y ∨ z)) ∧
-    (¬ x ∨ ¬ (y ∧ z))          ≈⟨ ∧-congʳ $ sym (deMorgan₁ _ _) ⟩
+    (¬ x ∨ ¬ (y ∧ z))          ≈˘⟨ ∧-congʳ (deMorgan₁ _ _) ⟩
     (x ∧ (y ∨ z)) ∧
     ¬ (x ∧ (y ∧ z))            ≈⟨ helper refl lem₁ ⟩
     (x ∧ (y ∨ z)) ∧
     ¬ ((x ∧ y) ∧ (x ∧ z))      ≈⟨ ∧-congˡ $ ∧-∨-distribˡ _ _ _ ⟩
     ((x ∧ y) ∨ (x ∧ z)) ∧
-    ¬ ((x ∧ y) ∧ (x ∧ z))      ≈⟨ sym $ ⊕-def _ _ ⟩
+    ¬ ((x ∧ y) ∧ (x ∧ z))      ≈˘⟨ ⊕-def _ _ ⟩
     (x ∧ y) ⊕ (x ∧ z)          ∎
       where
       lem₂ = begin
-        x ∧ (y ∧ z)  ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+        x ∧ (y ∧ z)  ≈˘⟨ ∧-assoc _ _ _ ⟩
         (x ∧ y) ∧ z  ≈⟨ ∧-congˡ $ ∧-comm _ _ ⟩
         (y ∧ x) ∧ z  ≈⟨ ∧-assoc _ _ _ ⟩
         y ∧ (x ∧ z)  ∎
 
       lem₁ = begin
-        x ∧ (y ∧ z)        ≈⟨ ∧-congˡ $ sym (∧-idempotent _) ⟩
+        x ∧ (y ∧ z)        ≈˘⟨ ∧-congˡ (∧-idempotent _) ⟩
         (x ∧ x) ∧ (y ∧ z)  ≈⟨ ∧-assoc _ _ _ ⟩
         x ∧ (x ∧ (y ∧ z))  ≈⟨ ∧-congʳ lem₂ ⟩
-        x ∧ (y ∧ (x ∧ z))  ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+        x ∧ (y ∧ (x ∧ z))  ≈˘⟨ ∧-assoc _ _ _ ⟩
         (x ∧ y) ∧ (x ∧ z)  ∎
 
       lem₃ = begin
-        ⊥                      ≈⟨ sym $ ∧-zeroʳ _ ⟩
-        (y ∨ z) ∧ ⊥            ≈⟨ ∧-congʳ $ sym (∧-complementʳ _) ⟩
-        (y ∨ z) ∧ (x ∧ ¬ x)    ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+        ⊥                      ≈˘⟨ ∧-zeroʳ _ ⟩
+        (y ∨ z) ∧ ⊥            ≈˘⟨ ∧-congʳ (∧-complementʳ _) ⟩
+        (y ∨ z) ∧ (x ∧ ¬ x)    ≈˘⟨ ∧-assoc _ _ _ ⟩
         ((y ∨ z) ∧ x) ∧ ¬ x    ≈⟨ ∧-comm _ _ ⟨ ∧-cong ⟩ refl  ⟩
         (x ∧ (y ∨ z)) ∧ ¬ x    ∎
 
@@ -458,45 +457,43 @@ module XorRing
     (((¬ x ∨ ¬ y) ∨ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ≈⟨ ∧-assoc _ _ _ ⟩
     ((x ∨ y) ∨ z) ∧
     (((x ∨ ¬ y) ∨ ¬ z) ∧
-     (((¬ x ∨ ¬ y) ∨ z) ∧ ((¬ x ∨ y) ∨ ¬ z)))  ≈⟨ refl ⟨ ∧-cong ⟩ lem₅ ⟩
+     (((¬ x ∨ ¬ y) ∨ z) ∧ ((¬ x ∨ y) ∨ ¬ z)))  ≈⟨ ∧-congʳ lem₅ ⟩
     ((x ∨ y) ∨ z) ∧
     (((¬ x ∨ ¬ y) ∨ z) ∧
-     (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)))  ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+     (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)))  ≈˘⟨ ∧-assoc _ _ _ ⟩
     (((x ∨ y) ∨ z) ∧ ((¬ x ∨ ¬ y) ∨ z)) ∧
     (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ≈⟨ lem₁ ⟨ ∧-cong ⟩ lem₂ ⟩
       (((x ∨ y) ∧ ¬ (x ∧ y)) ∨ z) ∧
-    ¬ (((x ∨ y) ∧ ¬ (x ∧ y)) ∧ z)              ≈⟨ sym $ ⊕-def _ _ ⟩
-    ((x ∨ y) ∧ ¬ (x ∧ y)) ⊕ z                  ≈⟨ sym $ ⊕-def _ _ ⟨ ⊕-cong ⟩ refl ⟩
+    ¬ (((x ∨ y) ∧ ¬ (x ∧ y)) ∧ z)              ≈˘⟨ ⊕-def _ _ ⟩
+    ((x ∨ y) ∧ ¬ (x ∧ y)) ⊕ z                  ≈˘⟨ ⊕-def _ _ ⟨ ⊕-cong ⟩ refl ⟩
     (x ⊕ y) ⊕ z                                ∎
     where
     lem₁ = begin
-      ((x ∨ y) ∨ z) ∧ ((¬ x ∨ ¬ y) ∨ z)  ≈⟨ sym $ ∨-∧-distribʳ _ _ _ ⟩
-      ((x ∨ y) ∧ (¬ x ∨ ¬ y)) ∨ z        ≈⟨ ∨-congˡ $ ∧-congʳ $ sym (deMorgan₁ _ _) ⟩
+      ((x ∨ y) ∨ z) ∧ ((¬ x ∨ ¬ y) ∨ z)  ≈˘⟨ ∨-∧-distribʳ _ _ _ ⟩
+      ((x ∨ y) ∧ (¬ x ∨ ¬ y)) ∨ z        ≈˘⟨ ∨-congˡ $ ∧-congʳ (deMorgan₁ _ _) ⟩
       ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ z          ∎
 
     lem₂' = begin
-      (x ∨ ¬ y) ∧ (¬ x ∨ y)              ≈⟨ sym $ ∧-identityˡ _ ⟨ ∧-cong ⟩ ∧-identityʳ _ ⟩
-      (⊤ ∧ (x ∨ ¬ y)) ∧ ((¬ x ∨ y) ∧ ⊤)  ≈⟨ sym $
-                                              (∨-complementˡ _ ⟨ ∧-cong ⟩ ∨-comm _ _)
+      (x ∨ ¬ y) ∧ (¬ x ∨ y)              ≈˘⟨ ∧-identityˡ _ ⟨ ∧-cong ⟩ ∧-identityʳ _ ⟩
+      (⊤ ∧ (x ∨ ¬ y)) ∧ ((¬ x ∨ y) ∧ ⊤)  ≈˘⟨  (∨-complementˡ _ ⟨ ∧-cong ⟩ ∨-comm _ _)
                                                 ⟨ ∧-cong ⟩
                                               (∧-congʳ $ ∨-complementˡ _) ⟩
       ((¬ x ∨ x) ∧ (¬ y ∨ x)) ∧
-      ((¬ x ∨ y) ∧ (¬ y ∨ y))            ≈⟨ sym $ lemma₂ _ _ _ _ ⟩
-      (¬ x ∧ ¬ y) ∨ (x ∧ y)              ≈⟨ sym $ deMorgan₂ _ _ ⟨ ∨-cong ⟩ ¬-involutive _ ⟩
-      ¬ (x ∨ y) ∨ ¬ ¬ (x ∧ y)            ≈⟨ sym (deMorgan₁ _ _) ⟩
+      ((¬ x ∨ y) ∧ (¬ y ∨ y))            ≈˘⟨ lemma₂ _ _ _ _ ⟩
+      (¬ x ∧ ¬ y) ∨ (x ∧ y)              ≈˘⟨ deMorgan₂ _ _ ⟨ ∨-cong ⟩ ¬-involutive _ ⟩
+      ¬ (x ∨ y) ∨ ¬ ¬ (x ∧ y)            ≈˘⟨ deMorgan₁ _ _ ⟩
       ¬ ((x ∨ y) ∧ ¬ (x ∧ y))            ∎
 
     lem₂ = begin
-      ((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)  ≈⟨ sym $ ∨-∧-distribʳ _ _ _ ⟩
+      ((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)  ≈˘⟨ ∨-∧-distribʳ _ _ _ ⟩
       ((x ∨ ¬ y) ∧ (¬ x ∨ y)) ∨ ¬ z          ≈⟨ ∨-congˡ lem₂' ⟩
-      ¬ ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ ¬ z          ≈⟨ sym $ deMorgan₁ _ _ ⟩
+      ¬ ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ ¬ z          ≈˘⟨ deMorgan₁ _ _ ⟩
       ¬ (((x ∨ y) ∧ ¬ (x ∧ y)) ∧ z)          ∎
 
     lem₃ = begin
       x ∨ ((y ∨ z) ∧ ¬ (y ∧ z))          ≈⟨ ∨-congʳ $ ∧-congʳ $ deMorgan₁ _ _ ⟩
       x ∨ ((y ∨ z) ∧ (¬ y ∨ ¬ z))        ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
-      (x ∨ (y ∨ z)) ∧ (x ∨ (¬ y ∨ ¬ z))  ≈⟨ sym (∨-assoc _ _ _) ⟨ ∧-cong ⟩
-                                            sym (∨-assoc _ _ _) ⟩
+      (x ∨ (y ∨ z)) ∧ (x ∨ (¬ y ∨ ¬ z))  ≈˘⟨ ∨-assoc _ _ _ ⟨ ∧-cong ⟩ ∨-assoc _ _ _ ⟩
       ((x ∨ y) ∨ z) ∧ ((x ∨ ¬ y) ∨ ¬ z)  ∎
 
     lem₄' = begin
@@ -516,8 +513,7 @@ module XorRing
       ¬ x ∨ ¬ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈⟨ ∨-congʳ lem₄' ⟩
       ¬ x ∨ ((y ∨ ¬ z) ∧ (¬ y ∨ z))  ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
       (¬ x ∨ (y     ∨ ¬ z)) ∧
-      (¬ x ∨ (¬ y ∨ z))              ≈⟨ sym (∨-assoc _ _ _) ⟨ ∧-cong ⟩
-                                        sym (∨-assoc _ _ _) ⟩
+      (¬ x ∨ (¬ y ∨ z))              ≈˘⟨ ∨-assoc _ _ _ ⟨ ∧-cong ⟩ ∨-assoc _ _ _ ⟩
       ((¬ x ∨ y)     ∨ ¬ z) ∧
       ((¬ x ∨ ¬ y) ∨ z)              ≈⟨ ∧-comm _ _ ⟩
       ((¬ x ∨ ¬ y) ∨ z) ∧
@@ -525,7 +521,7 @@ module XorRing
 
     lem₅ = begin
       ((x ∨ ¬ y) ∨ ¬ z) ∧
-      (((¬ x ∨ ¬ y) ∨ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ≈⟨ sym $ ∧-assoc _ _ _ ⟩
+      (((¬ x ∨ ¬ y) ∨ z) ∧ ((¬ x ∨ y) ∨ ¬ z))    ≈˘⟨ ∧-assoc _ _ _ ⟩
       (((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ ¬ y) ∨ z)) ∧
       ((¬ x ∨ y) ∨ ¬ z)                          ≈⟨ ∧-congˡ $ ∧-comm _ _ ⟩
       (((¬ x ∨ ¬ y) ∨ z) ∧ ((x ∨ ¬ y) ∨ ¬ z)) ∧

--- a/src/Data/List/Relation/Binary/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/Binary/BagAndSetEquality.agda
@@ -87,7 +87,7 @@ module ⊆-Reasoning where
     module PreOrder {a} {A : Set a} = PreorderReasoning (⊆-preorder A)
 
     open PreOrder public
-      hiding (_≈⟨_⟩_) renaming (_∼⟨_⟩_ to _⊆⟨_⟩_)
+      hiding (_≈⟨_⟩_; _≈˘⟨_⟩_) renaming (_∼⟨_⟩_ to _⊆⟨_⟩_)
 
   infixr 2 _∼⟨_⟩_
   infix  1 _∈⟨_⟩_

--- a/src/Data/List/Relation/Binary/Permutation/Inductive.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Inductive.agda
@@ -66,7 +66,7 @@ module PermutationReasoning where
 
   open EqReasoning ↭-setoid public
     using (begin_ ; _∎ ; _≡⟨⟩_; _≡⟨_⟩_)
-    renaming (_≈⟨_⟩_ to _↭⟨_⟩_)
+    renaming (_≈⟨_⟩_ to _↭⟨_⟩_; _≈˘⟨_⟩_ to _↭˘⟨_⟩_)
 
   infixr 2 _∷_<⟨_⟩_  _∷_∷_<<⟨_⟩_
 

--- a/src/Data/List/Relation/Binary/Permutation/Inductive/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Inductive/Properties.agda
@@ -289,6 +289,6 @@ module _ {a} {A : Set a} where
   ... | zs₁ , zs₂ , p rewrite p = begin
     x ∷ xs           <⟨ ~bag⇒↭ (drop-cons (Inv._∘_ (comm zs₁ (x ∷ zs₂)) eq)) ⟩
     x ∷ (zs₂ ++ zs₁) <⟨ ++-comm zs₂ zs₁ ⟩
-    x ∷ (zs₁ ++ zs₂) ↭⟨ ↭-sym (shift x zs₁ zs₂) ⟩
+    x ∷ (zs₁ ++ zs₂) ↭˘⟨ shift x zs₁ zs₂ ⟩
     zs₁ ++ x ∷ zs₂   ∎
     where open CommutativeMonoid (commutativeMonoid bag A)

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -162,9 +162,8 @@ import Relation.Binary.Reasoning.PartialOrder as POR
 module ⊆-Reasoning {a} {A : Set a}  where
   private module P = POR (⊆-poset A)
   open P public
-    renaming (_≤⟨_⟩_ to _⊆⟨_⟩_; _≈⟨⟩_ to _≡⟨⟩_)
-    hiding (_≈⟨_⟩_)
-
+    renaming (_≤⟨_⟩_ to _⊆⟨_⟩_)
+    hiding (_≈⟨_⟩_; _≈˘⟨_⟩_; _≈⟨⟩_)
 
 ------------------------------------------------------------------------
 -- Various functions' outputs are sublists

--- a/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
@@ -69,8 +69,8 @@ module _ {a} (A : Set a) where
 -- Reasoning over subsets
 
 module ⊆-Reasoning {a} (A : Set a) where
-  open Setoidₚ.⊆-Reasoning public
-    hiding (_≋⟨_⟩_) renaming (_≋⟨⟩_ to _≡⟨⟩_)
+  open Setoidₚ.⊆-Reasoning (setoid A) public
+    hiding (_≋⟨_⟩_; _≋˘⟨_⟩_; _≋⟨⟩_)
 
 ------------------------------------------------------------------------
 -- Properties relating _⊆_ to various list functions

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -56,7 +56,12 @@ module _ {a ℓ} (S : Setoid a ℓ) where
   -- Reasoning over subsets
   module ⊆-Reasoning where
     open PreorderReasoning ⊆-preorder public
-      renaming (_∼⟨_⟩_ to _⊆⟨_⟩_ ; _≈⟨_⟩_ to _≋⟨_⟩_ ; _≈⟨⟩_ to _≋⟨⟩_)
+      renaming
+      ( _∼⟨_⟩_  to _⊆⟨_⟩_
+      ; _≈⟨_⟩_  to _≋⟨_⟩_
+      ; _≈˘⟨_⟩_ to _≋˘⟨_⟩_
+      ; _≈⟨⟩_   to _≋⟨⟩_
+      )
 
     infix 1 _∈⟨_⟩_
     _∈⟨_⟩_ : ∀ x {xs ys} → x ∈ xs → xs IsRelatedTo ys → x ∈ ys

--- a/src/Relation/Binary/Reasoning/Base/Double.agda
+++ b/src/Relation/Binary/Reasoning/Base/Double.agda
@@ -19,7 +19,7 @@ module Relation.Binary.Reasoning.Base.Double {a ℓ₁ ℓ₂} {A : Set a}
 open import Data.Product using (proj₁; proj₂)
 open import Level using (Level; _⊔_; Lift; lift)
 open import Function using (case_of_; id)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym)
 open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Nullary.Decidable using (True; toWitness)
 
@@ -58,7 +58,7 @@ extractEquality (isEquality x≈y) = x≈y
 -- Reasoning combinators
 
 infix -1 begin_ begin-equality_
-infixr 0 _∼⟨_⟩_ _≈⟨_⟩_ _≡⟨_⟩_ _≡⟨⟩_
+infixr 0 _∼⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
 infix  1 _∎
 
 begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ∼ y
@@ -76,9 +76,15 @@ _≈⟨_⟩_ : ∀ (x : A) {y z} → x ≈ y → y IsRelatedTo z → x IsRelated
 x ≈⟨ x≈y ⟩ nonstrict y∼z = nonstrict (proj₂ ∼-resp-≈ (Eq.sym x≈y) y∼z)
 x ≈⟨ x≈y ⟩ equals    y≈z = equals    (Eq.trans x≈y y≈z)
 
+_≈˘⟨_⟩_ : ∀ x {y z} → y ≈ x → y IsRelatedTo z → x IsRelatedTo z
+x ≈˘⟨ x≈y ⟩ y∼z = x ≈⟨ Eq.sym x≈y ⟩ y∼z
+
 _≡⟨_⟩_ : ∀ (x : A) {y z} → x ≡ y → y IsRelatedTo z → x IsRelatedTo z
 x ≡⟨ x≡y ⟩ nonstrict y∼z = nonstrict (case x≡y of λ where refl → y∼z)
 x ≡⟨ x≡y ⟩ equals    y≈z = equals    (case x≡y of λ where refl → y≈z)
+
+_≡˘⟨_⟩_ : ∀ x {y z} → y ≡ x → y IsRelatedTo z → x IsRelatedTo z
+x ≡˘⟨ x≡y ⟩ y∼z = x ≡⟨ sym x≡y ⟩ y∼z
 
 _≡⟨⟩_ : ∀ (x : A) {y} → x IsRelatedTo y → x IsRelatedTo y
 x ≡⟨⟩ x≲y = x≲y

--- a/src/Relation/Binary/Reasoning/Base/Single.agda
+++ b/src/Relation/Binary/Reasoning/Base/Single.agda
@@ -17,7 +17,7 @@ open import Relation.Binary.PropositionalEquality as P using (_≡_)
 
 infix  4 _IsRelatedTo_
 infix  3 _∎
-infixr 2 _∼⟨_⟩_ _≡⟨_⟩_ _≡⟨⟩_
+infixr 2 _∼⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
 infix  1 begin_
 
 -- This seemingly unnecessary type is used to make it possible to
@@ -34,6 +34,9 @@ _ ∼⟨ x∼y ⟩ relTo y∼z = relTo (trans x∼y y∼z)
 
 _≡⟨_⟩_ : ∀ x {y z} → x ≡ y → y IsRelatedTo z → x IsRelatedTo z
 _ ≡⟨ P.refl ⟩ x∼z = x∼z
+
+_≡˘⟨_⟩_ : ∀ x {y z} → y ≡ x → y IsRelatedTo z → x IsRelatedTo z
+_ ≡˘⟨ P.refl ⟩ x∼z = x∼z
 
 _≡⟨⟩_ : ∀ x {y} → x IsRelatedTo y → x IsRelatedTo y
 _ ≡⟨⟩ x∼y = _ ≡⟨ P.refl ⟩ x∼y

--- a/src/Relation/Binary/Reasoning/Base/Triple.agda
+++ b/src/Relation/Binary/Reasoning/Base/Triple.agda
@@ -22,7 +22,7 @@ module Relation.Binary.Reasoning.Base.Triple {a ℓ₁ ℓ₂ ℓ₃} {A : Set a
 open import Data.Product using (proj₁; proj₂)
 open import Function using (case_of_; id)
 open import Level using (Level; _⊔_; Lift; lift)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; sym)
 open import Relation.Nullary using (Dec; yes; no)
 open import Relation.Nullary.Decidable using (True; toWitness)
 
@@ -71,7 +71,7 @@ extractEquality (isEquality x≈y) = x≈y
 -- Reasoning combinators
 
 infix -1 begin_ begin-strict_ begin-equality_
-infixr 0 _<⟨_⟩_ _≤⟨_⟩_ _≈⟨_⟩_ _≡⟨_⟩_ _≡⟨⟩_
+infixr 0 _<⟨_⟩_ _≤⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
 infix  1 _∎
 
 begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ≤ y
@@ -100,10 +100,16 @@ x ≈⟨ x≈y ⟩ strict    y<z = strict    (proj₂ <-resp-≈ (Eq.sym x≈y) 
 x ≈⟨ x≈y ⟩ nonstrict y≤z = nonstrict (proj₂ ≤-resp-≈ (Eq.sym x≈y) y≤z)
 x ≈⟨ x≈y ⟩ equals    y≈z = equals    (Eq.trans x≈y y≈z)
 
+_≈˘⟨_⟩_ : ∀ x {y z} → y ≈ x → y IsRelatedTo z → x IsRelatedTo z
+x ≈˘⟨ x≈y ⟩ y∼z = x ≈⟨ Eq.sym x≈y ⟩ y∼z
+
 _≡⟨_⟩_ : ∀ (x : A) {y z} → x ≡ y → y IsRelatedTo z → x IsRelatedTo z
 x ≡⟨ x≡y ⟩ strict    y<z = strict    (case x≡y of λ where refl → y<z)
 x ≡⟨ x≡y ⟩ nonstrict y≤z = nonstrict (case x≡y of λ where refl → y≤z)
 x ≡⟨ x≡y ⟩ equals    y≈z = equals    (case x≡y of λ where refl → y≈z)
+
+_≡˘⟨_⟩_ : ∀ x {y z} → y ≡ x → y IsRelatedTo z → x IsRelatedTo z
+x ≡˘⟨ x≡y ⟩ y∼z = x ≡⟨ sym x≡y ⟩ y∼z
 
 _≡⟨⟩_ : ∀ (x : A) {y} → x IsRelatedTo y → x IsRelatedTo y
 x ≡⟨⟩ x≲y = x≲y

--- a/src/Relation/Binary/Reasoning/MultiSetoid.agda
+++ b/src/Relation/Binary/Reasoning/MultiSetoid.agda
@@ -28,7 +28,7 @@ open import Relation.Binary.PropositionalEquality
 open Setoid renaming (_≈_ to [_]_≈_)
 
 infix 1 begin⟨_⟩_
-infixr 2 _≈⟨_⟩_ _≡⟨_⟩_ _≡⟨⟩_
+infixr 2 _≈⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
 infix 3 _∎
 
 begin⟨_⟩_ : ∀ {c l} (S : Setoid c l) {x y} → _IsRelatedTo_ S x y → [ S ] x ≈ y
@@ -39,6 +39,9 @@ _≈⟨_⟩_ {S = S} = EqR._≈⟨_⟩_ S
 
 _≡⟨_⟩_ : ∀ {c l} {S : Setoid c l} x {y z} → x ≡ y → _IsRelatedTo_ S y z → _IsRelatedTo_ S x z
 _≡⟨_⟩_ {S = S} = EqR._≡⟨_⟩_ S
+
+_≡˘⟨_⟩_ : ∀ {c l} {S : Setoid c l} x {y z} → y ≡ x → _IsRelatedTo_ S y z → _IsRelatedTo_ S x z
+_≡˘⟨_⟩_ {S = S} = EqR._≡˘⟨_⟩_ S
 
 _≡⟨⟩_ : ∀ {c l} {S : Setoid c l} x {y} → _IsRelatedTo_ S x y → _IsRelatedTo_ S x y
 _≡⟨⟩_ {S = S} = EqR._≡⟨⟩_ S

--- a/src/Relation/Binary/Reasoning/Setoid.agda
+++ b/src/Relation/Binary/Reasoning/Setoid.agda
@@ -31,3 +31,8 @@ open Setoid S
 
 open import Relation.Binary.Reasoning.Base.Single _≈_ refl trans public
   renaming (_∼⟨_⟩_ to _≈⟨_⟩_)
+
+infixr 2 _≈˘⟨_⟩_
+
+_≈˘⟨_⟩_ : ∀ x {y z} → y ≈ x → y IsRelatedTo z → x IsRelatedTo z
+x ≈˘⟨ x≈y ⟩ y∼z = x ≈⟨ sym x≈y ⟩ y∼z


### PR DESCRIPTION
Added symmetric reasoning combinators. They hopefully help strip out the noise of `sym` being included in every other line in reasoning proofs. I've updated the proofs in `Algebra.Properties.AbelianGroup` to demonstrate this. 