### PR TITLE
[ fix #868 ] Add Data.AVL.Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ The following new modules have been added to the library:
   Algebra.Properties.Semigroup
   Algebra.Properties.CommutativeSemigroup
 
+  Data.AVL.Map
+
   Data.Bin
   Data.Bin.Base
   Data.Bin.Properties

--- a/src/Data/AVL/Map.agda
+++ b/src/Data/AVL/Map.agda
@@ -1,0 +1,94 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Maps from keys to values, based on AVL trees
+-- This modules provides a simpler map interface, without a dependency
+-- between the key and value types.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Relation.Binary using (StrictTotalOrder)
+
+module Data.AVL.Map
+  {a ℓ₁ ℓ₂} (strictTotalOrder : StrictTotalOrder a ℓ₁ ℓ₂)
+  where
+
+open import Data.Bool.Base using (Bool)
+open import Data.List.Base using (List)
+open import Data.Maybe using (Maybe)
+open import Data.Product using (_×_)
+open import Level using (_⊔_)
+
+import Data.AVL strictTotalOrder as AVL
+open StrictTotalOrder strictTotalOrder renaming (Carrier to Key)
+
+------------------------------------------------------------------------
+-- The map type
+
+Map : ∀ {i} → (v : Set i) → Set (a ⊔ i ⊔ ℓ₂)
+Map v = AVL.Tree (AVL.const v)
+
+------------------------------------------------------------------------
+-- Repackaged functions
+
+module _ {i} {v : Set i} where
+
+  empty : Map v
+  empty = AVL.empty
+
+  singleton : Key → v → Map v
+  singleton = AVL.singleton
+
+  insert : Key → v → Map v → Map v
+  insert = AVL.insert
+
+  insertWith : Key → (Maybe v → v) → Map v → Map v
+  insertWith = AVL.insertWith
+
+  delete : Key → Map v → Map v
+  delete = AVL.delete
+
+  lookup : Key → Map v → Maybe v
+  lookup = AVL.lookup
+
+module _ {i j} {v : Set i} {w : Set j} where
+
+  map : (v → w) → Map v → Map w
+  map f = AVL.map f
+
+module _ {i} {v : Set i} where
+
+  infix 4 _∈?_
+
+  _∈?_ : Key → Map v → Bool
+  _∈?_ = AVL._∈?_
+
+  headTail : Map v → Maybe ((Key × v) × Map v)
+  headTail = AVL.headTail
+
+  initLast : Map v → Maybe (Map v × (Key × v))
+  initLast = AVL.initLast
+
+  fromList : List (Key × v) → Map v
+  fromList = AVL.fromList
+
+  toList : Map v → List (Key × v)
+  toList = AVL.toList
+
+module _ {i j} {v : Set i} {w : Set j} where
+
+  unionWith : (v → Maybe w → w) →
+              Map v → Map w → Map w
+  unionWith f = AVL.unionWith f
+
+module _ {i} {v : Set i} where
+
+  union : Map v → Map v → Map v
+  union = AVL.union
+
+  unionsWith : (v → Maybe v → v) → List (Map v) → Map v
+  unionsWith f = AVL.unionsWith f
+
+  unions : List (Map v) → Map v
+  unions = AVL.unions

--- a/src/Data/AVL/Map.agda
+++ b/src/Data/AVL/Map.agda
@@ -26,69 +26,69 @@ open StrictTotalOrder strictTotalOrder renaming (Carrier to Key)
 ------------------------------------------------------------------------
 -- The map type
 
-Map : ∀ {i} → (v : Set i) → Set (a ⊔ i ⊔ ℓ₂)
+Map : ∀ {v} → (V : Set v) → Set (a ⊔ v ⊔ ℓ₂)
 Map v = AVL.Tree (AVL.const v)
 
 ------------------------------------------------------------------------
 -- Repackaged functions
 
-module _ {i} {v : Set i} where
+module _ {v} {V : Set v} where
 
-  empty : Map v
+  empty : Map V
   empty = AVL.empty
 
-  singleton : Key → v → Map v
+  singleton : Key → V → Map V
   singleton = AVL.singleton
 
-  insert : Key → v → Map v → Map v
+  insert : Key → V → Map V → Map V
   insert = AVL.insert
 
-  insertWith : Key → (Maybe v → v) → Map v → Map v
+  insertWith : Key → (Maybe V → V) → Map V → Map V
   insertWith = AVL.insertWith
 
-  delete : Key → Map v → Map v
+  delete : Key → Map V → Map V
   delete = AVL.delete
 
-  lookup : Key → Map v → Maybe v
+  lookup : Key → Map V → Maybe V
   lookup = AVL.lookup
 
-module _ {i j} {v : Set i} {w : Set j} where
+module _ {v w} {V : Set v} {W : Set w} where
 
-  map : (v → w) → Map v → Map w
+  map : (V → W) → Map V → Map W
   map f = AVL.map f
 
-module _ {i} {v : Set i} where
+module _ {v} {V : Set v} where
 
   infix 4 _∈?_
 
-  _∈?_ : Key → Map v → Bool
+  _∈?_ : Key → Map V → Bool
   _∈?_ = AVL._∈?_
 
-  headTail : Map v → Maybe ((Key × v) × Map v)
+  headTail : Map V → Maybe ((Key × V) × Map V)
   headTail = AVL.headTail
 
-  initLast : Map v → Maybe (Map v × (Key × v))
+  initLast : Map V → Maybe (Map V × (Key × V))
   initLast = AVL.initLast
 
-  fromList : List (Key × v) → Map v
+  fromList : List (Key × V) → Map V
   fromList = AVL.fromList
 
-  toList : Map v → List (Key × v)
+  toList : Map V → List (Key × V)
   toList = AVL.toList
 
-module _ {i j} {v : Set i} {w : Set j} where
+module _ {v w} {V : Set v} {W : Set w} where
 
-  unionWith : (v → Maybe w → w) →
-              Map v → Map w → Map w
+  unionWith : (V → Maybe W → W) →
+              Map V → Map W → Map W
   unionWith f = AVL.unionWith f
 
-module _ {i} {v : Set i} where
+module _ {v} {V : Set v} where
 
-  union : Map v → Map v → Map v
+  union : Map V → Map V → Map V
   union = AVL.union
 
-  unionsWith : (v → Maybe v → v) → List (Map v) → Map v
+  unionsWith : (V → Maybe V → V) → List (Map V) → Map V
   unionsWith f = AVL.unionsWith f
 
-  unions : List (Map v) → Map v
+  unions : List (Map V) → Map V
   unions = AVL.unions


### PR DESCRIPTION
Implements the simple interface for maps in module `Data.AVL.Map`. Fixes #868 .

I kept the same order of the functions as in the `Data.AVL` module.

Let me know if something needs to be changed.