### PR TITLE
Drop IsMagma from IsRawMagmaMorphism

### DIFF
--- a/src/Algebra/Morphism.agda
+++ b/src/Algebra/Morphism.agda
@@ -48,28 +48,10 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsRawMagmaMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      F-isMagma : IsMagma F._≈_ F._∙_
-      T-isMagma : IsMagma T._≈_ T._∙_
       ⟦⟧-cong : ⟦_⟧ Preserves F._≈_ ⟶ T._≈_
       ∙-homo  : Homomorphic₂ ⟦_⟧ F._∙_ T._∙_
-
-    open IsMagma F-isMagma public using ()
-      renaming
-      ( ∙-cong  to F-∙-cong
-      ; ∙-congˡ to F-∙-congˡ
-      ; ∙-congʳ to F-∙-congʳ
-      ; setoid  to F-setoid
-      )
-
-    open IsMagma T-isMagma public using ()
-      renaming
-      ( ∙-cong  to T-∙-cong
-      ; ∙-congˡ to T-∙-congˡ
-      ; ∙-congʳ to T-∙-congʳ
-      ; setoid  to T-setoid
-      )
 
   IsRawMagmaMorphism-syntax = IsRawMagmaMorphism
   syntax IsRawMagmaMorphism-syntax From To F = F Is From -RawMagma⟶ To
@@ -85,7 +67,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsRawMonoidMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       magma-homo : IsRawMagmaMorphism F.rawMagma T.rawMagma ⟦_⟧
       ε-homo     : Homomorphic₀ ⟦_⟧ F.ε T.ε
@@ -109,7 +91,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsSemigroupMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       ⟦⟧-cong : ⟦_⟧ Preserves F._≈_ ⟶ T._≈_
       ∙-homo  : Homomorphic₂ ⟦_⟧ F._∙_ T._∙_
@@ -127,7 +109,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsMonoidMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       sm-homo : IsSemigroupMorphism F.semigroup T.semigroup ⟦_⟧
       ε-homo  : Homomorphic₀ ⟦_⟧ F.ε T.ε
@@ -147,7 +129,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsCommutativeMonoidMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
 
@@ -166,7 +148,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsIdempotentCommutativeMonoidMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
 
@@ -189,7 +171,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsGroupMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       mn-homo : IsMonoidMorphism F.monoid T.monoid ⟦_⟧
 
@@ -215,7 +197,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsAbelianGroupMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       gp-homo : IsGroupMorphism F.group T.group ⟦_⟧
 
@@ -234,7 +216,7 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
   open Definitions F.Carrier T.Carrier T._≈_
 
   record IsRingMorphism (⟦_⟧ : Morphism) :
-         Set (c₁ ⊔ ℓ₁ ⊔ c₂ ⊔ ℓ₂) where
+         Set (c₁ ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       +-abgp-homo : ⟦_⟧ Is F.+-abelianGroup -AbelianGroup⟶ T.+-abelianGroup
       *-mn-homo   : ⟦_⟧ Is F.*-monoid -Monoid⟶ T.*-monoid

--- a/src/Algebra/Morphism/RawMagma.agda
+++ b/src/Algebra/Morphism/RawMagma.agda
@@ -13,38 +13,46 @@ open import Function
 open RawMagma using (Carrier; _≈_)
 
 module Algebra.Morphism.RawMagma
-  {a b ℓ₁ ℓ₂} {From : RawMagma b ℓ₂} {To : RawMagma a ℓ₁}
-  {f : Carrier From → Carrier To}
-  (f-isRawMagmaMorphism : IsRawMagmaMorphism From To f)
-  (f-injective : Injective (_≈_ From) (_≈_ To) f)
+  {a b ℓ₁ ℓ₂} {From : RawMagma b ℓ₂} {To : Magma a ℓ₁}
+  {f : Carrier From → Magma.Carrier To}
+  (f-isRawMagmaMorphism : IsRawMagmaMorphism From (Magma.rawMagma To) f)
+  (f-injective : Injective (_≈_ From) (Magma._≈_ To) f)
   where
 
 open import Algebra.FunctionProperties
 open import Data.Product
 open import Data.Sum using (inj₁; inj₂)
+open import Relation.Binary using (IsEquivalence)
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 import Relation.Binary.Reasoning.MultiSetoid as MultiSetoidReasoning
 
 private
   module F = RawMagma From
-  module T = RawMagma To
+  module T = Magma To
 
 open Definitions F.Carrier T.Carrier T._≈_
 open T using () renaming (_∙_ to _⊕_)
 open F using (_∙_)
 
 open IsRawMagmaMorphism f-isRawMagmaMorphism
-open SetoidReasoning T-setoid
+open SetoidReasoning T.setoid
 
 ------------------------------------------------------------------------
 -- Properties
 
+∙-cong : Congruent₂ F._≈_ _∙_
+∙-cong {x} {y} {u} {v} x≈y u≈v = f-injective $ begin
+  f (x ∙ u) ≈⟨ ∙-homo x u ⟩
+  f x ⊕ f u ≈⟨ T.∙-cong (⟦⟧-cong x≈y) (⟦⟧-cong u≈v) ⟩
+  f y ⊕ f v ≈˘⟨ ∙-homo y v ⟩
+  f (y ∙ v) ∎
+
 assoc-homo : Associative T._≈_ _⊕_ → Associative F._≈_ _∙_
 assoc-homo assoc x y z = f-injective (begin
   f ((x ∙ y) ∙ z)    ≈⟨  ∙-homo (x ∙ y) z ⟩
-  f (x ∙ y) ⊕ f z    ≈⟨  T-∙-congʳ (∙-homo x y) ⟩
+  f (x ∙ y) ⊕ f z    ≈⟨  T.∙-congʳ (∙-homo x y) ⟩
   (f x ⊕ f y) ⊕ f z  ≈⟨  assoc (f x) (f y) (f z) ⟩
-  f x ⊕ (f y ⊕ f z)  ≈˘⟨ T-∙-congˡ (∙-homo y z) ⟩
+  f x ⊕ (f y ⊕ f z)  ≈˘⟨ T.∙-congˡ (∙-homo y z) ⟩
   f x ⊕ f (y ∙ z)    ≈˘⟨ ∙-homo x (y ∙ z) ⟩
   f (x ∙ (y ∙ z))    ∎)
 
@@ -92,11 +100,24 @@ cancel-homo (cancelˡ , cancelʳ) = cancelˡ-homo cancelˡ , cancelʳ-homo cance
 ------------------------------------------------------------------------
 -- Structures
 
+isEquivalence : IsEquivalence F._≈_
+isEquivalence = record
+  { refl = f-injective refl
+  ; sym = λ x≈y → f-injective (sym (⟦⟧-cong x≈y))
+  ; trans = λ x≈y y≈z → f-injective (trans (⟦⟧-cong x≈y) (⟦⟧-cong y≈z))
+  } where open IsEquivalence T.isEquivalence
+
+isMagma : IsMagma F._≈_ _∙_
+isMagma = record
+  { isEquivalence = isEquivalence
+  ; ∙-cong = ∙-cong
+  }
+
 isSemigroup-homo : IsSemigroup T._≈_ _⊕_ → IsSemigroup F._≈_ _∙_
 isSemigroup-homo isSemigroup = record
-  { isMagma = F-isMagma
+  { isMagma = isMagma
   ; assoc   = assoc-homo assoc
-  } where open IsSemigroup isSemigroup
+  } where open IsSemigroup isSemigroup using (assoc)
 
 isBand-homo : IsBand T._≈_ _⊕_ → IsBand F._≈_ _∙_
 isBand-homo isBand = record
@@ -112,6 +133,6 @@ isSemilattice-homo isSemilattice = record
 
 isSelectiveMagma-homo : IsSelectiveMagma T._≈_ _⊕_ → IsSelectiveMagma F._≈_ _∙_
 isSelectiveMagma-homo isSelMagma = record
-  { isMagma = F-isMagma
+  { isMagma = isMagma
   ; sel     = sel-homo sel
-  } where open IsSelectiveMagma isSelMagma
+  } where open IsSelectiveMagma isSelMagma using (sel)

--- a/src/Algebra/Morphism/RawMonoid.agda
+++ b/src/Algebra/Morphism/RawMonoid.agda
@@ -8,12 +8,14 @@
 
 open import Algebra
 open import Algebra.Morphism
+open import Algebra.Structures using (IsMagma)
 open import Function
 open RawMonoid using (Carrier; _≈_)
 
 module Algebra.Morphism.RawMonoid
   {a b ℓ₁ ℓ₂} {From : RawMonoid b ℓ₂} {To : RawMonoid a ℓ₁}
   {f : Carrier From → Carrier To}
+  (T-isMagma : IsMagma (_≈_ To) (RawMonoid._∙_ To))
   (f-isRawMonoidMorphism : IsRawMonoidMorphism From To f)
   (f-injective : Injective (_≈_ From) (_≈_ To) f)
   where
@@ -28,20 +30,24 @@ open import Level
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
 private
+  T-magma : Magma _ _
+  T-magma = record { isMagma = T-isMagma }
+
   module F = RawMonoid From
   module T = RawMonoid To
+  module TM = Magma T-magma
 
 open Definitions F.Carrier T.Carrier T._≈_
 open T using () renaming (_∙_ to _⊕_)
 open F using (_∙_)
 
 open IsRawMonoidMorphism f-isRawMonoidMorphism
-open SetoidReasoning T-setoid
+open SetoidReasoning (IsMagma.setoid T-isMagma)
 
 ------------------------------------------------------------------------
 -- Export all properties of magma morphisms
 
-open import Algebra.Morphism.RawMagma magma-homo f-injective public
+open import Algebra.Morphism.RawMagma {To = T-magma} magma-homo f-injective public
 
 ------------------------------------------------------------------------
 -- Properties
@@ -49,14 +55,14 @@ open import Algebra.Morphism.RawMagma magma-homo f-injective public
 identityˡ-homo : LeftIdentity T._≈_ T.ε _⊕_ → LeftIdentity F._≈_ F.ε _∙_
 identityˡ-homo idˡ x = f-injective (begin
   f (F.ε ∙ x)  ≈⟨ ∙-homo F.ε x ⟩
-  f F.ε ⊕ f x ≈⟨ T-∙-congʳ ε-homo ⟩
+  f F.ε ⊕ f x ≈⟨ TM.∙-congʳ ε-homo ⟩
   T.ε ⊕ f x    ≈⟨ idˡ (f x) ⟩
   f x          ∎)
 
 identityʳ-homo : RightIdentity T._≈_ T.ε _⊕_ → RightIdentity F._≈_ F.ε _∙_
 identityʳ-homo idʳ x = f-injective (begin
   f (x ∙ F.ε)  ≈⟨ ∙-homo x F.ε ⟩
-  f x ⊕ f F.ε ≈⟨ T-∙-congˡ ε-homo ⟩
+  f x ⊕ f F.ε ≈⟨ TM.∙-congˡ ε-homo ⟩
   f x ⊕ T.ε    ≈⟨ idʳ (f x) ⟩
   f x          ∎)
 

--- a/src/Data/Bin/Properties.agda
+++ b/src/Data/Bin/Properties.agda
@@ -276,9 +276,7 @@ toℕ-homo-+ 1+[2 x ] 1+[2 y ] = begin
 
 toℕ-+-isRawMagmaMorphism : IsRawMagmaMorphism +-rawMagma ℕₚ.+-rawMagma toℕ
 toℕ-+-isRawMagmaMorphism = record
-  { F-isMagma = isMagma _+_
-  ; T-isMagma = ℕₚ.+-isMagma
-  ; ⟦⟧-cong   = cong toℕ
+  { ⟦⟧-cong   = cong toℕ
   ; ∙-homo    = toℕ-homo-+
   }
 
@@ -323,8 +321,8 @@ fromℕ-homo-+ (ℕ.suc m) n = begin
 -- by `toℕ`/`fromℕ`.
 
 module _ where
-
-  open MonoidMorphisms toℕ-+-isRawMonoidMorphism toℕ-injective
+  open MonoidMorphisms ℕₚ.+-isMagma toℕ-+-isRawMonoidMorphism toℕ-injective
+    hiding (isMagma)
 
   +-assoc :  Associative _+_
   +-assoc = assoc-homo ℕₚ.+-assoc
@@ -508,9 +506,7 @@ toℕ-homo-* x y = aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
 
 toℕ-*-isRawMagmaMorphism : IsRawMagmaMorphism *-rawMagma ℕₚ.*-rawMagma toℕ
 toℕ-*-isRawMagmaMorphism = record
-  { F-isMagma = isMagma _*_
-  ; T-isMagma = ℕₚ.*-isMagma
-  ; ⟦⟧-cong   = cong toℕ
+  { ⟦⟧-cong   = cong toℕ
   ; ∙-homo    = toℕ-homo-*
   }
 
@@ -537,7 +533,8 @@ fromℕ-homo-* m n = begin
 -- by `toℕ`/`fromℕ`.
 
 module _ where
-  open MonoidMorphisms toℕ-*-isRawMonoidMorphism toℕ-injective
+  open MonoidMorphisms ℕₚ.*-isMagma toℕ-*-isRawMonoidMorphism toℕ-injective
+    hiding (isMagma)
 
   *-assoc :  Associative _*_
   *-assoc = assoc-homo ℕₚ.*-assoc
@@ -590,7 +587,8 @@ module _ where
 -- Structures
 
 module _ where
-  open MonoidMorphisms toℕ-*-isRawMonoidMorphism toℕ-injective
+  open MonoidMorphisms ℕₚ.*-isMagma toℕ-*-isRawMonoidMorphism toℕ-injective
+    hiding (isMagma)
 
   *-isMagma : IsMagma _*_
   *-isMagma = isMagma _*_


### PR DESCRIPTION
I was a bit surprised to see that `IsRawMagmaMorphism` requires arguments of type `IsMagma` for domain and codomain, effectively making them not raw at all. Here is a proposal for dropping these parameters.

`IsRawMagmaMorphism` is mainly used in `Algebra.Morphism.RawMagma` to translate properties from the codomain to the domain assuming injectivity. There one needs to know that the codomain is a magma, but for the domain it follows by injectivity. Hence, I changed the `To` to be a `Magma` instead of a `RawMagma`.

`Algebra.Morphism.RawMonoid` is a bit awkward now as the codomain needs to be both a magma and a `RawMonoid`. I added an additional module parameter `IsMagma` for this.

Please let me know if this makes sense and if there is anything that could be improved.