### PR TITLE
[ fix #814 ] fix inconsistent fixity of reasoning combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,14 @@ Bug-fixes
   This lead to `x - x * x` being ambigous instead of being parsed as `x - (x * x)`.
   To fix this the precedence of `_-_` has been reduced from 7 to 6.
 
+* The infix precedence of the generic order reasoning combinators (`_∼⟨_⟩_`,
+  `_≈⟨_⟩_`, etc.) in `Relation.Binary.Reasoning.Base.{Double,Triple}` were
+  lowered when implementing new style reasoning (issue #185).  This lead to
+  inconsistencies in modules that add custom combinators (e.g. `StarReasoning`
+  from `Relation.Binary.Construct.Closure.ReflexiveTransitive.Properties`)
+  using the original fixity (see issue #814 for details).  The old fixity has
+  been restored now.
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/src/Relation/Binary/Reasoning/Base/Double.agda
+++ b/src/Relation/Binary/Reasoning/Base/Double.agda
@@ -28,6 +28,8 @@ open IsPreorder isPreorder
 ------------------------------------------------------------------------
 -- A datatype to hide the current relation type
 
+infix 4 _IsRelatedTo_
+
 data _IsRelatedTo_ (x y : A) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
   nonstrict : (x∼y : x ∼ y) → x IsRelatedTo y
   equals    : (x≈y : x ≈ y) → x IsRelatedTo y
@@ -57,9 +59,9 @@ extractEquality (isEquality x≈y) = x≈y
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
-infix -1 begin_ begin-equality_
-infixr 0 _∼⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
-infix  1 _∎
+infix  1 begin_ begin-equality_
+infixr 2 _∼⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
+infix  3 _∎
 
 begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ∼ y
 begin (nonstrict x∼y) = x∼y

--- a/src/Relation/Binary/Reasoning/Base/Triple.agda
+++ b/src/Relation/Binary/Reasoning/Base/Triple.agda
@@ -36,6 +36,8 @@ open IsPreorder isPreorder
 ------------------------------------------------------------------------
 -- A datatype to hide the current relation type
 
+infix 4 _IsRelatedTo_
+
 data _IsRelatedTo_ (x y : A) : Set (a ⊔ ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃) where
   strict    : (x<y : x < y) → x IsRelatedTo y
   nonstrict : (x≤y : x ≤ y) → x IsRelatedTo y
@@ -70,9 +72,9 @@ extractEquality (isEquality x≈y) = x≈y
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
-infix -1 begin_ begin-strict_ begin-equality_
-infixr 0 _<⟨_⟩_ _≤⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
-infix  1 _∎
+infix  1 begin_ begin-strict_ begin-equality_
+infixr 2 _<⟨_⟩_ _≤⟨_⟩_ _≈⟨_⟩_ _≈˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
+infix  3 _∎
 
 begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ≤ y
 begin (strict    x<y) = <⇒≤ x<y


### PR DESCRIPTION
The infix precedence of the generic order reasoning combinators (`_∼⟨_⟩_`, `_≈⟨_⟩_`, etc.) in `Relation.Binary.Reasoning.Base.{Double,Triple}` were lowered when implementing new style reasoning (issue #185).  This lead to inconsistencies in modules that add custom combinators (e.g. `StarReasoning` from `Relation.Binary.Construct.Closure.ReflexiveTransitive.Properties`) using the original fixity (see issue #814 for details).

This PR restores the old fixity.

