### PR TITLE
Work-arounds for failing forcing translation

### DIFF
--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -876,8 +876,8 @@ m-n≤m m n = ≤-steps-neg n ≤-refl
 m≤n⇒m-n≤0 : ∀ {m n} → m ≤ n → m - n ≤ + 0
 m≤n⇒m-n≤0 (-≤+ {n = n})         = ≤-steps-neg n -≤+
 m≤n⇒m-n≤0 (-≤- {n = n} n≤m)     = ≤-trans (⊖-monoʳ-≥-≤ n n≤m) (≤-reflexive (n⊖n≡0 n))
-m≤n⇒m-n≤0 (+≤+ {n = 0} z≤n)     = +≤+ z≤n
-m≤n⇒m-n≤0 (+≤+ {n = suc n} z≤n) = -≤+
+m≤n⇒m-n≤0 {n = + 0}     (+≤+ z≤n) = +≤+ z≤n
+m≤n⇒m-n≤0 {n = + suc n} (+≤+ z≤n) = -≤+
 m≤n⇒m-n≤0 (+≤+ (s≤s {m} m≤n))   = ≤-trans (⊖-monoʳ-≥-≤ m m≤n) (≤-reflexive (n⊖n≡0 m))
 
 m-n≤0⇒m≤n : ∀ {m n} → m - n ≤ + 0 → m ≤ n
@@ -1355,8 +1355,8 @@ neg-distribʳ-* x y = begin
 *-monoʳ-≤-pos _ (-≤+             {n = suc _})     = -≤+
 *-monoʳ-≤-pos x (-≤-                         n≤m) =
   -≤- (ℕₚ.≤-pred (ℕₚ.*-mono-≤ (s≤s n≤m) (ℕₚ.≤-refl {x = suc x})))
-*-monoʳ-≤-pos _ (+≤+ {m = 0}     {n = 0}     m≤n) = +≤+ m≤n
-*-monoʳ-≤-pos _ (+≤+ {m = 0}     {n = suc _} m≤n) = +≤+ z≤n
+*-monoʳ-≤-pos k {+ 0} {+ 0}     (+≤+ m≤n) = +≤+ m≤n
+*-monoʳ-≤-pos k {+ 0} {+ suc _} (+≤+ m≤n) = +≤+ z≤n
 *-monoʳ-≤-pos x (+≤+ {m = suc _} {n = suc _} m≤n) =
   +≤+ ((ℕₚ.*-mono-≤ m≤n (ℕₚ.≤-refl {x = suc x})))
 

--- a/src/Relation/Binary/Construct/Add/Infimum/NonStrict.agda
+++ b/src/Relation/Binary/Construct/Add/Infimum/NonStrict.agda
@@ -66,7 +66,7 @@ data _≤₋_ : Rel (A ₋) (a ⊔ ℓ) where
 ≤₋-reflexive-≡ ≤-reflexive {⊥₋}    refl = ⊥₋≤ ⊥₋
 
 ≤₋-antisym-≡ : Antisymmetric _≡_ _≤_ → Antisymmetric _≡_ _≤₋_
-≤₋-antisym-≡ antisym (⊥₋≤ ⊥₋) (⊥₋≤ ⊥₋) = refl
+≤₋-antisym-≡ antisym (⊥₋≤ _) (⊥₋≤ _) = refl
 ≤₋-antisym-≡ antisym [ p ] [ q ]       = P.cong [_] (antisym p q)
 
 ------------------------------------------------------------------------
@@ -81,7 +81,7 @@ module _ {e} {_≈_ : Rel A e} where
   ≤₋-reflexive ≤-reflexive [ p ] = [ ≤-reflexive p ]
 
   ≤₋-antisym : Antisymmetric _≈_ _≤_ → Antisymmetric _≈₋_ _≤₋_
-  ≤₋-antisym ≤≥⇒≈ (⊥₋≤ ⊥₋) (⊥₋≤ ⊥₋) = ⊥₋≈⊥₋
+  ≤₋-antisym ≤≥⇒≈ (⊥₋≤ _) (⊥₋≤ _) = ⊥₋≈⊥₋
   ≤₋-antisym ≤≥⇒≈ [ p ] [ q ] = [ ≤≥⇒≈ p q ]
 
 ------------------------------------------------------------------------

--- a/src/Relation/Binary/Construct/Add/Supremum/NonStrict.agda
+++ b/src/Relation/Binary/Construct/Add/Supremum/NonStrict.agda
@@ -65,7 +65,7 @@ data _≤⁺_ : Rel (A ⁺) (a ⊔ ℓ) where
 ≤⁺-reflexive-≡ ≤-reflexive {⊤⁺}    refl = ⊤⁺ ≤⊤⁺
 
 ≤⁺-antisym-≡ : Antisymmetric _≡_ _≤_ → Antisymmetric _≡_ _≤⁺_
-≤⁺-antisym-≡ antisym (⊤⁺ ≤⊤⁺) (⊥⁺ ≤⊤⁺) = refl
+≤⁺-antisym-≡ antisym (_ ≤⊤⁺) (_ ≤⊤⁺) = refl
 ≤⁺-antisym-≡ antisym [ p ] [ q ]       = P.cong [_] (antisym p q)
 
 ------------------------------------------------------------------------
@@ -80,8 +80,8 @@ module _ {e} {_≈_ : Rel A e} where
   ≤⁺-reflexive ≤-reflexive ⊤⁺≈⊤⁺ = ⊤⁺ ≤⊤⁺
 
   ≤⁺-antisym : Antisymmetric _≈_ _≤_ → Antisymmetric _≈⁺_ _≤⁺_
-  ≤⁺-antisym ≤-antisym [ p ]    [ q ]    = [ ≤-antisym p q ]
-  ≤⁺-antisym ≤-antisym (⊤⁺ ≤⊤⁺) (⊤⁺ ≤⊤⁺) = ⊤⁺≈⊤⁺
+  ≤⁺-antisym ≤-antisym [ p ]    [ q ]  = [ ≤-antisym p q ]
+  ≤⁺-antisym ≤-antisym (_ ≤⊤⁺) (_ ≤⊤⁺) = ⊤⁺≈⊤⁺
 
 ------------------------------------------------------------------------
 -- Structures + propositional equality


### PR DESCRIPTION
See agda/agda#3903. Previously Agda sometimes picked the wrong place to move a forced pattern to, resulting (in the worst case) in segfaulting or badly behaved compiled code. Now the forcing translation gives up when it's not sure, and this happens in a small number of places in the standard library. The workaround is to move the match manually to the correct non-forced position.