### PR TITLE
Fixed the missing argument of ⊆-Reasoning in the module Data.List.Rel…

### DIFF
--- a/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
@@ -69,7 +69,7 @@ module _ {a} (A : Set a) where
 -- Reasoning over subsets
 
 module ⊆-Reasoning {a} (A : Set a) where
-  open Setoidₚ.⊆-Reasoning public
+  open Setoidₚ.⊆-Reasoning (setoid A) public
     hiding (_≋⟨_⟩_) renaming (_≋⟨⟩_ to _≡⟨⟩_)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
…ation.Binary.Subset.Propositional.Properties

Setoidₚ.⊆-Reasoning requires a Setoid to work but the propositional setoid (setoid A) was not passed to it. Now it is fixed. 