### PR TITLE
[ re agda/agda#3701 ] Add a safe Word64 decidable equality Data.Word._≟_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,8 @@ Deprecated features
   strictTotalOrder ↦ <-strictTotalOrder-≈
   ```
 
+* Deprecated `Data.Word.Unsafe`.
+
 Other minor additions
 ---------------------
 
@@ -302,3 +304,5 @@ Other minor additions
 * The relation `_≅_` in `Relation.Binary.HeterogeneousEquality` has
   been generalised so that the types of the two equal elements need not
   be at the same universe level.
+
+* Added a safe decidable equality `Data.Word._≟_`.

--- a/src/Data/Word.agda
+++ b/src/Data/Word.agda
@@ -8,6 +8,10 @@
 
 module Data.Word where
 
+import Data.Nat as ℕ
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
+
 ------------------------------------------------------------------------
 -- Re-export built-ins publically
 
@@ -17,3 +21,9 @@ open import Agda.Builtin.Word public
   ( primWord64ToNat   to toℕ
   ; primWord64FromNat to fromℕ
   )
+open import Agda.Builtin.Word.Properties renaming (primWord64ToNatInjective to toℕ-injective)
+
+_≟_ : (a b : Word64) → Dec (a ≡ b)
+a ≟ b with toℕ a ℕ.≟ toℕ b
+(a ≟ b) | yes p = yes (toℕ-injective a b p)
+(a ≟ b) | no ¬p = no λ eq → ¬p (cong toℕ eq)

--- a/src/Data/Word/Unsafe.agda
+++ b/src/Data/Word/Unsafe.agda
@@ -22,3 +22,7 @@ a ≟ b with toℕ a ℕ.≟ toℕ b
 ... | yes _ = yes trustMe
 ... | no  _ = no whatever
   where postulate whatever : _
+{-# WARNING_ON_USAGE _≟_
+"Warning: Data.Word.Unsafe._≟_ was deprecated in v1.1.
+Please use Data.Word._≟_ instead."
+#-}

--- a/src/Reflection.agda
+++ b/src/Reflection.agda
@@ -23,8 +23,10 @@ open import Data.String using (String)
   renaming ( show to showString
            ; _≟_ to _≟s_
            )
-open import Data.Word using (Word64) renaming (toℕ to wordToℕ)
-open import Data.Word.Unsafe using () renaming (_≟_ to _≟w_)
+open import Data.Word using (Word64)
+  renaming ( toℕ to wordToℕ
+           ; _≟_ to _≟w_
+           )
 open import Data.Product
 open import Function
 open import Level


### PR DESCRIPTION
Based on the PR https://github.com/agda/agda/pull/3701, the decidable equality for `Word` is safe now.

[ For some silly reason, I closed my previous PR and recreate this one. ]