### PR TITLE
Update installation instructions to download the .tar file

### DIFF
--- a/notes/installation-guide.md
+++ b/notes/installation-guide.md
@@ -3,33 +3,50 @@ Installation instructions
 
 Use version v1.0.1 of the standard library with Agda 2.6.0.
 
-Install it as follows. Say you are in directory `$HERE` (replace appropriately).
-```
-  git clone https://github.com/agda/agda-stdlib.git
-  cd agda-stdlib
-  git checkout v1.0.1
-  cabal install
-```
-The last comment is optional, omit it if you are lacking [cabal](https://www.haskell.org/cabal/).
+1. Navigate to a suitable directory `$HERE` (replace appropriately) where
+   you would like to install the library.
 
-Register it by adding the following line to `$HOME/.agda/libraries`:
-```
-  $HERE/agda-stdlib/standard-library.agda-lib
-```
+2. Download the tarball of v1.0.1 of the standard library. This can either be
+   done manually by visiting the Github repository for the library, or via the
+   command line as follows:
+   ```
+   wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/tarball/v1.0.1
+   ```
+   (you can replace `wget` with other popular tools such as `curl`).
+   
+3. Extract the standard library from the tarball. Again this can either be
+   done manually or via the command line as follows:
+   ```
+   tar -zxvf agda-stdlib.tar
+   ```
 
-To use the standard library in you project `$PROJECT`, put a file
-`$PROJECT.agda-lib` file in the project root containing:
-```
-  depend: standard-library
-  include: $DIRS
-```
-where `$DIRS` is a list of directories where Agda
-searches for modules, for instance `.` (just the project root).
+4. [ OPTIONAL ] If using [cabal](https://www.haskell.org/cabal/) then run 
+   the commands to install via cabal:
+   ```
+   cd agda-stdlib
+   cabal install
+   ```
 
-If you want to refer to the standard library in all your
-projects, add the following line to `$HOME/.agda/defaults`
-```
-  standard-library
-```
+5. Register the standard library with Agda's package system by adding 
+   the following line to `$HOME/.agda/libraries`:
+   ```
+   $HERE/agda-stdlib/standard-library.agda-lib
+   ```
 
-Find the full story at [readthedocs](http://agda.readthedocs.io/en/latest/tools/package-system.html).
+6. [ OPTIONAL ] To use the standard library in your project `$PROJECT`, 
+   put a file `$PROJECT.agda-lib` file in the project root containing:
+   ```
+   depend: standard-library
+   include: $DIRS
+   ```
+   where `$DIRS` is a list of directories where Agda
+   searches for modules, for instance `.` (just the project root).
+
+7. [ OPTIONAL ] If you want to refer to the standard library in all your
+   projects, add the following line to `$HOME/.agda/defaults`
+   ```
+   standard-library
+   ```
+
+Find the full story about installing Agda libraries at 
+[readthedocs](http://agda.readthedocs.io/en/latest/tools/package-system.html).

--- a/notes/installation-guide.md
+++ b/notes/installation-guide.md
@@ -13,27 +13,27 @@ Use version v1.0.1 of the standard library with Agda 2.6.0.
    wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/tarball/v1.0.1
    ```
    (you can replace `wget` with other popular tools such as `curl`).
-   
+
 3. Extract the standard library from the tarball. Again this can either be
    done manually or via the command line as follows:
    ```
    tar -zxvf agda-stdlib.tar
    ```
 
-4. [ OPTIONAL ] If using [cabal](https://www.haskell.org/cabal/) then run 
+4. [ OPTIONAL ] If using [cabal](https://www.haskell.org/cabal/) then run
    the commands to install via cabal:
    ```
    cd agda-stdlib
    cabal install
    ```
 
-5. Register the standard library with Agda's package system by adding 
+5. Register the standard library with Agda's package system by adding
    the following line to `$HOME/.agda/libraries`:
    ```
    $HERE/agda-stdlib/standard-library.agda-lib
    ```
 
-6. [ OPTIONAL ] To use the standard library in your project `$PROJECT`, 
+6. [ OPTIONAL ] To use the standard library in your project `$PROJECT`,
    put a file `$PROJECT.agda-lib` file in the project root containing:
    ```
    depend: standard-library
@@ -48,5 +48,5 @@ Use version v1.0.1 of the standard library with Agda 2.6.0.
    standard-library
    ```
 
-Find the full story about installing Agda libraries at 
+Find the full story about installing Agda libraries at
 [readthedocs](http://agda.readthedocs.io/en/latest/tools/package-system.html).

--- a/notes/installation-guide.md
+++ b/notes/installation-guide.md
@@ -10,9 +10,10 @@ Use version v1.0.1 of the standard library with Agda 2.6.0.
    done manually by visiting the Github repository for the library, or via the
    command line as follows:
    ```
-   wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/tarball/v1.0.1
+   wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/archive/v1.0.1.tar.gz
    ```
-   (you can replace `wget` with other popular tools such as `curl`).
+   Note that you can replace `wget` with other popular tools such as `curl` and that
+   you can replace `1.0.1` with any other version of the library you desire.
 
 3. Extract the standard library from the tarball. Again this can either be
    done manually or via the command line as follows:
@@ -23,14 +24,14 @@ Use version v1.0.1 of the standard library with Agda 2.6.0.
 4. [ OPTIONAL ] If using [cabal](https://www.haskell.org/cabal/) then run
    the commands to install via cabal:
    ```
-   cd agda-stdlib
+   cd agda-stdlib-1.0.1
    cabal install
    ```
 
 5. Register the standard library with Agda's package system by adding
    the following line to `$HOME/.agda/libraries`:
    ```
-   $HERE/agda-stdlib/standard-library.agda-lib
+   $HERE/agda-stdlib-1.0.1/standard-library.agda-lib
    ```
 
 6. [ OPTIONAL ] To use the standard library in your project `$PROJECT`,


### PR DESCRIPTION
Trying to fix #743. The problem with downloading the .tar is that Github automatically gives the contents an ugly name. So when I extract from `agda-stdlib.tar` in step 3. I get a folder called `agda-agda-stdlib-c226a9b` rather than `agda-stdlib`.

Anyone know any bash hackery to get around having to have a release specific `mv agda-agda-stdlib-c226a9b agda-stdlib` command?