### PR TITLE
Improved inheritance in binary relation properties files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,30 +195,69 @@ Other minor additions
   magma   : (_∙_ : Op₂ A) → Magma a a
   ```
 
-* Added functions to extract the universe level from a type and a term.
+* Added new functions to `Data.Level`.
   ```agda
   levelOfType : ∀ {a} → Set a → Level
   levelOfTerm : ∀ {a} {A : Set a} → A → Level
   ```
 
-* Added Partial Equivalence Relations to `Relation.Binary.Core`:
+* Added new definition to `Relation.Binary.Core`:
   ```agda
   record IsPartialEquivalence {A : Set a} (_≈_ : Rel A ℓ) : Set (a ⊔ ℓ) where
-  field
+    field
       sym   : Symmetric _≈_
       trans : Transitive _≈_
   ```
 
-* Added Partial Setoids to `Relation.Binary`:
+* Added new definition to `Relation.Binary`:
   ```agda
   record PartialSetoid a ℓ : Set (suc (a ⊔ ℓ)) where
-  field
+    field
       Carrier         : Set a
       _≈_             : Rel Carrier ℓ
       isPartialEquivalence : IsPartialEquivalence _≈_
   ```
 
+* Added new proofs to `Relation.Binary.Construct.NonStrictToStrict`:
+  ```agda
+  <⇒≉   : x < y → x ≉ y
+  ≤∧≉⇒< : x ≤ y → x ≉ y → x < y
+  <⇒≱   : Antisymmetric _≈_ _≤_ → ∀ {x y} → x < y → ¬ (y ≤ x)
+  ≤⇒≯   : Antisymmetric _≈_ _≤_ → ∀ {x y} → x ≤ y → ¬ (y < x)
+  ≰⇒>   : Symmetric _≈_ → (_≈_ ⇒ _≤_) → Total _≤_ → ∀ {x y} → ¬ (x ≤ y) → y < x
+  ≮⇒≥   : Symmetric _≈_ → Decidable _≈_ → _≈_ ⇒ _≤_ → Total _≤_ → ∀ {x y} → ¬ (x < y) → y ≤ x
+  ```
+
+* Each module in the following list now re-export relevant proofs and relations from the previous modules.
+  ```
+  Relation.Binary.Properties.Preorder
+  Relation.Binary.Properties.Poset
+  Relation.Binary.Properties.TotalOrder
+  Relation.Binary.Properties.DecTotalOrder
+  ```
+
+* Added new relations and proofs to `Relation.Binary.Properties.Poset`:
+  ```agda
+  x ≥ y = y ≤ x
+  x < y = ¬ (y ≈ x)
+
+  <⇒≉   : x < y → x ≉ y
+  ≤∧≉⇒< : x ≤ y → x ≉ y → x < y
+  <⇒≱   : x < y → ¬ (y ≤ x)
+  ≤⇒≯   : x ≤ y → ¬ (y < x)
+  ```
+
+* Added new proof to `Relation.Binary.Properties.TotalOrder`:
+  ```agda
+  ≰⇒> : ¬ (x ≤ y) → y < x
+  ```
+
+* Added new proof to `Relation.Binary.Properties.DecTotalOrder`:
+  ```agda
+  ≮⇒≥ : ¬ (x < y) → y ≤ x
+  ```
+
 * Re-exported the maximum function for sizes in `Size`
   ```agda
-  _⊔ˢ_   : Size → Size → Size
+  _⊔ˢ_ : Size → Size → Size
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,18 @@ attached to all deprecated names to discourage their use.
   +-*-suc ↦ *-suc
   ```
 
+* In `Relation.Binary.Properties.Poset`:
+  ```agda
+  invIsPartialOrder  ↦ ≥-isPartialOrder
+  invPoset           ↦ ≥-poset
+  strictPartialOrder ↦ <-strictPartialOrder
+  ```
+
+* In `Relation.Binary.Properties.DecTotalOrder`
+  ```agda
+  strictTotalOrder = <-strictTotalOrder
+  ```
+
 Other minor additions
 ---------------------
 

--- a/src/Algebra/Properties/Semilattice.agda
+++ b/src/Algebra/Properties/Semilattice.agda
@@ -18,7 +18,7 @@ open import Data.Product
 open import Relation.Binary
 import Relation.Binary.Construct.NaturalOrder.Left _≈_ _∧_ as LeftNaturalOrder
 open import Relation.Binary.Lattice
-import Relation.Binary.Properties.Poset as R
+import Relation.Binary.Properties.Poset as PosetProperties
 open import Relation.Binary.Reasoning.Setoid setoid
 
 ------------------------------------------------------------------------
@@ -29,6 +29,7 @@ poset : Poset c ℓ ℓ
 poset = LeftNaturalOrder.poset isSemilattice
 
 open Poset poset using (_≤_; isPartialOrder)
+open PosetProperties poset using (_≥_; ≥-isPartialOrder)
 
 ------------------------------------------------------------------------
 -- Every algebraic semilattice can be turned into an order-theoretic one.
@@ -39,9 +40,9 @@ open Poset poset using (_≤_; isPartialOrder)
   ; infimum        = LeftNaturalOrder.infimum isSemilattice
   }
 
-∧-isOrderTheoreticJoinSemilattice : IsJoinSemilattice _≈_ (flip _≤_) _∧_
+∧-isOrderTheoreticJoinSemilattice : IsJoinSemilattice _≈_ _≥_ _∧_
 ∧-isOrderTheoreticJoinSemilattice = record
-  { isPartialOrder = R.invIsPartialOrder poset
+  { isPartialOrder = ≥-isPartialOrder
   ; supremum       = IsMeetSemilattice.infimum
                        ∧-isOrderTheoreticMeetSemilattice
   }

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -49,13 +49,13 @@ module _ {_∼_ : Rel A ℓ} {P : A → Set p} where
 module _ {_≈_ : Rel A ℓ₁} {_≤_ : Rel A ℓ₂} where
 
   total⟶refl : _≤_ Respects₂ _≈_ → Symmetric _≈_ →
-                 Total _≤_ → _≈_ ⇒ _≤_
+               Total _≤_ → _≈_ ⇒ _≤_
   total⟶refl (respʳ , respˡ) sym total {x} {y} x≈y with total x y
   ... | inj₁ x∼y = x∼y
   ... | inj₂ y∼x = respʳ x≈y (respˡ (sym x≈y) y∼x)
 
   total+dec⟶dec : _≈_ ⇒ _≤_ → Antisymmetric _≈_ _≤_ →
-                    Total _≤_ → Decidable _≈_ → Decidable _≤_
+                  Total _≤_ → Decidable _≈_ → Decidable _≤_
   total+dec⟶dec refl antisym total _≟_ x y with total x y
   ... | inj₁ x≤y = yes x≤y
   ... | inj₂ y≤x with x ≟ y
@@ -81,7 +81,7 @@ module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
   asym⟶antisym asym x<y y<x = ⊥-elim (asym x<y y<x)
 
   asym⟶irr : _<_ Respects₂ _≈_ → Symmetric _≈_ →
-               Asymmetric _<_ → Irreflexive _≈_ _<_
+             Asymmetric _<_ → Irreflexive _≈_ _<_
   asym⟶irr (respʳ , respˡ) sym asym {x} {y} x≈y x<y =
     asym x<y (respʳ (sym x≈y) (respˡ x≈y x<y))
 
@@ -144,7 +144,6 @@ module _  {_R_ : Rel A ℓ₁} {Q : Rel A ℓ₂} where
   ... | inj₁ aRb = prf a b aRb
   ... | inj₂ bRa = q-sym (prf b a bRa)
 
-
 ------------------------------------------------------------------------
 -- Other proofs
 
@@ -167,5 +166,5 @@ module _ {P : REL A B ℓ₁} {Q : REL B A ℓ₂} where
 
 module _ {r} {R : REL A B r} where
 
-     dec⟶recomputable : Decidable R → Recomputable R
-     dec⟶recomputable dec {a} {b} = recompute $ dec a b
+  dec⟶recomputable : Decidable R → Recomputable R
+  dec⟶recomputable dec {a} {b} = recompute $ dec a b

--- a/src/Relation/Binary/Construct/NonStrictToStrict.agda
+++ b/src/Relation/Binary/Construct/NonStrictToStrict.agda
@@ -15,19 +15,51 @@ open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum using (inj₁; inj₂)
 open import Function using (_∘_; flip)
 open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary.Negation using (contradiction)
+
+private
+  _≉_ : Rel A ℓ₁
+  x ≉ y = ¬ (x ≈ y)
 
 ------------------------------------------------------------------------
 -- _≤_ can be turned into _<_ as follows:
 
 _<_ : Rel A _
-x < y = (x ≤ y) × ¬ (x ≈ y)
+x < y = x ≤ y × x ≉ y
 
 ------------------------------------------------------------------------
--- The converted relations have certain properties
--- (if the original relations have certain other properties)
+-- Relationship between relations
 
 <⇒≤ : _<_ ⇒ _≤_
 <⇒≤ = proj₁
+
+<⇒≉ : ∀ {x y} → x < y → x ≉ y
+<⇒≉ = proj₂
+
+≤∧≉⇒< : ∀ {x y} → x ≤ y → x ≉ y → x < y
+≤∧≉⇒< = _,_
+
+<⇒≱ : Antisymmetric _≈_ _≤_ → ∀ {x y} → x < y → ¬ (y ≤ x)
+<⇒≱ antisym (x≤y , x≉y) y≤x = x≉y (antisym x≤y y≤x)
+
+≤⇒≯ : Antisymmetric _≈_ _≤_ → ∀ {x y} → x ≤ y → ¬ (y < x)
+≤⇒≯ antisym x≤y y<x = <⇒≱ antisym y<x x≤y
+
+≰⇒> : Symmetric _≈_ → (_≈_ ⇒ _≤_) → Total _≤_ →
+      ∀ {x y} → ¬ (x ≤ y) → y < x
+≰⇒> sym refl total {x} {y} x≰y with total x y
+... | inj₁ x≤y = contradiction x≤y x≰y
+... | inj₂ y≤x = y≤x , x≰y ∘ refl ∘ sym
+
+≮⇒≥ : Symmetric _≈_ → Decidable _≈_ → _≈_ ⇒ _≤_ → Total _≤_ →
+      ∀ {x y} → ¬ (x < y) → y ≤ x
+≮⇒≥ sym _≟_ ≤-refl _≤?_ {x} {y} x≮y with x ≟ y | y ≤? x
+... | yes x≈y  | _        = ≤-refl (sym x≈y)
+... | _        | inj₁ y≤x = y≤x
+... | no  x≉y  | inj₂ x≤y = contradiction (x≤y , x≉y) x≮y
+
+------------------------------------------------------------------------
+-- Relational properties
 
 <-irrefl : Irreflexive _≈_ _<_
 <-irrefl x≈y (_ , x≉y) = x≉y x≈y
@@ -52,11 +84,11 @@ x < y = (x ≤ y) × ¬ (x ≈ y)
 
 <-respˡ-≈ : Transitive _≈_ → _≤_ Respectsˡ _≈_ → _<_ Respectsˡ _≈_
 <-respˡ-≈ trans respˡ y≈z (y≤x , y≉x) =
-  (respˡ y≈z y≤x) , (λ z≈x → y≉x (trans y≈z z≈x))
+  respˡ y≈z y≤x , y≉x ∘ trans y≈z
 
 <-respʳ-≈ : Symmetric _≈_ → Transitive _≈_ →
             _≤_ Respectsʳ _≈_ → _<_ Respectsʳ _≈_
-<-respʳ-≈ sym trans respʳ {x} {y} {z} y≈z (x≤y , x≉y) =
+<-respʳ-≈ sym trans respʳ y≈z (x≤y , x≉y) =
   (respʳ y≈z x≤y) , λ x≈z → x≉y (trans x≈z (sym y≈z))
 
 <-resp-≈ : IsEquivalence _≈_ → _≤_ Respects₂ _≈_ → _<_ Respects₂ _≈_
@@ -70,16 +102,17 @@ x < y = (x ≤ y) × ¬ (x ≈ y)
 <-trichotomous ≈-sym _≟_ antisym total x y with x ≟ y
 ... | yes x≈y = tri≈ (<-irrefl x≈y) x≈y (<-irrefl (≈-sym x≈y))
 ... | no  x≉y with total x y
-...   | inj₁ x≤y = tri< (x≤y , x≉y) x≉y
-                        (x≉y ∘ antisym x≤y ∘ proj₁)
-...   | inj₂ x≥y = tri> (x≉y ∘ flip antisym x≥y ∘ proj₁) x≉y
-                        (x≥y , x≉y ∘ ≈-sym)
+...   | inj₁ x≤y = tri< (x≤y , x≉y) x≉y (x≉y ∘ antisym x≤y ∘ proj₁)
+...   | inj₂ y≤x = tri> (x≉y ∘ flip antisym y≤x ∘ proj₁) x≉y (y≤x , x≉y ∘ ≈-sym)
 
 <-decidable : Decidable _≈_ → Decidable _≤_ → Decidable _<_
 <-decidable _≟_ _≤?_ x y with x ≟ y | x ≤? y
-... | yes x≈y | _       = no (flip proj₂ x≈y)
+... | yes x≈y | _       = no  (flip proj₂ x≈y)
 ... | no  x≉y | yes x≤y = yes (x≤y , x≉y)
-... | no  x≉y | no  x≰y = no (x≰y ∘ proj₁)
+... | no  x≉y | no  x≰y = no  (x≰y ∘ proj₁)
+
+------------------------------------------------------------------------
+-- Structures
 
 <-isStrictPartialOrder : IsPartialOrder _≈_ _≤_ →
                          IsStrictPartialOrder _≈_ _<_

--- a/src/Relation/Binary/Properties/DecTotalOrder.agda
+++ b/src/Relation/Binary/Properties/DecTotalOrder.agda
@@ -9,14 +9,97 @@
 open import Relation.Binary
 
 module Relation.Binary.Properties.DecTotalOrder
-         {d₁ d₂ d₃} (DT : DecTotalOrder d₁ d₂ d₃) where
+  {d₁ d₂ d₃} (DT : DecTotalOrder d₁ d₂ d₃) where
 
-open Relation.Binary.DecTotalOrder DT hiding (trans)
-open import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_
+open DecTotalOrder DT hiding (trans)
 
-strictTotalOrder : StrictTotalOrder _ _ _
-strictTotalOrder = record
-  { isStrictTotalOrder = <-isStrictTotalOrder₂ isDecTotalOrder
+import Relation.Binary.Construct.Converse as Converse
+import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_ as ToStrict
+import Relation.Binary.Properties.TotalOrder totalOrder as TotalOrderProperties
+open import Relation.Nullary using (¬_)
+
+------------------------------------------------------------------------
+-- _≥_ - the flipped relation is also a total order
+
+open TotalOrderProperties public
+  using
+  ( _≥_
+  ; ≥-refl
+  ; ≥-reflexive
+  ; ≥-trans
+  ; ≥-antisym
+  ; ≥-total
+  ; ≥-isPreorder
+  ; ≥-isPartialOrder
+  ; ≥-isTotalOrder
+  ; ≥-preorder
+  ; ≥-poset
+  ; ≥-totalOrder
+  )
+
+≥-isDecTotalOrder : IsDecTotalOrder _≈_ _≥_
+≥-isDecTotalOrder = Converse.isDecTotalOrder isDecTotalOrder
+
+≥-decTotalOrder : DecTotalOrder _ _ _
+≥-decTotalOrder = record
+  { isDecTotalOrder = ≥-isDecTotalOrder
   }
 
-open StrictTotalOrder strictTotalOrder public
+open DecTotalOrder ≥-decTotalOrder public
+  using () renaming (_≤?_ to _≥?_)
+
+------------------------------------------------------------------------
+-- _<_ - the strict version is a strict total order
+
+open TotalOrderProperties public
+  using
+  ( _<_
+  ; <-resp-≈
+  ; <-respʳ-≈
+  ; <-respˡ-≈
+  ; <-irrefl
+  ; <-asym
+  ; <-trans
+  ; <-isStrictPartialOrder
+  ; <-strictPartialOrder
+  ; <⇒≉
+  ; ≤∧≉⇒<
+  ; <⇒≱
+  ; ≤⇒≯
+  ; ≰⇒>
+  )
+
+<-isStrictTotalOrder : IsStrictTotalOrder _≈_ _<_
+<-isStrictTotalOrder = ToStrict.<-isStrictTotalOrder₂ isDecTotalOrder
+
+<-strictTotalOrder : StrictTotalOrder _ _ _
+<-strictTotalOrder = record
+  { isStrictTotalOrder = <-isStrictTotalOrder
+  }
+
+open StrictTotalOrder <-strictTotalOrder public
+  using () renaming (compare to <-compare)
+
+≮⇒≥ : ∀ {x y} → ¬ (x < y) → y ≤ x
+≮⇒≥ = ToStrict.≮⇒≥ Eq.sym _≟_ reflexive total
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.2
+
+strictPartialOrder = <-strictPartialOrder
+{-# WARNING_ON_USAGE strictPartialOrder
+"Warning: strictPartialOrder was deprecated in v1.2.
+Please use <-strictPartialOrder instead."
+#-}
+
+strictTotalOrder = <-strictTotalOrder
+{-# WARNING_ON_USAGE strictTotalOrder
+"Warning: strictTotalOrder was deprecated in v1.2.
+Please use <-strictTotalOrder instead."
+#-}

--- a/src/Relation/Binary/Properties/DecTotalOrder.agda
+++ b/src/Relation/Binary/Properties/DecTotalOrder.agda
@@ -92,12 +92,6 @@ open StrictTotalOrder <-strictTotalOrder public
 
 -- Version 1.2
 
-strictPartialOrder = <-strictPartialOrder
-{-# WARNING_ON_USAGE strictPartialOrder
-"Warning: strictPartialOrder was deprecated in v1.2.
-Please use <-strictPartialOrder instead."
-#-}
-
 strictTotalOrder = <-strictTotalOrder
 {-# WARNING_ON_USAGE strictTotalOrder
 "Warning: strictTotalOrder was deprecated in v1.2.

--- a/src/Relation/Binary/Properties/Poset.agda
+++ b/src/Relation/Binary/Properties/Poset.agda
@@ -9,30 +9,113 @@
 open import Relation.Binary
 
 module Relation.Binary.Properties.Poset
-         {p₁ p₂ p₃} (P : Poset p₁ p₂ p₃) where
+   {p₁ p₂ p₃} (P : Poset p₁ p₂ p₃) where
 
-open Relation.Binary.Poset P hiding (trans)
-open import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_
-open import Relation.Binary.Properties.Preorder preorder
+open Poset P renaming (Carrier to A)
+
 open import Function using (flip)
+import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_ as ToStrict
+import Relation.Binary.Properties.Preorder preorder as PreorderProperties
+open import Relation.Nullary using (¬_)
 
--- The inverse relation is also a poset.
+private
+  _≉_ : Rel A p₂
+  x ≉ y = ¬ (x ≈ y)
 
-invIsPartialOrder : IsPartialOrder _≈_ (flip _≤_)
-invIsPartialOrder = record
-  { isPreorder   = invIsPreorder
+------------------------------------------------------------------------
+-- The _≥_ relation is also a poset.
+
+infix 4 _≥_
+
+_≥_ : Rel A p₃
+x ≥ y = y ≤ x
+
+open PreorderProperties public
+  using ()
+  renaming
+  ( invIsPreorder to ≥-isPreorder
+  ; invPreorder   to ≥-preorder
+  )
+
+≥-isPartialOrder : IsPartialOrder _≈_ _≥_
+≥-isPartialOrder = record
+  { isPreorder   = PreorderProperties.invIsPreorder
   ; antisym      = flip antisym
   }
 
-invPoset : Poset p₁ p₂ p₃
-invPoset = record { isPartialOrder = invIsPartialOrder }
-
-------------------------------------------------------------------------
--- Posets can be turned into strict partial orders
-
-strictPartialOrder : StrictPartialOrder _ _ _
-strictPartialOrder = record
-  { isStrictPartialOrder = <-isStrictPartialOrder isPartialOrder
+≥-poset : Poset p₁ p₂ p₃
+≥-poset = record
+  { isPartialOrder = ≥-isPartialOrder
   }
 
-open StrictPartialOrder strictPartialOrder
+open Poset ≥-poset public
+  using ()
+  renaming
+  ( refl      to ≥-refl
+  ; reflexive to ≥-reflexive
+  ; trans     to ≥-trans
+  ; antisym   to ≥-antisym
+  )
+
+------------------------------------------------------------------------
+-- Partial orders can be turned into strict partial orders
+
+infix 4 _<_
+
+_<_ : Rel A _
+_<_ = ToStrict._<_
+
+<-isStrictPartialOrder : IsStrictPartialOrder _≈_ _<_
+<-isStrictPartialOrder = ToStrict.<-isStrictPartialOrder isPartialOrder
+
+<-strictPartialOrder : StrictPartialOrder _ _ _
+<-strictPartialOrder = record
+  { isStrictPartialOrder = <-isStrictPartialOrder
+  }
+
+open StrictPartialOrder <-strictPartialOrder public
+  using ( <-resp-≈; <-respʳ-≈; <-respˡ-≈)
+  renaming
+  ( irrefl to <-irrefl
+  ; asym   to <-asym
+  ; trans  to <-trans
+  )
+
+<⇒≉ : ∀ {x y} → x < y → x ≉ y
+<⇒≉ = ToStrict.<⇒≉
+
+≤∧≉⇒< : ∀ {x y} → x ≤ y → x ≉ y → x < y
+≤∧≉⇒< = ToStrict.≤∧≉⇒<
+
+<⇒≱ : ∀ {x y} → x < y → ¬ (y ≤ x)
+<⇒≱ = ToStrict.<⇒≱ antisym
+
+≤⇒≯ : ∀ {x y} → x ≤ y → ¬ (y < x)
+≤⇒≯ = ToStrict.≤⇒≯ antisym
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.2
+
+invIsPartialOrder = ≥-isPartialOrder
+{-# WARNING_ON_USAGE invIsPartialOrder
+"Warning: invIsPartialOrder was deprecated in v1.2.
+Please use ≥-isPartialOrder instead."
+#-}
+
+invPoset = ≥-poset
+{-# WARNING_ON_USAGE invPoset
+"Warning: invPoset was deprecated in v1.2.
+Please use ≥-poset instead."
+#-}
+
+strictPartialOrder = <-strictPartialOrder
+{-# WARNING_ON_USAGE strictPartialOrder
+"Warning: strictPartialOrder was deprecated in v1.2.
+Please use <-strictPartialOrder instead."
+#-}

--- a/src/Relation/Binary/Properties/Preorder.agda
+++ b/src/Relation/Binary/Properties/Preorder.agda
@@ -9,13 +9,14 @@
 open import Relation.Binary
 
 module Relation.Binary.Properties.Preorder
-         {p₁ p₂ p₃} (P : Preorder p₁ p₂ p₃) where
+  {p₁ p₂ p₃} (P : Preorder p₁ p₂ p₃) where
 
 open import Function
 open import Data.Product as Prod
 
-open Relation.Binary.Preorder P
+open Preorder P
 
+------------------------------------------------------------------------
 -- The inverse relation is also a preorder.
 
 invIsPreorder : IsPreorder _≈_ (flip _∼_)
@@ -26,7 +27,9 @@ invIsPreorder = record
   }
 
 invPreorder : Preorder p₁ p₂ p₃
-invPreorder = record { isPreorder = invIsPreorder }
+invPreorder = record
+  { isPreorder = invIsPreorder
+  }
 
 ------------------------------------------------------------------------
 -- For every preorder there is an induced equivalence

--- a/src/Relation/Binary/Properties/StrictTotalOrder.agda
+++ b/src/Relation/Binary/Properties/StrictTotalOrder.agda
@@ -18,7 +18,7 @@ import Relation.Binary.Properties.StrictPartialOrder as SPO
 open import Relation.Binary.Consequences
 
 ------------------------------------------------------------------------
--- Strict total orders can be converted to decidable total orders
+-- _<_ - the strict version is a strict total order
 
 decTotalOrder : DecTotalOrder _ _ _
 decTotalOrder = record

--- a/src/Relation/Binary/Properties/TotalOrder.agda
+++ b/src/Relation/Binary/Properties/TotalOrder.agda
@@ -9,16 +9,80 @@
 open import Relation.Binary
 
 module Relation.Binary.Properties.TotalOrder
-         {t₁ t₂ t₃} (T : TotalOrder t₁ t₂ t₃) where
+  {t₁ t₂ t₃} (T : TotalOrder t₁ t₂ t₃) where
 
-open Relation.Binary.TotalOrder T
+open TotalOrder T
+
+open import Data.Sum using (inj₁; inj₂)
+import Relation.Binary.Construct.Converse as Converse
+import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_ as ToStrict
+import Relation.Binary.Properties.Poset poset as PosetProperties
 open import Relation.Binary.Consequences
+open import Relation.Nullary using (¬_)
+open import Relation.Nullary.Negation using (contradiction)
+
+------------------------------------------------------------------------
+-- Total orders are almost decidable total orders
 
 decTotalOrder : Decidable _≈_ → DecTotalOrder _ _ _
 decTotalOrder ≟ = record
   { isDecTotalOrder = record
-      { isTotalOrder = isTotalOrder
-      ; _≟_          = ≟
-      ; _≤?_         = total+dec⟶dec reflexive antisym total ≟
-      }
+    { isTotalOrder = isTotalOrder
+    ; _≟_          = ≟
+    ; _≤?_         = total+dec⟶dec reflexive antisym total ≟
+    }
   }
+
+------------------------------------------------------------------------
+-- _≥_ - the flipped relation is also a total order
+
+open PosetProperties public
+  using
+  ( _≥_
+  ; ≥-refl
+  ; ≥-reflexive
+  ; ≥-trans
+  ; ≥-antisym
+  ; ≥-isPreorder
+  ; ≥-isPartialOrder
+  ; ≥-preorder
+  ; ≥-poset
+  )
+
+≥-isTotalOrder : IsTotalOrder _≈_ _≥_
+≥-isTotalOrder = Converse.isTotalOrder isTotalOrder
+
+≥-totalOrder : TotalOrder _ _ _
+≥-totalOrder = record
+  { isTotalOrder = ≥-isTotalOrder
+  }
+
+open TotalOrder ≥-totalOrder public
+  using () renaming (total to ≥-total)
+
+------------------------------------------------------------------------
+-- _<_ - the strict version is a strict partial order
+
+-- Note that total orders can NOT be turned into strict total orders as
+-- in order to distinguish between the _≤_ and _<_ cases we must have
+-- decidable equality _≈_.
+
+open PosetProperties public
+  using
+  ( _<_
+  ; <-resp-≈
+  ; <-respʳ-≈
+  ; <-respˡ-≈
+  ; <-irrefl
+  ; <-asym
+  ; <-trans
+  ; <-isStrictPartialOrder
+  ; <-strictPartialOrder
+  ; <⇒≉
+  ; ≤∧≉⇒<
+  ; <⇒≱
+  ; ≤⇒≯
+  )
+
+≰⇒> : ∀ {x y} → ¬ (x ≤ y) → y < x
+≰⇒> = ToStrict.≰⇒> Eq.sym reflexive total


### PR DESCRIPTION
Started off as an attempt to simply add a few proofs to `Relation.Binary.Construct.NonStrictToStrict` but morphed into fixing the hierarchy in the following properties files:
  ```
  Relation.Binary.Properties.Preorder
  Relation.Binary.Properties.Poset
  Relation.Binary.Properties.TotalOrder
  Relation.Binary.Properties.DecTotalOrder
  ```