### PR TITLE
[ fix #428 ] Increased the consistency of where "\sim" is used vs "~"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,13 @@ Deprecated features
   <-irrelevance ↦ <-irrelevant
   ```
 
+* In `Data.List.Relation.Binary.Permutation.Inductive.Properties`:
+  ```agda
+  ↭⇒~bag ↦ ↭⇒∼bag
+  ~bag⇒↭ ↦ ∼bag⇒↭
+  ```
+  (now typed with "\sim" rather than "~")
+
 * In `Data.List.Relation.Binary.Pointwise`:
   ```agda
   decidable-≡   ↦ Data.List.Properties.≡-dec

--- a/src/Data/List/Relation/Binary/Permutation/Inductive/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Inductive/Properties.agda
@@ -257,8 +257,8 @@ module _ {a} {A : Set a} where
 
 module _ {a} {A : Set a} where
 
-  ↭⇒~bag : _↭_ ⇒ _∼[ bag ]_
-  ↭⇒~bag xs↭ys {v} = inverse (to xs↭ys) (from xs↭ys) (from∘to xs↭ys) (to∘from xs↭ys)
+  ↭⇒∼bag : _↭_ ⇒ _∼[ bag ]_
+  ↭⇒∼bag xs↭ys {v} = inverse (to xs↭ys) (from xs↭ys) (from∘to xs↭ys) (to∘from xs↭ys)
     where
     to : ∀ {xs ys} → xs ↭ ys → v ∈ xs → v ∈ ys
     to xs↭ys = Any-resp-↭ {A = A} xs↭ys
@@ -281,14 +281,35 @@ module _ {a} {A : Set a} where
     to∘from p with from∘to (↭-sym p)
     ... | res rewrite ↭-sym-involutive p = res
 
-  ~bag⇒↭ : _∼[ bag ]_ ⇒ _↭_
-  ~bag⇒↭ {[]} eq with empty-unique (Inv.sym eq)
+  ∼bag⇒↭ : _∼[ bag ]_ ⇒ _↭_
+  ∼bag⇒↭ {[]} eq with empty-unique (Inv.sym eq)
   ... | refl = refl
-  ~bag⇒↭ {x ∷ xs} eq with ∈-∃++ (to ⟨$⟩ (here ≡.refl))
+  ∼bag⇒↭ {x ∷ xs} eq with ∈-∃++ (to ⟨$⟩ (here ≡.refl))
     where open Inv.Inverse (eq {x})
   ... | zs₁ , zs₂ , p rewrite p = begin
-    x ∷ xs           <⟨ ~bag⇒↭ (drop-cons (Inv._∘_ (comm zs₁ (x ∷ zs₂)) eq)) ⟩
+    x ∷ xs           <⟨ ∼bag⇒↭ (drop-cons (Inv._∘_ (comm zs₁ (x ∷ zs₂)) eq)) ⟩
     x ∷ (zs₂ ++ zs₁) <⟨ ++-comm zs₂ zs₁ ⟩
     x ∷ (zs₁ ++ zs₂) ↭˘⟨ shift x zs₁ zs₂ ⟩
     zs₁ ++ x ∷ zs₂   ∎
     where open CommutativeMonoid (commutativeMonoid bag A)
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.0
+
+↭⇒~bag = ↭⇒∼bag
+{-# WARNING_ON_USAGE ↭⇒~bag
+"Warning: ↭⇒~bag was deprecated in v1.0.
+Please use ? instead (now typed with '\\sim' rather than '~')."
+#-}
+
+~bag⇒↭ = ∼bag⇒↭
+{-# WARNING_ON_USAGE ~bag⇒↭
+"Warning: ~bag⇒↭ was deprecated in v1.0.
+Please use ? instead (now typed with '\\sim' rather than '~')."
+#-}

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -46,49 +46,49 @@ tail : ∀ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ}
        Pointwise _∼_ (x ∷ xs) (y ∷ ys) → Pointwise _∼_ xs ys
 tail (ext app) = ext (app ∘ suc)
 
-map : ∀ {a b ℓ} {A : Set a} {B : Set b} {_~_ _~′_ : REL A B ℓ} {n} →
-      _~_ ⇒ _~′_ → Pointwise _~_ ⇒ Pointwise _~′_ {n}
-map ~⇒~′ xs~ys = ext (~⇒~′ ∘ Pointwise.app xs~ys)
+map : ∀ {a b ℓ} {A : Set a} {B : Set b} {_∼_ _∼′_ : REL A B ℓ} {n} →
+      _∼_ ⇒ _∼′_ → Pointwise _∼_ ⇒ Pointwise _∼′_ {n}
+map ∼⇒∼′ xs∼ys = ext (∼⇒∼′ ∘ Pointwise.app xs∼ys)
 
 gmap : ∀ {a b ℓ} {A : Set a} {B : Set b}
-       {_~_ : Rel A ℓ} {_~′_ : Rel B ℓ} {f : A → B} {n} →
-       _~_ =[ f ]⇒ _~′_ →
-       Pointwise _~_ =[ Vec.map {n = n} f ]⇒ Pointwise _~′_
-gmap {_}          ~⇒~′ {[]}      {[]}      xs~ys = ext λ()
-gmap {_~′_ = _~′_} ~⇒~′ {x ∷ xs} {y ∷ ys} xs~ys = ext λ
-  { zero    → ~⇒~′ (head xs~ys)
-  ; (suc i) → Pointwise.app (gmap {_~′_ = _~′_} ~⇒~′ (tail xs~ys)) i
+       {_∼_ : Rel A ℓ} {_∼′_ : Rel B ℓ} {f : A → B} {n} →
+       _∼_ =[ f ]⇒ _∼′_ →
+       Pointwise _∼_ =[ Vec.map {n = n} f ]⇒ Pointwise _∼′_
+gmap {_}          ∼⇒∼′ {[]}      {[]}      xs∼ys = ext λ()
+gmap {_∼′_ = _∼′_} ∼⇒∼′ {x ∷ xs} {y ∷ ys} xs∼ys = ext λ
+  { zero    → ∼⇒∼′ (head xs∼ys)
+  ; (suc i) → Pointwise.app (gmap {_∼′_ = _∼′_} ∼⇒∼′ (tail xs∼ys)) i
   }
 
 ------------------------------------------------------------------------
 -- The inductive and extensional definitions are equivalent.
 
-module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
+module _ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} where
 
   extensional⇒inductive : ∀ {n} {xs : Vec A n} {ys : Vec B n} →
-                           Pointwise _~_ xs ys → IPointwise _~_ xs ys
-  extensional⇒inductive {zero} {[]}       {[]}      xs~ys = []
-  extensional⇒inductive {suc n} {x ∷ xs} {y ∷ ys} xs~ys =
-    (head xs~ys) ∷ extensional⇒inductive (tail xs~ys)
+                           Pointwise _∼_ xs ys → IPointwise _∼_ xs ys
+  extensional⇒inductive {zero} {[]}       {[]}      xs∼ys = []
+  extensional⇒inductive {suc n} {x ∷ xs} {y ∷ ys} xs∼ys =
+    (head xs∼ys) ∷ extensional⇒inductive (tail xs∼ys)
 
   inductive⇒extensional : ∀ {n} {xs : Vec A n} {ys : Vec B n} →
-                           IPointwise _~_ xs ys → Pointwise _~_ xs ys
+                           IPointwise _∼_ xs ys → Pointwise _∼_ xs ys
   inductive⇒extensional []             = ext λ()
-  inductive⇒extensional (x~y ∷ xs~ys) = ext λ
-    { zero    → x~y
-    ; (suc i) → Pointwise.app (inductive⇒extensional xs~ys) i
+  inductive⇒extensional (x∼y ∷ xs∼ys) = ext λ
+    { zero    → x∼y
+    ; (suc i) → Pointwise.app (inductive⇒extensional xs∼ys) i
     }
 
   equivalent : ∀ {n} {xs : Vec A n} {ys : Vec B n} →
-               Pointwise _~_ xs ys ⇔ IPointwise _~_ xs ys
+               Pointwise _∼_ xs ys ⇔ IPointwise _∼_ xs ys
   equivalent = equivalence extensional⇒inductive inductive⇒extensional
 
 ------------------------------------------------------------------------
 -- Relational properties
 
-refl : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-       ∀ {n} → Reflexive _~_ → Reflexive (Pointwise _~_ {n = n})
-refl ~-rfl = ext (λ _ → ~-rfl)
+refl : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+       ∀ {n} → Reflexive _∼_ → Reflexive (Pointwise _∼_ {n = n})
+refl ∼-rfl = ext (λ _ → ∼-rfl)
 
 sym : ∀ {a b ℓ} {A : Set a} {B : Set b} {P : REL A B ℓ} {Q : REL B A ℓ}
       {n} → Sym P Q → Sym (Pointwise P) (Pointwise Q {n = n})
@@ -107,18 +107,18 @@ decidable dec xs ys = Dec.map
   (Setoid.sym (⇔-setoid _) equivalent)
   (Inductive.decidable dec xs ys)
 
-isEquivalence : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-                ∀ {n} → IsEquivalence _~_ →
-                IsEquivalence (Pointwise _~_ {n = n})
+isEquivalence : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+                ∀ {n} → IsEquivalence _∼_ →
+                IsEquivalence (Pointwise _∼_ {n = n})
 isEquivalence equiv = record
   { refl  = refl  (IsEquivalence.refl  equiv)
   ; sym   = sym   (IsEquivalence.sym   equiv)
   ; trans = trans (IsEquivalence.trans equiv)
   }
 
-isDecEquivalence : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-                   ∀ {n} → IsDecEquivalence _~_ →
-                   IsDecEquivalence (Pointwise _~_ {n = n})
+isDecEquivalence : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+                   ∀ {n} → IsDecEquivalence _∼_ →
+                   IsDecEquivalence (Pointwise _∼_ {n = n})
 isDecEquivalence decEquiv = record
   { isEquivalence = isEquivalence (IsDecEquivalence.isEquivalence decEquiv)
   ; _≟_           = decidable (IsDecEquivalence._≟_ decEquiv)
@@ -132,8 +132,8 @@ module _ {a} {A : Set a} where
   Pointwise-≡⇒≡ : ∀ {n} {xs ys : Vec A n} →
                      Pointwise _≡_ xs ys → xs ≡ ys
   Pointwise-≡⇒≡ {zero}  {[]}      {[]}      (ext app) = P.refl
-  Pointwise-≡⇒≡ {suc n} {x ∷ xs} {y ∷ ys} xs~ys =
-    P.cong₂ _∷_ (head xs~ys) (Pointwise-≡⇒≡ (tail xs~ys))
+  Pointwise-≡⇒≡ {suc n} {x ∷ xs} {y ∷ ys} xs∼ys =
+    P.cong₂ _∷_ (head xs∼ys) (Pointwise-≡⇒≡ (tail xs∼ys))
 
   ≡⇒Pointwise-≡ : ∀ {n} {xs ys : Vec A n} →
                      xs ≡ ys → Pointwise _≡_ xs ys

--- a/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
@@ -34,56 +34,56 @@ data Pointwise {a b ℓ} {A : Set a} {B : Set b} (_∼_ : REL A B ℓ) :
         (x∼y : x ∼ y) (xs∼ys : Pointwise _∼_ xs ys) →
         Pointwise _∼_ (x ∷ xs) (y ∷ ys)
 
-length-equal : ∀ {a b m n ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ}
+length-equal : ∀ {a b m n ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ}
                {xs : Vec A m} {ys : Vec B n} →
-               Pointwise _~_ xs ys → m ≡ n
+               Pointwise _∼_ xs ys → m ≡ n
 length-equal []          = P.refl
-length-equal (_ ∷ xs~ys) = P.cong suc (length-equal xs~ys)
+length-equal (_ ∷ xs∼ys) = P.cong suc (length-equal xs∼ys)
 
 ------------------------------------------------------------------------
 -- Operations
 
-module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
+module _ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} where
 
   head : ∀ {m n x y} {xs : Vec A m} {ys : Vec B n} →
-         Pointwise _~_ (x ∷ xs) (y ∷ ys) → x ~ y
+         Pointwise _∼_ (x ∷ xs) (y ∷ ys) → x ∼ y
   head (x∼y ∷ xs∼ys) = x∼y
 
   tail : ∀ {m n x y} {xs : Vec A m} {ys : Vec B n} →
-         Pointwise _~_ (x ∷ xs) (y ∷ ys) → Pointwise _~_ xs ys
+         Pointwise _∼_ (x ∷ xs) (y ∷ ys) → Pointwise _∼_ xs ys
   tail (x∼y ∷ xs∼ys) = xs∼ys
 
-  lookup : ∀ {n} {xs : Vec A n} {ys : Vec B n} → Pointwise _~_ xs ys →
-           ∀ i → (Vec.lookup i xs) ~ (Vec.lookup i ys)
-  lookup (x~y ∷ _)     zero    = x~y
-  lookup (_   ∷ xs~ys) (suc i) = lookup xs~ys i
+  lookup : ∀ {n} {xs : Vec A n} {ys : Vec B n} → Pointwise _∼_ xs ys →
+           ∀ i → (Vec.lookup i xs) ∼ (Vec.lookup i ys)
+  lookup (x∼y ∷ _)     zero    = x∼y
+  lookup (_   ∷ xs∼ys) (suc i) = lookup xs∼ys i
 
   map : ∀ {ℓ₂} {_≈_ : REL A B ℓ₂} →
-        _≈_ ⇒ _~_ → ∀ {m n} → Pointwise _≈_ ⇒ Pointwise _~_ {m} {n}
-  map ~₁⇒~₂ []             = []
-  map ~₁⇒~₂ (x∼y ∷ xs~ys) = ~₁⇒~₂ x∼y ∷ map ~₁⇒~₂ xs~ys
+        _≈_ ⇒ _∼_ → ∀ {m n} → Pointwise _≈_ ⇒ Pointwise _∼_ {m} {n}
+  map ∼₁⇒∼₂ []             = []
+  map ∼₁⇒∼₂ (x∼y ∷ xs∼ys) = ∼₁⇒∼₂ x∼y ∷ map ∼₁⇒∼₂ xs∼ys
 
 ------------------------------------------------------------------------
 -- Relational properties
 
-refl : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-       ∀ {n} → Reflexive _~_ → Reflexive (Pointwise _~_ {n})
-refl ~-refl {[]}      = []
-refl ~-refl {x ∷ xs} = ~-refl ∷ refl ~-refl
+refl : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+       ∀ {n} → Reflexive _∼_ → Reflexive (Pointwise _∼_ {n})
+refl ∼-refl {[]}      = []
+refl ∼-refl {x ∷ xs} = ∼-refl ∷ refl ∼-refl
 
 sym : ∀ {a b ℓ} {A : Set a} {B : Set b}
       {P : REL A B ℓ} {Q : REL B A ℓ} {m n} →
       Sym P Q → Sym (Pointwise P) (Pointwise Q {m} {n})
 sym sm []             = []
-sym sm (x∼y ∷ xs~ys) = sm x∼y ∷ sym sm xs~ys
+sym sm (x∼y ∷ xs∼ys) = sm x∼y ∷ sym sm xs∼ys
 
 trans : ∀ {a b c ℓ} {A : Set a} {B : Set b} {C : Set c}
         {P : REL A B ℓ} {Q : REL B C ℓ} {R : REL A C ℓ} {m n o} →
         Trans P Q R →
         Trans (Pointwise P {m}) (Pointwise Q {n} {o}) (Pointwise R)
 trans trns []             []             = []
-trans trns (x∼y ∷ xs~ys) (y∼z ∷ ys~zs) =
-  trns x∼y y∼z ∷ trans trns xs~ys ys~zs
+trans trns (x∼y ∷ xs∼ys) (y∼z ∷ ys∼zs) =
+  trns x∼y y∼z ∷ trans trns xs∼ys ys∼zs
 
 decidable : ∀ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} →
             Decidable _∼_ → ∀ {m n} → Decidable (Pointwise _∼_ {m} {n})
@@ -96,18 +96,18 @@ decidable dec (x ∷ xs) (y ∷ ys) with dec x y
 ...   | no ¬xs∼ys = no (¬xs∼ys ∘ tail)
 ...   | yes xs∼ys = yes (x∼y ∷ xs∼ys)
 
-isEquivalence : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-                IsEquivalence _~_ → ∀ n →
-                IsEquivalence (Pointwise _~_ {n})
+isEquivalence : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+                IsEquivalence _∼_ → ∀ n →
+                IsEquivalence (Pointwise _∼_ {n})
 isEquivalence equiv n = record
   { refl  = refl  (IsEquivalence.refl  equiv)
   ; sym   = sym   (IsEquivalence.sym   equiv)
   ; trans = trans (IsEquivalence.trans equiv)
   }
 
-isDecEquivalence : ∀ {a ℓ} {A : Set a} {_~_ : Rel A ℓ} →
-                   IsDecEquivalence _~_ → ∀ n →
-                   IsDecEquivalence (Pointwise _~_ {n})
+isDecEquivalence : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} →
+                   IsDecEquivalence _∼_ → ∀ n →
+                   IsDecEquivalence (Pointwise _∼_ {n})
 isDecEquivalence decEquiv n = record
   { isEquivalence = isEquivalence (IsDecEquivalence.isEquivalence decEquiv) n
   ; _≟_           = decidable (IsDecEquivalence._≟_ decEquiv)
@@ -128,59 +128,59 @@ decSetoid S n = record
 
 module _ {a b c d} {A : Set a} {B : Set b} {C : Set c} {D : Set d} where
 
-  map⁺ : ∀ {ℓ₁ ℓ₂} {_~₁_ : REL A B ℓ₁} {_~₂_ : REL C D ℓ₂}
+  map⁺ : ∀ {ℓ₁ ℓ₂} {_∼₁_ : REL A B ℓ₁} {_∼₂_ : REL C D ℓ₂}
          {f : A → C} {g : B → D} →
-         (∀ {x y} → x ~₁ y → f x ~₂ g y) →
-         ∀ {m n xs ys} → Pointwise _~₁_ {m} {n} xs ys →
-         Pointwise _~₂_ (Vec.map f xs) (Vec.map g ys)
-  map⁺ ~₁⇒~₂ []             = []
-  map⁺ ~₁⇒~₂ (x∼y ∷ xs~ys) = ~₁⇒~₂ x∼y ∷ map⁺ ~₁⇒~₂ xs~ys
+         (∀ {x y} → x ∼₁ y → f x ∼₂ g y) →
+         ∀ {m n xs ys} → Pointwise _∼₁_ {m} {n} xs ys →
+         Pointwise _∼₂_ (Vec.map f xs) (Vec.map g ys)
+  map⁺ ∼₁⇒∼₂ []             = []
+  map⁺ ∼₁⇒∼₂ (x∼y ∷ xs∼ys) = ∼₁⇒∼₂ x∼y ∷ map⁺ ∼₁⇒∼₂ xs∼ys
 
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
+module _ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} where
 
   ++⁺ : ∀ {m n p q}
         {ws : Vec A m} {xs : Vec B p} {ys : Vec A n} {zs : Vec B q} →
-        Pointwise _~_ ws xs → Pointwise _~_ ys zs →
-        Pointwise _~_ (ws ++ ys) (xs ++ zs)
-  ++⁺ []            ys~zs = ys~zs
-  ++⁺ (w~x ∷ ws~xs) ys~zs = w~x ∷ (++⁺ ws~xs ys~zs)
+        Pointwise _∼_ ws xs → Pointwise _∼_ ys zs →
+        Pointwise _∼_ (ws ++ ys) (xs ++ zs)
+  ++⁺ []            ys∼zs = ys∼zs
+  ++⁺ (w∼x ∷ ws∼xs) ys∼zs = w∼x ∷ (++⁺ ws∼xs ys∼zs)
 
   ++ˡ⁻ : ∀ {m n}
          (ws : Vec A m) (xs : Vec B m) {ys : Vec A n} {zs : Vec B n} →
-         Pointwise _~_ (ws ++ ys) (xs ++ zs) → Pointwise _~_ ws xs
+         Pointwise _∼_ (ws ++ ys) (xs ++ zs) → Pointwise _∼_ ws xs
   ++ˡ⁻ []       []        _                    = []
-  ++ˡ⁻ (w ∷ ws) (x ∷ xs) (w~x ∷ ps) = w~x ∷ ++ˡ⁻ ws xs ps
+  ++ˡ⁻ (w ∷ ws) (x ∷ xs) (w∼x ∷ ps) = w∼x ∷ ++ˡ⁻ ws xs ps
 
   ++ʳ⁻ : ∀ {m n}
          (ws : Vec A m) (xs : Vec B m) {ys : Vec A n} {zs : Vec B n} →
-         Pointwise _~_ (ws ++ ys) (xs ++ zs) → Pointwise _~_ ys zs
-  ++ʳ⁻ [] [] ys~zs = ys~zs
+         Pointwise _∼_ (ws ++ ys) (xs ++ zs) → Pointwise _∼_ ys zs
+  ++ʳ⁻ [] [] ys∼zs = ys∼zs
   ++ʳ⁻ (w ∷ ws) (x ∷ xs) (_ ∷ ps) = ++ʳ⁻ ws xs ps
 
   ++⁻ : ∀ {m n}
         (ws : Vec A m) (xs : Vec B m) {ys : Vec A n} {zs : Vec B n} →
-        Pointwise _~_ (ws ++ ys) (xs ++ zs) →
-        Pointwise _~_ ws xs × Pointwise _~_ ys zs
+        Pointwise _∼_ (ws ++ ys) (xs ++ zs) →
+        Pointwise _∼_ ws xs × Pointwise _∼_ ys zs
   ++⁻ ws xs ps = ++ˡ⁻ ws xs ps , ++ʳ⁻ ws xs ps
 
 ------------------------------------------------------------------------
 -- concat
 
-module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
+module _ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} where
 
   concat⁺ : ∀ {m n p q}
             {xss : Vec (Vec A m) n} {yss : Vec (Vec B p) q} →
-            Pointwise (Pointwise _~_) xss yss →
-            Pointwise _~_ (concat xss) (concat yss)
+            Pointwise (Pointwise _∼_) xss yss →
+            Pointwise _∼_ (concat xss) (concat yss)
   concat⁺ []           = []
-  concat⁺ (xs~ys ∷ ps) = ++⁺ xs~ys (concat⁺ ps)
+  concat⁺ (xs∼ys ∷ ps) = ++⁺ xs∼ys (concat⁺ ps)
 
   concat⁻ : ∀ {m n} (xss : Vec (Vec A m) n) (yss : Vec (Vec B m) n) →
-            Pointwise _~_ (concat xss) (concat yss) →
-            Pointwise (Pointwise _~_) xss yss
+            Pointwise _∼_ (concat xss) (concat yss) →
+            Pointwise (Pointwise _∼_) xss yss
   concat⁻ []         []         [] = []
   concat⁻ (xs ∷ xss) (ys ∷ yss) ps =
     ++ˡ⁻ xs ys ps ∷ concat⁻ xss yss (++ʳ⁻ xs ys ps)
@@ -188,19 +188,19 @@ module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
 ------------------------------------------------------------------------
 -- tabulate
 
-module _ {a b ℓ} {A : Set a} {B : Set b} {_~_ : REL A B ℓ} where
+module _ {a b ℓ} {A : Set a} {B : Set b} {_∼_ : REL A B ℓ} where
 
   tabulate⁺ : ∀ {n} {f : Fin n → A} {g : Fin n → B} →
-              (∀ i → f i ~ g i) →
-              Pointwise _~_ (tabulate f) (tabulate g)
-  tabulate⁺ {zero}  f~g = []
-  tabulate⁺ {suc n} f~g = f~g zero ∷ tabulate⁺ (f~g ∘ suc)
+              (∀ i → f i ∼ g i) →
+              Pointwise _∼_ (tabulate f) (tabulate g)
+  tabulate⁺ {zero}  f∼g = []
+  tabulate⁺ {suc n} f∼g = f∼g zero ∷ tabulate⁺ (f∼g ∘ suc)
 
   tabulate⁻ : ∀ {n} {f : Fin n → A} {g : Fin n → B} →
-              Pointwise _~_ (tabulate f) (tabulate g) →
-              (∀ i → f i ~ g i)
-  tabulate⁻ (f₀~g₀ ∷ _)   zero    = f₀~g₀
-  tabulate⁻ (_     ∷ f~g) (suc i) = tabulate⁻ f~g i
+              Pointwise _∼_ (tabulate f) (tabulate g) →
+              (∀ i → f i ∼ g i)
+  tabulate⁻ (f₀∼g₀ ∷ _)   zero    = f₀∼g₀
+  tabulate⁻ (_     ∷ f∼g) (suc i) = tabulate⁻ f∼g i
 
 ------------------------------------------------------------------------
 -- Degenerate pointwise relations
@@ -235,7 +235,7 @@ module _ {a} {A : Set a} where
   Pointwise-≡⇒≡ : ∀ {n} {xs ys : Vec A n} →
                   Pointwise _≡_ xs ys → xs ≡ ys
   Pointwise-≡⇒≡ []               = P.refl
-  Pointwise-≡⇒≡ (P.refl ∷ xs~ys) = P.cong (_ ∷_) (Pointwise-≡⇒≡ xs~ys)
+  Pointwise-≡⇒≡ (P.refl ∷ xs∼ys) = P.cong (_ ∷_) (Pointwise-≡⇒≡ xs∼ys)
 
   ≡⇒Pointwise-≡ : ∀ {n} {xs ys : Vec A n} →
                   xs ≡ ys → Pointwise _≡_ xs ys

--- a/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
+++ b/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Example of a Quotient: ℤ as (ℕ × ℕ / ~)
+-- Example of a Quotient: ℤ as (ℕ × ℕ / ∼)
 ------------------------------------------------------------------------
 
 {-# OPTIONS --with-K --safe #-}
@@ -9,7 +9,7 @@
 module Relation.Binary.HeterogeneousEquality.Quotients.Examples where
 
 open import Relation.Binary.HeterogeneousEquality.Quotients
-open import Level as L hiding (lift)
+open import Level using (0ℓ)
 open import Relation.Binary
 open import Relation.Binary.HeterogeneousEquality hiding (isEquivalence)
 import Relation.Binary.PropositionalEquality as ≡
@@ -40,17 +40,17 @@ infix 10 _∼_
   y₂ + x₃ + y₁   ≡⟨ +-assoc y₂ x₃ y₁ ⟩
   y₂ + (x₃ + y₁) ∎
 
-~-isEquivalence : IsEquivalence _∼_
-~-isEquivalence = record
+∼-isEquivalence : IsEquivalence _∼_
+∼-isEquivalence = record
   { refl  = refl
   ; sym   = sym
   ; trans = λ {i} {j} {k} → ∼-trans {i} {j} {k}
   }
 
-ℕ²-∼-setoid : Setoid L.zero L.zero
-ℕ²-∼-setoid = record { isEquivalence = ~-isEquivalence }
+ℕ²-∼-setoid : Setoid 0ℓ 0ℓ
+ℕ²-∼-setoid = record { isEquivalence = ∼-isEquivalence }
 
-module Integers (quot : Quotients L.zero L.zero) where
+module Integers (quot : Quotients 0ℓ 0ℓ) where
 
   Int : Quotient ℕ²-∼-setoid
   Int = quot _
@@ -61,18 +61,18 @@ module Integers (quot : Quotients L.zero L.zero) where
   (x₁ , y₁) +² (x₂ , y₂) = x₁ + x₂ , y₁ + y₂
 
   +²-cong : ∀{a b a' b'} → a ∼ a' → b ∼ b' → a +² b ∼ a' +² b'
-  +²-cong {a₁ , b₁} {c₁ , d₁} {a₂ , b₂} {c₂ , d₂} ab~cd₁ ab~cd₂ = begin
+  +²-cong {a₁ , b₁} {c₁ , d₁} {a₂ , b₂} {c₂ , d₂} ab∼cd₁ ab∼cd₂ = begin
     (a₁ + c₁) + (b₂ + d₂) ≡⟨ ≡.cong (_+ (b₂ + d₂)) (+-comm a₁ c₁) ⟩
     (c₁ + a₁) + (b₂ + d₂) ≡⟨ +-assoc c₁ a₁ (b₂ + d₂) ⟩
     c₁ + (a₁ + (b₂ + d₂)) ≡⟨ ≡.cong (c₁ +_) (≡.sym (+-assoc a₁ b₂ d₂)) ⟩
-    c₁ + (a₁ + b₂ + d₂)   ≅⟨ cong (λ n → c₁ + (n + d₂)) ab~cd₁ ⟩
+    c₁ + (a₁ + b₂ + d₂)   ≅⟨ cong (λ n → c₁ + (n + d₂)) ab∼cd₁ ⟩
     c₁ + (a₂ + b₁ + d₂)   ≡⟨ ≡.cong (c₁ +_) (+-assoc a₂ b₁ d₂) ⟩
     c₁ + (a₂ + (b₁ + d₂)) ≡⟨ ≡.cong (λ n → c₁ + (a₂ + n)) (+-comm b₁ d₂) ⟩
     c₁ + (a₂ + (d₂ + b₁)) ≡⟨ ≡.sym (+-assoc c₁ a₂ (d₂ + b₁)) ⟩
     (c₁ + a₂) + (d₂ + b₁) ≡⟨ ≡.cong (_+ (d₂ + b₁)) (+-comm c₁ a₂) ⟩
     (a₂ + c₁) + (d₂ + b₁) ≡⟨ +-assoc a₂ c₁ (d₂ + b₁) ⟩
     a₂ + (c₁ + (d₂ + b₁)) ≡⟨ ≡.cong (a₂ +_) (≡.sym (+-assoc c₁ d₂ b₁)) ⟩
-    a₂ + (c₁ + d₂ + b₁)   ≅⟨ cong (λ n → a₂ + (n + b₁)) ab~cd₂ ⟩
+    a₂ + (c₁ + d₂ + b₁)   ≅⟨ cong (λ n → a₂ + (n + b₁)) ab∼cd₂ ⟩
     a₂ + (c₂ + d₁ + b₁)   ≡⟨ ≡.cong (a₂ +_) (+-assoc c₂ d₁ b₁) ⟩
     a₂ + (c₂ + (d₁ + b₁)) ≡⟨ ≡.cong (λ n → a₂ + (c₂ + n)) (+-comm d₁ b₁) ⟩
     a₂ + (c₂ + (b₁ + d₁)) ≡⟨ ≡.sym (+-assoc a₂ c₂ (b₁ + d₁)) ⟩


### PR DESCRIPTION
Fixes #428. I have changed "~" to "\sim" everywhere where they were being used inconsistently. 

This leaves "\sim" being used everywhere except in `Relation.Unary` which uses "~" for the negation operation. I haven't changed this to "\sim" because I'm unsure what the correct symbol to use is semantically, and "\sim" doesn't seem right. Anyone have any strong opinions?