### PR TITLE
deprecate `Foreign.Haskell.Unit`

### DIFF
--- a/src/Foreign/Haskell.agda
+++ b/src/Foreign/Haskell.agda
@@ -13,8 +13,16 @@ open import Level
 -- A unit type.
 
 open import Data.Unit using () renaming (⊤ to Unit; tt to unit) public
-{-# WARNING_ON_USAGE Unit "DEPRECATED: Use `⊤` instead of `Unit`" #-}
-{-# WARNING_ON_USAGE unit "DEPRECATED: Use `tt` instead of `unit`" #-}
+
+{-# WARNING_ON_USAGE Unit
+"Warning: Unit was deprecated in v1.1.
+Please use ⊤ from Data.Unit instead."
+#-}
+
+{-# WARNING_ON_USAGE unit
+"Warning: unit was deprecated in v1.1.
+Please use tt from Data.Unit instead."
+#-}
 
 -- A pair type
 

--- a/src/Foreign/Haskell.agda
+++ b/src/Foreign/Haskell.agda
@@ -12,11 +12,9 @@ open import Level
 
 -- A unit type.
 
-data Unit : Set where
-  unit : Unit
-
-{-# COMPILE GHC Unit = data () (()) #-}
-{-# COMPILE UHC Unit = data __UNIT__ (__UNIT__) #-}
+open import Data.Unit using () renaming (⊤ to Unit; tt to unit) public
+{-# WARNING_ON_USAGE Unit "DEPRECATED: Use `⊤` instead of `Unit`" #-}
+{-# WARNING_ON_USAGE unit "DEPRECATED: Use `tt` instead of `unit`" #-}
 
 -- A pair type
 


### PR DESCRIPTION
It seems to me like the `Unit` in `Foreign.Haskell` was added at least as early as 2009, and since then, a change was committed that makes the `⊤` type from `Data.Unit` actually map to Haskell’s `()` (from `Agda.Builtin.Unit`), which renders the `Unit` type useless.