### PR TITLE
[ fix #724 ] rename setoid and order results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Deprecated features
   ```agda
   setoid           ↦ ≡-setoid
   decSetoid        ↦ ≡-decSetoid
-  strictTotalOrder ↦ <-strictTotalOrder
+  strictTotalOrder ↦ ≈-<-strictTotalOrder
   ```
 
 Other minor additions
@@ -96,6 +96,30 @@ Other minor additions
 * Added new function to `Data.AVL.Indexed`:
   ```agda
   toList : Tree V l u h → List (K& V)
+  ```
+
+* Added new definitions to `Data.Char.Base`:
+  ```agda
+  _≈_ : Rel Char zero
+  _<_ : Rel Char zero
+  ```
+
+* Added new properties to `Data.Char.Properties`:
+  ```agda
+  ≈⇒≡         : _≈_ ⇒ _≡_
+  ≈-reflexive : _≡_ ⇒ _≈_
+  ≈-refl      : Reflexive _≈_
+  ≈-sym       : Symmetric _≈_
+  ≈-trans     : Transitive _≈_
+  ≈-subst     : ∀ {ℓ} → Substitutive _≈_ ℓ
+  _≈?_        : Decidable _≈_
+
+  ≈-isEquivalence    : IsEquivalence _≈_
+  ≈-setoid           : Setoid _ _
+  ≈-isDecEquivalence : IsDecEquivalence _≈_
+  ≈-decSetoid        : DecSetoid _ _
+
+  _<?_ : Decidable _<_
   ```
 
 * Added new function to `Data.Digit`:
@@ -148,6 +172,30 @@ Other minor additions
 * Added new functions to `Data.Product`:
   ```agda
   zip′ : (A → B → C) → (D → E → F) → A × D → B × E → C × F
+  ```
+
+* Added new definitions to `Data.String.Base`:
+  ```agda
+  _≈_ : Rel String zero
+  _<_ : Rel String zero
+  ```
+
+* Added new properties to `Data.String.Properties`:
+  ```agda
+  ≈⇒≡         : _≈_ ⇒ _≡_
+  ≈-reflexive : _≡_ ⇒ _≈_
+  ≈-refl      : Reflexive _≈_
+  ≈-sym       : Symmetric _≈_
+  ≈-trans     : Transitive _≈_
+  ≈-subst     : ∀ {ℓ} → Substitutive _≈_ ℓ
+  _≈?_        : Decidable _≈_
+
+  ≈-isEquivalence    : IsEquivalence _≈_
+  ≈-setoid           : Setoid _ _
+  ≈-isDecEquivalence : IsDecEquivalence _≈_
+  ≈-decSetoid        : DecSetoid _ _
+
+  _<?_ : Decidable _<_
   ```
 
 * Added new proof to `Relation.Binary.PropositionalEquality.Core`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ Deprecated features
   ```agda
   setoid           ↦ ≡-setoid
   decSetoid        ↦ ≡-decSetoid
-  strictTotalOrder ↦ ≈-<-strictTotalOrder
+  strictTotalOrder ↦ <-strictTotalOrder-≈
   ```
 
 Other minor additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ Deprecated features
   returnTC ↦ return
   ```
 
+* In `Data.(Char/String).Properties`:
+  ```agda
+  setoid           ↦ ≡-setoid
+  decSetoid        ↦ ≡-decSetoid
+  strictTotalOrder ↦ <-strictTotalOrder
+  ```
+
 Other minor additions
 ---------------------
 

--- a/README/List.agda
+++ b/README/List.agda
@@ -9,7 +9,7 @@
 module README.List where
 
 open import Algebra.Structures
-open import Data.Char
+open import Data.Char.Base using (Char; fromNat)
 open import Data.Char.Properties as CharProp hiding (setoid)
 open import Data.Nat
 open import Data.Nat.Properties as NatProp

--- a/README/Trie/NonDependent.agda
+++ b/README/Trie/NonDependent.agda
@@ -62,7 +62,7 @@ open import Data.These         as These
 
 open import Function using (case_of_; _$_; _∘′_; id)
 
-open import Data.Trie Char.≈-<-strictTotalOrder
+open import Data.Trie Char.<-strictTotalOrder-≈
 open import Data.AVL.Value
 
 ------------------------------------------------------------------------

--- a/README/Trie/NonDependent.agda
+++ b/README/Trie/NonDependent.agda
@@ -62,7 +62,7 @@ open import Data.These         as These
 
 open import Function using (case_of_; _$_; _∘′_; id)
 
-open import Data.Trie Char.strictTotalOrder
+open import Data.Trie Char.<-strictTotalOrder
 open import Data.AVL.Value
 
 ------------------------------------------------------------------------

--- a/README/Trie/NonDependent.agda
+++ b/README/Trie/NonDependent.agda
@@ -62,7 +62,7 @@ open import Data.These         as These
 
 open import Function using (case_of_; _$_; _∘′_; id)
 
-open import Data.Trie Char.<-strictTotalOrder
+open import Data.Trie Char.≈-<-strictTotalOrder
 open import Data.AVL.Value
 
 ------------------------------------------------------------------------

--- a/src/Data/Char.agda
+++ b/src/Data/Char.agda
@@ -12,4 +12,4 @@ module Data.Char where
 -- Re-export base definitions and decidability of equality
 
 open import Data.Char.Base public
-open import Data.Char.Properties using (_≟_; _==_) public
+open import Data.Char.Properties using (_≈?_; _≟_; _<?_; _==_) public

--- a/src/Data/Char/Base.agda
+++ b/src/Data/Char/Base.agda
@@ -8,6 +8,12 @@
 
 module Data.Char.Base where
 
+open import Level using (zero)
+import Data.Nat.Base as ℕ
+open import Function
+open import Relation.Binary using (Rel)
+open import Relation.Binary.PropositionalEquality
+
 ------------------------------------------------------------------------
 -- Re-export the type, and renamed primitives
 
@@ -32,3 +38,11 @@ open import Agda.Builtin.Char public using ( Char )
 
 open import Agda.Builtin.String public using ()
   renaming ( primShowChar to show )
+
+infix 4 _≈_
+_≈_ : Rel Char zero
+_≈_ = _≡_ on toNat
+
+infix 4 _<_
+_<_ : Rel Char zero
+_<_ = ℕ._<_ on toNat

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -16,7 +16,8 @@ import Data.Nat.Properties as ℕₚ
 open import Function
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable using (map′;  ⌊_⌋)
-open import Relation.Binary using (Decidable; Setoid; DecSetoid; StrictTotalOrder)
+open import Relation.Binary
+  using (Decidable; Setoid; DecSetoid; StrictTotalOrder)
 open import Relation.Binary.PropositionalEquality.Core
 import Relation.Binary.Construct.On as On
 import Relation.Binary.PropositionalEquality as PropEq
@@ -62,11 +63,32 @@ private
 ------------------------------------------------------------------------
 -- Structures
 
-setoid : Setoid _ _
-setoid = PropEq.setoid Char
+≡-setoid : Setoid _ _
+≡-setoid = PropEq.setoid Char
 
-decSetoid : DecSetoid _ _
-decSetoid = PropEq.decSetoid _≟_
+≡-decSetoid : DecSetoid _ _
+≡-decSetoid = PropEq.decSetoid _≟_
 
-strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
+<-strictTotalOrder : StrictTotalOrder _ _ _
+<-strictTotalOrder = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
+
+
+-- Version 1.1
+
+setoid = ≡-setoid
+{-# WARNING_ON_USAGE setoid
+"Warning: setoid was deprecated in v1.1.
+Please use ≡-setoid instead."
+#-}
+
+decSetoid = ≡-decSetoid
+{-# WARNING_ON_USAGE decSetoid
+"Warning: decSetoid was deprecated in v1.1.
+Please use ≡-decSetoid instead."
+#-}
+
+strictTotalOrder = <-strictTotalOrder
+{-# WARNING_ON_USAGE strictTotalOrder
+"Warning: strictTotalOrder was deprecated in v1.1.
+Please use <-strictTotalOrder instead."
+#-}

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -11,13 +11,16 @@ module Data.Char.Properties where
 open import Data.Bool using (Bool)
 open import Data.Char.Base
 
+import Data.Nat.Base as ℕ
 import Data.Nat.Properties as ℕₚ
 
 open import Function
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable using (map′;  ⌊_⌋)
 open import Relation.Binary
-  using (Decidable; Setoid; DecSetoid; StrictTotalOrder)
+  using ( _⇒_; Reflexive; Symmetric; Transitive; Substitutive
+        ; Decidable; IsEquivalence; IsDecEquivalence
+        ; Setoid; DecSetoid; StrictTotalOrder)
 open import Relation.Binary.PropositionalEquality.Core
 import Relation.Binary.Construct.On as On
 import Relation.Binary.PropositionalEquality as PropEq
@@ -30,12 +33,64 @@ open import Agda.Builtin.Char.Properties
   public
 
 ------------------------------------------------------------------------
--- Decidable equality
+-- Properties of _≈_
+
+≈⇒≡ : _≈_ ⇒ _≡_
+≈⇒≡ = toNat-injective _ _
+
+≈-reflexive : _≡_ ⇒ _≈_
+≈-reflexive = cong toNat
+
+≈-refl : Reflexive _≈_
+≈-refl = refl
+
+≈-sym : Symmetric _≈_
+≈-sym = sym
+
+≈-trans : Transitive _≈_
+≈-trans = trans
+
+≈-subst : ∀ {ℓ} → Substitutive _≈_ ℓ
+≈-subst P x≈y p = subst P (≈⇒≡ x≈y) p
+
+infix 4 _≈?_
+_≈?_ : Decidable _≈_
+x ≈? y = toNat x ℕₚ.≟ toNat y
+
+≈-isEquivalence : IsEquivalence _≈_
+≈-isEquivalence = record
+  { refl  = λ {i} → ≈-refl {i}
+  ; sym   = λ {i j} → ≈-sym {i} {j}
+  ; trans = λ {i j k} → ≈-trans {i} {j} {k}
+  }
+
+≈-setoid : Setoid _ _
+≈-setoid = record
+  { isEquivalence = ≈-isEquivalence
+  }
+
+≈-isDecEquivalence : IsDecEquivalence _≈_
+≈-isDecEquivalence = record
+  { isEquivalence = ≈-isEquivalence
+  ; _≟_           = _≈?_
+  }
+
+≈-decSetoid : DecSetoid _ _
+≈-decSetoid = record
+  { isDecEquivalence = ≈-isDecEquivalence
+  }
+------------------------------------------------------------------------
+-- Properties of _≡_
 
 infix 4 _≟_
 _≟_ : Decidable {A = Char} _≡_
-x ≟ y = map′ (toNat-injective x y) (cong toNat)
-      $ toNat x ℕₚ.≟ toNat y
+x ≟ y = map′ ≈⇒≡ ≈-reflexive $ x ≈? y
+
+≡-setoid : Setoid _ _
+≡-setoid = PropEq.setoid Char
+
+≡-decSetoid : DecSetoid _ _
+≡-decSetoid = PropEq.decSetoid _≟_
 
 ------------------------------------------------------------------------
 -- Boolean equality test.
@@ -61,17 +116,14 @@ private
   unit-test = p _
 
 ------------------------------------------------------------------------
--- Structures
+-- Properties of _<_
 
-≡-setoid : Setoid _ _
-≡-setoid = PropEq.setoid Char
+infix 4 _<?_
+_<?_ : Decidable _<_
+_<?_ = On.decidable toNat ℕ._<_ ℕₚ._<?_
 
-≡-decSetoid : DecSetoid _ _
-≡-decSetoid = PropEq.decSetoid _≟_
-
-<-strictTotalOrder : StrictTotalOrder _ _ _
-<-strictTotalOrder = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
-
+≈-<-strictTotalOrder : StrictTotalOrder _ _ _
+≈-<-strictTotalOrder = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
 
 -- Version 1.1
 
@@ -87,8 +139,8 @@ decSetoid = ≡-decSetoid
 Please use ≡-decSetoid instead."
 #-}
 
-strictTotalOrder = <-strictTotalOrder
+strictTotalOrder = ≈-<-strictTotalOrder
 {-# WARNING_ON_USAGE strictTotalOrder
 "Warning: strictTotalOrder was deprecated in v1.1.
-Please use <-strictTotalOrder instead."
+Please use ≈-<-strictTotalOrder instead."
 #-}

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -95,7 +95,7 @@ x ≟ y = map′ ≈⇒≡ ≈-reflexive $ x ≈? y
 ------------------------------------------------------------------------
 -- Boolean equality test.
 --
--- Why is the definition _==_ = primCharEquality not used? One reason
+-- Why is the definition _==_ = primCharEquality not used? One reason
 -- is that the present definition can sometimes improve type
 -- inference, at least with the version of Agda that is current at the
 -- time of writing: see unit-test below.
@@ -122,8 +122,8 @@ infix 4 _<?_
 _<?_ : Decidable _<_
 _<?_ = On.decidable toNat ℕ._<_ ℕₚ._<?_
 
-≈-<-strictTotalOrder : StrictTotalOrder _ _ _
-≈-<-strictTotalOrder = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
+<-strictTotalOrder-≈ : StrictTotalOrder _ _ _
+<-strictTotalOrder-≈ = On.strictTotalOrder ℕₚ.<-strictTotalOrder toNat
 
 -- Version 1.1
 
@@ -139,8 +139,8 @@ decSetoid = ≡-decSetoid
 Please use ≡-decSetoid instead."
 #-}
 
-strictTotalOrder = ≈-<-strictTotalOrder
+strictTotalOrder = <-strictTotalOrder-≈
 {-# WARNING_ON_USAGE strictTotalOrder
 "Warning: strictTotalOrder was deprecated in v1.1.
-Please use ≈-<-strictTotalOrder instead."
+Please use <-strictTotalOrder-≈ instead."
 #-}

--- a/src/Data/String.agda
+++ b/src/Data/String.agda
@@ -15,7 +15,7 @@ open import Data.Char as Char using (Char)
 -- Re-export contents of base, and decidability of equality
 
 open import Data.String.Base public
-open import Data.String.Properties using (_≟_; _==_) public
+open import Data.String.Properties using (_≈?_; _≟_; _<?_; _==_) public
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -8,11 +8,16 @@
 
 module Data.String.Base where
 
+open import Level using (zero)
 open import Data.Nat.Base as Nat using (ℕ)
 open import Data.List.Base as List using (List)
 open import Data.List.NonEmpty as NE using (List⁺)
-open import Agda.Builtin.Char using (Char)
+open import Data.List.Relation.Binary.Pointwise using (Pointwise)
+open import Data.List.Relation.Binary.Lex.Strict using (Lex-<)
+open import Data.Char.Base as Char using (Char)
 open import Function
+open import Relation.Binary using (Rel)
+open import Relation.Binary.PropositionalEquality
 
 ------------------------------------------------------------------------
 -- From Agda.Builtin: type and renamed primitives
@@ -28,6 +33,21 @@ open String public using ( String )
   ; primStringFromList to fromList
   ; primShowString     to show
   )
+
+------------------------------------------------------------------------
+-- Relations
+
+-- Pointwise equality on Strings
+
+infix 4 _≈_
+_≈_ : Rel String zero
+_≈_ = Pointwise Char._≈_ on toList
+
+-- Lexicographic ordering on Strings
+
+infix 4 _<_
+_<_ : Rel String zero
+_<_ = Lex-< Char._≈_ Char._<_ on toList
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/String/Properties.agda
+++ b/src/Data/String/Properties.agda
@@ -107,10 +107,10 @@ infix 4 _<?_
 _<?_ : Decidable _<_
 x <? y = StrictLex.<-decidable Charₚ._≈?_ Charₚ._<?_ (toList x) (toList y)
 
-≈-<-strictTotalOrder : StrictTotalOrder _ _ _
-≈-<-strictTotalOrder =
+<-strictTotalOrder-≈ : StrictTotalOrder _ _ _
+<-strictTotalOrder-≈ =
   On.strictTotalOrder
-    (StrictLex.<-strictTotalOrder Charₚ.≈-<-strictTotalOrder)
+    (StrictLex.<-strictTotalOrder Charₚ.<-strictTotalOrder-≈)
     toList
 
 ------------------------------------------------------------------------
@@ -150,8 +150,8 @@ decSetoid = ≡-decSetoid
 Please use ≡-decSetoid instead."
 #-}
 
-strictTotalOrder = ≈-<-strictTotalOrder
+strictTotalOrder = <-strictTotalOrder-≈
 {-# WARNING_ON_USAGE strictTotalOrder
 "Warning: strictTotalOrder was deprecated in v1.1.
-Please use ≈-<-strictTotalOrder instead."
+Please use <-strictTotalOrder-≈ instead."
 #-}

--- a/src/Data/String/Properties.agda
+++ b/src/Data/String/Properties.agda
@@ -17,9 +17,10 @@ import Data.List.Properties as Listₚ
 open import Function
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable using (map′; ⌊_⌋)
-open import Relation.Binary using (Decidable; Setoid; DecSetoid; StrictTotalOrder)
+open import Relation.Binary
+  using (Decidable; Setoid; DecSetoid; StrictTotalOrder)
 open import Relation.Binary.PropositionalEquality.Core
-open import Data.List.Relation.Binary.Lex.Strict as StrictLex
+import Data.List.Relation.Binary.Lex.Strict as StrictLex
 import Relation.Binary.Construct.On as On
 import Relation.Binary.PropositionalEquality as PropEq
 
@@ -37,19 +38,19 @@ _≟_ : Decidable {A = String} _≡_
 x ≟ y = map′ (toList-injective x y) (cong toList)
       $ Listₚ.≡-dec Charₚ._≟_ (toList x) (toList y)
 
-setoid : Setoid _ _
-setoid = PropEq.setoid String
+≡-setoid : Setoid _ _
+≡-setoid = PropEq.setoid String
 
-decSetoid : DecSetoid _ _
-decSetoid = PropEq.decSetoid _≟_
+≡-decSetoid : DecSetoid _ _
+≡-decSetoid = PropEq.decSetoid _≟_
 
 ------------------------------------------------------------------------
 -- Lexicographic ordering on strings.
 
-strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder =
+<-strictTotalOrder : StrictTotalOrder _ _ _
+<-strictTotalOrder =
   On.strictTotalOrder
-    (StrictLex.<-strictTotalOrder Charₚ.strictTotalOrder)
+    (StrictLex.<-strictTotalOrder Charₚ.<-strictTotalOrder)
     toList
 
 ------------------------------------------------------------------------
@@ -74,3 +75,23 @@ private
 
   unit-test : P (_==_ "")
   unit-test = p _
+
+-- Version 1.1
+
+setoid = ≡-setoid
+{-# WARNING_ON_USAGE setoid
+"Warning: setoid was deprecated in v1.1.
+Please use ≡-setoid instead."
+#-}
+
+decSetoid = ≡-decSetoid
+{-# WARNING_ON_USAGE decSetoid
+"Warning: decSetoid was deprecated in v1.1.
+Please use ≡-decSetoid instead."
+#-}
+
+strictTotalOrder = <-strictTotalOrder
+{-# WARNING_ON_USAGE strictTotalOrder
+"Warning: strictTotalOrder was deprecated in v1.1.
+Please use <-strictTotalOrder instead."
+#-}


### PR DESCRIPTION
In Data.(Char/String).Properties we should be using more explicit
names.