### PR TITLE
point at Induction.Nat in docs of Data.Nat.Base

### DIFF
--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -2,6 +2,8 @@
 -- The Agda standard library
 --
 -- Natural numbers, basic types and operations
+--
+-- See also Induction.Nat (for example, if you're seeking an eliminator).
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}


### PR DESCRIPTION
I figured there must be an eliminator defined in the standard library, but it took me a while to find it...
