### PR TITLE
[ re #184 ] Add additional axiom modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -295,6 +295,22 @@ Non-backwards compatible changes
   (and renamed it to `Pointwise`) and its properties to
   `Data.Container.Relation.Binary.Pointwise.Properties`.
 
+#### New `Axiom` modules
+
+* A new top level `Axiom` directory has been created that contains modules
+  for various additional axioms that users may want to postulate.
+
+* `Excluded-Middle` and associated proofs have been moved out of `Relation.Nullary.Negation`
+  and into `Axiom.ExcludedMiddle`.
+
+* `Extensionality` and associated proofs have been moved out of
+  `Relation.Binary.PropositionalEquality` and into `Axiom.Extensionality.Propositional`.
+
+* `Extensionality` and associated proofs have been moved out of
+  `Relation.Binary.HeterogeneousEquality` and into `Axiom.Extensionality.Heterogeneous`.
+
+* The old names still exist for backwards compatability but have been deprecated.
+
 #### Other
 
 * The proof `sel⇒idem` has been moved from `Algebra.FunctionProperties.Consequences` to
@@ -344,6 +360,10 @@ List of new modules
 
   Axiom.UIP
   Axiom.UIP.WithK
+  Axiom.ExcludedMiddle
+  Axiom.DoubleNegationElimination
+  Axiom.Extensionality.Propositional
+  Axiom.Extensionality.Heterogeneous
 
   Codata.Cowriter
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -342,7 +342,7 @@ Non-backwards compatible changes
 * The functions `_∷=_` and `_─_` have been removed from `Data.List.Membership.Setoid` as they are subsumed by the more general versions now part of `Data.List.Any`.
 
 * Changed the type of `≡-≟-identity` to make use of the fact that equality
-  being decidable implies UIP.
+  being decidable implies uniqueness of identity proofs.
 
 * Changed the implementation of _≟_ and _≤″?_ for natural numbers to use a (fast)
   boolean test.
@@ -358,8 +358,8 @@ List of new modules
 
   Algebra.FunctionProperties.Consequences.Propositional
 
-  Axiom.UIP
-  Axiom.UIP.WithK
+  Axiom.UniquenessOfIdentityProofs
+  Axiom.UniquenessOfIdentityProofs.WithK
   Axiom.ExcludedMiddle
   Axiom.DoubleNegationElimination
   Axiom.Extensionality.Propositional

--- a/src/Axiom/DoubleNegationElimination.agda
+++ b/src/Axiom/DoubleNegationElimination.agda
@@ -1,0 +1,34 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Results concerning double negation elimination.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Axiom.DoubleNegationElimination where
+
+open import Axiom.ExcludedMiddle
+open import Level
+open import Relation.Nullary
+open import Relation.Nullary.Negation
+
+------------------------------------------------------------------------
+-- Definition
+
+-- The classical statement of double negation elimination says that
+-- if a property is not not true then it is true.
+
+DoubleNegationElimination : (ℓ : Level) → Set (suc ℓ)
+DoubleNegationElimination ℓ = {P : Set ℓ} → ¬ ¬ P → P
+
+------------------------------------------------------------------------
+-- Properties
+
+-- Double negation elimination is equivalent to excluded middle
+
+em⇒dne : ∀ {ℓ} → ExcludedMiddle ℓ → DoubleNegationElimination ℓ
+em⇒dne em = decidable-stable em
+
+dne⇒em : ∀ {ℓ} → DoubleNegationElimination ℓ → ExcludedMiddle ℓ
+dne⇒em dne = dne excluded-middle

--- a/src/Axiom/ExcludedMiddle.agda
+++ b/src/Axiom/ExcludedMiddle.agda
@@ -1,0 +1,21 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Results concerning the excluded middle axiom.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Axiom.ExcludedMiddle where
+
+open import Level
+open import Relation.Nullary
+
+------------------------------------------------------------------------
+-- Definition
+
+-- The classical statement of excluded middle says that every
+-- statement/set is decidable (i.e. it either holds or it doesn't hold).
+
+ExcludedMiddle : (ℓ : Level) → Set (suc ℓ)
+ExcludedMiddle ℓ = {P : Set ℓ} → Dec P

--- a/src/Axiom/Extensionality/Heterogeneous.agda
+++ b/src/Axiom/Extensionality/Heterogeneous.agda
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Results concerning function extensionality for propositional equality
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Axiom.Extensionality.Heterogeneous where
+
+import Axiom.Extensionality.Propositional as P
+open import Function
+open import Level
+open import Relation.Binary.HeterogeneousEquality.Core
+open import Relation.Binary.PropositionalEquality.Core
+
+------------------------------------------------------------------------
+-- Function extensionality states that if two functions are
+-- propositionally equal for every input, then the functions themselves
+-- must be propositionally equal.
+
+Extensionality : (a b : Level) → Set _
+Extensionality a b =
+  {A : Set a} {B₁ B₂ : A → Set b}
+  {f₁ : (x : A) → B₁ x} {f₂ : (x : A) → B₂ x} →
+  (∀ x → B₁ x ≡ B₂ x) → (∀ x → f₁ x ≅ f₂ x) → f₁ ≅ f₂
+
+------------------------------------------------------------------------
+-- Properties
+
+-- This form of extensionality follows from extensionality for _≡_.
+
+≡-ext⇒≅-ext : ∀ {ℓ₁ ℓ₂} →
+              P.Extensionality ℓ₁ (suc ℓ₂) →
+              Extensionality ℓ₁ ℓ₂
+≡-ext⇒≅-ext {ℓ₁} {ℓ₂} ext B₁≡B₂ f₁≅f₂ with ext B₁≡B₂
+... | refl = ≡-to-≅ $ ext′ (≅-to-≡ ∘ f₁≅f₂)
+  where
+  ext′ : P.Extensionality ℓ₁ ℓ₂
+  ext′ = P.lower ℓ₁ (suc ℓ₂) ext

--- a/src/Axiom/Extensionality/Heterogeneous.agda
+++ b/src/Axiom/Extensionality/Heterogeneous.agda
@@ -37,4 +37,4 @@ Extensionality a b =
 ... | refl = ≡-to-≅ $ ext′ (≅-to-≡ ∘ f₁≅f₂)
   where
   ext′ : P.Extensionality ℓ₁ ℓ₂
-  ext′ = P.lower ℓ₁ (suc ℓ₂) ext
+  ext′ = P.lower-extensionality ℓ₁ (suc ℓ₂) ext

--- a/src/Axiom/Extensionality/Propositional.agda
+++ b/src/Axiom/Extensionality/Propositional.agda
@@ -1,0 +1,46 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Results concerning function extensionality for propositional equality
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Axiom.Extensionality.Propositional where
+
+open import Function
+open import Level using (Level; _⊔_; suc; lift)
+open import Relation.Binary.Core
+open import Relation.Binary.PropositionalEquality.Core
+
+------------------------------------------------------------------------
+-- Function extensionality states that if two functions are
+-- propositionally equal for every input, then the functions themselves
+-- must be propositionally equal.
+
+Extensionality : (a b : Level) → Set _
+Extensionality a b =
+  {A : Set a} {B : A → Set b} {f g : (x : A) → B x} →
+  (∀ x → f x ≡ g x) → f ≡ g
+
+------------------------------------------------------------------------
+-- Properties
+
+-- If extensionality holds for a given universe level, then it also
+-- holds for lower ones.
+
+lower : ∀ {a₁ b₁} a₂ b₂ →
+        Extensionality (a₁ ⊔ a₂) (b₁ ⊔ b₂) →
+        Extensionality a₁ b₁
+lower a₂ b₂ ext f≡g = cong (λ h → Level.lower ∘ h ∘ lift) $
+    ext (cong (lift {ℓ = b₂}) ∘ f≡g ∘ Level.lower {ℓ = a₂})
+
+-- Functional extensionality implies a form of extensionality for
+-- Π-types.
+
+∀-extensionality : ∀ {a b} → Extensionality a (suc b) →
+                   {A : Set a} (B₁ B₂ : A → Set b) →
+                   (∀ x → B₁ x ≡ B₂ x) →
+                   (∀ x → B₁ x) ≡ (∀ x → B₂ x)
+∀-extensionality ext B₁ B₂ B₁≡B₂ with ext B₁≡B₂
+∀-extensionality ext B .B  B₁≡B₂ | refl = refl

--- a/src/Axiom/Extensionality/Propositional.agda
+++ b/src/Axiom/Extensionality/Propositional.agda
@@ -29,10 +29,10 @@ Extensionality a b =
 -- If extensionality holds for a given universe level, then it also
 -- holds for lower ones.
 
-lower : ∀ {a₁ b₁} a₂ b₂ →
-        Extensionality (a₁ ⊔ a₂) (b₁ ⊔ b₂) →
-        Extensionality a₁ b₁
-lower a₂ b₂ ext f≡g = cong (λ h → Level.lower ∘ h ∘ lift) $
+lower-extensionality : ∀ {a₁ b₁} a₂ b₂ →
+                       Extensionality (a₁ ⊔ a₂) (b₁ ⊔ b₂) →
+                       Extensionality a₁ b₁
+lower-extensionality a₂ b₂ ext f≡g = cong (λ h → Level.lower ∘ h ∘ lift) $
     ext (cong (lift {ℓ = b₂}) ∘ f≡g ∘ Level.lower {ℓ = a₂})
 
 -- Functional extensionality implies a form of extensionality for

--- a/src/Axiom/UIP.agda
+++ b/src/Axiom/UIP.agda
@@ -14,6 +14,8 @@ open import Relation.Binary.Core
 open import Relation.Binary.PropositionalEquality.Core
 
 ------------------------------------------------------------------------
+-- Definition
+--
 -- Uniqueness of Identity Proofs (UIP) states that all proofs of
 -- equality are themselves equal. In other words, the equality relation
 -- is irrelevant. Here we define UIP relative to a given type.
@@ -22,9 +24,10 @@ UIP : ∀ {a} (A : Set a) → Set a
 UIP A = Irrelevant {A = A} _≡_
 
 ------------------------------------------------------------------------
+-- Properties
+
 -- UIP always holds when using axiom K (see `Axiom.UIP.WithK`).
 
-------------------------------------------------------------------------
 -- The existence of a constant function over proofs of equality for
 -- elements in A is enough to prove UIP for A. Indeed, we can relate any
 -- proof to its image via this function which we then know is equal to
@@ -45,8 +48,6 @@ module Constant⇒UIP
     trans (sym (f refl)) (f q) ≡⟨ ≡-canonical q ⟩
     q                          ∎ where open ≡-Reasoning
 
-
-------------------------------------------------------------------------
 -- If equality is decidable for a given type, then we can prove UIP for
 -- that type. Indeed, the decision procedure allows us to define a
 -- function over proofs of equality which is constant: it returns the

--- a/src/Axiom/UIP/WithK.agda
+++ b/src/Axiom/UIP/WithK.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Results concerning uniqueness of identity proofs, with K axiom
+-- Results concerning uniqueness of identity proofs, with axiom K
 ------------------------------------------------------------------------
 
 {-# OPTIONS --with-K --safe #-}
@@ -11,7 +11,7 @@ module Axiom.UIP.WithK where
 open import Axiom.UIP
 open import Relation.Binary.PropositionalEquality.Core
 
--- K implies UIP.
+-- Axiom K implies UIP.
 
 uip : ∀ {a A} → UIP {a} A
 uip refl refl = refl

--- a/src/Axiom/UniquenessOfIdentityProofs.agda
+++ b/src/Axiom/UniquenessOfIdentityProofs.agda
@@ -6,7 +6,7 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-module Axiom.UIP where
+module Axiom.UniquenessOfIdentityProofs where
 
 open import Data.Empty
 open import Relation.Nullary
@@ -26,7 +26,8 @@ UIP A = Irrelevant {A = A} _≡_
 ------------------------------------------------------------------------
 -- Properties
 
--- UIP always holds when using axiom K (see `Axiom.UIP.WithK`).
+-- UIP always holds when using axiom K
+-- (see `Axiom.UniquenessOfIdentityProofs.WithK`).
 
 -- The existence of a constant function over proofs of equality for
 -- elements in A is enough to prove UIP for A. Indeed, we can relate any

--- a/src/Axiom/UniquenessOfIdentityProofs/WithK.agda
+++ b/src/Axiom/UniquenessOfIdentityProofs/WithK.agda
@@ -6,9 +6,9 @@
 
 {-# OPTIONS --with-K --safe #-}
 
-module Axiom.UIP.WithK where
+module Axiom.UniquenessOfIdentityProofs.WithK where
 
-open import Axiom.UIP
+open import Axiom.UniquenessOfIdentityProofs
 open import Relation.Binary.PropositionalEquality.Core
 
 -- Axiom K implies UIP.

--- a/src/Data/Container/Combinator/Properties.agda
+++ b/src/Data/Container/Combinator/Properties.agda
@@ -8,18 +8,17 @@
 
 module Data.Container.Combinator.Properties where
 
-open import Level using (_⊔_; lower)
-open import Data.Empty using (⊥-elim)
-open import Data.Product as Prod using (∃; _,_; proj₁; proj₂; <_,_>; uncurry; curry)
-open import Data.Sum as S using (inj₁; inj₂; [_,_]′; [_,_])
-
-open import Function as F using (_∘′_)
-open import Function.Inverse as Inv using (_↔_; inverse; module Inverse)
-open import Relation.Binary.PropositionalEquality as P using (_≡_; _≗_)
-
+open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Container.Core
 open import Data.Container.Combinator
 open import Data.Container.Relation.Unary.Any
+open import Data.Empty using (⊥-elim)
+open import Data.Product as Prod using (∃; _,_; proj₁; proj₂; <_,_>; uncurry; curry)
+open import Data.Sum as S using (inj₁; inj₂; [_,_]′; [_,_])
+open import Function as F using (_∘′_)
+open import Function.Inverse as Inv using (_↔_; inverse; module Inverse)
+open import Level using (_⊔_; lower)
+open import Relation.Binary.PropositionalEquality as P using (_≡_; _≗_)
 
 -- I have proved some of the correctness statements under the
 -- assumption of functional extensionality. I could have reformulated
@@ -36,7 +35,7 @@ module Identity where
     from : F.id X → ⟦ id ⟧ X
     from x = (_ , λ _ → x)
 
-module Constant (ext : ∀ {ℓ ℓ′} → P.Extensionality ℓ ℓ′) where
+module Constant (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′) where
 
   correct : ∀ {x p y} (X : Set x) {Y : Set y} → ⟦ const {x} {p ⊔ y} X ⟧ Y ↔ F.const X Y
   correct {x} {y} X {Y} = inverse proj₁ from from∘to λ _ → P.refl
@@ -59,7 +58,7 @@ module Composition {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Co
     from : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₁ ∘ C₂ ⟧ X
     from (s , f) = ((s , proj₁ F.∘ f) , uncurry (proj₂ F.∘ f) ∘′ ◇.proof)
 
-module Product (ext : ∀ {ℓ ℓ′} → P.Extensionality ℓ ℓ′)
+module Product (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′)
        {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
   correct : ∀ {x} {X : Set x} →  ⟦ C₁ × C₂ ⟧ X ↔ (⟦ C₁ ⟧ X Prod.× ⟦ C₂ ⟧ X)

--- a/src/Data/Container/Indexed/Combinator.agda
+++ b/src/Data/Container/Indexed/Combinator.agda
@@ -8,7 +8,7 @@
 
 module Data.Container.Indexed.Combinator where
 
-open import Level
+open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Container.Indexed
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤)
@@ -16,6 +16,7 @@ open import Data.Product as Prod hiding (Σ) renaming (_×_ to _⟨×⟩_)
 open import Data.Sum renaming (_⊎_ to _⟨⊎⟩_)
 open import Function as F hiding (id; const) renaming (_∘_ to _⟨∘⟩_)
 open import Function.Inverse using (_↔̇_; inverse)
+open import Level
 open import Relation.Unary using (Pred; _⊆_; _∪_; _∩_; ⋃; ⋂)
   renaming (_⟨×⟩_ to _⟪×⟫_; _⟨⊙⟩_ to _⟪⊙⟫_; _⟨⊎⟩_ to _⟪⊎⟫_)
 open import Relation.Binary.PropositionalEquality as P
@@ -147,7 +148,7 @@ module Identity where
     from : ∀ {x} → F.id X x → ⟦ id ⟧ X x
     from x = (_ , λ _ → x)
 
-module Constant (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
+module Constant (ext : ∀ {ℓ} → Extensionality ℓ ℓ) where
 
   correct : ∀ {i o ℓ₁ ℓ₂} {I : Set i} {O : Set o} (X : Pred O ℓ₁)
             {Y : Pred O ℓ₂} → ⟦ const X ⟧ Y ↔̇ F.const X Y
@@ -190,7 +191,7 @@ module Composition where
     from : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) ⊆ ⟦ C₁ ∘ C₂ ⟧ X
     from (c , f) = ((c , proj₁ ⟨∘⟩ f) , uncurry (proj₂ ⟨∘⟩ f))
 
-module Product (ext : ∀ {ℓ} → P.Extensionality ℓ ℓ) where
+module Product (ext : ∀ {ℓ} → Extensionality ℓ ℓ) where
 
   correct : ∀ {i o c r} {I : Set i} {O : Set o}
               (C₁ C₂ : Container I O c r) {X} →

--- a/src/Data/Container/Indexed/WithK.agda
+++ b/src/Data/Container/Indexed/WithK.agda
@@ -13,10 +13,11 @@
 
 module Data.Container.Indexed.WithK where
 
-open import Level
+open import Axiom.Extensionality.Heterogeneous using (Extensionality)
 open import Data.Container.Indexed hiding (module PlainMorphism)
 open import Data.Product as Prod hiding (map)
 open import Function renaming (id to ⟨id⟩; _∘_ to _⟨∘⟩_)
+open import Level
 open import Relation.Unary using (Pred; _⊆_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
 open import Relation.Binary.HeterogeneousEquality as H using (_≅_; refl)
@@ -38,7 +39,7 @@ private
 
   Eq⇒≅ : ∀ {i o c r ℓ} {I : Set i} {O : Set o}
          {C : Container I O c r} {X : Pred I ℓ} {o₁ o₂ : O}
-         {xs : ⟦ C ⟧ X o₁} {ys : ⟦ C ⟧ X o₂} → H.Extensionality r ℓ →
+         {xs : ⟦ C ⟧ X o₁} {ys : ⟦ C ⟧ X o₂} → Extensionality r ℓ →
          Eq C X X (λ x₁ x₂ → x₁ ≅ x₂) xs ys → xs ≅ ys
   Eq⇒≅ {xs = c , k} {.c , k′} ext (refl , refl , k≈k′) =
     H.cong (_,_ c) (ext (λ _ → refl) (λ r → k≈k′ r r refl))

--- a/src/Data/Container/Relation/Binary/Pointwise.agda
+++ b/src/Data/Container/Relation/Binary/Pointwise.agda
@@ -8,13 +8,12 @@
 
 module Data.Container.Relation.Binary.Pointwise where
 
-open import Level using (_⊔_)
 open import Data.Product using (_,_; Σ-syntax; -,_; proj₁; proj₂)
 open import Function
-
+open import Level using (_⊔_)
 open import Relation.Binary using (REL; _⇒_)
-open import Relation.Binary.PropositionalEquality
-  as P using (_≡_; subst; cong; Extensionality)
+open import Relation.Binary.PropositionalEquality as P
+  using (_≡_; subst; cong)
 
 open import Data.Container.Core using (Container; ⟦_⟧)
 

--- a/src/Data/Container/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Container/Relation/Binary/Pointwise/Properties.agda
@@ -8,14 +8,14 @@
 
 module Data.Container.Relation.Binary.Pointwise.Properties where
 
-open import Level using (_⊔_)
-open import Data.Product using (_,_; Σ-syntax; -,_)
-open import Relation.Binary
-open import Relation.Binary.PropositionalEquality
-  as P using (_≡_; subst; cong; Extensionality)
-
+open import Axiom.Extensionality.Propositional
 open import Data.Container.Core
 open import Data.Container.Relation.Binary.Pointwise
+open import Data.Product using (_,_; Σ-syntax; -,_)
+open import Level using (_⊔_)
+open import Relation.Binary
+open import Relation.Binary.PropositionalEquality as P
+  using (_≡_; subst; cong)
 
 module _ {s p x r} {X : Set x} (C : Container s p) (R : Rel X r) where
 

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -8,6 +8,7 @@
 
 module Data.List.Relation.Unary.All.Properties where
 
+open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Bool.Base using (Bool; T)
 open import Data.Bool.Properties
 open import Data.Empty
@@ -68,7 +69,7 @@ module _ {a p} {A : Set a} {P : A → Set p} where
     -- If equality of functions were extensional, then the surjection
     -- could be strengthened to a bijection.
 
-    from∘to : P.Extensionality _ _ →
+    from∘to : Extensionality _ _ →
               ∀ xs → (¬p : ¬ Any P xs) → All¬⇒¬Any (¬Any⇒All¬ xs ¬p) ≡ ¬p
     from∘to ext []       ¬p = ext λ ()
     from∘to ext (x ∷ xs) ¬p = ext λ
@@ -81,7 +82,7 @@ module _ {a p} {A : Set a} {P : A → Set p} where
     where
     -- If equality of functions were extensional, then the logical
     -- equivalence could be strengthened to a surjection.
-    to∘from : P.Extensionality _ _ →
+    to∘from : Extensionality _ _ →
               ∀ {xs} (¬∀ : ¬ All P xs) → Any¬→¬All (¬All⇒Any¬ dec xs ¬∀) ≡ ¬∀
     to∘from ext ¬∀ = ext (⊥-elim ∘ ¬∀)
 
@@ -241,8 +242,7 @@ module _ {a p} {A : Set a} {P : A → Set p} (P? : Decidable P) where
   ... | yes Px = Px ∷ all-filter xs
   ... | no  _  = all-filter xs
 
-  filter⁺ : ∀ {q} {Q : A → Set q} {xs} →
-             All Q xs → All Q (filter P? xs)
+  filter⁺ : ∀ {q} {Q : A → Set q} {xs} → All Q xs → All Q (filter P? xs)
   filter⁺ {xs = _}     [] = []
   filter⁺ {xs = x ∷ _} (Qx ∷ Qxs) with P? x
   ... | no  _ = filter⁺ Qxs

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -11,7 +11,7 @@
 
 module Data.Nat.Properties where
 
-open import Axiom.UIP
+open import Axiom.UniquenessOfIdentityProofs
 open import Algebra
 open import Algebra.Morphism
 open import Function

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -11,6 +11,7 @@ module Function.Related.TypeIsomorphisms where
 
 open import Algebra
 import Algebra.FunctionProperties as FP
+open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Algebra.Structures
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Product as Prod hiding (swap)
@@ -271,7 +272,7 @@ A⇔B →-cong-⇔ C⇔D = Eq.equivalence
 
 →-cong :
   ∀ {a b c d} →
-  P.Extensionality a c → P.Extensionality b d →
+  Extensionality a c → Extensionality b d →
   ∀ {k} {A : Set a} {B : Set b} {C : Set c} {D : Set d} →
   A ∼[ ⌊ k ⌋ ] B → C ∼[ ⌊ k ⌋ ] D → (A → C) ∼[ ⌊ k ⌋ ] (B → D)
 →-cong extAC extBD {equivalence} A⇔B C⇔D = A⇔B →-cong-⇔ C⇔D
@@ -303,9 +304,7 @@ A⇔B →-cong-⇔ C⇔D = Eq.equivalence
 ¬-cong-⇔ A⇔B = A⇔B →-cong-⇔ (⊥ ∎)
   where open EquationalReasoning
 
-¬-cong : ∀ {a b} →
-         P.Extensionality a 0ℓ →
-         P.Extensionality b 0ℓ →
+¬-cong : ∀ {a b} → Extensionality a 0ℓ → Extensionality b 0ℓ →
          ∀ {k} {A : Set a} {B : Set b} →
          A ∼[ ⌊ k ⌋ ] B → (¬ A) ∼[ ⌊ k ⌋ ] (¬ B)
 ¬-cong extA extB A≈B = →-cong extA extB A≈B (⊥ ∎)

--- a/src/Relation/Binary/HeterogeneousEquality.agda
+++ b/src/Relation/Binary/HeterogeneousEquality.agda
@@ -8,10 +8,11 @@
 
 module Relation.Binary.HeterogeneousEquality where
 
+import Axiom.Extensionality.Heterogeneous as Ext
 open import Data.Product
+open import Data.Unit.NonEta
 open import Function
 open import Function.Inverse using (Inverse)
-open import Data.Unit.NonEta
 open import Level
 open import Relation.Nullary
 open import Relation.Binary
@@ -39,10 +40,7 @@ x ≇ y = ¬ x ≅ y
 ------------------------------------------------------------------------
 -- Conversion
 
-open Core public using (≅-to-≡)
-
-≡-to-≅ : ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≅ y
-≡-to-≅ refl = refl
+open Core public using (≅-to-≡; ≡-to-≅)
 
 ≅-to-type-≡ : ∀ {a} {A B : Set a} {x : A} {y : B} →
                 x ≅ y → A ≡ B
@@ -265,28 +263,6 @@ module ≅-Reasoning where
   _∎ _ = relTo refl
 
 ------------------------------------------------------------------------
--- Functional extensionality
-
--- A form of functional extensionality for _≅_.
-
-Extensionality : (a b : Level) → Set _
-Extensionality a b =
-  {A : Set a} {B₁ B₂ : A → Set b}
-  {f₁ : (x : A) → B₁ x} {f₂ : (x : A) → B₂ x} →
-  (∀ x → B₁ x ≡ B₂ x) → (∀ x → f₁ x ≅ f₂ x) → f₁ ≅ f₂
-
--- This form of extensionality follows from extensionality for _≡_.
-
-≡-ext-to-≅-ext : ∀ {ℓ₁ ℓ₂} →
-  P.Extensionality ℓ₁ (suc ℓ₂) → Extensionality ℓ₁ ℓ₂
-≡-ext-to-≅-ext           ext B₁≡B₂ f₁≅f₂ with ext B₁≡B₂
-≡-ext-to-≅-ext {ℓ₁} {ℓ₂} ext B₁≡B₂ f₁≅f₂ | P.refl =
-  ≡-to-≅ $ ext′ (≅-to-≡ ∘ f₁≅f₂)
-  where
-  ext′ : P.Extensionality ℓ₁ ℓ₂
-  ext′ = P.extensionality-for-lower-levels ℓ₁ (suc ℓ₂) ext
-
-------------------------------------------------------------------------
 -- Inspect
 
 -- Inspect can be used when you want to pattern match on the result r
@@ -343,4 +319,14 @@ Please use ≅-heterogeneous-irrelevantˡ instead."
 {-# WARNING_ON_USAGE ≅-heterogeneous-irrelevanceʳ
 "Warning: ≅-heterogeneous-irrelevanceʳ was deprecated in v1.0.
 Please use ≅-heterogeneous-irrelevantʳ instead."
+#-}
+Extensionality = Ext.Extensionality
+{-# WARNING_ON_USAGE Extensionality
+"Warning: Extensionality was deprecated in v1.0.
+Please use Extensionality from `Axiom.Extensionality.Heterogeneous` instead."
+#-}
+≡-ext-to-≅-ext = Ext.≡-ext⇒≅-ext
+{-# WARNING_ON_USAGE ≡-ext-to-≅-ext
+"Warning: ≡-ext-to-≅-ext was deprecated in v1.0.
+Please use ≡-ext⇒≅-ext from `Axiom.Extensionality.Heterogeneous` instead."
 #-}

--- a/src/Relation/Binary/HeterogeneousEquality/Core.agda
+++ b/src/Relation/Binary/HeterogeneousEquality/Core.agda
@@ -26,3 +26,6 @@ data _≅_ {ℓ} {A : Set ℓ} (x : A) : {B : Set ℓ} → B → Set ℓ where
 
 ≅-to-≡ : ∀ {a} {A : Set a} {x y : A} → x ≅ y → x ≡ y
 ≅-to-≡ refl = refl
+
+≡-to-≅ : ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≅ y
+≡-to-≅ refl = refl

--- a/src/Relation/Binary/PropositionalEquality.agda
+++ b/src/Relation/Binary/PropositionalEquality.agda
@@ -8,6 +8,7 @@
 
 module Relation.Binary.PropositionalEquality where
 
+import Axiom.Extensionality.Propositional as Ext
 open import Function
 open import Function.Equality using (Π; _⟶_; ≡-setoid)
 open import Level
@@ -119,48 +120,15 @@ inspect f x = [ refl ]
 -- f x y | c z | [ eq ] = ...
 
 ------------------------------------------------------------------------
--- Functional extensionality
-
--- If _≡_ were extensional, then the following statement could be
--- proved.
-
-Extensionality : (a b : Level) → Set _
-Extensionality a b =
-  {A : Set a} {B : A → Set b} {f g : (x : A) → B x} →
-  (∀ x → f x ≡ g x) → f ≡ g
-
--- If extensionality holds for a given universe level, then it also
--- holds for lower ones.
-
-extensionality-for-lower-levels :
-  ∀ {a₁ b₁} a₂ b₂ →
-  Extensionality (a₁ ⊔ a₂) (b₁ ⊔ b₂) → Extensionality a₁ b₁
-extensionality-for-lower-levels a₂ b₂ ext f≡g =
-  cong (λ h → lower ∘ h ∘ lift) $
-    ext (cong (lift {ℓ = b₂}) ∘ f≡g ∘ lower {ℓ = a₂})
-
--- Functional extensionality implies a form of extensionality for
--- Π-types.
-
-∀-extensionality :
-  ∀ {a b} →
-  Extensionality a (suc b) →
-  {A : Set a} (B₁ B₂ : A → Set b) →
-  (∀ x → B₁ x ≡ B₂ x) → (∀ x → B₁ x) ≡ (∀ x → B₂ x)
-∀-extensionality ext B₁ B₂ B₁≡B₂ with ext B₁≡B₂
-∀-extensionality ext B .B  B₁≡B₂ | refl = refl
-
-------------------------------------------------------------------------
 -- Propositionality
 
 isPropositional : ∀ {a} → Set a → Set a
 isPropositional A = (a b : A) → a ≡ b
 
-
-module _ {a} {A : Set a} {x y : A} where
-
 ------------------------------------------------------------------------
 -- Various equality rearrangement lemmas
+
+module _ {a} {A : Set a} {x y : A} where
 
   trans-injectiveˡ : ∀ {z} {p₁ p₂ : x ≡ y} (q : y ≡ z) →
                      trans p₁ q ≡ trans p₂ q → p₁ ≡ p₂
@@ -257,3 +225,29 @@ module _ {a} {A : Set a} (_≟_ : Decidable (_≡_ {A = A})) {a : A} where
   ≢-≟-identity {b} ¬eq with a ≟ b
   ... | yes p = ⊥-elim (¬eq p)
   ... | no ¬p = ¬p , refl
+
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.0
+
+Extensionality = Ext.Extensionality
+{-# WARNING_ON_USAGE Extensionality
+"Warning: Extensionality was deprecated in v1.0.
+Please use Extensionality from `Axiom.Extensionality.Propositional` instead."
+#-}
+extensionality-for-lower-levels = Ext.lower
+{-# WARNING_ON_USAGE extensionality-for-lower-levels
+"Warning: extensionality-for-lower-levels was deprecated in v1.0.
+Please use lower from `Axiom.Extensionality.Propositional` instead."
+#-}
+∀-extensionality = Ext.∀-extensionality
+{-# WARNING_ON_USAGE ∀-extensionality
+"Warning: ∀-extensionality was deprecated in v1.0.
+Please use ∀-extensionality from `Axiom.Extensionality.Propositional` instead."
+#-}

--- a/src/Relation/Binary/PropositionalEquality.agda
+++ b/src/Relation/Binary/PropositionalEquality.agda
@@ -9,6 +9,7 @@
 module Relation.Binary.PropositionalEquality where
 
 import Axiom.Extensionality.Propositional as Ext
+open import Axiom.UniquenessOfIdentityProofs
 open import Function
 open import Function.Equality using (Π; _⟶_; ≡-setoid)
 open import Level
@@ -16,7 +17,6 @@ open import Data.Empty
 open import Data.Product
 open import Relation.Nullary using (yes ; no)
 open import Relation.Unary using (Pred)
-open import Axiom.UIP
 open import Relation.Binary
 open import Relation.Binary.Indexed.Heterogeneous
   using (IndexedSetoid)

--- a/src/Relation/Binary/PropositionalEquality.agda
+++ b/src/Relation/Binary/PropositionalEquality.agda
@@ -241,10 +241,10 @@ Extensionality = Ext.Extensionality
 "Warning: Extensionality was deprecated in v1.0.
 Please use Extensionality from `Axiom.Extensionality.Propositional` instead."
 #-}
-extensionality-for-lower-levels = Ext.lower
+extensionality-for-lower-levels = Ext.lower-extensionality
 {-# WARNING_ON_USAGE extensionality-for-lower-levels
 "Warning: extensionality-for-lower-levels was deprecated in v1.0.
-Please use lower from `Axiom.Extensionality.Propositional` instead."
+Please use lower-extensionality from `Axiom.Extensionality.Propositional` instead."
 #-}
 ∀-extensionality = Ext.∀-extensionality
 {-# WARNING_ON_USAGE ∀-extensionality

--- a/src/Relation/Binary/PropositionalEquality/WithK.agda
+++ b/src/Relation/Binary/PropositionalEquality/WithK.agda
@@ -9,7 +9,7 @@
 
 module Relation.Binary.PropositionalEquality.WithK where
 
-open import Axiom.UIP.WithK
+open import Axiom.UniquenessOfIdentityProofs.WithK
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality.Core
 

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -165,22 +165,25 @@ private
     helper (true  , f) = inj₁ f
     helper (false , f) = inj₂ f
 
--- The classical statements of excluded middle and double-negation
--- elimination.
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.0
 
 Excluded-Middle : (ℓ : Level) → Set (suc ℓ)
 Excluded-Middle p = {P : Set p} → Dec P
+{-# WARNING_ON_USAGE Excluded-Middle
+"Warning: Excluded-Middle was deprecated in v1.0.
+Please use ExcludedMiddle from `Axiom.ExcludedMiddle` instead."
+#-}
 
 Double-Negation-Elimination : (ℓ : Level) → Set (suc ℓ)
 Double-Negation-Elimination p = {P : Set p} → Stable P
-
-private
-
-  -- The two statements above are equivalent. The proofs are so
-  -- simple, given the definitions above, that they are not exported.
-
-  em⇒dne : ∀ {ℓ} → Excluded-Middle ℓ → Double-Negation-Elimination ℓ
-  em⇒dne em = decidable-stable em
-
-  dne⇒em : ∀ {ℓ} → Double-Negation-Elimination ℓ → Excluded-Middle ℓ
-  dne⇒em dne = dne excluded-middle
+{-# WARNING_ON_USAGE Double-Negation-Elimination
+"Warning: Double-Negation-Elimination was deprecated in v1.0.
+Please use DoubleNegationElimination from `Axiom.DoubleNegationElimination` instead."
+#-}


### PR DESCRIPTION
Trying to sneak one more thing in before v1.0. I've moved the existing axioms out of their old places in `Relation.Binary.PropositionalEquality` and `Relation.Nullary.Negation` and into new `Axiom` modules.

@gallais I'd appreciate a review in case I've written anything silly! Also is the hierarchy deep enough? I know you said you want to add implicit extensionality in #184 and uninformative excluded middle?