### PR TITLE
n-ary decidable equality transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ New modules
 
   Data.Product.Nary.NonDependent
   Function.Nary.NonDependent
+  Function.Nary.NonDependent.Base
   Relation.Nary
 
   Data.Sign.Base
@@ -674,14 +675,6 @@ Other minor additions
 * In `Relation.Binary.HeterogeneousEquality` the relation `_≅_` has
   been generalised so that the types of the two equal elements need not
   be at the same universe level.
-
-* Added new proof to `Relation.Binary.PropositionalEquality`:
-  ```
-  Congₙ  : ∀ n (f g : Arrows n as b) → Set _
-  congₙ  : ∀ n (f : Arrows n as b) → Congₙ n f f
-  Substₙ : ∀ n (f g : Arrows n as (Set r)) → Set _
-  substₙ : (f : Arrows n as (Set r)) → Substₙ n f f
-  ```
 
 * Added new proof to `Relation.Binary.PropositionalEquality.Core`:
   ```agda

--- a/src/Data/Product/Nary/NonDependent.agda
+++ b/src/Data/Product/Nary/NonDependent.agda
@@ -27,7 +27,7 @@ open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Binary using (Rel)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong₂)
 
-open import Function.Nary.NonDependent
+open import Function.Nary.NonDependent.Base
 
 -- Provided n Levels and a corresponding "vector" of `n` Sets, we can build a big
 -- right-nested product type packing a value for each one of these Sets.

--- a/src/Data/Product/Nary/NonDependent.agda
+++ b/src/Data/Product/Nary/NonDependent.agda
@@ -22,6 +22,7 @@ open import Data.Nat.Base using (ℕ; zero; suc; pred)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Function
 open import Relation.Nullary
+open import Relation.Nullary.Product using (_×-dec_)
 
 open import Function.Nary.NonDependent
 
@@ -98,6 +99,13 @@ uncurry⊤ₙ : ∀ n {ls} {as : Sets n ls} {r} {b : Set r} →
             as ⇉ b → (Product⊤ n as → b)
 uncurry⊤ₙ zero    f = const f
 uncurry⊤ₙ (suc n) f = uncurry (uncurry⊤ₙ n ∘′ f)
+
+------------------------------------------------------------------------
+-- decidability
+
+Product⊤-dec : ∀ n {ls} {as : Sets n ls} → Product⊤ n (Dec <$> as) → Dec (Product⊤ n as)
+Product⊤-dec zero    _          = yes _
+Product⊤-dec (suc n) (p? , ps?) = p? ×-dec Product⊤-dec n ps?
 
 ------------------------------------------------------------------------
 -- projection of the k-th component

--- a/src/Data/Product/Nary/NonDependent.agda
+++ b/src/Data/Product/Nary/NonDependent.agda
@@ -91,11 +91,13 @@ uncurryₙ (suc n@(suc _)) f = uncurry (uncurryₙ n ∘′ f)
 
 curry⊤ₙ : ∀ n {ls} {as : Sets n ls} {r} {b : Set r} →
           (Product⊤ n as → b) → as ⇉ b
-curry⊤ₙ n f = curryₙ n (f ∘ toProduct⊤ n)
+curry⊤ₙ zero    f = f _
+curry⊤ₙ (suc n) f = curry⊤ₙ n ∘′ curry f
 
 uncurry⊤ₙ : ∀ n {ls} {as : Sets n ls} {r} {b : Set r} →
             as ⇉ b → (Product⊤ n as → b)
-uncurry⊤ₙ n f = uncurryₙ n f ∘ toProduct n
+uncurry⊤ₙ zero    f = const f
+uncurry⊤ₙ (suc n) f = uncurry (uncurry⊤ₙ n ∘′ f)
 
 ------------------------------------------------------------------------
 -- projection of the k-th component

--- a/src/Function/Nary/NonDependent.agda
+++ b/src/Function/Nary/NonDependent.agda
@@ -18,78 +18,22 @@ open import Level using (Level; 0ℓ; _⊔_; Lift)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Product using (_×_; _,_)
-open import Data.Unit.Base
+open import Data.Product.Nary.NonDependent
 open import Function using (_∘′_; _$′_; const; flip)
 open import Relation.Unary using (IUniversal)
+open import Relation.Binary.PropositionalEquality
 
 private
   variable
-    a b c : Level
-    A : Set a
-    B : Set b
-    C : Set c
+    r : Level
 
 ------------------------------------------------------------------------
--- Type Definitions
+-- Re-exporting the basic operations
 
--- We want to define n-ary function spaces and generic n-ary operations on
--- them such as (un)currying, zipWith, alignWith, etc.
-
--- We want users to be able to use these seamlessly whenever n is concrete.
-
--- In other words, we want Agda to infer the sets `A₁, ⋯, Aₙ` when we write
--- `uncurryₙ n f` where `f` has type `A₁ → ⋯ → Aₙ → B`. For this to happen,
--- we need the structure in which these Sets are stored to effectively
--- η-expand to `A₁, ⋯, Aₙ` when the parameter `n` is known.
-
--- Hence the following definitions:
-------------------------------------------------------------------------
-
--- First, a "vector" of `n` Levels (defined by induction on n so that it
--- may be built by η-expansion and unification). Each Level will be that
--- of one of the Sets we want to take the n-ary product of.
-
-Levels : ℕ → Set
-Levels zero    = ⊤
-Levels (suc n) = Level × Levels n
-
--- The overall Level of a `n` Sets of respective levels `l₁, ⋯, lₙ` will
--- be the least upper bound `l₁ ⊔ ⋯ ⊔ lₙ` of all of the Levels involved.
--- Hence the following definition of n-ary least upper bound:
-
-⨆ : ∀ n → Levels n → Level
-⨆ zero    _        = Level.zero
-⨆ (suc n) (l , ls) = l ⊔ (⨆ n ls)
-
--- Second, a "vector" of `n` Sets whose respective Levels are determined
--- by the `Levels n` input.
-
-Sets : ∀ n (ls : Levels n) → Set (Level.suc (⨆ n ls))
-Sets zero    _        = Lift _ ⊤
-Sets (suc n) (l , ls) = Set l × Sets n ls
-
--- Third, a function type whose domains are given by a "vector" of `n` Sets
--- `A₁, ⋯, Aₙ` and whose codomain is `B`. `Arrows` forms such a type of
--- shape `A₁ → ⋯ → Aₙ → B` by induction on `n`.
-
-Arrows : ∀ n {r ls} → Sets n ls → Set r → Set (r ⊔ (⨆ n ls))
-Arrows zero    _        b = b
-Arrows (suc n) (a , as) b = a → Arrows n as b
-
--- We introduce a notation for this definition
-
-infixr 0 _⇉_
-_⇉_ : ∀ {n ls r} → Sets n ls → Set r → Set (r ⊔ (⨆ n ls))
-_⇉_ = Arrows _
-
-
+open import Function.Nary.NonDependent.Base public
 
 ------------------------------------------------------------------------
--- Operations on Levels
-
-lmap : (Level → Level) → ∀ n → Levels n → Levels n
-lmap f zero    ls       = _
-lmap f (suc n) (l , ls) = f l , lmap f n ls
+-- Additional operations on Levels
 
 ltabulate : ∀ n → (Fin n → Level) → Levels n
 ltabulate zero    f = _
@@ -101,55 +45,33 @@ lreplicate n ℓ = ltabulate n (const ℓ)
 0ℓs : ∀[ Levels ]
 0ℓs = lreplicate _ 0ℓ
 
+------------------------------------------------------------------------
+-- Congruence
+
+module _ n {ls} {as : Sets n ls} {R : Set r} (f : as ⇉ R) where
+
+-- Congruentₙ : ∀ n. ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
+--                   a₁₁ ≡ a₁₂ → ⋯ → aₙ₁ ≡ aₙ₂ →
+--                   f a₁₁ ⋯ aₙ₁ ≡ f a₁₂ ⋯ aₙ₂
+
+  Congruentₙ : Set (r Level.⊔ ⨆ n ls)
+  Congruentₙ = ∀ {l r} → Equalₙ n l r ⇉ (uncurryₙ n f l ≡ uncurryₙ n f r)
+
+  congₙ : Congruentₙ
+  congₙ = curryₙ n (cong (uncurryₙ n f) ∘′ fromEqualₙ n)
 
 ------------------------------------------------------------------------
--- Operations on Sets
+-- Injectivitiy
 
-_<$>_ : (∀ {l} → Set l → Set l) →
-        ∀ {n ls} → Sets n ls → Sets n ls
-_<$>_ f {zero}   as        = _
-_<$>_ f {suc n}  (a , as)  = f a , f <$> as
+module _ n {ls} {as : Sets n ls} {R : Set r} (con : as ⇉ R) where
 
--- generalised map
+-- Injectiveₙ : ∀ n. ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
+--                   con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂ →
+--                   a₁₁ ≡ a₁₂ × ⋯ × aₙ₁ ≡ aₙ₂
 
-smap : ∀ f → (∀ {l} → Set l → Set (f l)) →
-       ∀ n {ls} → Sets n ls → Sets n (lmap f n ls)
-smap f F zero    as       = _
-smap f F (suc n) (a , as) = F a , smap f F n as
+  Injectiveₙ : Set (r Level.⊔ ⨆ n ls)
+  Injectiveₙ = ∀ {l r} → uncurryₙ n con l ≡ uncurryₙ n con r → Product n (Equalₙ n l r)
 
-
-------------------------------------------------------------------------
--- Operations on Functions
-
--- mapping under n arguments
-
-mapₙ : ∀ n {ls} {as : Sets n ls} → (B → C) → as ⇉ B → as ⇉ C
-mapₙ zero    f v = f v
-mapₙ (suc n) f g = mapₙ n f ∘′ g
-
--- compose function at the n-th position
-
-_%=_⊢_ : ∀ n {ls} {as : Sets n ls} → (A → B) → as ⇉ (B → C) → as ⇉ (A → C)
-n %= f ⊢ g = mapₙ n (_∘′ f) g
-
--- partially apply function at the n-th position
-
-_∷=_⊢_ : ∀ n {ls} {as : Sets n ls} → A → as ⇉ (A → B) → as ⇉ B
-n ∷= x ⊢ g = mapₙ n (_$′ x) g
-
--- hole at the n-th position
-
-holeₙ : ∀ n {ls} {as : Sets n ls} → (A → as ⇉ B) → as ⇉ (A → B)
-holeₙ zero    f = f
-holeₙ (suc n) f = holeₙ n ∘′ flip f
-
--- function constant in its n first arguments
-
--- Note that its type will only be inferred if it is used in a context
--- specifying what the type of the function ought to be. Just like the
--- usual const: there is no way to infer its domain from its argument.
-
-constₙ : ∀ n {ls r} {as : Sets n ls} {b : Set r} → b → as ⇉ b
-constₙ zero    v = v
-constₙ (suc n) v = const (constₙ n v)
-
+  injectiveₙ : (∀ {l r} → uncurryₙ n con l ≡ uncurryₙ n con r → l ≡ r) →
+               Injectiveₙ
+  injectiveₙ con-inj eq = toEqualₙ n (con-inj eq)

--- a/src/Function/Nary/NonDependent/Base.agda
+++ b/src/Function/Nary/NonDependent/Base.agda
@@ -1,0 +1,138 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Heterogeneous N-ary Functions: basic types and operations
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Function.Nary.NonDependent.Base where
+
+------------------------------------------------------------------------
+-- Concrete examples can be found in README.Nary. This file's comments
+-- are more focused on the implementation details and the motivations
+-- behind the design decisions.
+------------------------------------------------------------------------
+
+open import Level using (Level; 0ℓ; _⊔_; Lift)
+open import Data.Nat.Base using (ℕ; zero; suc)
+open import Data.Product using (_×_; _,_)
+open import Data.Unit.Base
+open import Function using (_∘′_; _$′_; const; flip)
+
+private
+  variable
+    a b c : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Type Definitions
+
+-- We want to define n-ary function spaces and generic n-ary operations on
+-- them such as (un)currying, zipWith, alignWith, etc.
+
+-- We want users to be able to use these seamlessly whenever n is concrete.
+
+-- In other words, we want Agda to infer the sets `A₁, ⋯, Aₙ` when we write
+-- `uncurryₙ n f` where `f` has type `A₁ → ⋯ → Aₙ → B`. For this to happen,
+-- we need the structure in which these Sets are stored to effectively
+-- η-expand to `A₁, ⋯, Aₙ` when the parameter `n` is known.
+
+-- Hence the following definitions:
+------------------------------------------------------------------------
+
+-- First, a "vector" of `n` Levels (defined by induction on n so that it
+-- may be built by η-expansion and unification). Each Level will be that
+-- of one of the Sets we want to take the n-ary product of.
+
+Levels : ℕ → Set
+Levels zero    = ⊤
+Levels (suc n) = Level × Levels n
+
+-- The overall Level of a `n` Sets of respective levels `l₁, ⋯, lₙ` will
+-- be the least upper bound `l₁ ⊔ ⋯ ⊔ lₙ` of all of the Levels involved.
+-- Hence the following definition of n-ary least upper bound:
+
+⨆ : ∀ n → Levels n → Level
+⨆ zero    _        = Level.zero
+⨆ (suc n) (l , ls) = l ⊔ (⨆ n ls)
+
+-- Second, a "vector" of `n` Sets whose respective Levels are determined
+-- by the `Levels n` input.
+
+Sets : ∀ n (ls : Levels n) → Set (Level.suc (⨆ n ls))
+Sets zero    _        = Lift _ ⊤
+Sets (suc n) (l , ls) = Set l × Sets n ls
+
+-- Third, a function type whose domains are given by a "vector" of `n` Sets
+-- `A₁, ⋯, Aₙ` and whose codomain is `B`. `Arrows` forms such a type of
+-- shape `A₁ → ⋯ → Aₙ → B` by induction on `n`.
+
+Arrows : ∀ n {r ls} → Sets n ls → Set r → Set (r ⊔ (⨆ n ls))
+Arrows zero    _        b = b
+Arrows (suc n) (a , as) b = a → Arrows n as b
+
+-- We introduce a notation for this definition
+
+infixr 0 _⇉_
+_⇉_ : ∀ {n ls r} → Sets n ls → Set r → Set (r ⊔ (⨆ n ls))
+_⇉_ = Arrows _
+
+------------------------------------------------------------------------
+-- Operations on Sets
+
+-- Level-respecting map
+
+_<$>_ : (∀ {l} → Set l → Set l) →
+        ∀ {n ls} → Sets n ls → Sets n ls
+_<$>_ f {zero}   as        = _
+_<$>_ f {suc n}  (a , as)  = f a , f <$> as
+
+-- Level-modifying generalised map
+
+lmap : (Level → Level) → ∀ n → Levels n → Levels n
+lmap f zero    ls       = _
+lmap f (suc n) (l , ls) = f l , lmap f n ls
+
+smap : ∀ f → (∀ {l} → Set l → Set (f l)) →
+       ∀ n {ls} → Sets n ls → Sets n (lmap f n ls)
+smap f F zero    as       = _
+smap f F (suc n) (a , as) = F a , smap f F n as
+
+------------------------------------------------------------------------
+-- Operations on Functions
+
+-- mapping under n arguments
+
+mapₙ : ∀ n {ls} {as : Sets n ls} → (B → C) → as ⇉ B → as ⇉ C
+mapₙ zero    f v = f v
+mapₙ (suc n) f g = mapₙ n f ∘′ g
+
+-- compose function at the n-th position
+
+_%=_⊢_ : ∀ n {ls} {as : Sets n ls} → (A → B) → as ⇉ (B → C) → as ⇉ (A → C)
+n %= f ⊢ g = mapₙ n (_∘′ f) g
+
+-- partially apply function at the n-th position
+
+_∷=_⊢_ : ∀ n {ls} {as : Sets n ls} → A → as ⇉ (A → B) → as ⇉ B
+n ∷= x ⊢ g = mapₙ n (_$′ x) g
+
+-- hole at the n-th position
+
+holeₙ : ∀ n {ls} {as : Sets n ls} → (A → as ⇉ B) → as ⇉ (A → B)
+holeₙ zero    f = f
+holeₙ (suc n) f = holeₙ n ∘′ flip f
+
+-- function constant in its n first arguments
+
+-- Note that its type will only be inferred if it is used in a context
+-- specifying what the type of the function ought to be. Just like the
+-- usual const: there is no way to infer its domain from its argument.
+
+constₙ : ∀ n {ls r} {as : Sets n ls} {b : Set r} → b → as ⇉ b
+constₙ zero    v = v
+constₙ (suc n) v = const (constₙ n v)
+

--- a/src/Relation/Binary/PropositionalEquality.agda
+++ b/src/Relation/Binary/PropositionalEquality.agda
@@ -12,12 +12,10 @@ import Axiom.Extensionality.Propositional as Ext
 open import Axiom.UniquenessOfIdentityProofs
 open import Function
 open import Function.Equality using (Π; _⟶_; ≡-setoid)
-open import Function.Nary.NonDependent
 open import Level as L
 open import Data.Empty
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Product
-open import Function.Nary.NonDependent
 
 open import Relation.Nullary using (yes ; no)
 open import Relation.Nullary.Decidable.Core
@@ -52,29 +50,6 @@ cong-app refl x = refl
 
 cong₂ : ∀ (f : A → B → C) {x y u v} → x ≡ y → u ≡ v → f x u ≡ f y v
 cong₂ f refl refl = refl
-
-------------------------------------------------------------------------
--- n-ary versions of `cong` and `subst`
-
-Congₙ : ∀ n {ls} {as : Sets n ls} {r} {b : Set r} →
-        (f g : as ⇉ b) → Set (r ⊔ (⨆ n ls))
-Congₙ zero    f g = f ≡ g
-Congₙ (suc n) f g = ∀ {x y} → x ≡ y → Congₙ n (f x) (g y)
-
-congₙ : ∀ n {ls} {as : Sets n ls} {r} {b : Set r} →
-        (f : as ⇉ b) → Congₙ n f f
-congₙ zero    f      = refl
-congₙ (suc n) f refl = congₙ n (f _)
-
-Substₙ : ∀ n {r ls} {as : Sets n ls} →
-         (f g : as ⇉ Set r) → Set (r ⊔ (⨆ n ls))
-Substₙ zero    f g = f → g
-Substₙ (suc n) f g = ∀ {x y} → x ≡ y → Substₙ n (f x) (g y)
-
-substₙ : ∀ {n r ls} {as : Sets n ls} →
-        (f : as ⇉ Set r) → Substₙ n f f
-substₙ {zero}  f x    = x
-substₙ {suc n} f refl = substₙ (f _)
 
 ------------------------------------------------------------------------
 -- Structure of equality as a binary relation

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -16,13 +16,16 @@ module Relation.Nary where
 
 open import Level using (Level; _⊔_)
 open import Data.Nat.Base using (zero; suc)
-open import Data.Product using (_×_; _,_)
-open import Data.Product.Nary.NonDependent using (Product⊤; curry⊤ₙ; uncurry⊤ₙ)
+open import Data.Product as Prod using (_×_; _,_; uncurry)
+open import Data.Product.Nary.NonDependent
 open import Data.Sum using (_⊎_)
-open import Function using (_$_)
+open import Function using (_$_; _∘′_)
 open import Function.Nary.NonDependent
-open import Relation.Nullary using (¬_)
+open import Relation.Nullary using (¬_; Dec; yes; no)
+import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 import Relation.Unary as Unary
+open import Relation.Binary.PropositionalEquality using (_≡_; cong)
 
 private
   variable
@@ -70,7 +73,28 @@ infix 5 ∃⟨_⟩ Π[_] ∀[_]
 ∀[_] : ∀ {n ls r} {as : Sets n ls} → as ⇉ Set r → Set (r ⊔ (⨆ n ls))
 ∀[_] = quantₙ Unary.IUniversal _
 
+------------------------------------------------------------------------
+-- Decidability transformer
 
+-- Injectiveₙ : ∀ n. ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
+--                   con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂ →
+--                   a₁₁ ≡ a₁₂ × ⋯ × aₙ₁ ≡ aₙ₂
+
+Injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} → Arrows n as R → Set (r Level.⊔ ⨆ n ls)
+Injectiveₙ n f = ∀ {l r} → uncurryₙ n f l ≡ uncurryₙ n f r → Product n (Equalₙ n l r)
+
+-- ≟-mapₙ : ∀ n. (con : A₁ → ⋯ → Aₙ → R) →
+--               Injectiveₙ n con →
+--               ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
+--               Dec (a₁₁ ≡ a₁₂) → ⋯ Dec (aₙ₁ ≡ aₙ₂) →
+--               Dec (con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂)
+
+≟-mapₙ : ∀ n {ls} {as : Sets n ls} (con : Arrows n as R) →
+         Injectiveₙ n con → ∀ {l r : Product n as} →
+         Arrows n (Dec <$> Equalₙ n l r) (Dec (uncurryₙ n con l ≡ uncurryₙ n con r))
+≟-mapₙ n con con-inj =
+  curryₙ n λ a?s → let as? = Product-dec n a?s in
+  Dec.map′ (cong (uncurryₙ n con) ∘′ fromEqualₙ n) con-inj as?
 
 ------------------------------------------------------------------------
 -- Pointwise liftings of k-ary operators

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -25,7 +25,7 @@ open import Relation.Nullary using (¬_; Dec; yes; no)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Product using (_×-dec_)
 import Relation.Unary as Unary
-open import Relation.Binary.PropositionalEquality using (_≡_; cong)
+open import Relation.Binary.PropositionalEquality using (_≡_; cong; subst)
 
 private
   variable
@@ -73,27 +73,10 @@ infix 5 ∃⟨_⟩ Π[_] ∀[_]
 ∀[_] : ∀ {n ls r} {as : Sets n ls} → as ⇉ Set r → Set (r ⊔ (⨆ n ls))
 ∀[_] = quantₙ Unary.IUniversal _
 
-------------------------------------------------------------------------
--- Decidability transformer
-
--- Injectiveₙ : ∀ n. ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
---                   con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂ →
---                   a₁₁ ≡ a₁₂ × ⋯ × aₙ₁ ≡ aₙ₂
-
-Injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} →
-             Arrows n as R → Set (r Level.⊔ ⨆ n ls)
-Injectiveₙ n f = ∀ {l r} → uncurryₙ n f l ≡ uncurryₙ n f r →
-                 Product n (Equalₙ n l r)
-
-injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} (con : Arrows n as R) →
-             (∀ {l r} → uncurryₙ n con l ≡ uncurryₙ n con r → l ≡ r) →
-             Injectiveₙ n con
-injectiveₙ n con con-inj eq = toEqualₙ n (con-inj eq)
-
 -- ≟-mapₙ : ∀ n. (con : A₁ → ⋯ → Aₙ → R) →
 --               Injectiveₙ n con →
 --               ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
---               Dec (a₁₁ ≡ a₁₂) → ⋯ Dec (aₙ₁ ≡ aₙ₂) →
+--               Dec (a₁₁ ≡ a₁₂) → ⋯ → Dec (aₙ₁ ≡ aₙ₂) →
 --               Dec (con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂)
 
 ≟-mapₙ : ∀ n {ls} {as : Sets n ls} (con : Arrows n as R) → Injectiveₙ n con →
@@ -101,6 +84,21 @@ injectiveₙ n con con-inj eq = toEqualₙ n (con-inj eq)
 ≟-mapₙ n con con-inj =
   curryₙ n λ a?s → let as? = Product-dec n a?s in
   Dec.map′ (cong (uncurryₙ n con) ∘′ fromEqualₙ n) con-inj as?
+
+------------------------------------------------------------------------
+-- Substitution
+
+module _ {n r ls} {as : Sets n ls} (P : as ⇉ Set r) where
+
+-- Substitutionₙ : ∀ n. ∀ a₁₁ a₁₂ ⋯ aₙ₁ aₙ₂ →
+--                      a₁₁ ≡ a₁₂ → ⋯ → aₙ₁ ≡ aₙ₂ →
+--                      P a₁₁ ⋯ aₙ₁ → P a₁₂ ⋯ aₙ₂
+
+  Substitutionₙ : Set (r ⊔ (⨆ n ls))
+  Substitutionₙ = ∀ {l r} → Equalₙ n l r ⇉ (uncurryₙ n P l → uncurryₙ n P r)
+
+  substₙ : Substitutionₙ
+  substₙ = curryₙ n (subst (uncurryₙ n P) ∘′ fromEqualₙ n)
 
 ------------------------------------------------------------------------
 -- Pointwise liftings of k-ary operators

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -80,8 +80,15 @@ infix 5 ∃⟨_⟩ Π[_] ∀[_]
 --                   con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂ →
 --                   a₁₁ ≡ a₁₂ × ⋯ × aₙ₁ ≡ aₙ₂
 
-Injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} → Arrows n as R → Set (r Level.⊔ ⨆ n ls)
-Injectiveₙ n f = ∀ {l r} → uncurryₙ n f l ≡ uncurryₙ n f r → Product n (Equalₙ n l r)
+Injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} →
+             Arrows n as R → Set (r Level.⊔ ⨆ n ls)
+Injectiveₙ n f = ∀ {l r} → uncurryₙ n f l ≡ uncurryₙ n f r →
+                 Product n (Equalₙ n l r)
+
+injectiveₙ : ∀ n {ls} {as : Sets n ls} {R : Set r} (con : Arrows n as R) →
+             (∀ {l r} → uncurryₙ n con l ≡ uncurryₙ n con r → l ≡ r) →
+             Injectiveₙ n con
+injectiveₙ n con con-inj eq = toEqualₙ n (con-inj eq)
 
 -- ≟-mapₙ : ∀ n. (con : A₁ → ⋯ → Aₙ → R) →
 --               Injectiveₙ n con →
@@ -89,9 +96,8 @@ Injectiveₙ n f = ∀ {l r} → uncurryₙ n f l ≡ uncurryₙ n f r → Produ
 --               Dec (a₁₁ ≡ a₁₂) → ⋯ Dec (aₙ₁ ≡ aₙ₂) →
 --               Dec (con a₁₁ ⋯ aₙ₁ ≡ con a₁₂ ⋯ aₙ₂)
 
-≟-mapₙ : ∀ n {ls} {as : Sets n ls} (con : Arrows n as R) →
-         Injectiveₙ n con → ∀ {l r : Product n as} →
-         Arrows n (Dec <$> Equalₙ n l r) (Dec (uncurryₙ n con l ≡ uncurryₙ n con r))
+≟-mapₙ : ∀ n {ls} {as : Sets n ls} (con : Arrows n as R) → Injectiveₙ n con →
+         ∀ {l r} → Arrows n (Dec <$> Equalₙ n l r) (Dec (uncurryₙ n con l ≡ uncurryₙ n con r))
 ≟-mapₙ n con con-inj =
   curryₙ n λ a?s → let as? = Product-dec n a?s in
   Dec.map′ (cong (uncurryₙ n con) ∘′ fromEqualₙ n) con-inj as?

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -16,7 +16,7 @@ module Relation.Nary where
 
 open import Level using (Level; _⊔_)
 open import Data.Nat.Base using (zero; suc)
-open import Data.Product as Prod using (_×_; _,_; uncurry)
+open import Data.Product as Prod using (_×_; _,_)
 open import Data.Product.Nary.NonDependent
 open import Data.Sum using (_⊎_)
 open import Function using (_$_; _∘′_)


### PR DESCRIPTION
I got tired of writing `uncurry (cong₂ _∷_)` and invoking `_×-dec_` in #799
so here we go.