### PR TITLE
[ fix #392] Added cancellative and conical properties for _++_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -483,6 +483,10 @@ Other minor additions
 
 * Added new types to `Algebra.FunctionProperties`:
   ```agda
+  LeftConical e _∙_  = ∀ x y → (x ∙ y) ≈ e → x ≈ e
+  RightConical e _∙_ = ∀ x y → (x ∙ y) ≈ e → y ≈ e
+  Conical e ∙        = LeftConical e ∙ × RightConical e ∙
+
   LeftCongruent  _∙_ = ∀ {x} → (_∙ x) Preserves _≈_ ⟶ _≈_
   RightCongruent _∙_ = ∀ {x} → (x ∙_) Preserves _≈_ ⟶ _≈_
   ```
@@ -773,15 +777,21 @@ Other minor additions
 
 * Added new proofs to `Data.List.Properties`:
   ```agda
-  ≡-dec : Decidable _≡_ → Decidable {A = List A} _≡_
+  ≡-dec       : Decidable _≡_ → Decidable {A = List A} _≡_
 
-  ++-isMagma : IsMagma _++_
+  ++-cancelˡ  : xs ++ ys ≡ xs ++ zs → ys ≡ zs
+  ++-cancelʳ  : ys ++ xs ≡ zs ++ xs → ys ≡ zs
+  ++-cancel   : Cancellative _++_
+  ++-conicalˡ : xs ++ ys ≡ [] → xs ≡ []
+  ++-conicalʳ : xs ++ ys ≡ [] → ys ≡ []
+  ++-conical  : Conical [] _++_
+  ++-isMagma  : IsMagma _++_
 
-  length-%=  : length (xs [ k ]%= f) ≡ length xs
-  length-∷=  : length (xs [ k ]∷= v) ≡ length xs
-  map-∷=     : map f (xs [ k ]∷= v) ≡ map f xs [ cast eq k ]∷= f v
-  length-─   : length (xs ─ k) ≡ pred (length xs)
-  map-─      : map f (xs ─ k) ≡ map f xs ─ cast eq k
+  length-%=   : length (xs [ k ]%= f) ≡ length xs
+  length-∷=   : length (xs [ k ]∷= v) ≡ length xs
+  map-∷=      : map f (xs [ k ]∷= v) ≡ map f xs [ cast eq k ]∷= f v
+  length-─    : length (xs ─ k) ≡ pred (length xs)
+  map-─       : map f (xs ─ k) ≡ map f xs ─ cast eq k
 
   length-applyUpTo     : length (applyUpTo     f n) ≡ n
   length-applyDownFrom : length (applyDownFrom f n) ≡ n
@@ -893,6 +903,7 @@ Other minor additions
   m⊔n<o⇒n<o : ∀ m n {o} → m ⊔ n < o → n < o
 
   m≢0⇒suc[pred[m]]≡m : m ≢ 0 → suc (pred m) ≡ m
+  m≢1+n+m            : m ≢ suc (n + m)
 
   ≡ᵇ⇒≡         : T (m ≡ᵇ n) → m ≡ n
   ≡⇒≡ᵇ         : m ≡ n → T (m ≡ᵇ n)

--- a/src/Algebra/FunctionProperties.agda
+++ b/src/Algebra/FunctionProperties.agda
@@ -38,7 +38,7 @@ RightIdentity : A → Op₂ A → Set _
 RightIdentity e _∙_ = ∀ x → (x ∙ e) ≈ x
 
 Identity : A → Op₂ A → Set _
-Identity e ∙ = LeftIdentity e ∙ × RightIdentity e ∙
+Identity e ∙ = (LeftIdentity e ∙) × (RightIdentity e ∙)
 
 LeftZero : A → Op₂ A → Set _
 LeftZero z _∙_ = ∀ x → (z ∙ x) ≈ z
@@ -47,7 +47,7 @@ RightZero : A → Op₂ A → Set _
 RightZero z _∙_ = ∀ x → (x ∙ z) ≈ z
 
 Zero : A → Op₂ A → Set _
-Zero z ∙ = LeftZero z ∙ × RightZero z ∙
+Zero z ∙ = (LeftZero z ∙) × (RightZero z ∙)
 
 LeftInverse : A → Op₁ A → Op₂ A → Set _
 LeftInverse e _⁻¹ _∙_ = ∀ x → ((x ⁻¹) ∙ x) ≈ e
@@ -56,7 +56,16 @@ RightInverse : A → Op₁ A → Op₂ A → Set _
 RightInverse e _⁻¹ _∙_ = ∀ x → (x ∙ (x ⁻¹)) ≈ e
 
 Inverse : A → Op₁ A → Op₂ A → Set _
-Inverse e ⁻¹ ∙ = LeftInverse e ⁻¹ ∙ × RightInverse e ⁻¹ ∙
+Inverse e ⁻¹ ∙ = (LeftInverse e ⁻¹) ∙ × (RightInverse e ⁻¹ ∙)
+
+LeftConical : A → Op₂ A → Set _
+LeftConical e _∙_ = ∀ x y → (x ∙ y) ≈ e → x ≈ e
+
+RightConical : A → Op₂ A → Set _
+RightConical e _∙_ = ∀ x y → (x ∙ y) ≈ e → y ≈ e
+
+Conical : A → Op₂ A → Set _
+Conical e ∙ = (LeftConical e ∙) × (RightConical e ∙)
 
 _DistributesOverˡ_ : Op₂ A → Op₂ A → Set _
 _*_ DistributesOverˡ _+_ =
@@ -97,7 +106,7 @@ RightCancellative : Op₂ A → Set _
 RightCancellative _•_ = ∀ {x} y z → (y • x) ≈ (z • x) → y ≈ z
 
 Cancellative : Op₂ A → Set _
-Cancellative _•_ = LeftCancellative _•_ × RightCancellative _•_
+Cancellative _•_ = (LeftCancellative _•_) × (RightCancellative _•_)
 
 Congruent₁ : Op₁ A → Set _
 Congruent₁ f = f Preserves _≈_ ⟶ _≈_

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -461,6 +461,9 @@ m≢1+m+n : ∀ m {n} → m ≢ suc (m + n)
 m≢1+m+n zero    ()
 m≢1+m+n (suc m) eq = m≢1+m+n m (cong pred eq)
 
+m≢1+n+m : ∀ m {n} → m ≢ suc (n + m)
+m≢1+n+m m m≡1+n+m = m≢1+m+n m (trans m≡1+n+m (cong suc (+-comm _ m)))
+
 i+1+j≢i : ∀ i {j} → i + suc j ≢ i
 i+1+j≢i zero    ()
 i+1+j≢i (suc i) = (i+1+j≢i i) ∘ suc-injective


### PR DESCRIPTION
Fixes #392 as a present for @andreasabel as #540 may not make it in for v1.0.

Note I'm trying a new style for left and right operators, where we write the type explicitly to help aid readability. We then use the shorthand notation when combining the two. This ensures that we get both readability and that we get the type right. Obviously the style isn't applicable to properties that don't have left and right versions.