### PR TITLE
[ Sublist.Setoid ] RawPushout for merging two extensions of a list

### DIFF
--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -133,6 +133,28 @@ lookup-⊆-trans = Any-resp-⊆-trans
 
 lookup-injective : ∀ {P : Pred A ℓ} {xs ys} {τ : xs ⊆ ys} {i j : Any P xs} →
                    lookup τ i ≡ lookup τ j → i ≡ j
-lookup-injective {τ = _  ∷ʳ _}                      = lookup-injective ∘′ there-injective
+lookup-injective {τ = _   ∷ʳ _}                     = lookup-injective ∘′ there-injective
 lookup-injective {τ = refl ∷ _} {here  _} {here  _} = cong here ∘′ here-injective
-lookup-injective {τ = _   ∷ _}  {there _} {there _} = cong there ∘′ lookup-injective ∘′ there-injective
+lookup-injective {τ = _    ∷ _} {there _} {there _} = cong there ∘′ lookup-injective ∘′ there-injective
+
+------------------------------------------------------------------------
+-- Weak pushout (wpo)
+
+-- A raw pushout is a weak pushout if the pushout square commutes.
+
+IsWeakPushout : ∀{xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+                RawPushout τ σ → Set a
+IsWeakPushout {τ = τ} {σ = σ} rpo =
+  ⊆-trans τ (RawPushout.leg₁ rpo) ≡
+  ⊆-trans σ (RawPushout.leg₂ rpo)
+
+-- Joining two list extensions with ⊆-join produces a weak pushout.
+
+⊆-joinˡ-is-wpo : ∀{xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+                 IsWeakPushout (⊆-joinˡ τ σ)
+⊆-joinˡ-is-wpo {τ = []} {σ = σ}
+  rewrite ⊆-trans-idʳ {τ = σ}
+        = ⊆-trans-idˡ {xs = []}
+⊆-joinˡ-is-wpo {τ = y   ∷ʳ _}                = cong (y   ∷ʳ_) ⊆-joinˡ-is-wpo
+⊆-joinˡ-is-wpo {τ = _   ∷  _} {σ = z   ∷ʳ _} = cong (z   ∷ʳ_) ⊆-joinˡ-is-wpo
+⊆-joinˡ-is-wpo {τ = refl ∷ _} {σ = refl ∷ _} = cong (refl ∷_) ⊆-joinˡ-is-wpo

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -148,13 +148,13 @@ IsWeakPushout {τ = τ} {σ = σ} rpo =
   ⊆-trans τ (RawPushout.leg₁ rpo) ≡
   ⊆-trans σ (RawPushout.leg₂ rpo)
 
--- Joining two list extensions with ⊆-join produces a weak pushout.
+-- Joining two list extensions with ⊆-pushout produces a weak pushout.
 
-⊆-joinˡ-is-wpo : ∀{xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
-                 IsWeakPushout (⊆-joinˡ τ σ)
-⊆-joinˡ-is-wpo {τ = []} {σ = σ}
+⊆-pushoutˡ-is-wpo : ∀{xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+                 IsWeakPushout (⊆-pushoutˡ τ σ)
+⊆-pushoutˡ-is-wpo {τ = []} {σ = σ}
   rewrite ⊆-trans-idʳ {τ = σ}
         = ⊆-trans-idˡ {xs = []}
-⊆-joinˡ-is-wpo {τ = y   ∷ʳ _}                = cong (y   ∷ʳ_) ⊆-joinˡ-is-wpo
-⊆-joinˡ-is-wpo {τ = _   ∷  _} {σ = z   ∷ʳ _} = cong (z   ∷ʳ_) ⊆-joinˡ-is-wpo
-⊆-joinˡ-is-wpo {τ = refl ∷ _} {σ = refl ∷ _} = cong (refl ∷_) ⊆-joinˡ-is-wpo
+⊆-pushoutˡ-is-wpo {τ = y   ∷ʳ _}                = cong (y   ∷ʳ_) ⊆-pushoutˡ-is-wpo
+⊆-pushoutˡ-is-wpo {τ = _   ∷  _} {σ = z   ∷ʳ _} = cong (z   ∷ʳ_) ⊆-pushoutˡ-is-wpo
+⊆-pushoutˡ-is-wpo {τ = refl ∷ _} {σ = refl ∷ _} = cong (refl ∷_) ⊆-pushoutˡ-is-wpo

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -92,7 +92,7 @@ open HeterogeneousProperties.Antisymmetry {R = _≈_} {S = _≈_} (λ x≈y _ �
   }
 
 ------------------------------------------------------------------------
--- Weak pushout
+-- Raw pushout
 --
 -- The category _⊆_ does not have proper pushouts.  For instance consider:
 --
@@ -128,12 +128,11 @@ open HeterogeneousProperties.Antisymmetry {R = _≈_} {S = _≈_} (λ x≈y _ �
 
 private
   variable
-    x y z : A
-    xs ys zs us vs : List A
-    τ τ′ τ₁ τ₂ σ σ′ : xs ⊆ ys
+    x y z    : A
+    xs ys zs : List A
+    τ σ      : xs ⊆ ys
 
 record RawPushout (τ : xs ⊆ ys) (σ : xs ⊆ zs) : Set (c ⊔ ℓ) where
-  constructor rawPushout
   field
     {upperBound} : List A
     leg₁         : ys ⊆ upperBound

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -146,17 +146,26 @@ open RawPushout
 -- Extending the right upper corner.
 
 _∷ʳ₁_ : ∀ y → RawPushout τ σ → RawPushout (y ∷ʳ τ) σ
-y ∷ʳ₁ rpo = record { leg₁ = refl ∷ leg₁ rpo ; leg₂ = y ∷ʳ leg₂ rpo }
+y ∷ʳ₁ rpo = record
+  { leg₁ = refl ∷ leg₁ rpo
+  ; leg₂ = y   ∷ʳ leg₂ rpo
+  }
 
 -- Extending the left lower corner.
 
 _∷ʳ₂_ : ∀ z → RawPushout τ σ → RawPushout τ (z ∷ʳ σ)
-z ∷ʳ₂ rpo = record { leg₁ = z ∷ʳ leg₁ rpo ; leg₂ = refl ∷ leg₂ rpo }
+z ∷ʳ₂ rpo = record
+  { leg₁ = z   ∷ʳ leg₁ rpo
+  ; leg₂ = refl ∷ leg₂ rpo
+  }
 
 -- Extending both of these corners with equal elements.
 
 ∷-rpo : (x≈y : x ≈ y) (x≈z : x ≈ z) → RawPushout τ σ → RawPushout (x≈y ∷ τ) (x≈z ∷ σ)
-∷-rpo x≈y x≈z rpo = record { leg₁ = sym x≈y ∷ leg₁ rpo; leg₂ = sym x≈z ∷ leg₂ rpo }
+∷-rpo x≈y x≈z rpo = record
+  { leg₁ = sym x≈y ∷ leg₁ rpo
+  ; leg₂ = sym x≈z ∷ leg₂ rpo
+  }
 
 ------------------------------------------------------------------------
 -- Left-biased pushout: add elements of left extension first.

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -14,6 +14,7 @@ module Data.List.Relation.Binary.Sublist.Setoid
   {c ℓ} (S : Setoid c ℓ) where
 
 open import Level using (_⊔_)
+
 open import Data.List.Base using (List; []; _∷_)
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
 import Data.List.Relation.Binary.Sublist.Heterogeneous as Heterogeneous
@@ -21,6 +22,8 @@ import Data.List.Relation.Binary.Sublist.Heterogeneous.Core
   as HeterogeneousCore
 import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeterogeneousProperties
+open import Data.Product using (∃; _,_)
+
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary using (¬_)
@@ -170,8 +173,16 @@ z ∷ʳ₂ rpo = record
 ------------------------------------------------------------------------
 -- Left-biased pushout: add elements of left extension first.
 
-⊆-joinˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
-⊆-joinˡ []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
-⊆-joinˡ (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-joinˡ τ σ
-⊆-joinˡ τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-joinˡ τ σ
-⊆-joinˡ (x≈y ∷ τ) (x≈z ∷ σ) = ∷-rpo x≈y x≈z (⊆-joinˡ τ σ)
+⊆-pushoutˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
+⊆-pushoutˡ []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
+⊆-pushoutˡ (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-pushoutˡ τ σ
+⊆-pushoutˡ τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-pushoutˡ τ σ
+⊆-pushoutˡ (x≈y ∷ τ) (x≈z ∷ σ) = ∷-rpo x≈y x≈z (⊆-pushoutˡ τ σ)
+
+-- Join two extensions, returning the upper bound and the diagonal
+-- of the pushout square.
+
+⊆-joinˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → ∃ λ us → xs ⊆ us
+⊆-joinˡ τ σ = upperBound rpo , ⊆-trans τ (leg₁ rpo)
+  where
+  rpo = ⊆-pushoutˡ τ σ

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -129,13 +129,7 @@ open HeterogeneousProperties.Antisymmetry {R = _≈_} {S = _≈_} (λ x≈y _ �
 -- Such a property is given e.g. if _≈_ is proof irrelevant
 -- or forms a groupoid.
 
-private
-  variable
-    x y z    : A
-    xs ys zs : List A
-    τ σ      : xs ⊆ ys
-
-record RawPushout (τ : xs ⊆ ys) (σ : xs ⊆ zs) : Set (c ⊔ ℓ) where
+record RawPushout {xs ys zs : List A} (τ : xs ⊆ ys) (σ : xs ⊆ zs) : Set (c ⊔ ℓ) where
   field
     {upperBound} : List A
     leg₁         : ys ⊆ upperBound
@@ -148,7 +142,8 @@ open RawPushout
 
 -- Extending the right upper corner.
 
-_∷ʳ₁_ : ∀ y → RawPushout τ σ → RawPushout (y ∷ʳ τ) σ
+_∷ʳ₁_ : ∀ {xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+        (y : A) → RawPushout τ σ → RawPushout (y ∷ʳ τ) σ
 y ∷ʳ₁ rpo = record
   { leg₁ = refl ∷ leg₁ rpo
   ; leg₂ = y   ∷ʳ leg₂ rpo
@@ -156,7 +151,8 @@ y ∷ʳ₁ rpo = record
 
 -- Extending the left lower corner.
 
-_∷ʳ₂_ : ∀ z → RawPushout τ σ → RawPushout τ (z ∷ʳ σ)
+_∷ʳ₂_ : ∀ {xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+        (z : A) → RawPushout τ σ → RawPushout τ (z ∷ʳ σ)
 z ∷ʳ₂ rpo = record
   { leg₁ = z   ∷ʳ leg₁ rpo
   ; leg₂ = refl ∷ leg₂ rpo
@@ -164,7 +160,8 @@ z ∷ʳ₂ rpo = record
 
 -- Extending both of these corners with equal elements.
 
-∷-rpo : (x≈y : x ≈ y) (x≈z : x ≈ z) → RawPushout τ σ → RawPushout (x≈y ∷ τ) (x≈z ∷ σ)
+∷-rpo : ∀ {x y z : A} {xs ys zs : List A} {τ : xs ⊆ ys} {σ : xs ⊆ zs} →
+        (x≈y : x ≈ y) (x≈z : x ≈ z) → RawPushout τ σ → RawPushout (x≈y ∷ τ) (x≈z ∷ σ)
 ∷-rpo x≈y x≈z rpo = record
   { leg₁ = sym x≈y ∷ leg₁ rpo
   ; leg₂ = sym x≈z ∷ leg₂ rpo
@@ -173,7 +170,8 @@ z ∷ʳ₂ rpo = record
 ------------------------------------------------------------------------
 -- Left-biased pushout: add elements of left extension first.
 
-⊆-pushoutˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
+⊆-pushoutˡ : ∀ {xs ys zs : List A} →
+             (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
 ⊆-pushoutˡ []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
 ⊆-pushoutˡ (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-pushoutˡ τ σ
 ⊆-pushoutˡ τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-pushoutˡ τ σ
@@ -182,7 +180,8 @@ z ∷ʳ₂ rpo = record
 -- Join two extensions, returning the upper bound and the diagonal
 -- of the pushout square.
 
-⊆-joinˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → ∃ λ us → xs ⊆ us
+⊆-joinˡ : ∀ {xs ys zs : List A} →
+          (τ : xs ⊆ ys) (σ : xs ⊆ zs) → ∃ λ us → xs ⊆ us
 ⊆-joinˡ τ σ = upperBound rpo , ⊆-trans τ (leg₁ rpo)
   where
   rpo = ⊆-pushoutˡ τ σ

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -162,8 +162,8 @@ z ∷ʳ₂ rpo = record { leg₁ = z ∷ʳ leg₁ rpo ; leg₂ = refl ∷ leg₂
 ------------------------------------------------------------------------
 -- Left-biased pushout: add elements of left extension first.
 
-⊆-merge : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
-⊆-merge []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
-⊆-merge (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-merge τ σ
-⊆-merge τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-merge τ σ
-⊆-merge (x≈y ∷ τ) (x≈z ∷ σ) = ∷-rpo x≈y x≈z (⊆-merge τ σ)
+⊆-joinˡ : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
+⊆-joinˡ []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
+⊆-joinˡ (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-joinˡ τ σ
+⊆-joinˡ τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-joinˡ τ σ
+⊆-joinˡ (x≈y ∷ τ) (x≈z ∷ σ) = ∷-rpo x≈y x≈z (⊆-joinˡ τ σ)

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -90,3 +90,80 @@ open HeterogeneousProperties.Antisymmetry {R = _≈_} {S = _≈_} (λ x≈y _ �
 ⊆-poset = record
   { isPartialOrder = ⊆-isPartialOrder
   }
+
+------------------------------------------------------------------------
+-- Weak pushout
+--
+-- The category _⊆_ does not have proper pushouts.  For instance consider:
+--
+--   τᵤ : [] ⊆ (u ∷ [])
+--   τᵥ : [] ⊆ (v ∷ [])
+--
+-- Then, there are two unrelated upper bounds (u ∷ v ∷ []) and (v ∷ u ∷ []),
+-- since _⊆_ does not include permutations.
+--
+-- Even though there are no unique least upper bounds, we can merge two
+-- extensions of a list, producing a minimial superlist of both.
+--
+-- For the example, the left-biased merge would produce the pair:
+--
+--   τᵤ′ : (u ∷ []) ⊆ (u ∷ v ∷ [])
+--   τᵥ′ : (v ∷ []) ⊆ (u ∷ v ∷ [])
+--
+-- We call such a pair a raw pushout.  It is then a weak pushout if the
+-- resulting square commutes, i.e.:
+--
+--   ⊆-trans τᵤ τᵤ′ ~ ⊆-trans τᵥ τᵥ′
+--
+-- This requires a notion of equality _~_ on sublist morphisms.
+--
+-- Further, commutation requires a similar commutation property
+-- for the underlying equality _≈_, namely
+--
+--   trans x≈y (sym x≈y) == trans x≈z (sym x≈z)
+--
+-- for some notion of equality _==_ for equality proofs _≈_.
+-- Such a property is given e.g. if _≈_ is proof irrelevant
+-- or forms a groupoid.
+
+private
+  variable
+    x y z : A
+    xs ys zs us vs : List A
+    τ τ′ τ₁ τ₂ σ σ′ : xs ⊆ ys
+
+record RawPushout (τ : xs ⊆ ys) (σ : xs ⊆ zs) : Set (c ⊔ ℓ) where
+  constructor rawPushout
+  field
+    {upperBound} : List A
+    leg₁         : ys ⊆ upperBound
+    leg₂         : zs ⊆ upperBound
+
+open RawPushout
+
+------------------------------------------------------------------------
+-- Extending corners of a raw pushout square
+
+-- Extending the right upper corner.
+
+_∷ʳ₁_ : ∀ y → RawPushout τ σ → RawPushout (y ∷ʳ τ) σ
+y ∷ʳ₁ rpo = record { leg₁ = refl ∷ leg₁ rpo ; leg₂ = y ∷ʳ leg₂ rpo }
+
+-- Extending the left lower corner.
+
+_∷ʳ₂_ : ∀ z → RawPushout τ σ → RawPushout τ (z ∷ʳ σ)
+z ∷ʳ₂ rpo = record { leg₁ = z ∷ʳ leg₁ rpo ; leg₂ = refl ∷ leg₂ rpo }
+
+-- Extending both of these corners with equal elements.
+
+∷-rpo : (x≈y : x ≈ y) (x≈z : x ≈ z) → RawPushout τ σ → RawPushout (x≈y ∷ τ) (x≈z ∷ σ)
+∷-rpo x≈y x≈z rpo = record { leg₁ = sym x≈y ∷ leg₁ rpo; leg₂ = sym x≈z ∷ leg₂ rpo }
+
+------------------------------------------------------------------------
+-- Left-biased pushout: add elements of left extension first.
+
+⊆-merge : (τ : xs ⊆ ys) (σ : xs ⊆ zs) → RawPushout τ σ
+⊆-merge []        σ         = record { leg₁ = σ ; leg₂ = ⊆-refl }
+⊆-merge (y  ∷ʳ τ) σ         = y ∷ʳ₁ ⊆-merge τ σ
+⊆-merge τ@(_ ∷ _) (z  ∷ʳ σ) = z ∷ʳ₂ ⊆-merge τ σ
+⊆-merge (x≈y ∷ τ) (x≈z ∷ σ) = ∷-rpo x≈y x≈z (⊆-merge τ σ)


### PR DESCRIPTION
OPE does not have proper pushouts.
For weak pushouts, we would need a groupoid rather than a setoid.
However, we can still have raw pushout diagrams without any proven properties.

I plan to extend this PR to weak pushouts in case of Sublist.Propositional.