### PR TITLE
,-injectiveʳ and ≡-dec for non-dependent product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Deprecated features
 
 * In `Data.Product.Relation.Binary.Pointwise.NonDependent`:
   ```agda
-  ≡?×≡?⇒≡? ↦ Data.Product.Properites.≡-dec
+  ≡?×≡?⇒≡? ↦ Data.Product.Properties.≡-dec
   ```
 
 Other minor additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ Other minor additions
 * Added new proofs to `Data.Product.Properties`:
   ```agda
   ,-injectiveʳ : (a , b) ≡ (c , d) → b ≡ d
+  ,-injective : (a , b) ≡ (c , d) → a ≡ c × b ≡ d
   ≡-dec : Decidable {A} _≡_ → Decidable {B} _≡_ → Decidable {A × B} _≡_
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ Deprecated features
   strictTotalOrder ↦ <-strictTotalOrder-≈
   ```
 
+* In `Data.Product.Relation.Binary.Pointwise.NonDependent`:
+  ```agda
+  ≡?×≡?⇒≡? ↦ Data.Product.Properites.≡-dec
+  ```
+
 Other minor additions
 ---------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,12 @@ Other minor additions
   zip′ : (A → B → C) → (D → E → F) → A × D → B × E → C × F
   ```
 
+* Added new proofs to `Data.Product.Properties`:
+  ```agda
+  ,-injectiveʳ : (a , b) ≡ (c , d) → b ≡ d
+  ≡-dec : Decidable {A} _≡_ → Decidable {B} _≡_ → Decidable {A × B} _≡_
+  ```
+
 * Added new proofs to `Data.Rational.Properties`:
   ```agda
   ≡-setoid    : Setoid 0ℓ 0ℓ

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -32,6 +32,9 @@ module _ {a b} {A : Set a} {B : Set b} where
   ,-injectiveʳ : ∀ {a c : A} {b d : B} → (a , b) ≡ (c , d) → b ≡ d
   ,-injectiveʳ refl = refl
 
+  ,-injective : ∀ {a c : A} {b d : B} → (a , b) ≡ (c , d) → a ≡ c × b ≡ d
+  ,-injective refl = refl , refl
+
   ≡-dec : Decidable {A = A} _≡_ → Decidable {A = B} _≡_ →
           Decidable {A = A × B} _≡_
   ≡-dec dec₁ dec₂ (a , b) (c , d) with dec₁ a c

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -12,7 +12,8 @@ open import Data.Product
 open import Function using (_∘_)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Product
+import Relation.Nullary.Decidable as Dec
 
 ------------------------------------------------------------------------
 -- Equality (dependent)
@@ -37,8 +38,5 @@ module _ {a b} {A : Set a} {B : Set b} where
 
   ≡-dec : Decidable {A = A} _≡_ → Decidable {A = B} _≡_ →
           Decidable {A = A × B} _≡_
-  ≡-dec dec₁ dec₂ (a , b) (c , d) with dec₁ a c
-  ... | no a≢c = no (a≢c ∘ ,-injectiveˡ)
-  ... | yes refl with dec₂ b d
-  ...   | no b≢d  = no (b≢d ∘ ,-injectiveʳ)
-  ...   | yes refl = yes refl
+  ≡-dec dec₁ dec₂ (a , b) (c , d) =
+    Dec.map′ (uncurry (cong₂ _,_)) ,-injective (dec₁ a c ×-dec dec₂ b d)

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -9,13 +9,14 @@
 module Data.Product.Properties where
 
 open import Data.Product
+open import Data.Product.Relation.Binary.Pointwise.NonDependent as PwND
 open import Function using (_∘_)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
 
 ------------------------------------------------------------------------
--- Equality
+-- Equality (dependent)
 
 module _ {a b} {A : Set a} {B : A → Set b} where
 
@@ -23,3 +24,16 @@ module _ {a b} {A : Set a} {B : A → Set b} where
   ,-injectiveˡ refl = refl
 
   -- See also Data.Product.Properties.WithK.,-injectiveʳ.
+
+------------------------------------------------------------------------
+-- Equality (non-dependent)
+
+module _ {a b} {A : Set a} {B : Set b} where
+
+  ,-injectiveʳ : ∀ {a c : A} {b d : B} → (a , b) ≡ (c , d) → b ≡ d
+  ,-injectiveʳ refl = refl
+
+  ≡-dec : Decidable {A = A} _≡_ →
+          Decidable {A = B} _≡_ →
+          Decidable {A = A × B} _≡_
+  ≡-dec = PwND.≡?×≡?⇒≡?

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -9,7 +9,6 @@
 module Data.Product.Properties where
 
 open import Data.Product
-open import Data.Product.Relation.Binary.Pointwise.NonDependent as PwND
 open import Function using (_∘_)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
@@ -35,4 +34,8 @@ module _ {a b} {A : Set a} {B : Set b} where
 
   ≡-dec : Decidable {A = A} _≡_ → Decidable {A = B} _≡_ →
           Decidable {A = A × B} _≡_
-  ≡-dec = PwND.≡?×≡?⇒≡?
+  ≡-dec dec₁ dec₂ (a , b) (c , d) with dec₁ a c
+  ... | no a≢c = no (a≢c ∘ ,-injectiveˡ)
+  ... | yes refl with dec₂ b d
+  ...   | no b≢d  = no (b≢d ∘ ,-injectiveʳ)
+  ...   | yes refl = yes refl

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -33,7 +33,6 @@ module _ {a b} {A : Set a} {B : Set b} where
   ,-injectiveʳ : ∀ {a c : A} {b d : B} → (a , b) ≡ (c , d) → b ≡ d
   ,-injectiveʳ refl = refl
 
-  ≡-dec : Decidable {A = A} _≡_ →
-          Decidable {A = B} _≡_ →
+  ≡-dec : Decidable {A = A} _≡_ → Decidable {A = B} _≡_ →
           Decidable {A = A × B} _≡_
   ≡-dec = PwND.≡?×≡?⇒≡?

--- a/src/Data/Product/Properties/WithK.agda
+++ b/src/Data/Product/Properties/WithK.agda
@@ -9,7 +9,7 @@
 module Data.Product.Properties.WithK where
 
 open import Data.Product
-open import Data.Product.Properties
+open import Data.Product.Properties hiding (≡-dec; ,-injectiveʳ)
 open import Function
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality

--- a/src/Data/Product/Properties/WithK.agda
+++ b/src/Data/Product/Properties/WithK.agda
@@ -9,7 +9,7 @@
 module Data.Product.Properties.WithK where
 
 open import Data.Product
-open import Data.Product.Properties hiding (≡-dec; ,-injectiveʳ)
+open import Data.Product.Properties using (,-injectiveˡ)
 open import Function
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -9,6 +9,7 @@
 module Data.Product.Relation.Binary.Pointwise.NonDependent where
 
 open import Data.Product as Prod
+open import Data.Product.Properties using (≡-dec)
 open import Data.Sum
 open import Data.Unit.Base using (⊤)
 open import Function
@@ -244,10 +245,6 @@ module _ {a b} {A : Set a} {B : Set b} where
       }
     }
 
-  ≡?×≡?⇒≡? : Decidable {A = A} _≡_ → Decidable {A = B} _≡_ →
-              Decidable {A = A × B} _≡_
-  ≡?×≡?⇒≡? ≟₁ ≟₂ p q = Dec.map′ ≡×≡⇒≡ ≡⇒≡×≡ (×-decidable ≟₁ ≟₂ p q)
-
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
 ------------------------------------------------------------------------
@@ -352,8 +349,13 @@ _×-strictPartialOrder_    = ×-strictPartialOrder
 "Warning: _×-strictPartialOrder_ was deprecated in v0.15.
 Please use ×-strictPartialOrder instead."
 #-}
-_×-≟_                     = ≡?×≡?⇒≡?
+_×-≟_                     = ≡-dec
 {-# WARNING_ON_USAGE _×-≟_
 "Warning: _×-≟_ was deprecated in v0.15.
-Please use ≡?×≡?⇒≡? instead."
+Please use ≡-dec from Data.Product.Properties instead."
+#-}
+≡?×≡?⇒≡?                  = ≡-dec
+{-# WARNING_ON_USAGE ≡?×≡?⇒≡?
+"Warning: ≡?×≡?⇒≡? was deprecated in v1.1.
+Please use ≡-dec from Data.Product.Properties instead."
 #-}


### PR DESCRIPTION
These lemmas are easier to find than those in the Pointwise module. They are basically the same as the WithK variants under the same name, but since they are for non-dependent products, they do not require K.

closes #755 