### PR TITLE
Implement Reader monad (transformer)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ New modules
 
 The following new modules have been added to the library:
 ```
+Category.Monad.Reader
+
 Data.List.Relation.Binary.Disjoint.Propositional
 Data.List.Relation.Binary.Disjoint.Setoid
 Data.List.Relation.Binary.Disjoint.Setoid.Properties

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -1,0 +1,76 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The reader monad
+------------------------------------------------------------------------
+
+module Category.Monad.Reader where
+
+open import Level
+open import Function
+open import Function.Identity.Categorical as Id using (Identity)
+open import Category.Applicative.Indexed using (IFun)
+open import Category.Monad.Indexed
+open import Category.Monad
+open import Data.Unit
+
+------------------------------------------------------------------------
+-- Indexed reader
+
+IReaderT : ∀ {r} (R : Set r) {i} {I : Set i} (M : IFun I r) → IFun I r
+IReaderT R M i j A = R → M i j A
+
+------------------------------------------------------------------------
+-- Indexed reader monad
+
+ReaderTIMonad : ∀ {r} (R : Set r) {i} {I : Set i} {M : IFun I r} →
+                RawIMonad M → RawIMonad (IReaderT R M)
+ReaderTIMonad R Mon = record
+  { return = λ x r → return x
+  ; _>>=_ = λ m f r → m r >>= flip f r
+  } where open RawIMonad Mon
+
+------------------------------------------------------------------------
+-- Reader monad operations
+
+record RawIMonadReader {r} (R : Set r) {i} {I : Set i}
+                       (M : IFun I r) : Set (i ⊔ suc r) where
+  field
+    monad : RawIMonad M
+    ask   : ∀ {i} → M i i R
+    local : ∀ {i j} → (R → R) → M i j R → M i j R
+
+  open RawIMonad monad public
+
+  asks : ∀ {i A} → (R → A) → M i i A
+  asks f = f <$> ask
+
+ReaderTIMonadReader : ∀ {r} (R : Set r) {i} {I : Set i} {M : IFun I r} →
+                      RawIMonad M → RawIMonadReader R (IReaderT R M)
+ReaderTIMonadReader R Mon = record
+  { monad = ReaderTIMonad R Mon
+  ; ask = return
+  ; local = λ f m → m ∘ f
+  } where open RawIMonad Mon
+
+------------------------------------------------------------------------
+-- Ordinary reader monad
+
+ReaderT : ∀ {r} (R : Set r) (M : Set r → Set r) → Set r → Set r
+ReaderT R M = IReaderT R {I = ⊤} (λ _ _ → M) _ _
+
+RawMonadReader : ∀ {r} → Set r → (Set r → Set r) → Set _
+RawMonadReader R M = RawIMonadReader R {I = ⊤} (λ _ _ → M)
+
+module RawMonadReader {r} {R : Set r} {M : Set r → Set r}
+                      (Mon : RawMonadReader R M) where
+  open RawIMonadReader Mon public
+
+Reader : ∀ {r} → Set r → Set r → Set r
+Reader R = ReaderT R Identity
+
+ReaderMonad : ∀ {r} (R : Set r) → RawMonad (Reader R)
+ReaderMonad R = ReaderTIMonad R Id.monad
+
+ReaderMonadReader : ∀ {r} (R : Set r) → RawMonadReader R (Reader R)
+ReaderMonadReader R = ReaderTIMonadReader R Id.monad

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -17,60 +17,56 @@ open import Category.Monad.Indexed
 open import Category.Monad
 open import Data.Unit
 
-private
-  variable
-    ℓ : Level
-    I : Set ℓ
-    M : IFun I (r ⊔ a)
-
 ------------------------------------------------------------------------
 -- Indexed reader
 
-IReaderT : IFun I (r ⊔ a) → IFun I (r ⊔ a)
+IReaderT : ∀ {ℓ} {I : Set ℓ} → IFun I (r ⊔ a) → IFun I (r ⊔ a)
 IReaderT M i j A = R → M i j A
 
-------------------------------------------------------------------------
--- Indexed reader applicative
+module _ {ℓ} {I : Set ℓ} {M : IFun I (r ⊔ a)} where
 
-ReaderTIApplicative : RawIApplicative M → RawIApplicative (IReaderT M)
-ReaderTIApplicative App = record
-  { pure = λ x r → pure x
-  ; _⊛_ = λ m n r → m r ⊛ n r
-  } where open RawIApplicative App
+  ------------------------------------------------------------------------
+  -- Indexed reader applicative
 
-ReaderTIApplicativeZero : RawIApplicativeZero M →
-                          RawIApplicativeZero (IReaderT M)
-ReaderTIApplicativeZero App = record
-  { applicative = ReaderTIApplicative applicative
-  ; ∅ = const ∅
-  } where open RawIApplicativeZero App
+  ReaderTIApplicative : RawIApplicative M → RawIApplicative (IReaderT M)
+  ReaderTIApplicative App = record
+    { pure = λ x r → pure x
+    ; _⊛_ = λ m n r → m r ⊛ n r
+    } where open RawIApplicative App
 
-ReaderTIAlternative : RawIAlternative M → RawIAlternative (IReaderT M)
-ReaderTIAlternative Alt = record
-  { applicativeZero = ReaderTIApplicativeZero applicativeZero
-  ; _∣_ = λ m n r → m r ∣ n r
-  } where open RawIAlternative Alt
+  ReaderTIApplicativeZero : RawIApplicativeZero M →
+                            RawIApplicativeZero (IReaderT M)
+  ReaderTIApplicativeZero App = record
+    { applicative = ReaderTIApplicative applicative
+    ; ∅ = const ∅
+    } where open RawIApplicativeZero App
 
-------------------------------------------------------------------------
--- Indexed reader monad
+  ReaderTIAlternative : RawIAlternative M → RawIAlternative (IReaderT M)
+  ReaderTIAlternative Alt = record
+    { applicativeZero = ReaderTIApplicativeZero applicativeZero
+    ; _∣_ = λ m n r → m r ∣ n r
+    } where open RawIAlternative Alt
 
-ReaderTIMonad : RawIMonad M → RawIMonad (IReaderT M)
-ReaderTIMonad Mon = record
-  { return = λ x r → return x
-  ; _>>=_ = λ m f r → m r >>= flip f r
-  } where open RawIMonad Mon
+  ------------------------------------------------------------------------
+  -- Indexed reader monad
 
-ReaderTIMonadZero : RawIMonadZero M → RawIMonadZero (IReaderT M)
-ReaderTIMonadZero Mon = record
-  { monad = ReaderTIMonad monad
-  ; applicativeZero = ReaderTIApplicativeZero applicativeZero
-  } where open RawIMonadZero Mon
+  ReaderTIMonad : RawIMonad M → RawIMonad (IReaderT M)
+  ReaderTIMonad Mon = record
+    { return = λ x r → return x
+    ; _>>=_ = λ m f r → m r >>= flip f r
+    } where open RawIMonad Mon
 
-ReaderTIMonadPlus : RawIMonadPlus M → RawIMonadPlus (IReaderT M)
-ReaderTIMonadPlus Mon = record
-  { monad = ReaderTIMonad monad
-  ; alternative = ReaderTIAlternative alternative
-  } where open RawIMonadPlus Mon
+  ReaderTIMonadZero : RawIMonadZero M → RawIMonadZero (IReaderT M)
+  ReaderTIMonadZero Mon = record
+    { monad = ReaderTIMonad monad
+    ; applicativeZero = ReaderTIApplicativeZero applicativeZero
+    } where open RawIMonadZero Mon
+
+  ReaderTIMonadPlus : RawIMonadPlus M → RawIMonadPlus (IReaderT M)
+  ReaderTIMonadPlus Mon = record
+    { monad = ReaderTIMonad monad
+    ; alternative = ReaderTIAlternative alternative
+    } where open RawIMonadPlus Mon
 
 ------------------------------------------------------------------------
 -- Reader monad operations
@@ -90,7 +86,8 @@ record RawIMonadReader {ℓ} {I : Set ℓ} (M : IFun I (r ⊔ a))
   asks : ∀ {i A} → (R → A) → M i i A
   asks = reader
 
-ReaderTIMonadReader : RawIMonad M → RawIMonadReader (IReaderT M)
+ReaderTIMonadReader : ∀ {ℓ} {I : Set ℓ} {M : IFun I (r ⊔ a)} →
+                      RawIMonad M → RawIMonadReader (IReaderT M)
 ReaderTIMonadReader Mon = record
   { monad = ReaderTIMonad Mon
   ; reader = λ f r → return (f r)

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -54,10 +54,7 @@ ReaderTIMonadReader R Mon = record
   } where open RawIMonad Mon
 
 ------------------------------------------------------------------------
--- Ordinary reader monad
-
-ReaderT : ∀ {r} (R : Set r) (M : Set r → Set r) → Set r → Set r
-ReaderT R M = IReaderT R {I = ⊤} (λ _ _ → M) _ _
+-- Ordinary reader monads
 
 RawMonadReader : ∀ {r} → Set r → (Set r → Set r) → Set _
 RawMonadReader R M = RawIMonadReader R {I = ⊤} (λ _ _ → M)
@@ -65,6 +62,16 @@ RawMonadReader R M = RawIMonadReader R {I = ⊤} (λ _ _ → M)
 module RawMonadReader {r} {R : Set r} {M : Set r → Set r}
                       (Mon : RawMonadReader R M) where
   open RawIMonadReader Mon public
+
+ReaderT : ∀ {r} (R : Set r) (M : Set r → Set r) → Set r → Set r
+ReaderT R M = IReaderT R {I = ⊤} (λ _ _ → M) _ _
+
+ReaderTMonad : ∀ {r} (R : Set r) {M} → RawMonad M → RawMonad (ReaderT R M)
+ReaderTMonad R Mon = ReaderTIMonad R Mon
+
+ReaderTMonadReader : ∀ {r} (R : Set r) {M} →
+                     RawMonad M → RawMonadReader R (ReaderT R M)
+ReaderTMonadReader R Mon = ReaderTIMonadReader R Mon
 
 Reader : ∀ {r} → Set r → Set r → Set r
 Reader R = ReaderT R Identity

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -4,6 +4,8 @@
 -- The reader monad
 ------------------------------------------------------------------------
 
+{-# OPTIONS --without-K --safe #-}
+
 module Category.Monad.Reader where
 
 open import Level


### PR DESCRIPTION
Closes #690 

EDIT: now it is properly universe polymorphic

```agda
module Category.Monad.Reader {r} (R : Set r) (a : Level) where

IReaderT : ∀ {ℓ} {I : Set ℓ} → IFun I (r ⊔ a) → IFun I (r ⊔ a)
IReaderT M i j A = R → M i j A

ReaderT : (Set (r ⊔ a) → Set (r ⊔ a)) → Set (r ⊔ a) → Set (r ⊔ a)
ReaderT M A = R → M A

Reader : Set (r ⊔ a) → Set (r ⊔ a)
Reader A = R → A

record RawIMonadReader {ℓ} {I : Set ℓ} (M : IFun I (r ⊔ a))
                       : Set (ℓ ⊔ suc (r ⊔ a)) where
  field
    monad  : RawIMonad M
    reader : ∀ {i A} → (R → A) → M i i A
    local  : ∀ {i j A} → (R → R) → M i j A → M i j A
```