### PR TITLE
[ fix #826 ] Coercible type class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,8 @@ script:
   - agda $RTS_OPTIONS -i . -i src/ --safe EverythingSafeSizedTypes.agda
   # detecting basic compilation errors
   - agda $RTS_OPTIONS -i . -i src/ -c --no-main Everything.agda
+  # compiling & running the examples using the FFI
+  - agda $RTS_OPTIONS -i . -i src/ -c README/Foreign/Haskell.agda && ./Haskell
   # building the docs
   - agda $RTS_OPTIONS -i . -i src/ --html safe.agda
   - agda $RTS_OPTIONS -i . -i src/ --html index.agda

--- a/GenerateEverything.hs
+++ b/GenerateEverything.hs
@@ -38,6 +38,7 @@ unsafeModules = map toAgdaFilePath
   , "Data.Word.Unsafe"
   , "Debug.Trace"
   , "Foreign.Haskell"
+  , "Foreign.Haskell.Coerce"
   , "Foreign.Haskell.Maybe"
   , "Foreign.Haskell.Pair"
   , "IO"

--- a/README/Foreign/Haskell.agda
+++ b/README/Foreign/Haskell.agda
@@ -89,7 +89,7 @@ open import Relation.Nullary.Negation
 -- example program using uncons, catMaybes, and testChar
 
 main = run $
-  ♯ readFiniteFile "Haskell.agda" {- read this file -} >>= λ f →
+  ♯ readFiniteFile "README/Foreign/Haskell.agda" {- read this file -} >>= λ f →
   ♯ let chars   = toList f in
     let cleanup = catMaybes ∘ List.map (λ c → if testChar c then just c else nothing) in
     let cleaned = dropWhile ('\n' ≟_) $ cleanup chars in

--- a/README/Foreign/Haskell.agda
+++ b/README/Foreign/Haskell.agda
@@ -11,13 +11,18 @@ module README.Foreign.Haskell where
 -- Haskell types.
 
 -- To work around this limitation, we have defined FFI-friendly versions
--- of these types together with zero-cost coercions
+-- of these types together with a zero-cost coercion `coerce`.
 
 open import Level using (Level)
-open import Data.List.Base using (List; _∷_; []; takeWhile)
+open import Agda.Builtin.Int
+open import Agda.Builtin.Nat
+open import Data.Bool.Base using (Bool; if_then_else_)
+open import Data.Char as Char
+open import Data.List.Base as List using (List; _∷_; []; takeWhile; dropWhile)
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Product
 open import Function
+open import Relation.Nullary.Decidable
 
 import Foreign.Haskell as FFI
 open import Foreign.Haskell.Coerce
@@ -27,9 +32,13 @@ private
     a : Level
     A : Set a
 
--- Here we use the FFI version of Maybe and Pair
+-- Here we use the FFI version of Maybe and Pair.
 
-postulate primUncons : List A → FFI.Maybe (FFI.Pair A (List A))
+postulate
+  primUncons    : List A → FFI.Maybe (FFI.Pair A (List A))
+  primCatMaybes : List (FFI.Maybe A) → List A
+  primTestChar  : Char → Bool
+  primIntEq     : Int → Int → Bool
 
 {-# COMPILE GHC primUncons = \ _ _ xs -> case xs of
   { []       -> Nothing
@@ -37,27 +46,58 @@ postulate primUncons : List A → FFI.Maybe (FFI.Pair A (List A))
   }
 #-}
 
--- And `coerce` takes us back to the types we are used to
+{-# FOREIGN GHC import Data.Maybe #-}
+{-# COMPILE GHC primCatMaybes = \ _ _ -> catMaybes #-}
+
+{-# COMPILE GHC primTestChar = ('-' /=) #-}
+
+{-# COMPILE GHC primIntEq = (==) #-}
+
+-- We however want to use the notion of Maybe and Pair internal to
+-- the standard library. For this we use `coerce` to take use back
+-- to the types we are used to.
+
+-- The typeclass mechanism uses the coercion rules for Maybe and Pair,
+-- as well as the knowledge that natural numbers are represented as
+-- integers.
+-- We additionally benefit from the congruence rules for List, Char,
+-- Bool, and a reflexivity principle for variable A.
 
 uncons : List A → Maybe (A × List A)
 uncons = coerce primUncons
 
+catMaybes : List (Maybe A) → List A
+catMaybes = coerce primCatMaybes
+
+testChar : Char → Bool
+testChar = coerce primTestChar
+  -- note that coerce is useless here but the proof could come from
+  -- either `coerce-fun coerce-refl coerce-refl` or `coerce-refl` alone
+  -- We (and Agda) do not care which proof we got.
+
+eqNat : Nat → Nat → Bool
+eqNat = coerce primIntEq
+  -- We can coerce `Nat` to `Int` but not `Int` to `Nat`. This fundamentally
+  -- relies on the fact that `Coercible` understands that functions are
+  -- contravariant.
+
 open import IO
 open import Codata.Musical.Notation
-open import Data.Char as Char
 open import Data.String.Base
 open import Relation.Nullary.Negation
 
--- example program using uncons
+-- example program using uncons, catMaybes, and testChar
 
 main = run $
   ♯ readFiniteFile "Haskell.agda" {- read this file -} >>= λ f →
-  ♯ let cs = toList f in
-  case uncons cs of λ where
-    nothing         → putStrLn "I cannot believe this file is empty!"
+  ♯ let chars   = toList f in
+    let cleanup = catMaybes ∘ List.map (λ c → if testChar c then just c else nothing) in
+    let cleaned = dropWhile ('\n' ≟_) $ cleanup chars in
+  case uncons cleaned of λ where
+    nothing         → putStrLn "I cannot believe this file is filed with dashes only!"
     (just (c , cs)) → putStrLn $ unlines
-                    $ ("First character: " ++ Char.show c)
-                    ∷ ("Rest of the line: " ++ fromList (takeWhile (¬? ∘ ('\n' ≟_)) cs))
+                    $ ("First (non dash) character: " ++ Char.show c)
+                    ∷ ("Rest (dash free) of the line: " ++ fromList (takeWhile (¬? ∘ ('\n' ≟_)) cs))
                     ∷ []
 
 -- You can compile and run this test by writing:
@@ -65,5 +105,5 @@ main = run $
 -- ../../Haskell
 
 -- You should see the following text (without the indentation on the left):
---   First character: '-'
---   Rest of the line: -----------------------------------------------------------------------
+--   First (non dash) character: ' '
+--   Rest (dash free) of the line: The Agda standard library

--- a/README/Foreign/Haskell.agda
+++ b/README/Foreign/Haskell.agda
@@ -1,0 +1,69 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- A simple example of a program using the foreign function interface
+------------------------------------------------------------------------
+
+module README.Foreign.Haskell where
+
+-- In order to be considered safe by Agda, the standard library cannot
+-- add COMPILE pragmas binding the inductive types it defines to concrete
+-- Haskell types.
+
+-- To work around this limitation, we have defined FFI-friendly versions
+-- of these types together with zero-cost coercions
+
+open import Level using (Level)
+open import Data.List.Base using (List; _∷_; []; takeWhile)
+open import Data.Maybe.Base using (Maybe; just; nothing)
+open import Data.Product
+open import Function
+
+import Foreign.Haskell as FFI
+open import Foreign.Haskell.Coerce
+
+private
+  variable
+    a : Level
+    A : Set a
+
+-- Here we use the FFI version of Maybe and Pair
+
+postulate primUncons : List A → FFI.Maybe (FFI.Pair A (List A))
+
+{-# COMPILE GHC primUncons = \ _ _ xs -> case xs of
+  { []       -> Nothing
+  ; (x : xs) -> Just (x, xs)
+  }
+#-}
+
+-- And `coerce` takes us back to the types we are used to
+
+uncons : List A → Maybe (A × List A)
+uncons = coerce primUncons
+
+open import IO
+open import Codata.Musical.Notation
+open import Data.Char as Char
+open import Data.String.Base
+open import Relation.Nullary.Negation
+
+-- example program using uncons
+
+main = run $
+  ♯ readFiniteFile "Haskell.agda" {- read this file -} >>= λ f →
+  ♯ let cs = toList f in
+  case uncons cs of λ where
+    nothing         → putStrLn "I cannot believe this file is empty!"
+    (just (c , cs)) → putStrLn $ unlines
+                    $ ("First character: " ++ Char.show c)
+                    ∷ ("Rest of the line: " ++ fromList (takeWhile (¬? ∘ ('\n' ≟_)) cs))
+                    ∷ []
+
+-- You can compile and run this test by writing:
+-- agda -c Haskell.agda
+-- ../../Haskell
+
+-- You should see the following text (without the indentation on the left):
+--   First character: '-'
+--   Rest of the line: -----------------------------------------------------------------------

--- a/src/Data/Maybe/Base.agda
+++ b/src/Data/Maybe/Base.agda
@@ -29,8 +29,9 @@ private
 -- Definition
 
 data Maybe (A : Set a) : Set a where
-  just    : (x : A) → Maybe A
   nothing : Maybe A
+  just    : (x : A) → Maybe A
+
 
 ------------------------------------------------------------------------
 -- Some operations

--- a/src/Foreign/Haskell/Coerce.agda
+++ b/src/Foreign/Haskell/Coerce.agda
@@ -60,7 +60,7 @@ postulate Coercible : (A : Set a) (B : Set b) → Set (a ⊔ b)
 -- Once we get our hands on a proof that `Coercible A B` we know that
 -- it is safe to an `A` to a `B`. This is done by using `unsafeCoerce`.
 
-postulate coerce : {{Coercible A B}} → A → B
+postulate coerce : {{_ : Coercible A B}} → A → B
 
 {-# FOREIGN GHC import Unsafe.Coerce #-}
 {-# COMPILE GHC coerce = \ _ _ _ _ _ -> unsafeCoerce #-}
@@ -69,10 +69,10 @@ postulate coerce : {{Coercible A B}} → A → B
 -- Variants
 
 Coercible₁ : ∀ a c → (T : Set a → Set b) (U : Set c → Set d) → Set _
-Coercible₁ _ _ T U = ∀ {A B} → {{Coercible A B}} → Coercible (T A) (U B)
+Coercible₁ _ _ T U = ∀ {A B} → {{_ : Coercible A B}} → Coercible (T A) (U B)
 
 Coercible₂ : ∀ a b d e → (T : Set a → Set b → Set c) (U : Set d → Set e → Set f) → Set _
-Coercible₂ _ _ _ _ T U = ∀ {A B} → {{Coercible A B}} → Coercible₁ _ _ (T A) (U B)
+Coercible₂ _ _ _ _ T U = ∀ {A B} → {{_ : Coercible A B}} → Coercible₁ _ _ (T A) (U B)
 
 ------------------------------------------------------------------------
 -- Instances
@@ -90,15 +90,11 @@ instance
 
 -- Maybe
 
-instance
-  postulate
     maybe-toFFI   : Coercible₁ a b STD.Maybe FFI.Maybe
     maybe-fromFFI : Coercible₁ a b FFI.Maybe STD.Maybe
 
 -- Product
 
-instance
-  postulate
     pair-toFFI   : Coercible₂ a b c d STD._×_ FFI.Pair
     pair-fromFFI : Coercible₂ a b c d FFI.Pair STD._×_
 
@@ -106,12 +102,8 @@ instance
 
 -- Functions are contravariant in their domain.
 
-instance
-  postulate
-    coerce-fun : {{Coercible A B}} → Coercible₁ c d (λ C → B → C) (λ D → A → D)
+    coerce-fun : {{_ : Coercible A B}} → Coercible₁ c d (λ C → B → C) (λ D → A → D)
 
 -- Reflexivity
 
-instance
-  postulate
     coerce-refl : Coercible A A

--- a/src/Foreign/Haskell/Coerce.agda
+++ b/src/Foreign/Haskell/Coerce.agda
@@ -1,0 +1,117 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Zero-cost coercion to cross the FFI boundary
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K #-}
+
+module Foreign.Haskell.Coerce where
+
+------------------------------------------------------------------------
+-- Motivation
+
+-- Problem: No COMPILE directives for common inductive types
+
+-- In order to guarantee that the vast majority of the libary is
+-- considered safe by Agda, we had to remove the COMPILE pragmas
+-- associated to common inductive types.
+-- These directives cannot possibly be checked by the compiler and
+-- the user could define unsound mappings (e.g. swapping Bool's
+-- true and false).
+
+-- Solution: Essentially identical definitions + zero-cost coercions
+
+-- To solve this problem, we have introduced a number of essentially
+-- identical definitions in the Foreign.Haskell.* modules. However
+-- converting back and forth between the FFI-friendly type and its
+-- safe counterpart would take linear time.
+-- This module defines zero cost coercions between these types.
+
+------------------------------------------------------------------------
+-- Definition
+
+open import Level using (Level; _⊔_)
+open import Agda.Builtin.Nat
+open import Agda.Builtin.Int
+
+import Data.Maybe.Base as STD
+import Data.Product    as STD
+
+import Foreign.Haskell.Maybe as FFI
+import Foreign.Haskell.Pair  as FFI
+
+private
+  variable
+    a b c d e f : Level
+    A : Set a
+    B : Set b
+    C : Set c
+    D : Set d
+
+-- We postulate a type `Coercible`. A value of `Coercible A B` is a
+-- proof that ̀A` and `B` have the same underlying representation.
+
+postulate Coercible : (A : Set a) (B : Set b) → Set (a ⊔ b)
+
+{-# FOREIGN GHC type AgdaCoerce l1 l2 a b = () #-}
+{-# COMPILE GHC Coercible = type AgdaCoerce #-}
+
+-- Once we get our hands on a proof that `Coercible A B` we know that
+-- it is safe to an `A` to a `B`. This is done by using `unsafeCoerce`.
+
+postulate coerce : {{Coercible A B}} → A → B
+
+{-# FOREIGN GHC import Unsafe.Coerce #-}
+{-# COMPILE GHC coerce = \ _ _ _ _ _ -> unsafeCoerce #-}
+
+------------------------------------------------------------------------
+-- Variants
+
+Coercible₁ : ∀ a c → (T : Set a → Set b) (U : Set c → Set d) → Set _
+Coercible₁ _ _ T U = ∀ {A B} → {{Coercible A B}} → Coercible (T A) (U B)
+
+Coercible₂ : ∀ a b d e → (T : Set a → Set b → Set c) (U : Set d → Set e → Set f) → Set _
+Coercible₂ _ _ _ _ T U = ∀ {A B} → {{Coercible A B}} → Coercible₁ _ _ (T A) (U B)
+
+------------------------------------------------------------------------
+-- Instances
+
+-- Nat
+
+-- Our first example of such a case reveals one of Agda's secrets:
+-- natural numbers are represented by (arbitrary precision) integers
+-- at runtime! Note that we may only coerce in one direction: integers
+-- may actually be negative.
+
+instance
+  postulate
+    nat-toInt : Coercible Nat Int
+
+-- Maybe
+
+instance
+  postulate
+    maybe-toFFI   : Coercible₁ a b STD.Maybe FFI.Maybe
+    maybe-fromFFI : Coercible₁ a b FFI.Maybe STD.Maybe
+
+-- Product
+
+instance
+  postulate
+    pair-toFFI   : Coercible₂ a b c d STD._×_ FFI.Pair
+    pair-fromFFI : Coercible₂ a b c d FFI.Pair STD._×_
+
+-- Function
+
+-- Functions are contravariant in their domain.
+
+instance
+  postulate
+    coerce-fun : {{Coercible A B}} → Coercible₁ c d (λ C → B → C) (λ D → A → D)
+
+-- Reflexivity
+
+instance
+  postulate
+    coerce-refl : Coercible A A

--- a/src/Foreign/Haskell/Coerce.agda
+++ b/src/Foreign/Haskell/Coerce.agda
@@ -35,6 +35,7 @@ open import Level using (Level; _⊔_)
 open import Agda.Builtin.Nat
 open import Agda.Builtin.Int
 
+import IO.Primitive    as STD
 import Data.List.Base  as STD
 import Data.Maybe.Base as STD
 import Data.Product    as STD
@@ -127,6 +128,11 @@ instance
 
   coerce-list : Coercible₁ a b STD.List STD.List
   coerce-list = TrustMe
+
+-- IO
+
+  coerce-IO : Coercible₁ a b STD.IO STD.IO
+  coerce-IO = TrustMe
 
 -- Function
 -- Note that functions are contravariant in their domain.

--- a/src/Foreign/Haskell/Maybe.agda
+++ b/src/Foreign/Haskell/Maybe.agda
@@ -20,7 +20,7 @@ private
 -- Definition
 
 data Maybe (A : Set a) : Set a where
-  just : A → Maybe A
+  just    : A → Maybe A
   nothing : Maybe A
 
 {-# FOREIGN GHC type AgdaMaybe l a = Maybe a #-}

--- a/src/Foreign/Haskell/Pair.agda
+++ b/src/Foreign/Haskell/Pair.agda
@@ -27,7 +27,7 @@ record Pair (A : Set a) (B : Set b) : Set (a ⊔ b) where
 open Pair public
 
 {-# FOREIGN GHC type AgdaPair l1 l2 a b = (a , b) #-}
-{-# COMPILE GHC Pair = data MAlonzo.Code.Foreign.Haskell.AgdaPair ((,)) #-}
+{-# COMPILE GHC Pair = data MAlonzo.Code.Foreign.Haskell.Pair.AgdaPair ((,)) #-}
 
 ------------------------------------------------------------------------
 -- Conversion


### PR DESCRIPTION
To cross FFI boundaries easily, we can use `coerce` to convert
between the FFI-friendly types and the ones actually use in the
core library with all the functions we know and love.

Note that I had to swap Data.Maybe.Base's constructors so that
they would appear in the same order as the ones for Maybe as
defined in ghc's base.