### PR TITLE
Proofs about identity and composition for the new function hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Other non-backwards compatible changes
 
 #### New function hierarchy
 
-The main problems with the current way various types of functions are
+* The main problems with the current way various types of functions are
 handled are:
   1. The raw functions were wrapped in the  equality-preserving
          type `_⟶_` from `Function.Equality`. As the rest of the library
@@ -40,7 +40,7 @@ handled are:
      possible to specify that for example an operation is commutative
      without providing all the proofs associated with the equality relation.
 
-To address these problems a new function hierarchy similar to the ones in
+* To address these problems a new function hierarchy similar to the ones in
 `Relation.Binary` and `Algebra` has been created. The new modules are as
 follows:
   - `Function.Definitions` containing definitions like `Injective`,
@@ -55,13 +55,19 @@ follows:
   - The old file `Function` has been moved to `Function.Core` and `Function`
     now exports the whole of this hierarchy, just like `Relation.Binary`.
 
-These changes are nearly entirely backwards compatible. The only problem will occur
+* These changes are nearly entirely backwards compatible. The only problem will occur
 is when code imports both `Function` and e.g. `Function.Injection` in which case the
 old and new definitions of `Injection` will clash. In the short term this can
 immediately be fixed by importing `Function.Core` instead of `Function`. However
 we would encourage to the new hierarchy in the medium to long term.
 
-The old modules will probably be deprecated (NOT COMPLETED AS OF YET)
+* The list of new modules is as follows:
+  ```agda
+  Function.Construct.Identity
+  Function.Construct.Composition
+  ```
+
+* The old modules will probably be deprecated (NOT COMPLETED AS OF YET)
   ```agda
   Function.Equivalence
   Function.Equality

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -196,20 +196,22 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} {T : Setoid c ℓ₃} where
 ------------------------------------------------------------------------
 -- Propositional packages
 
-↣ : A ↣ B → B ↣ C → A ↣ C
-↣ = injection
+infix 8 _∘-↣_ _∘-↠_ _∘-⤖_ _∘-⇔_ _∘-↞_ _∘-↔_
 
-↠ : A ↠ B → B ↠ C → A ↠ C
-↠ = surjection
+_∘-↣_ : A ↣ B → B ↣ C → A ↣ C
+_∘-↣_ = injection
 
-⤖ : A ⤖ B → B ⤖ C → A ⤖ C
-⤖ = bijection
+_∘-↠_ : A ↠ B → B ↠ C → A ↠ C
+_∘-↠_ = surjection
 
-⇔ : A ⇔ B → B ⇔ C → A ⇔ C
-⇔ = equivalence
+_∘-⤖_ : A ⤖ B → B ⤖ C → A ⤖ C
+_∘-⤖_ = bijection
 
-↞ : A ↞ B → B ↞ C → A ↞ C
-↞ = leftInverse
+_∘-⇔_ : A ⇔ B → B ⇔ C → A ⇔ C
+_∘-⇔_ = equivalence
 
-↔ : A ↔ B → B ↔ C → A ↔ C
-↔ = inverse
+_∘-↞_ : A ↞ B → B ↞ C → A ↞ C
+_∘-↞_ = leftInverse
+
+_∘-↔_ : A ↔ B → B ↔ C → A ↔ C
+_∘-↔_ = inverse

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -1,0 +1,215 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The identity function
+------------------------------------------------------------------------
+
+module Function.Construct.Composition where
+
+open import Data.Product using (_,_)
+open import Function
+open import Level
+open import Relation.Binary
+
+private
+  variable
+    a b c ℓ₁ ℓ₂ ℓ₃ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Properties
+
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈₃ : Rel C ℓ₃)
+         {f : A → B} {g : B → C}
+         where
+
+  congruent : Congruent ≈₁ ≈₂ f → Congruent ≈₂ ≈₃ g →
+              Congruent ≈₁ ≈₃ (g ∘ f)
+  congruent f-cong g-cong = g-cong ∘ f-cong
+
+  injective : Injective ≈₁ ≈₂ f → Injective ≈₂ ≈₃ g →
+              Injective ≈₁ ≈₃ (g ∘ f)
+  injective f-inj g-inj = f-inj ∘ g-inj
+
+  surjective : Transitive ≈₃ → Congruent ≈₂ ≈₃ g →
+               Surjective ≈₁ ≈₂ f → Surjective ≈₂ ≈₃ g →
+               Surjective ≈₁ ≈₃ (g ∘ f)
+  surjective trans g-cong f-sur g-sur x with g-sur x
+  ... | y , fy≈x  with f-sur y
+  ...   | z , fz≈y = z , trans (g-cong fz≈y) fy≈x
+
+  bijective : Transitive ≈₃ → Congruent ≈₂ ≈₃ g →
+              Bijective ≈₁ ≈₂ f → Bijective ≈₂ ≈₃ g →
+              Bijective ≈₁ ≈₃ (g ∘ f)
+  bijective trans g-cong (f-inj , f-sur) (g-inj , g-sur) =
+    injective f-inj g-inj , surjective trans g-cong f-sur g-sur
+
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈₃ : Rel C ℓ₃)
+         (f : A → B) {f⁻¹ : B → A} {g : B → C} (g⁻¹ : C → B)
+         where
+
+  inverseˡ : Transitive ≈₃ → Congruent ≈₂ ≈₃ g →
+             Inverseˡ ≈₁ ≈₂ f f⁻¹ → Inverseˡ ≈₂ ≈₃ g g⁻¹ →
+             Inverseˡ ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  inverseˡ trn g-cong f-inv g-inv x = trn (g-cong (f-inv _)) (g-inv x)
+
+  inverseʳ : Transitive ≈₁ → Congruent ≈₂ ≈₁ f⁻¹ →
+             Inverseʳ ≈₁ ≈₂ f f⁻¹ → Inverseʳ ≈₂ ≈₃ g g⁻¹ →
+             Inverseʳ ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  inverseʳ trn f⁻¹-cong f-inv g-inv x = trn (f⁻¹-cong (g-inv _)) (f-inv x)
+
+  inverseᵇ : Transitive ≈₁ → Transitive ≈₃ →
+             Congruent ≈₂ ≈₃ g → Congruent ≈₂ ≈₁ f⁻¹ →
+             Inverseᵇ ≈₁ ≈₂ f f⁻¹ → Inverseᵇ ≈₂ ≈₃ g g⁻¹ →
+             Inverseᵇ ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  inverseᵇ trn₁ trn₃ g-cong f⁻¹-cong (f-invˡ , f-invʳ) (g-invˡ , g-invʳ) =
+    inverseˡ trn₃ g-cong f-invˡ g-invˡ , inverseʳ trn₁ f⁻¹-cong f-invʳ g-invʳ
+
+------------------------------------------------------------------------
+-- Structures
+
+module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
+         {f : A → B} {g : B → C}
+         where
+
+  isCongruent : IsCongruent ≈₁ ≈₂ f → IsCongruent ≈₂ ≈₃ g →
+                IsCongruent ≈₁ ≈₃ (g ∘ f)
+  isCongruent f-cong g-cong = record
+    { cong           = G.cong ∘ F.cong
+    ; isEquivalence₁ = F.isEquivalence₁
+    ; isEquivalence₂ = G.isEquivalence₂
+    } where module F = IsCongruent _ _ f-cong; module G = IsCongruent _ _ g-cong
+
+  isInjection : IsInjection ≈₁ ≈₂ f → IsInjection ≈₂ ≈₃ g →
+                IsInjection ≈₁ ≈₃ (g ∘ f)
+  isInjection f-inj g-inj = record
+    { isCongruent = isCongruent F.isCongruent G.isCongruent
+    ; injective   = injective ≈₁ ≈₂ ≈₃ F.injective G.injective
+    } where module F = IsInjection _ _ f-inj; module G = IsInjection _ _ g-inj
+
+  isSurjection : IsSurjection ≈₁ ≈₂ f → IsSurjection ≈₂ ≈₃ g →
+                 IsSurjection ≈₁ ≈₃ (g ∘ f)
+  isSurjection f-surj g-surj = record
+    { isCongruent = isCongruent F.isCongruent G.isCongruent
+    ; surjective   = surjective ≈₁ ≈₂ ≈₃ G.Eq₂.trans G.cong F.surjective G.surjective
+    } where module F = IsSurjection _ _ f-surj; module G = IsSurjection _ _ g-surj
+
+  isBijection : IsBijection ≈₁ ≈₂ f → IsBijection ≈₂ ≈₃ g →
+                IsBijection ≈₁ ≈₃ (g ∘ f)
+  isBijection f-bij g-bij = record
+    { isInjection = isInjection F.isInjection G.isInjection
+    ; surjective  = surjective ≈₁ ≈₂ ≈₃ G.Eq₂.trans G.cong F.surjective G.surjective
+    } where module F = IsBijection _ _ f-bij; module G = IsBijection _ _ g-bij
+
+module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
+         {f : A → B} {g : B → C} {f⁻¹ : B → A} {g⁻¹ : C → B}
+         where
+
+  isLeftInverse : IsLeftInverse ≈₁ ≈₂ f f⁻¹ → IsLeftInverse ≈₂ ≈₃ g g⁻¹ →
+                  IsLeftInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  isLeftInverse f-invˡ g-invˡ = record
+    { isCongruent = isCongruent F.isCongruent G.isCongruent
+    ; cong₂       = congruent ≈₃ ≈₂ ≈₁ G.cong₂ F.cong₂
+    ; inverseˡ    = inverseˡ ≈₁ ≈₂ ≈₃ f _ G.Eq₂.trans G.cong₁ F.inverseˡ G.inverseˡ
+    } where module F = IsLeftInverse _ _ f-invˡ; module G = IsLeftInverse _ _ g-invˡ
+
+  isRightInverse : IsRightInverse ≈₁ ≈₂ f f⁻¹ → IsRightInverse ≈₂ ≈₃ g g⁻¹ →
+                   IsRightInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  isRightInverse f-invʳ g-invʳ = record
+    { isCongruent = isCongruent F.isCongruent G.isCongruent
+    ; cong₂       = congruent ≈₃ ≈₂ ≈₁ G.cong₂ F.cong₂
+    ; inverseʳ    = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.cong₂ F.inverseʳ G.inverseʳ
+    } where module F = IsRightInverse _ _ f-invʳ; module G = IsRightInverse _ _ g-invʳ
+
+  isInverse : IsInverse ≈₁ ≈₂ f f⁻¹ → IsInverse ≈₂ ≈₃ g g⁻¹ →
+              IsInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
+  isInverse f-inv g-inv = record
+    { isLeftInverse = isLeftInverse F.isLeftInverse G.isLeftInverse
+    ; inverseʳ      = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.cong₂ F.inverseʳ G.inverseʳ
+    } where module F = IsInverse _ _ f-inv; module G = IsInverse _ _ g-inv
+
+------------------------------------------------------------------------
+-- Setoid packages
+
+module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} {T : Setoid c ℓ₃} where
+
+  open Setoid renaming (_≈_ to ≈)
+
+  injection : Injection R S → Injection S T → Injection R T
+  injection inj₁ inj₂ = record
+    { f         = G.f ∘ F.f
+    ; cong      = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
+    ; injective = injective (≈ R) (≈ S) (≈ T) F.injective G.injective
+    } where module F = Injection inj₁; module G = Injection inj₂
+
+  surjection : Surjection R S → Surjection S T → Surjection R T
+  surjection surj₁ surj₂ = record
+    { f          = G.f ∘ F.f
+    ; cong       = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
+    ; surjective = surjective (≈ R) (≈ S) (≈ T) G.Eq₂.trans G.cong F.surjective G.surjective
+    } where module F = Surjection surj₁; module G = Surjection surj₂
+
+  bijection : Bijection R S → Bijection S T → Bijection R T
+  bijection bij₁ bij₂ = record
+    { f         = G.f ∘ F.f
+    ; cong      = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
+    ; bijective = bijective (≈ R) (≈ S) (≈ T) (trans T) G.cong F.bijective G.bijective
+    } where module F = Bijection bij₁; module G = Bijection bij₂
+
+  equivalence : Equivalence R S → Equivalence S T → Equivalence R T
+  equivalence equiv₁ equiv₂ = record
+    { f        = G.f ∘ F.f
+    ; g        = F.g ∘ G.g
+    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
+    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
+    } where module F = Equivalence equiv₁; module G = Equivalence equiv₂
+
+  leftInverse : LeftInverse R S → LeftInverse S T → LeftInverse R T
+  leftInverse invˡ₁ invˡ₂ = record
+    { f        = G.f ∘ F.f
+    ; g        = F.g ∘ G.g
+    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
+    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
+    ; inverseˡ = inverseˡ (≈ R) (≈ S) (≈ T) F.f _ (trans T) G.cong₁ F.inverseˡ G.inverseˡ
+    } where module F = LeftInverse invˡ₁; module G = LeftInverse invˡ₂
+
+  rightInverse : RightInverse R S → RightInverse S T → RightInverse R T
+  rightInverse invʳ₁ invʳ₂ = record
+    { f        = G.f ∘ F.f
+    ; g        = F.g ∘ G.g
+    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
+    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
+    ; inverseʳ = inverseʳ (≈ R) (≈ S) (≈ T) _ G.g (trans R) F.cong₂ F.inverseʳ G.inverseʳ
+    } where module F = RightInverse invʳ₁; module G = RightInverse invʳ₂
+
+  inverse : Inverse R S → Inverse S T → Inverse R T
+  inverse inv₁ inv₂ = record
+    { f       = G.f ∘ F.f
+    ; f⁻¹     = F.f⁻¹ ∘ G.f⁻¹
+    ; cong₁   = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
+    ; cong₂   = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
+    ; inverse = inverseᵇ (≈ R) (≈ S) (≈ T) _ G.f⁻¹ (trans R) (trans T) G.cong₁ F.cong₂ F.inverse G.inverse
+    } where module F = Inverse inv₁; module G = Inverse inv₂
+
+------------------------------------------------------------------------
+-- Propositional packages
+
+↣ : A ↣ B → B ↣ C → A ↣ C
+↣ = injection
+
+↠ : A ↠ B → B ↠ C → A ↠ C
+↠ = surjection
+
+⤖ : A ⤖ B → B ⤖ C → A ⤖ C
+⤖ = bijection
+
+⇔ : A ⇔ B → B ⇔ C → A ⇔ C
+⇔ = equivalence
+
+↞ : A ↞ B → B ↞ C → A ↞ C
+↞ = leftInverse
+
+↔ : A ↔ B → B ↔ C → A ↔ C
+↔ = inverse

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -4,6 +4,8 @@
 -- The identity function
 ------------------------------------------------------------------------
 
+{-# OPTIONS --without-K --safe #-}
+
 module Function.Construct.Composition where
 
 open import Data.Product using (_,_)

--- a/src/Function/Construct/Identity.agda
+++ b/src/Function/Construct/Identity.agda
@@ -166,20 +166,20 @@ module _ (A : Set a) where
 
   open Function {A = A} {A} _≡_ _≡_
 
-  ↣ : A ↣ A
-  ↣ = injection (setoid A)
+  id-↣ : A ↣ A
+  id-↣ = injection (setoid A)
 
-  ↠ : A ↠ A
-  ↠ = surjection (setoid A)
+  id-↠ : A ↠ A
+  id-↠ = surjection (setoid A)
 
-  ⤖ : A ⤖ A
-  ⤖ = bijection (setoid A)
+  id-⤖ : A ⤖ A
+  id-⤖ = bijection (setoid A)
 
-  ⇔ : A ⇔ A
-  ⇔ = equivalence (setoid A)
+  id-⇔ : A ⇔ A
+  id-⇔ = equivalence (setoid A)
 
-  ↞ : A ↞ A
-  ↞ = leftInverse (setoid A)
+  id-↞ : A ↞ A
+  id-↞ = leftInverse (setoid A)
 
-  ↔ : A ↔ A
-  ↔ = inverse (setoid A)
+  id-↔ : A ↔ A
+  id-↔ = inverse (setoid A)

--- a/src/Function/Construct/Identity.agda
+++ b/src/Function/Construct/Identity.agda
@@ -4,6 +4,8 @@
 -- The identity function
 ------------------------------------------------------------------------
 
+{-# OPTIONS --without-K --safe #-}
+
 module Function.Construct.Identity where
 
 open import Data.Product using (_,_)

--- a/src/Function/Construct/Identity.agda
+++ b/src/Function/Construct/Identity.agda
@@ -1,0 +1,185 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The identity function
+------------------------------------------------------------------------
+
+module Function.Construct.Identity where
+
+open import Data.Product using (_,_)
+import Function
+open import Level
+open import Relation.Binary
+open import Relation.Binary.PropositionalEquality using (_≡_; setoid)
+
+private
+  variable
+    a ℓ : Level
+    A : Set a
+
+------------------------------------------------------------------------
+-- Properties
+
+module _ (_≈_ : Rel A ℓ) where
+
+  open Function _≈_ _≈_
+
+  injective : Injective id
+  injective = id
+
+  surjective : Reflexive _≈_ → Surjective id
+  surjective refl x = x , refl
+
+  bijective : Reflexive _≈_ → Bijective id
+  bijective refl = injective , surjective refl
+
+  inverseˡ : Reflexive _≈_ → Inverseˡ id id
+  inverseˡ refl x = refl
+
+  inverseʳ : Reflexive _≈_ → Inverseʳ id id
+  inverseʳ refl x = refl
+
+  inverseᵇ : Reflexive _≈_ → Inverseᵇ id id
+  inverseᵇ refl = inverseˡ refl , inverseʳ refl
+
+------------------------------------------------------------------------
+-- Structures
+
+module _ {_≈_ : Rel A ℓ} (isEq : IsEquivalence _≈_) where
+
+  open Function _≈_ _≈_
+  open IsEquivalence isEq
+
+  isCongruent : IsCongruent id
+  isCongruent = record
+    { cong           = id
+    ; isEquivalence₁ = isEq
+    ; isEquivalence₂ = isEq
+    }
+
+  isInjection : IsInjection id
+  isInjection = record
+    { isCongruent = isCongruent
+    ; injective   = injective _≈_
+    }
+
+  isSurjection : IsSurjection id
+  isSurjection = record
+    { isCongruent = isCongruent
+    ; surjective  = surjective _≈_ refl
+    }
+
+  isBijection : IsBijection id
+  isBijection = record
+    { isInjection = isInjection
+    ; surjective  = surjective _≈_ refl
+    }
+
+  isLeftInverse : IsLeftInverse id id
+  isLeftInverse = record
+    { isCongruent = isCongruent
+    ; cong₂       = id
+    ; inverseˡ    = inverseˡ _≈_ refl
+    }
+
+  isRightInverse : IsRightInverse id id
+  isRightInverse = record
+    { isCongruent = isCongruent
+    ; cong₂       = id
+    ; inverseʳ    = inverseʳ _≈_ refl
+    }
+
+  isInverse : IsInverse id id
+  isInverse = record
+    { isLeftInverse = isLeftInverse
+    ; inverseʳ      = inverseʳ _≈_ refl
+    }
+
+------------------------------------------------------------------------
+-- Setoid packages
+
+module _ (S : Setoid a ℓ) where
+
+  open Setoid S
+  open Function _≈_ _≈_
+
+  injection : Injection S S
+  injection = record
+    { f         = id
+    ; cong      = id
+    ; injective = injective _≈_
+    }
+
+  surjection : Surjection S S
+  surjection = record
+    { f          = id
+    ; cong       = id
+    ; surjective = surjective _≈_ refl
+    }
+
+  bijection : Bijection S S
+  bijection = record
+    { f         = id
+    ; cong      = id
+    ; bijective = bijective _≈_ refl
+    }
+
+  equivalence : Equivalence S S
+  equivalence = record
+    { f     = id
+    ; g     = id
+    ; cong₁ = id
+    ; cong₂ = id
+    }
+
+  leftInverse : LeftInverse S S
+  leftInverse = record
+    { f        = id
+    ; g        = id
+    ; cong₁    = id
+    ; cong₂    = id
+    ; inverseˡ = inverseˡ _≈_ refl
+    }
+
+  rightInverse : RightInverse S S
+  rightInverse = record
+    { f        = id
+    ; g        = id
+    ; cong₁    = id
+    ; cong₂    = id
+    ; inverseʳ = inverseʳ _≈_ refl
+    }
+
+  inverse : Inverse S S
+  inverse = record
+    { f       = id
+    ; f⁻¹     = id
+    ; cong₁   = id
+    ; cong₂   = id
+    ; inverse = inverseᵇ _≈_ refl
+    }
+
+------------------------------------------------------------------------
+-- Propositional packages
+
+module _ (A : Set a) where
+
+  open Function {A = A} {A} _≡_ _≡_
+
+  ↣ : A ↣ A
+  ↣ = injection (setoid A)
+
+  ↠ : A ↠ A
+  ↠ = surjection (setoid A)
+
+  ⤖ : A ⤖ A
+  ⤖ = bijection (setoid A)
+
+  ⇔ : A ⇔ A
+  ⇔ = equivalence (setoid A)
+
+  ↞ : A ↞ A
+  ↞ = leftInverse (setoid A)
+
+  ↔ : A ↔ A
+  ↔ = inverse (setoid A)

--- a/src/Function/Packages.agda
+++ b/src/Function/Packages.agda
@@ -55,12 +55,13 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       ; isEquivalence₂ = isEquivalence To
       }
 
+    open IsCongruent isCongruent public using (module Eq₁; module Eq₂)
+
     isInjection : IsInjection f
     isInjection = record
       { isCongruent = isCongruent
       ; injective   = injective
       }
-
 
   record Surjection : Set (a ⊔ b ⊔ suc (ℓ₁ ⊔ ℓ₂)) where
     field
@@ -74,6 +75,8 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       ; isEquivalence₁ = isEquivalence From
       ; isEquivalence₂ = isEquivalence To
       }
+
+    open IsCongruent isCongruent public using (module Eq₁; module Eq₂)
 
     isSurjection : IsSurjection f
     isSurjection = record
@@ -115,6 +118,8 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       ; surjective  = surjective
       }
 
+    open IsBijection isBijection public using (module Eq₁; module Eq₂)
+
 
   record Equivalence : Set (a ⊔ b ⊔ suc (ℓ₁ ⊔ ℓ₂)) where
     field
@@ -138,6 +143,8 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       ; isEquivalence₁ = isEquivalence From
       ; isEquivalence₂ = isEquivalence To
       }
+
+    open IsCongruent isCongruent public using (module Eq₁; module Eq₂)
 
     isLeftInverse : IsLeftInverse f g
     isLeftInverse = record
@@ -218,6 +225,8 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       { isLeftInverse = isLeftInverse
       ; inverseʳ      = inverseʳ
       }
+
+    open IsInverse isInverse public using (module Eq₁; module Eq₂)
 
 ------------------------------------------------------------------------
 -- Packages specialised for propositional equality

--- a/src/Function/Structures.agda
+++ b/src/Function/Structures.agda
@@ -28,15 +28,23 @@ record IsCongruent (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     isEquivalence₁ : IsEquivalence _≈₁_
     isEquivalence₂ : IsEquivalence _≈₂_
 
-  setoid₁ : Setoid a ℓ₁
-  setoid₁ = record
-    { isEquivalence = isEquivalence₁
-    }
+  module Eq₁ where
 
-  setoid₂ : Setoid b ℓ₂
-  setoid₂ = record
-    { isEquivalence = isEquivalence₂
-    }
+    setoid : Setoid a ℓ₁
+    setoid = record
+      { isEquivalence = isEquivalence₁
+      }
+
+    open Setoid setoid public
+
+  module Eq₂ where
+
+    setoid : Setoid b ℓ₂
+    setoid = record
+      { isEquivalence = isEquivalence₂
+      }
+
+    open Setoid setoid public
 
 
 record IsInjection (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
@@ -108,4 +116,3 @@ record IsInverse (f : A → B) (g : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ�
 
   inverse : Inverseᵇ _≈₁_ _≈₂_ f g
   inverse = inverseˡ , inverseʳ
-


### PR DESCRIPTION
Transferred across the identity and composition constructs to the new function hierarchy. Seems to work pretty well! 

The only major change is that the packages didn't previously export the equality proofs so I've added two modules `Eq₁` and `Eq₂` that contains the equalities for the domain and codomain in the same way that `Eq` does for the binary relation hierarchy.

Comments welcome as always!