### PR TITLE
[ Sublist.Setoid.Properties ] removed spurious module parameters

### DIFF
--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -200,7 +200,7 @@ module _ {as bs : List A} where
 -- Inversion lemmas
 ------------------------------------------------------------------------
 
-module _ {a b} {A : Set a} {B : Set b} {a as b bs} where
+module _ {a as b bs} where
 
   ∷⁻¹ : a ≈ b → as ⊆ bs ⇔ a ∷ as ⊆ b ∷ bs
   ∷⁻¹ = HeteroProperties.∷⁻¹
@@ -225,8 +225,6 @@ module _ where
 
 ------------------------------------------------------------------------
 -- Irrelevant special case
-
-module _ {a b} {A : Set a} {B : Set b}  where
 
   []⊆-irrelevant : Irrelevant ([] ⊆_)
   []⊆-irrelevant = HeteroProperties.Sublist-[]-irrelevant


### PR DESCRIPTION
Were probably present due to a cut-and-paste error.