### PR TITLE
Changed symbol for left-inverse package and added symbol for right-inverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ Other non-backwards compatible changes
 * The main problems with the current way various types of functions are
 handled are:
   1. The raw functions were wrapped in the  equality-preserving
-         type `_⟶_` from `Function.Equality`. As the rest of the library
+     type `_⟶_` from `Function.Equality`. As the rest of the library
      very rarely used such wrapped functions, it was almost impossible
-     to write code that interfaces neatly  between the `Function` hierarchy
+     to write code that interfaced neatly  between the `Function` hierarchy
      and, for example, the `Algebra` hierarchy.
   2. The symbol `_⟶_` that was used for equality preserving functions
      was almost indistinguishable from ordinary functions `_→_` in many fonts,
@@ -76,6 +76,9 @@ we would encourage to the new hierarchy in the medium to long term.
   Function.Surjection
   Function.LeftInverse
   ```
+
+* Minor change: the propositional package for left inverses has been renamed
+from `_↞_` to `_↩_` in order to make room for the new package for right inverse `_↪_`.
 
 #### Re-implementation of `Data.Bin`
 

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -198,7 +198,7 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} {T : Setoid c ℓ₃} where
 ------------------------------------------------------------------------
 -- Propositional packages
 
-infix 8 _∘-↣_ _∘-↠_ _∘-⤖_ _∘-⇔_ _∘-↞_ _∘-↔_
+infix 8 _∘-↣_ _∘-↠_ _∘-⤖_ _∘-⇔_ _∘-↩_ _∘-↪_ _∘-↔_
 
 _∘-↣_ : A ↣ B → B ↣ C → A ↣ C
 _∘-↣_ = injection
@@ -212,8 +212,11 @@ _∘-⤖_ = bijection
 _∘-⇔_ : A ⇔ B → B ⇔ C → A ⇔ C
 _∘-⇔_ = equivalence
 
-_∘-↞_ : A ↞ B → B ↞ C → A ↞ C
-_∘-↞_ = leftInverse
+_∘-↩_ : A ↩ B → B ↩ C → A ↩ C
+_∘-↩_ = leftInverse
+
+_∘-↪_ : A ↪ B → B ↪ C → A ↪ C
+_∘-↪_ = rightInverse
 
 _∘-↔_ : A ↔ B → B ↔ C → A ↔ C
 _∘-↔_ = inverse

--- a/src/Function/Construct/Identity.agda
+++ b/src/Function/Construct/Identity.agda
@@ -180,8 +180,11 @@ module _ (A : Set a) where
   id-⇔ : A ⇔ A
   id-⇔ = equivalence (setoid A)
 
-  id-↞ : A ↞ A
-  id-↞ = leftInverse (setoid A)
+  id-↩ : A ↩ A
+  id-↩ = leftInverse (setoid A)
+
+  id-↪ : A ↪ A
+  id-↪ = rightInverse (setoid A)
 
   id-↔ : A ↔ A
   id-↔ = inverse (setoid A)

--- a/src/Function/Packages.agda
+++ b/src/Function/Packages.agda
@@ -231,7 +231,7 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 ------------------------------------------------------------------------
 -- Packages specialised for propositional equality
 
-infix 3 _↣_ _↠_ _⤖_ _⇔_ _↞_ _↔_
+infix 3 _↣_ _↠_ _⤖_ _⇔_ _↩_ _↪_ _↔_
 
 _↣_ : Set a → Set b → Set _
 A ↣ B = Injection (≡.setoid A) (≡.setoid B)
@@ -245,8 +245,11 @@ A ⤖ B = Bijection (≡.setoid A) (≡.setoid B)
 _⇔_ : Set a → Set b → Set _
 A ⇔ B = Equivalence (≡.setoid A) (≡.setoid B)
 
-_↞_ : Set a → Set b → Set _
-A ↞ B = LeftInverse (≡.setoid A) (≡.setoid B)
+_↩_ : Set a → Set b → Set _
+A ↩ B = LeftInverse (≡.setoid A) (≡.setoid B)
+
+_↪_ : Set a → Set b → Set _
+A ↪ B = RightInverse (≡.setoid A) (≡.setoid B)
 
 _↔_ : Set a → Set b → Set _
 A ↔ B = Inverse (≡.setoid A) (≡.setoid B)
@@ -287,13 +290,22 @@ module _ {A : Set a} {B : Set b} where
     ; cong₂ = ≡.cong g
     }
 
-  mk↞ : ∀ {f : A → B} {g : B → A} → Inverseˡ f g → A ↞ B
-  mk↞ {f} {g} invˡ = record
+  mk↩ : ∀ {f : A → B} {g : B → A} → Inverseˡ f g → A ↩ B
+  mk↩ {f} {g} invˡ = record
     { f        = f
     ; g        = g
     ; cong₁    = ≡.cong f
     ; cong₂    = ≡.cong g
     ; inverseˡ = invˡ
+    }
+
+  mk↪ : ∀ {f : A → B} {g : B → A} → Inverseʳ f g → A ↪ B
+  mk↪ {f} {g} invʳ = record
+    { f        = f
+    ; g        = g
+    ; cong₁    = ≡.cong f
+    ; cong₂    = ≡.cong g
+    ; inverseʳ = invʳ
     }
 
   mk↔ : ∀ {f : A → B} {f⁻¹ : B → A} → Inverseᵇ f f⁻¹ → A ↔ B


### PR DESCRIPTION
It's always annoyed me that there was no corresponding symbol for the right inverse propositional package. The right version of the left-inverse symbol is already used for surjection, so I've taken advantage of the new function hierarchy to re-assign left-inverse to the new symbol `↩` and right inverse now has `↪`.