### PR TITLE
Functional vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,11 @@ The following new modules have been added to the library:
   Data.Rational.Unnormalised
   Data.Rational.Unnormalised.Properties
 
+  Data.Vec.Functional
+  Data.Vec.Functional.Relation.Binary.Pointwise
+  Data.Vec.Functional.Relation.Unary.All
+  Data.Vec.Functional.Relation.Unary.Any
+
   Function.Definitions
   Function.Packages
   Function.Structures

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -14,7 +14,7 @@ module Data.Fin.Base where
 
 open import Data.Empty using (⊥-elim)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s)
-open import Data.Sum as ⊎ using (_⊎_; inj₁; inj₂)
+open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 open import Function.Core using (id; _∘_; _on_)
 import Data.Nat.Properties as ℕₚ
 open import Level using () renaming (zero to ℓ₀)
@@ -128,7 +128,7 @@ strengthen (suc i) = suc (strengthen i)
 splitAt : ∀ m {n} → Fin (m ℕ.+ n) → Fin m ⊎ Fin n
 splitAt zero i = inj₂ i
 splitAt (suc m) zero = inj₁ zero
-splitAt (suc m) (suc i) = ⊎.map suc id (splitAt m i)
+splitAt (suc m) (suc i) = Sum.map suc id (splitAt m i)
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -14,7 +14,8 @@ module Data.Fin.Base where
 
 open import Data.Empty using (⊥-elim)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s)
-open import Function.Core using (_∘_; _on_)
+open import Data.Sum as ⊎ using (_⊎_; inj₁; inj₂)
+open import Function.Core using (id; _∘_; _on_)
 import Data.Nat.Properties as ℕₚ
 open import Level using () renaming (zero to ℓ₀)
 open import Relation.Nullary using (yes; no)
@@ -119,6 +120,14 @@ lower₁ {suc n} (suc i) ne = suc (lower₁ i λ x → ne (cong suc x))
 strengthen : ∀ {n} (i : Fin n) → Fin′ (suc i)
 strengthen zero    = zero
 strengthen (suc i) = suc (strengthen i)
+
+-- split+ m "i" = inj₁ "i"      if i < m
+--                inj₂ "i - m"  if i ≥ m
+
+split+ : ∀ m {n} → Fin (m ℕ.+ n) → Fin m ⊎ Fin n
+split+ zero i = inj₂ i
+split+ (suc m) zero = inj₁ zero
+split+ (suc m) (suc i) = ⊎.map suc id (split+ m i)
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -121,13 +121,14 @@ strengthen : ∀ {n} (i : Fin n) → Fin′ (suc i)
 strengthen zero    = zero
 strengthen (suc i) = suc (strengthen i)
 
--- split+ m "i" = inj₁ "i"      if i < m
---                inj₂ "i - m"  if i ≥ m
+-- splitAt m "i" = inj₁ "i"      if i < m
+--                 inj₂ "i - m"  if i ≥ m
+-- This is dual to splitAt from Data.Vec.
 
-split+ : ∀ m {n} → Fin (m ℕ.+ n) → Fin m ⊎ Fin n
-split+ zero i = inj₂ i
-split+ (suc m) zero = inj₁ zero
-split+ (suc m) (suc i) = ⊎.map suc id (split+ m i)
+splitAt : ∀ m {n} → Fin (m ℕ.+ n) → Fin m ⊎ Fin n
+splitAt zero i = inj₂ i
+splitAt (suc m) zero = inj₁ zero
+splitAt (suc m) (suc i) = ⊎.map suc id (splitAt m i)
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -384,13 +384,13 @@ inject≤-idempotent {_} {suc n} {suc k} (suc i) _ _ _ =
 ------------------------------------------------------------------------
 -- Fin (m + n) ≃ Fin m ⊎ Fin n
 
-split+-inject+ : ∀ m n i → split+ m (inject+ n i) ≡ inj₁ i
-split+-inject+ (suc m) n zero = refl
-split+-inject+ (suc m) n (suc i) rewrite split+-inject+ m n i = refl
+splitAt-inject+ : ∀ m n i → splitAt m (inject+ n i) ≡ inj₁ i
+splitAt-inject+ (suc m) n zero = refl
+splitAt-inject+ (suc m) n (suc i) rewrite splitAt-inject+ m n i = refl
 
-split+-raise : ∀ m n i → split+ m (raise {n} m i) ≡ inj₂ i
-split+-raise zero n i = refl
-split+-raise (suc m) n i rewrite split+-raise m n i = refl
+splitAt-raise : ∀ m n i → splitAt m (raise {n} m i) ≡ inj₂ i
+splitAt-raise zero n i = refl
+splitAt-raise (suc m) n i rewrite splitAt-raise m n i = refl
 
 ------------------------------------------------------------------------
 -- _≺_

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -23,6 +23,7 @@ open import Data.Nat as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
 open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁)
+open import Data.Sum as ⊎ using (_⊎_; inj₁; inj₂)
 open import Function.Core using (_∘_; id)
 open import Function.Injection using (_↣_)
 open import Relation.Binary as B hiding (Decidable)
@@ -379,6 +380,17 @@ inject≤-idempotent : ∀ {m n k} (i : Fin m)
 inject≤-idempotent {_} {suc n} {suc k} zero    _ _ _ = refl
 inject≤-idempotent {_} {suc n} {suc k} (suc i) _ _ _ =
   cong suc (inject≤-idempotent i _ _ _)
+
+------------------------------------------------------------------------
+-- Fin (m + n) ≃ Fin m ⊎ Fin n
+
+split+-inject+ : ∀ m n i → split+ m (inject+ n i) ≡ inj₁ i
+split+-inject+ (suc m) n zero = refl
+split+-inject+ (suc m) n (suc i) rewrite split+-inject+ m n i = refl
+
+split+-raise : ∀ m n i → split+ m (raise {n} m i) ≡ inj₂ i
+split+-raise zero n i = refl
+split+-raise (suc m) n i rewrite split+-raise m n i = refl
 
 ------------------------------------------------------------------------
 -- _≺_

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -23,7 +23,7 @@ open import Data.Nat as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
 open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁)
-open import Data.Sum as ⊎ using (_⊎_; inj₁; inj₂)
+open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Function.Core using (_∘_; id)
 open import Function.Injection using (_↣_)
 open import Relation.Binary as B hiding (Decidable)

--- a/src/Data/Vec.agda
+++ b/src/Data/Vec.agda
@@ -4,6 +4,14 @@
 -- Vectors
 ------------------------------------------------------------------------
 
+-- This implementation is designed for reasoning about dynamic
+-- vectors which may increase or decrease in size.
+
+-- See `Data.Vec.Functional` for an alternative implementation as
+-- functions from finite sets, which is more suitable for reasoning
+-- about fixed sized vectors and for when ease of retrevial is
+-- important.
+
 {-# OPTIONS --without-K --safe #-}
 
 module Data.Vec where

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -75,7 +75,7 @@ _⊛_ : ∀ {n} → Vector (A → B) n → Vector A n → Vector B n
 _⊛_ = _ˢ_
 
 zipWith : (A → B → C) → ∀ {n} → Vector A n → Vector B n → Vector C n
-zipWith f xs ys = replicate f ⊛ xs ⊛ ys
+zipWith f xs ys i = f (xs i) (ys i)
 
 zip : ∀ {n} → Vector A n → Vector B n → Vector (A × B) n
 zip = zipWith _,_

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -8,7 +8,7 @@
 
 module Data.Vec.Functional where
 
-open import Data.Fin using (Fin; zero; suc; split+)
+open import Data.Fin using (Fin; zero; suc; splitAt)
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Product using (Σ; ∃; _×_; _,_; proj₁; proj₂)
 open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
@@ -52,7 +52,7 @@ uncons : ∀ {n} → Vector A (suc n) → A × Vector A n
 uncons xs = head xs , tail xs
 
 _++_ : ∀ {m n} → Vector A m → Vector A n → Vector A (m + n)
-_++_ {m = m} xs ys i = [ xs , ys ] (split+ m i)
+_++_ {m = m} xs ys i = [ xs , ys ] (splitAt m i)
 
 foldr : (A → B → B) → B → ∀ {n} → Vector A n → B
 foldr f z {n = zero} xs = z

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -29,39 +29,39 @@ Vector : Set a → ℕ → Set a
 Vector A n = Fin n → A
 
 map : (A → B) → ∀ {n} → (Vector A n → Vector B n)
-map f v = f ∘ v
+map f xs = f ∘ xs
 
 rearrange : ∀ {m n} → (Fin m → Fin n) → (Vector A n → Vector A m)
-rearrange r v = v ∘ r
+rearrange r xs = xs ∘ r
 
 [] : Vector A zero
 [] ()
 
 _∷_ : ∀ {n} → A → Vector A n → Vector A (suc n)
-(x ∷ v) zero = x
-(x ∷ v) (suc i) = v i
+(x ∷ xs) zero = x
+(x ∷ xs) (suc i) = xs i
 
 head : ∀ {n} → Vector A (suc n) → A
-head v = v zero
+head xs = xs zero
 
 tail : ∀ {n} → Vector A (suc n) → Vector A n
-tail v = v ∘ suc
+tail xs = xs ∘ suc
 
 uncons : ∀ {n} → Vector A (suc n) → A × Vector A n
-uncons v = head v , tail v
+uncons xs = head xs , tail xs
 
 _++_ : ∀ {m n} → Vector A m → Vector A n → Vector A (m + n)
-_++_ {m = zero} u v i = v i
-_++_ {m = suc m} u v zero = u zero
-_++_ {m = suc m} u v (suc i) = (tail u ++ v) i
+_++_ {m = zero} xs ys i = ys i
+_++_ {m = suc m} xs ys zero = xs zero
+_++_ {m = suc m} xs ys (suc i) = (tail xs ++ ys) i
 
 foldr : (A → B → B) → B → ∀ {n} → Vector A n → B
-foldr f z {n = zero} v = z
-foldr f z {n = suc n} v = f (head v) (foldr f z (tail v))
+foldr f z {n = zero} xs = z
+foldr f z {n = suc n} xs = f (head xs) (foldr f z (tail xs))
 
 foldl : (B → A → B) → B → ∀ {n} → Vector A n → B
-foldl f z {n = zero} v = z
-foldl f z {n = suc n} v = foldl f (f z (head v)) (tail v)
+foldl f z {n = zero} xs = z
+foldl f z {n = suc n} xs = foldl f (f z (head xs)) (tail xs)
 
 toVec : ∀ {n} → Vector A n → Vec A n
 toVec = V.tabulate

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -8,9 +8,10 @@
 
 module Data.Vec.Functional where
 
-open import Data.Fin using (Fin; zero; suc)
+open import Data.Fin using (Fin; zero; suc; split+)
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Product using (Σ; ∃; _×_; _,_; proj₁; proj₂)
+open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec as V using (Vec)
 open import Function
 open import Level using (Level)
@@ -51,9 +52,7 @@ uncons : ∀ {n} → Vector A (suc n) → A × Vector A n
 uncons xs = head xs , tail xs
 
 _++_ : ∀ {m n} → Vector A m → Vector A n → Vector A (m + n)
-_++_ {m = zero} xs ys i = ys i
-_++_ {m = suc m} xs ys zero = xs zero
-_++_ {m = suc m} xs ys (suc i) = (tail xs ++ ys) i
+_++_ {m = m} xs ys i = [ xs , ys ] (split+ m i)
 
 foldr : (A → B → B) → B → ∀ {n} → Vector A n → B
 foldr f z {n = zero} xs = z

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -15,13 +15,15 @@ open import Data.Vec as V using (Vec)
 open import Function
 open import Level using (Level)
 
-infixr 5 _∷_
+infixr 5 _∷_ _++_
+infixl 4 _⊛_
 
 private
   variable
-    a b : Level
+    a b c : Level
     A : Set a
     B : Set b
+    C : Set c
 
 Vector : Set a → ℕ → Set a
 Vector A n = Fin n → A
@@ -72,3 +74,9 @@ replicate = const
 
 _⊛_ : ∀ {n} → Vector (A → B) n → Vector A n → Vector B n
 _⊛_ = _ˢ_
+
+zipWith : (A → B → C) → ∀ {n} → Vector A n → Vector B n → Vector C n
+zipWith f xs ys = replicate f ⊛ xs ⊛ ys
+
+zip : ∀ {n} → Vector A n → Vector B n → Vector (A × B) n
+zip = zipWith _,_

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -22,54 +22,53 @@ private
     a b : Level
     A : Set a
     B : Set b
-    m n : ℕ
 
 Vector : Set a → ℕ → Set a
 Vector A n = Fin n → A
 
-map : (A → B) → (Vector A n → Vector B n)
+map : (A → B) → ∀ {n} → (Vector A n → Vector B n)
 map f v = f ∘ v
 
-rearrange : (Fin m → Fin n) → (Vector A n → Vector A m)
+rearrange : ∀ {m n} → (Fin m → Fin n) → (Vector A n → Vector A m)
 rearrange r v = v ∘ r
 
 [] : Vector A zero
 [] ()
 
-_∷_ : A → Vector A n → Vector A (suc n)
+_∷_ : ∀ {n} → A → Vector A n → Vector A (suc n)
 (x ∷ v) zero = x
 (x ∷ v) (suc i) = v i
 
-head : Vector A (suc n) → A
+head : ∀ {n} → Vector A (suc n) → A
 head v = v zero
 
-tail : Vector A (suc n) → Vector A n
+tail : ∀ {n} → Vector A (suc n) → Vector A n
 tail v = v ∘ suc
 
-uncons : Vector A (suc n) → A × Vector A n
+uncons : ∀ {n} → Vector A (suc n) → A × Vector A n
 uncons v = head v , tail v
 
-_++_ : Vector A m → Vector A n → Vector A (m + n)
+_++_ : ∀ {m n} → Vector A m → Vector A n → Vector A (m + n)
 _++_ {m = zero} u v i = v i
 _++_ {m = suc m} u v zero = u zero
 _++_ {m = suc m} u v (suc i) = (tail u ++ v) i
 
-foldr : (A → B → B) → B → Vector A n → B
-foldr {n = zero} f z v = z
-foldr {n = suc n} f z v = f (head v) (foldr f z (tail v))
+foldr : (A → B → B) → B → ∀ {n} → Vector A n → B
+foldr f z {n = zero} v = z
+foldr f z {n = suc n} v = f (head v) (foldr f z (tail v))
 
-foldl : (B → A → B) → B → Vector A n → B
-foldl {n = zero} f z v = z
-foldl {n = suc n} f z v = foldl f (f z (head v)) (tail v)
+foldl : (B → A → B) → B → ∀ {n} → Vector A n → B
+foldl f z {n = zero} v = z
+foldl f z {n = suc n} v = foldl f (f z (head v)) (tail v)
 
-toVec : Vector A n → Vec A n
+toVec : ∀ {n} → Vector A n → Vec A n
 toVec = V.tabulate
 
-fromVec : Vec A n → Vector A n
+fromVec : ∀ {n} → Vec A n → Vector A n
 fromVec = V.lookup
 
-replicate : A → Vector A n
+replicate : ∀ {n} → A → Vector A n
 replicate = const
 
-_⊛_ : Vector (A → B) n → Vector A n → Vector B n
+_⊛_ : ∀ {n} → Vector (A → B) n → Vector A n → Vector B n
 _⊛_ = _ˢ_

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -1,0 +1,75 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors defined via index notation
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional where
+
+open import Data.Fin using (Fin; zero; suc)
+open import Data.Nat using (ℕ; zero; suc; _+_)
+open import Data.Product using (Σ; ∃; _×_; _,_; proj₁; proj₂)
+open import Data.Vec as V using (Vec)
+open import Function
+open import Level using (Level)
+
+infixr 5 _∷_
+
+private
+  variable
+    a b : Level
+    A : Set a
+    B : Set b
+    m n : ℕ
+
+Vector : Set a → ℕ → Set a
+Vector A n = Fin n → A
+
+map : (A → B) → (Vector A n → Vector B n)
+map f v = f ∘ v
+
+rearrange : (Fin m → Fin n) → (Vector A n → Vector A m)
+rearrange r v = v ∘ r
+
+[] : Vector A zero
+[] ()
+
+_∷_ : A → Vector A n → Vector A (suc n)
+(x ∷ v) zero = x
+(x ∷ v) (suc i) = v i
+
+head : Vector A (suc n) → A
+head v = v zero
+
+tail : Vector A (suc n) → Vector A n
+tail v = v ∘ suc
+
+uncons : Vector A (suc n) → A × Vector A n
+uncons v = head v , tail v
+
+_++_ : Vector A m → Vector A n → Vector A (m + n)
+_++_ {m = zero} u v i = v i
+_++_ {m = suc m} u v zero = u zero
+_++_ {m = suc m} u v (suc i) = (tail u ++ v) i
+
+foldr : (A → B → B) → B → Vector A n → B
+foldr {n = zero} f z v = z
+foldr {n = suc n} f z v = f (head v) (foldr f z (tail v))
+
+foldl : (B → A → B) → B → Vector A n → B
+foldl {n = zero} f z v = z
+foldl {n = suc n} f z v = foldl f (f z (head v)) (tail v)
+
+toVec : Vector A n → Vec A n
+toVec = V.tabulate
+
+fromVec : Vec A n → Vector A n
+fromVec = V.lookup
+
+replicate : A → Vector A n
+replicate = const
+
+_⊛_ : Vector (A → B) n → Vector A n → Vector B n
+_⊛_ = _ˢ_

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -24,96 +24,98 @@ private
     B : Set b
     A′ : Set a′
     B′ : Set b′
-    R : REL A B r
-    S : REL A B s
-    m n : ℕ
 
 ------------------------------------------------------------------------
 -- Definition
 
-Pointwise : REL A B ℓ → Vector A n → Vector B n → Set ℓ
+Pointwise : REL A B ℓ → ∀ {n} → Vector A n → Vector B n → Set ℓ
 Pointwise R u v = ∀ i → R (u i) (v i)
 
 ------------------------------------------------------------------------
 -- Operations
 
-map : R ⇒ S → Pointwise {n = n} R ⇒ Pointwise S
+map : {R : REL A B r} {S : REL A B s} →
+      R ⇒ S → ∀ {n} → Pointwise R ⇒ Pointwise S {n = n}
 map f rs i = f (rs i)
 
 ------------------------------------------------------------------------
 -- Relational properties
 
-refl : {R : Rel A ℓ} → Reflexive R → Reflexive (Pointwise {n = n} R)
-refl r i = r
+module _ {R : Rel A ℓ} where
 
-sym : {R : Rel A ℓ} → Symmetric R → Symmetric (Pointwise {n = n} R)
-sym s uv i = s (uv i)
+  refl : Reflexive R → ∀ {n} → Reflexive (Pointwise R {n = n})
+  refl r i = r
 
-trans : {R : Rel A ℓ} → Transitive R → Transitive (Pointwise {n = n} R)
-trans t uv vw i = t (uv i) (vw i)
+  sym : Symmetric R → ∀ {n} → Symmetric (Pointwise R {n = n})
+  sym s uv i = s (uv i)
 
-decidable : Decidable R → Decidable (Pointwise {n = n} R)
-decidable r? u v = all? λ i → r? (u i) (v i)
+  trans : Transitive R → ∀ {n} → Transitive (Pointwise R {n = n})
+  trans t uv vw i = t (uv i) (vw i)
+
+  decidable : Decidable R → ∀ {n} → Decidable (Pointwise R {n = n})
+  decidable r? u v = all? λ i → r? (u i) (v i)
 
 ------------------------------------------------------------------------
 -- map
 
 map⁺ : {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} →
-       (∀ {x y} → R x y → S (f x) (g y)) →
-       ∀ {xs ys} → Pointwise {n = n} R xs ys →
+       (∀ {x y} → R x y → S (f x) (g y)) → ∀ {n} →
+       ∀ {xs ys} → Pointwise R {n = n} xs ys →
                    Pointwise S (VF.map f xs) (VF.map g ys)
 map⁺ f rs i = f (rs i)
 
 ------------------------------------------------------------------------
 -- head
 
-head⁺ : ∀ (R : REL A B r) {u v} →
-        Pointwise {n = suc n} R u v → R (head u) (head v)
+head⁺ : ∀ (R : REL A B r) {n u v} →
+        Pointwise R u v → R (head u) (head {n = n} v)
 head⁺ R rs = rs zero
 
 ------------------------------------------------------------------------
 -- tail
 
-tail⁺ : ∀ (R : REL A B r) {u v} →
-        Pointwise {n = suc n} R u v → Pointwise R (tail u) (tail v)
+tail⁺ : ∀ (R : REL A B r) {n u v} →
+        Pointwise R u v → Pointwise R (tail u) (tail {n = n} v)
 tail⁺ R rs = rs ∘ suc
 
 ------------------------------------------------------------------------
 -- _++_
 
-++⁺ : ∀ (R : REL A B r) {xs ys xs′ ys′} →
-      Pointwise {n = m} R xs ys → Pointwise {n = n} R xs′ ys′ →
+++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
+      Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
       Pointwise R (xs ++ xs′) (ys ++ ys′)
-++⁺ {m = zero} R rs rs′ i = rs′ i
-++⁺ {m = suc m} R rs rs′ zero = rs zero
-++⁺ {m = suc m} R rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
+++⁺ R {m = zero} rs rs′ i = rs′ i
+++⁺ R {m = suc m} rs rs′ zero = rs zero
+++⁺ R {m = suc m} rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
 
-++⁻ˡ : ∀ (R : REL A B r) (xs : Vector A m) (ys : Vector B m)
+++⁻ˡ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
 ++⁻ˡ R _ _ rs zero = rs zero
 ++⁻ˡ R _ _ rs (suc i) = ++⁻ˡ R _ _ (tail⁺ R rs) i
 
-++⁻ʳ : ∀ (R : REL A B r) (xs : Vector A m) (ys : Vector B m)
+++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
-++⁻ʳ {m = zero} R _ _ rs = rs
-++⁻ʳ {m = suc m} R _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
+++⁻ʳ R {m = zero} _ _ rs = rs
+++⁻ʳ R {m = suc m} _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
 
-++⁻ : ∀ (R : REL A B r) xs ys {xs′ ys′} → Pointwise R (xs ++ xs′) (ys ++ ys′) →
-      Pointwise {n = m} R xs ys × Pointwise {n = n} R xs′ ys′
+++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
+      Pointwise R (xs ++ xs′) (ys ++ ys′) →
+      Pointwise R {n = m} xs ys × Pointwise R {n = n} xs′ ys′
 ++⁻ R _ _ rs = ++⁻ˡ R _ _ rs , ++⁻ʳ R _ _ rs
 
 ------------------------------------------------------------------------
 -- replicate
 
-replicate⁺ : ∀ {x y} → R x y → Pointwise {n = n} R (replicate x) (replicate y)
+replicate⁺ : ∀ {R : REL A B r} {x y n} → R x y →
+             Pointwise R {n = n} (replicate x) (replicate y)
 replicate⁺ = const
 
 ------------------------------------------------------------------------
 -- _⊛_
 
-⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s}
+⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n}
        {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
      Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
      Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -31,7 +31,7 @@ private
 -- Definition
 
 Pointwise : REL A B ℓ → ∀ {n} → Vector A n → Vector B n → Set ℓ
-Pointwise R u v = ∀ i → R (u i) (v i)
+Pointwise R xs ys = ∀ i → R (xs i) (ys i)
 
 ------------------------------------------------------------------------
 -- Operations
@@ -49,13 +49,13 @@ module _ {R : Rel A ℓ} where
   refl r i = r
 
   sym : Symmetric R → ∀ {n} → Symmetric (Pointwise R {n = n})
-  sym s uv i = s (uv i)
+  sym s xsys i = s (xsys i)
 
   trans : Transitive R → ∀ {n} → Transitive (Pointwise R {n = n})
-  trans t uv vw i = t (uv i) (vw i)
+  trans t xsys yszs i = t (xsys i) (yszs i)
 
   decidable : Decidable R → ∀ {n} → Decidable (Pointwise R {n = n})
-  decidable r? u v = all? λ i → r? (u i) (v i)
+  decidable r? xs ys = all? λ i → r? (xs i) (ys i)
 
 ------------------------------------------------------------------------
 -- map
@@ -69,15 +69,15 @@ map⁺ f rs i = f (rs i)
 ------------------------------------------------------------------------
 -- head
 
-head⁺ : ∀ (R : REL A B r) {n u v} →
-        Pointwise R u v → R (head u) (head {n = n} v)
+head⁺ : ∀ (R : REL A B r) {n xs ys} →
+        Pointwise R xs ys → R (head xs) (head {n = n} ys)
 head⁺ R rs = rs zero
 
 ------------------------------------------------------------------------
 -- tail
 
-tail⁺ : ∀ (R : REL A B r) {n u v} →
-        Pointwise R u v → Pointwise R (tail u) (tail {n = n} v)
+tail⁺ : ∀ (R : REL A B r) {n xs ys} →
+        Pointwise R xs ys → Pointwise R (tail xs) (tail {n = n} ys)
 tail⁺ R rs = rs ∘ suc
 
 ------------------------------------------------------------------------
@@ -121,7 +121,7 @@ replicate⁺ = const
        {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
      Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
      Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
-⊛⁺ fs xs i = (fs i) (xs i)
+⊛⁺ rss rs i = (rss i) (rs i)
 
 ------------------------------------------------------------------------
 -- zipWith
@@ -140,7 +140,7 @@ zip⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
        Pointwise R xs ys → Pointwise S xs′ ys′ →
        Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
                  (zip xs xs′) (zip {n = n} ys ys′)
-zip⁺ xs ys i = xs i , ys i
+zip⁺ rs ss i = rs i , ss i
 
 zip⁻ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
        Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -11,7 +11,7 @@ module Data.Vec.Functional.Relation.Binary.Pointwise where
 open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat
-open import Data.Product using (_×_; _,_)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Vec.Functional as VF hiding (map)
 open import Function
 open import Level using (Level)
@@ -19,11 +19,13 @@ open import Relation.Binary
 
 private
   variable
-    a a′ b b′ r s ℓ : Level
+    a a′ a″ b b′ b″ r s t ℓ : Level
     A : Set a
     B : Set b
     A′ : Set a′
     B′ : Set b′
+    A″ : Set a″
+    B″ : Set b″
 
 ------------------------------------------------------------------------
 -- Definition
@@ -120,3 +122,28 @@ replicate⁺ = const
      Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
      Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
 ⊛⁺ fs xs i = (fs i) (xs i)
+
+------------------------------------------------------------------------
+-- zipWith
+
+zipWith⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {T : REL A″ B″ t}
+             {n xs ys xs′ ys′ f f′} →
+           (∀ {x y x′ y′} → R x y → S x′ y′ → T (f x x′) (f′ y y′)) →
+           Pointwise R xs ys → Pointwise S xs′ ys′ →
+           Pointwise T (zipWith f xs xs′) (zipWith f′ {n = n} ys ys′)
+zipWith⁺ t rs ss i = t (rs i) (ss i)
+
+------------------------------------------------------------------------
+-- zip
+
+zip⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
+       Pointwise R xs ys → Pointwise S xs′ ys′ →
+       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                 (zip xs xs′) (zip {n = n} ys ys′)
+zip⁺ xs ys i = xs i , ys i
+
+zip⁻ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
+       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                 (zip xs xs′) (zip {n = n} ys ys′) →
+       Pointwise R xs ys × Pointwise S xs′ ys′
+zip⁻ rss = proj₁ ∘ rss , proj₂ ∘ rss

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -9,23 +9,16 @@
 module Data.Vec.Functional.Relation.Binary.Pointwise where
 
 open import Data.Fin
-open import Data.Fin.Properties
 open import Data.Nat
-open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Vec.Functional as VF hiding (map)
-open import Function
 open import Level using (Level)
 open import Relation.Binary
 
 private
   variable
-    a a′ a″ b b′ b″ r s t ℓ : Level
+    a b r s ℓ : Level
     A : Set a
     B : Set b
-    A′ : Set a′
-    B′ : Set b′
-    A″ : Set a″
-    B″ : Set b″
 
 ------------------------------------------------------------------------
 -- Definition
@@ -39,111 +32,3 @@ Pointwise R xs ys = ∀ i → R (xs i) (ys i)
 map : {R : REL A B r} {S : REL A B s} →
       R ⇒ S → ∀ {n} → Pointwise R ⇒ Pointwise S {n = n}
 map f rs i = f (rs i)
-
-------------------------------------------------------------------------
--- Relational properties
-
-module _ {R : Rel A ℓ} where
-
-  refl : Reflexive R → ∀ {n} → Reflexive (Pointwise R {n = n})
-  refl r i = r
-
-  sym : Symmetric R → ∀ {n} → Symmetric (Pointwise R {n = n})
-  sym s xsys i = s (xsys i)
-
-  trans : Transitive R → ∀ {n} → Transitive (Pointwise R {n = n})
-  trans t xsys yszs i = t (xsys i) (yszs i)
-
-  decidable : Decidable R → ∀ {n} → Decidable (Pointwise R {n = n})
-  decidable r? xs ys = all? λ i → r? (xs i) (ys i)
-
-------------------------------------------------------------------------
--- map
-
-map⁺ : {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} →
-       (∀ {x y} → R x y → S (f x) (g y)) → ∀ {n} →
-       ∀ {xs ys} → Pointwise R {n = n} xs ys →
-                   Pointwise S (VF.map f xs) (VF.map g ys)
-map⁺ f rs i = f (rs i)
-
-------------------------------------------------------------------------
--- head
-
-head⁺ : ∀ (R : REL A B r) {n xs ys} →
-        Pointwise R xs ys → R (head xs) (head {n = n} ys)
-head⁺ R rs = rs zero
-
-------------------------------------------------------------------------
--- tail
-
-tail⁺ : ∀ (R : REL A B r) {n xs ys} →
-        Pointwise R xs ys → Pointwise R (tail xs) (tail {n = n} ys)
-tail⁺ R rs = rs ∘ suc
-
-------------------------------------------------------------------------
--- _++_
-
-++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
-      Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
-      Pointwise R (xs ++ xs′) (ys ++ ys′)
-++⁺ R {m = zero} rs rs′ i = rs′ i
-++⁺ R {m = suc m} rs rs′ zero = rs zero
-++⁺ R {m = suc m} rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
-
-++⁻ˡ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
-         {xs′ : Vector A n} {ys′ : Vector B n} →
-       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
-++⁻ˡ R _ _ rs zero = rs zero
-++⁻ˡ R _ _ rs (suc i) = ++⁻ˡ R _ _ (tail⁺ R rs) i
-
-++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
-         {xs′ : Vector A n} {ys′ : Vector B n} →
-       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
-++⁻ʳ R {m = zero} _ _ rs = rs
-++⁻ʳ R {m = suc m} _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
-
-++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
-      Pointwise R (xs ++ xs′) (ys ++ ys′) →
-      Pointwise R {n = m} xs ys × Pointwise R {n = n} xs′ ys′
-++⁻ R _ _ rs = ++⁻ˡ R _ _ rs , ++⁻ʳ R _ _ rs
-
-------------------------------------------------------------------------
--- replicate
-
-replicate⁺ : ∀ {R : REL A B r} {x y n} → R x y →
-             Pointwise R {n = n} (replicate x) (replicate y)
-replicate⁺ = const
-
-------------------------------------------------------------------------
--- _⊛_
-
-⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n}
-       {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
-     Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
-     Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
-⊛⁺ rss rs i = (rss i) (rs i)
-
-------------------------------------------------------------------------
--- zipWith
-
-zipWith⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {T : REL A″ B″ t}
-             {n xs ys xs′ ys′ f f′} →
-           (∀ {x y x′ y′} → R x y → S x′ y′ → T (f x x′) (f′ y y′)) →
-           Pointwise R xs ys → Pointwise S xs′ ys′ →
-           Pointwise T (zipWith f xs xs′) (zipWith f′ {n = n} ys ys′)
-zipWith⁺ t rs ss i = t (rs i) (ss i)
-
-------------------------------------------------------------------------
--- zip
-
-zip⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
-       Pointwise R xs ys → Pointwise S xs′ ys′ →
-       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
-                 (zip xs xs′) (zip {n = n} ys ys′)
-zip⁺ rs ss i = rs i , ss i
-
-zip⁻ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
-       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
-                 (zip xs xs′) (zip {n = n} ys ys′) →
-       Pointwise R xs ys × Pointwise S xs′ ys′
-zip⁻ rss = proj₁ ∘ rss , proj₂ ∘ rss

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Pointwise lifting of relations to index notation vectors
+-- Pointwise lifting of relations over Vector
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -29,6 +29,7 @@ Pointwise R xs ys = ∀ i → R (xs i) (ys i)
 ------------------------------------------------------------------------
 -- Operations
 
-map : {R : REL A B r} {S : REL A B s} →
-      R ⇒ S → ∀ {n} → Pointwise R ⇒ Pointwise S {n = n}
-map f rs i = f (rs i)
+module _ {R : REL A B r} {S : REL A B s} where
+
+  map : R ⇒ S → ∀ {n} → Pointwise R ⇒ Pointwise S {n = n}
+  map f rs i = f (rs i)

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise.agda
@@ -1,0 +1,120 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Pointwise lifting of relations to index notation vectors
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional.Relation.Binary.Pointwise where
+
+open import Data.Fin
+open import Data.Fin.Properties
+open import Data.Nat
+open import Data.Product using (_×_; _,_)
+open import Data.Vec.Functional as VF hiding (map)
+open import Function
+open import Level using (Level)
+open import Relation.Binary
+
+private
+  variable
+    a a′ b b′ r s ℓ : Level
+    A : Set a
+    B : Set b
+    A′ : Set a′
+    B′ : Set b′
+    R : REL A B r
+    S : REL A B s
+    m n : ℕ
+
+------------------------------------------------------------------------
+-- Definition
+
+Pointwise : REL A B ℓ → Vector A n → Vector B n → Set ℓ
+Pointwise R u v = ∀ i → R (u i) (v i)
+
+------------------------------------------------------------------------
+-- Operations
+
+map : R ⇒ S → Pointwise {n = n} R ⇒ Pointwise S
+map f rs i = f (rs i)
+
+------------------------------------------------------------------------
+-- Relational properties
+
+refl : {R : Rel A ℓ} → Reflexive R → Reflexive (Pointwise {n = n} R)
+refl r i = r
+
+sym : {R : Rel A ℓ} → Symmetric R → Symmetric (Pointwise {n = n} R)
+sym s uv i = s (uv i)
+
+trans : {R : Rel A ℓ} → Transitive R → Transitive (Pointwise {n = n} R)
+trans t uv vw i = t (uv i) (vw i)
+
+decidable : Decidable R → Decidable (Pointwise {n = n} R)
+decidable r? u v = all? λ i → r? (u i) (v i)
+
+------------------------------------------------------------------------
+-- map
+
+map⁺ : {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} →
+       (∀ {x y} → R x y → S (f x) (g y)) →
+       ∀ {xs ys} → Pointwise {n = n} R xs ys →
+                   Pointwise S (VF.map f xs) (VF.map g ys)
+map⁺ f rs i = f (rs i)
+
+------------------------------------------------------------------------
+-- head
+
+head⁺ : ∀ (R : REL A B r) {u v} →
+        Pointwise {n = suc n} R u v → R (head u) (head v)
+head⁺ R rs = rs zero
+
+------------------------------------------------------------------------
+-- tail
+
+tail⁺ : ∀ (R : REL A B r) {u v} →
+        Pointwise {n = suc n} R u v → Pointwise R (tail u) (tail v)
+tail⁺ R rs = rs ∘ suc
+
+------------------------------------------------------------------------
+-- _++_
+
+++⁺ : ∀ (R : REL A B r) {xs ys xs′ ys′} →
+      Pointwise {n = m} R xs ys → Pointwise {n = n} R xs′ ys′ →
+      Pointwise R (xs ++ xs′) (ys ++ ys′)
+++⁺ {m = zero} R rs rs′ i = rs′ i
+++⁺ {m = suc m} R rs rs′ zero = rs zero
+++⁺ {m = suc m} R rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
+
+++⁻ˡ : ∀ (R : REL A B r) (xs : Vector A m) (ys : Vector B m)
+         {xs′ : Vector A n} {ys′ : Vector B n} →
+       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
+++⁻ˡ R _ _ rs zero = rs zero
+++⁻ˡ R _ _ rs (suc i) = ++⁻ˡ R _ _ (tail⁺ R rs) i
+
+++⁻ʳ : ∀ (R : REL A B r) (xs : Vector A m) (ys : Vector B m)
+         {xs′ : Vector A n} {ys′ : Vector B n} →
+       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
+++⁻ʳ {m = zero} R _ _ rs = rs
+++⁻ʳ {m = suc m} R _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
+
+++⁻ : ∀ (R : REL A B r) xs ys {xs′ ys′} → Pointwise R (xs ++ xs′) (ys ++ ys′) →
+      Pointwise {n = m} R xs ys × Pointwise {n = n} R xs′ ys′
+++⁻ R _ _ rs = ++⁻ˡ R _ _ rs , ++⁻ʳ R _ _ rs
+
+------------------------------------------------------------------------
+-- replicate
+
+replicate⁺ : ∀ {x y} → R x y → Pointwise {n = n} R (replicate x) (replicate y)
+replicate⁺ = const
+
+------------------------------------------------------------------------
+-- _⊛_
+
+⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s}
+       {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
+     Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
+     Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
+⊛⁺ fs xs i = (fs i) (xs i)

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -12,11 +12,13 @@ open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat
 open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec.Functional as VF hiding (map)
 open import Data.Vec.Functional.Relation.Binary.Pointwise
 open import Function
 open import Level using (Level)
 open import Relation.Binary
+open import Relation.Binary.PropositionalEquality as ≡ using (_≡_)
 
 private
   variable
@@ -74,21 +76,21 @@ tail⁺ R rs = rs ∘ suc
 ++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
       Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
       Pointwise R (xs ++ xs′) (ys ++ ys′)
-++⁺ R {m = zero} rs rs′ i = rs′ i
-++⁺ R {m = suc m} rs rs′ zero = rs zero
-++⁺ R {m = suc m} rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
+++⁺ R {m} rs rs′ i with split+ m i
+... | inj₁ i′ = rs i′
+... | inj₂ j′ = rs′ j′
 
 ++⁻ˡ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
-++⁻ˡ R _ _ rs zero = rs zero
-++⁻ˡ R _ _ rs (suc i) = ++⁻ˡ R _ _ (tail⁺ R rs) i
+++⁻ˡ R {m} {n} _ _ rs i with rs (inject+ n i)
+... | r rewrite split+-inject+ m n i = r
 
 ++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
-++⁻ʳ R {m = zero} _ _ rs = rs
-++⁻ʳ R {m = suc m} _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
+++⁻ʳ R {m} {n} _ _ rs i with rs (raise m i)
+... | r rewrite split+-raise m n i = r
 
 ++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
       Pointwise R (xs ++ xs′) (ys ++ ys′) →

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -12,6 +12,8 @@ open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat
 open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Product.Relation.Binary.Pointwise.NonDependent
+  using () renaming (Pointwise to ×-Pointwise)
 open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec.Functional as VF hiding (map)
 open import Data.Vec.Functional.Relation.Binary.Pointwise
@@ -50,90 +52,96 @@ module _ {R : Rel A ℓ} where
 ------------------------------------------------------------------------
 -- map
 
-map⁺ : {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} →
-       (∀ {x y} → R x y → S (f x) (g y)) → ∀ {n} →
-       ∀ {xs ys} → Pointwise R {n = n} xs ys →
-                   Pointwise S (VF.map f xs) (VF.map g ys)
-map⁺ f rs i = f (rs i)
+module _ {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} where
+
+  map⁺ : (∀ {x y} → R x y → S (f x) (g y)) →
+         ∀ {n} {xs : Vector A n} {ys : Vector B n} →
+         Pointwise R xs ys → Pointwise S (VF.map f xs) (VF.map g ys)
+  map⁺ f rs i = f (rs i)
 
 ------------------------------------------------------------------------
 -- head
 
-head⁺ : ∀ (R : REL A B r) {n xs ys} →
-        Pointwise R xs ys → R (head xs) (head {n = n} ys)
-head⁺ R rs = rs zero
+module _ (R : REL A B r) {n} {xs : Vector A (suc n)} {ys} where
+
+  head⁺ : Pointwise R xs ys → R (head xs) (head ys)
+  head⁺ rs = rs zero
 
 ------------------------------------------------------------------------
 -- tail
 
-tail⁺ : ∀ (R : REL A B r) {n xs ys} →
-        Pointwise R xs ys → Pointwise R (tail xs) (tail {n = n} ys)
-tail⁺ R rs = rs ∘ suc
+module _ (R : REL A B r) {n} {xs : Vector A (suc n)} {ys} where
+
+  tail⁺ : Pointwise R xs ys → Pointwise R (tail xs) (tail ys)
+  tail⁺ rs = rs ∘ suc
 
 ------------------------------------------------------------------------
 -- _++_
 
-++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
-      Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
-      Pointwise R (xs ++ xs′) (ys ++ ys′)
-++⁺ R {m} rs rs′ i with splitAt m i
-... | inj₁ i′ = rs i′
-... | inj₂ j′ = rs′ j′
+module _ (R : REL A B r) where
 
-++⁻ˡ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
-         {xs′ : Vector A n} {ys′ : Vector B n} →
-       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
-++⁻ˡ R {m} {n} _ _ rs i with rs (inject+ n i)
-... | r rewrite splitAt-inject+ m n i = r
+  ++⁺ : ∀ {m n xs ys xs′ ys′} →
+        Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
+        Pointwise R (xs ++ xs′) (ys ++ ys′)
+  ++⁺ {m} rs rs′ i with splitAt m i
+  ... | inj₁ i′ = rs i′
+  ... | inj₂ j′ = rs′ j′
 
-++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
-         {xs′ : Vector A n} {ys′ : Vector B n} →
-       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
-++⁻ʳ R {m} {n} _ _ rs i with rs (raise m i)
-... | r rewrite splitAt-raise m n i = r
+  ++⁻ˡ : ∀ {m n} (xs : Vector A m) (ys : Vector B m) {xs′ ys′} →
+         Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
+  ++⁻ˡ {m} {n} _ _ rs i with rs (inject+ n i)
+  ... | r rewrite splitAt-inject+ m n i = r
 
-++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
-      Pointwise R (xs ++ xs′) (ys ++ ys′) →
-      Pointwise R {n = m} xs ys × Pointwise R {n = n} xs′ ys′
-++⁻ R _ _ rs = ++⁻ˡ R _ _ rs , ++⁻ʳ R _ _ rs
+  ++⁻ʳ : ∀ {m n} (xs : Vector A m) (ys : Vector B m) {xs′ ys′} →
+         Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
+  ++⁻ʳ {m} {n} _ _ rs i with rs (raise m i)
+  ... | r rewrite splitAt-raise m n i = r
+
+  ++⁻ : ∀ {m n} xs ys {xs′ ys′} →
+        Pointwise R (xs ++ xs′) (ys ++ ys′) →
+        Pointwise R {n = m} xs ys × Pointwise R {n = n} xs′ ys′
+  ++⁻ _ _ rs = ++⁻ˡ _ _ rs , ++⁻ʳ _ _ rs
 
 ------------------------------------------------------------------------
 -- replicate
 
-replicate⁺ : ∀ {R : REL A B r} {x y n} → R x y →
-             Pointwise R {n = n} (replicate x) (replicate y)
-replicate⁺ = const
+module _ {R : REL A B r} {x y n} where
+
+  replicate⁺ : R x y → Pointwise R {n = n} (replicate x) (replicate y)
+  replicate⁺ = const
 
 ------------------------------------------------------------------------
 -- _⊛_
 
-⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n}
-       {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
-     Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
-     Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
-⊛⁺ rss rs i = (rss i) (rs i)
+module _ {R : REL A B r} {S : REL A′ B′ s} {n} where
+
+  ⊛⁺ : ∀ {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} →
+       Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
+       ∀ {xs ys} → Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
+  ⊛⁺ rss rs i = (rss i) (rs i)
 
 ------------------------------------------------------------------------
 -- zipWith
 
-zipWith⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {T : REL A″ B″ t}
-             {n xs ys xs′ ys′ f f′} →
-           (∀ {x y x′ y′} → R x y → S x′ y′ → T (f x x′) (f′ y y′)) →
-           Pointwise R xs ys → Pointwise S xs′ ys′ →
-           Pointwise T (zipWith f xs xs′) (zipWith f′ {n = n} ys ys′)
-zipWith⁺ t rs ss i = t (rs i) (ss i)
+module _ {R : REL A B r} {S : REL A′ B′ s} {T : REL A″ B″ t} where
+
+  zipWith⁺ : ∀ {n xs ys xs′ ys′ f f′} →
+             (∀ {x y x′ y′} → R x y → S x′ y′ → T (f x x′) (f′ y y′)) →
+             Pointwise R xs ys → Pointwise S xs′ ys′ →
+             Pointwise T (zipWith f xs xs′) (zipWith f′ {n = n} ys ys′)
+  zipWith⁺ t rs ss i = t (rs i) (ss i)
 
 ------------------------------------------------------------------------
 -- zip
 
-zip⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
-       Pointwise R xs ys → Pointwise S xs′ ys′ →
-       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
-                 (zip xs xs′) (zip {n = n} ys ys′)
-zip⁺ rs ss i = rs i , ss i
+module _ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} where
 
-zip⁻ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
-       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
-                 (zip xs xs′) (zip {n = n} ys ys′) →
-       Pointwise R xs ys × Pointwise S xs′ ys′
-zip⁻ rss = proj₁ ∘ rss , proj₂ ∘ rss
+  zip⁺ : Pointwise R xs ys → Pointwise S xs′ ys′ →
+         Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                   (zip xs xs′) (zip {n = n} ys ys′)
+  zip⁺ rs ss i = rs i , ss i
+
+  zip⁻ : Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                   (zip xs xs′) (zip {n = n} ys ys′) →
+         Pointwise R xs ys × Pointwise S xs′ ys′
+  zip⁻ rss = proj₁ ∘ rss , proj₂ ∘ rss

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -76,7 +76,7 @@ tail⁺ R rs = rs ∘ suc
 ++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
       Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
       Pointwise R (xs ++ xs′) (ys ++ ys′)
-++⁺ R {m} rs rs′ i with split+ m i
+++⁺ R {m} rs rs′ i with splitAt m i
 ... | inj₁ i′ = rs i′
 ... | inj₂ j′ = rs′ j′
 
@@ -84,13 +84,13 @@ tail⁺ R rs = rs ∘ suc
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
 ++⁻ˡ R {m} {n} _ _ rs i with rs (inject+ n i)
-... | r rewrite split+-inject+ m n i = r
+... | r rewrite splitAt-inject+ m n i = r
 
 ++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
          {xs′ : Vector A n} {ys′ : Vector B n} →
        Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
 ++⁻ʳ R {m} {n} _ _ rs i with rs (raise m i)
-... | r rewrite split+-raise m n i = r
+... | r rewrite splitAt-raise m n i = r
 
 ++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
       Pointwise R (xs ++ xs′) (ys ++ ys′) →

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -1,0 +1,137 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties related to Pointwise
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional.Relation.Binary.Pointwise.Properties where
+
+open import Data.Fin
+open import Data.Fin.Properties
+open import Data.Nat
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Vec.Functional as VF hiding (map)
+open import Data.Vec.Functional.Relation.Binary.Pointwise
+open import Function
+open import Level using (Level)
+open import Relation.Binary
+
+private
+  variable
+    a a′ a″ b b′ b″ r s t ℓ : Level
+    A : Set a
+    B : Set b
+    A′ : Set a′
+    B′ : Set b′
+    A″ : Set a″
+    B″ : Set b″
+
+------------------------------------------------------------------------
+-- Relational properties
+
+module _ {R : Rel A ℓ} where
+
+  refl : Reflexive R → ∀ {n} → Reflexive (Pointwise R {n = n})
+  refl r i = r
+
+  sym : Symmetric R → ∀ {n} → Symmetric (Pointwise R {n = n})
+  sym s xsys i = s (xsys i)
+
+  trans : Transitive R → ∀ {n} → Transitive (Pointwise R {n = n})
+  trans t xsys yszs i = t (xsys i) (yszs i)
+
+  decidable : Decidable R → ∀ {n} → Decidable (Pointwise R {n = n})
+  decidable r? xs ys = all? λ i → r? (xs i) (ys i)
+
+------------------------------------------------------------------------
+-- map
+
+map⁺ : {R : REL A B r} {S : REL A′ B′ s} {f : A → A′} {g : B → B′} →
+       (∀ {x y} → R x y → S (f x) (g y)) → ∀ {n} →
+       ∀ {xs ys} → Pointwise R {n = n} xs ys →
+                   Pointwise S (VF.map f xs) (VF.map g ys)
+map⁺ f rs i = f (rs i)
+
+------------------------------------------------------------------------
+-- head
+
+head⁺ : ∀ (R : REL A B r) {n xs ys} →
+        Pointwise R xs ys → R (head xs) (head {n = n} ys)
+head⁺ R rs = rs zero
+
+------------------------------------------------------------------------
+-- tail
+
+tail⁺ : ∀ (R : REL A B r) {n xs ys} →
+        Pointwise R xs ys → Pointwise R (tail xs) (tail {n = n} ys)
+tail⁺ R rs = rs ∘ suc
+
+------------------------------------------------------------------------
+-- _++_
+
+++⁺ : ∀ (R : REL A B r) {m n xs ys xs′ ys′} →
+      Pointwise R {n = m} xs ys → Pointwise R {n = n} xs′ ys′ →
+      Pointwise R (xs ++ xs′) (ys ++ ys′)
+++⁺ R {m = zero} rs rs′ i = rs′ i
+++⁺ R {m = suc m} rs rs′ zero = rs zero
+++⁺ R {m = suc m} rs rs′ (suc i) = ++⁺ R (rs ∘ suc) rs′ i
+
+++⁻ˡ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
+         {xs′ : Vector A n} {ys′ : Vector B n} →
+       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
+++⁻ˡ R _ _ rs zero = rs zero
+++⁻ˡ R _ _ rs (suc i) = ++⁻ˡ R _ _ (tail⁺ R rs) i
+
+++⁻ʳ : ∀ (R : REL A B r) {m n} (xs : Vector A m) (ys : Vector B m)
+         {xs′ : Vector A n} {ys′ : Vector B n} →
+       Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
+++⁻ʳ R {m = zero} _ _ rs = rs
+++⁻ʳ R {m = suc m} _ _ rs = ++⁻ʳ R _ _ (tail⁺ R rs)
+
+++⁻ : ∀ (R : REL A B r) {m n} xs ys {xs′ ys′} →
+      Pointwise R (xs ++ xs′) (ys ++ ys′) →
+      Pointwise R {n = m} xs ys × Pointwise R {n = n} xs′ ys′
+++⁻ R _ _ rs = ++⁻ˡ R _ _ rs , ++⁻ʳ R _ _ rs
+
+------------------------------------------------------------------------
+-- replicate
+
+replicate⁺ : ∀ {R : REL A B r} {x y n} → R x y →
+             Pointwise R {n = n} (replicate x) (replicate y)
+replicate⁺ = const
+
+------------------------------------------------------------------------
+-- _⊛_
+
+⊛⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n}
+       {fs : Vector (A → A′) n} {gs : Vector (B → B′) n} {xs ys} →
+     Pointwise (λ f g → ∀ {x y} → R x y → S (f x) (g y)) fs gs →
+     Pointwise R xs ys → Pointwise S (fs ⊛ xs) (gs ⊛ ys)
+⊛⁺ rss rs i = (rss i) (rs i)
+
+------------------------------------------------------------------------
+-- zipWith
+
+zipWith⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {T : REL A″ B″ t}
+             {n xs ys xs′ ys′ f f′} →
+           (∀ {x y x′ y′} → R x y → S x′ y′ → T (f x x′) (f′ y y′)) →
+           Pointwise R xs ys → Pointwise S xs′ ys′ →
+           Pointwise T (zipWith f xs xs′) (zipWith f′ {n = n} ys ys′)
+zipWith⁺ t rs ss i = t (rs i) (ss i)
+
+------------------------------------------------------------------------
+-- zip
+
+zip⁺ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
+       Pointwise R xs ys → Pointwise S xs′ ys′ →
+       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                 (zip xs xs′) (zip {n = n} ys ys′)
+zip⁺ rs ss i = rs i , ss i
+
+zip⁻ : ∀ {R : REL A B r} {S : REL A′ B′ s} {n xs ys xs′ ys′} →
+       Pointwise (λ xx yy → R (proj₁ xx) (proj₁ yy) × S (proj₂ xx) (proj₂ yy))
+                 (zip xs xs′) (zip {n = n} ys ys′) →
+       Pointwise R xs ys × Pointwise S xs′ ys′
+zip⁻ rss = proj₁ ∘ rss , proj₂ ∘ rss

--- a/src/Data/Vec/Functional/Relation/Unary/All.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All.agda
@@ -1,0 +1,107 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- All lifting of predicates to index notation vectors
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional.Relation.Unary.All where
+
+open import Data.Fin
+open import Data.Fin.Properties
+open import Data.Nat
+open import Data.Product using (_×_; _,_)
+open import Data.Vec.Functional as VF hiding (map)
+open import Function
+open import Level using (Level)
+open import Relation.Unary
+
+private
+  variable
+    a b p q ℓ : Level
+    A : Set a
+    B : Set b
+    P : Pred A p
+    Q : Pred A q
+    m n : ℕ
+
+------------------------------------------------------------------------
+-- Definition
+
+All : Pred A ℓ → Vector A n → Set ℓ
+All P u = ∀ i → P (u i)
+
+------------------------------------------------------------------------
+-- Operations
+
+map : P ⊆ Q → All {n = n} P ⊆ All Q
+map f ps i = f (ps i)
+
+------------------------------------------------------------------------
+-- map
+
+map⁺ : {P : Pred A p} {Q : Pred B q} {f : A → B} →
+       (∀ {x} → P x → Q (f x)) →
+       (∀ {xs} → All {n = n} P xs → All Q (VF.map f xs))
+map⁺ f ps i = f (ps i)
+
+------------------------------------------------------------------------
+-- replicate
+
+replicate⁺ : ∀ {x} → P x → All P (replicate {n = n} x)
+replicate⁺ = const
+
+------------------------------------------------------------------------
+-- _⊛_
+
+⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {fs : Vector (A → B) n} {xs} →
+     All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
+⊛⁺ fs xs i = (fs i) (xs i)
+
+------------------------------------------------------------------------
+-- head
+
+head⁺ : ∀ (P : Pred A p) {v} → All P v → P (head {n = n} v)
+head⁺ P ps = ps zero
+
+------------------------------------------------------------------------
+-- tail
+
+tail⁺ : ∀ (P : Pred A p) {v} → All P v → All P (tail {n = n} v)
+tail⁺ P ps = ps ∘ suc
+
+------------------------------------------------------------------------
+-- Properties of predicates preserved by All
+
+all : ∀ {n} → Decidable P → Decidable (All {n = n} P)
+all p? u = all? λ i → p? (u i)
+
+universal : Universal P → Universal (All {n = n} P)
+universal uni u i = uni (u i)
+
+satisfiable : Satisfiable P → Satisfiable (All {n = n} P)
+satisfiable {P = P} (x , px) = replicate x , replicate⁺ {P = P} px
+
+------------------------------------------------------------------------
+-- ++
+
+++⁺ : ∀ (P : Pred A p) {xs ys} →
+      All {n = m} P xs → All {n = n} P ys → All P (xs ++ ys)
+++⁺ {m = zero} P pxs pys = pys
+++⁺ {m = suc m} P pxs pys zero = head⁺ P pxs
+++⁺ {m = suc m} P pxs pys (suc i) = ++⁺ P (tail⁺ P pxs) pys i
+
+++⁻ˡ : ∀ (P : Pred A p) (xs : Vector A m) {ys : Vector A n} →
+       All P (xs ++ ys) → All P xs
+++⁻ˡ P _ ps zero = head⁺ P ps
+++⁻ˡ P _ ps (suc i) = ++⁻ˡ P _ (tail⁺ P ps) i
+
+++⁻ʳ : ∀ (P : Pred A p) (xs : Vector A m) {ys : Vector A n} →
+       All P (xs ++ ys) → All P ys
+++⁻ʳ {m = zero} P _ ps = ps
+++⁻ʳ {m = suc m} P _ ps = ++⁻ʳ P _ (tail⁺ P ps)
+
+++⁻ : ∀ (P : Pred A p) (xs : Vector A m) {ys : Vector A n} →
+      All P (xs ++ ys) → All P xs × All P ys
+++⁻ P _ ps = ++⁻ˡ P _ ps , ++⁻ʳ P _ ps

--- a/src/Data/Vec/Functional/Relation/Unary/All.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All.agda
@@ -28,13 +28,13 @@ private
 -- Definition
 
 All : Pred A ℓ → ∀ {n} → Vector A n → Set ℓ
-All P u = ∀ i → P (u i)
+All P xs = ∀ i → P (xs i)
 
 ------------------------------------------------------------------------
 -- Operations
 
 map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → All P {n = n} ⊆ All Q
-map f ps i = f (ps i)
+map pq ps i = pq (ps i)
 
 ------------------------------------------------------------------------
 -- map
@@ -42,7 +42,7 @@ map f ps i = f (ps i)
 map⁺ : {P : Pred A p} {Q : Pred B q} {f : A → B} →
        (∀ {x} → P x → Q (f x)) → ∀ {n} →
        (∀ {xs} → All P {n = n} xs → All Q (VF.map f xs))
-map⁺ f ps i = f (ps i)
+map⁺ pq ps i = pq (ps i)
 
 ------------------------------------------------------------------------
 -- replicate
@@ -55,7 +55,7 @@ replicate⁺ = const
 
 ⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n} {fs : Vector (A → B) n} {xs} →
      All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
-⊛⁺ fs xs i = (fs i) (xs i)
+⊛⁺ pqs ps i = (pqs i) (ps i)
 
 ------------------------------------------------------------------------
 -- zipWith
@@ -63,18 +63,18 @@ replicate⁺ = const
 zipWith⁺ : ∀ {P : Pred A p} {Q : Pred B q} {R : Pred C r} {n xs ys f} →
            (∀ {x y} → P x → Q y → R (f x y)) →
            All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
-zipWith⁺ f xs ys i = f (xs i) (ys i)
+zipWith⁺ pqr ps qs i = pqr (ps i) (qs i)
 
 ------------------------------------------------------------------------
 -- zip
 
 zip⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
        All P xs → All Q ys → All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys)
-zip⁺ xs ys i = xs i , ys i
+zip⁺ ps qs i = ps i , qs i
 
 zip⁻ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
        All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys) → All P xs × All Q ys
-zip⁻ xys = proj₁ ∘ xys , proj₂ ∘ xys
+zip⁻ pqs = proj₁ ∘ pqs , proj₂ ∘ pqs
 
 ------------------------------------------------------------------------
 -- head
@@ -94,10 +94,10 @@ tail⁺ P ps = ps ∘ suc
 module _ {P : Pred A p} where
 
   all : Decidable P → ∀ {n} → Decidable (All P {n = n})
-  all p? u = all? λ i → p? (u i)
+  all p? xs = all? λ i → p? (xs i)
 
   universal : Universal P → ∀ {n} → Universal (All P {n = n})
-  universal uni u i = uni (u i)
+  universal uni xs i = uni (xs i)
 
   satisfiable : Satisfiable P → ∀ {n} → Satisfiable (All P {n = n})
   satisfiable (x , px) = replicate x , replicate⁺ {P = P} px

--- a/src/Data/Vec/Functional/Relation/Unary/All.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All.agda
@@ -11,7 +11,7 @@ module Data.Vec.Functional.Relation.Unary.All where
 open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat
-open import Data.Product using (_×_; _,_)
+open import Data.Product as Σ using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Data.Vec.Functional as VF hiding (map)
 open import Function
 open import Level using (Level)
@@ -19,9 +19,10 @@ open import Relation.Unary
 
 private
   variable
-    a b p q ℓ : Level
+    a b c p q r ℓ : Level
     A : Set a
     B : Set b
+    C : Set c
 
 ------------------------------------------------------------------------
 -- Definition
@@ -55,6 +56,25 @@ replicate⁺ = const
 ⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n} {fs : Vector (A → B) n} {xs} →
      All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
 ⊛⁺ fs xs i = (fs i) (xs i)
+
+------------------------------------------------------------------------
+-- zipWith
+
+zipWith⁺ : ∀ {P : Pred A p} {Q : Pred B q} {R : Pred C r} {n xs ys f} →
+           (∀ {x y} → P x → Q y → R (f x y)) →
+           All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
+zipWith⁺ f xs ys i = f (xs i) (ys i)
+
+------------------------------------------------------------------------
+-- zip
+
+zip⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
+       All P xs → All Q ys → All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys)
+zip⁺ xs ys i = xs i , ys i
+
+zip⁻ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
+       All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys) → All P xs × All Q ys
+zip⁻ xys = proj₁ ∘ xys , proj₂ ∘ xys
 
 ------------------------------------------------------------------------
 -- head

--- a/src/Data/Vec/Functional/Relation/Unary/All.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All.agda
@@ -11,18 +11,15 @@ module Data.Vec.Functional.Relation.Unary.All where
 open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat
-open import Data.Product as Σ using (_×_; _,_; proj₁; proj₂; uncurry)
+open import Data.Product using (_,_)
 open import Data.Vec.Functional as VF hiding (map)
-open import Function
 open import Level using (Level)
 open import Relation.Unary
 
 private
   variable
-    a b c p q r ℓ : Level
+    a p q ℓ : Level
     A : Set a
-    B : Set b
-    C : Set c
 
 ------------------------------------------------------------------------
 -- Definition
@@ -37,58 +34,6 @@ map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → All P {n = n} �
 map pq ps i = pq (ps i)
 
 ------------------------------------------------------------------------
--- map
-
-map⁺ : {P : Pred A p} {Q : Pred B q} {f : A → B} →
-       (∀ {x} → P x → Q (f x)) → ∀ {n} →
-       (∀ {xs} → All P {n = n} xs → All Q (VF.map f xs))
-map⁺ pq ps i = pq (ps i)
-
-------------------------------------------------------------------------
--- replicate
-
-replicate⁺ : ∀ {P : Pred A p} {x n} → P x → All P (replicate {n = n} x)
-replicate⁺ = const
-
-------------------------------------------------------------------------
--- _⊛_
-
-⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n} {fs : Vector (A → B) n} {xs} →
-     All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
-⊛⁺ pqs ps i = (pqs i) (ps i)
-
-------------------------------------------------------------------------
--- zipWith
-
-zipWith⁺ : ∀ {P : Pred A p} {Q : Pred B q} {R : Pred C r} {n xs ys f} →
-           (∀ {x y} → P x → Q y → R (f x y)) →
-           All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
-zipWith⁺ pqr ps qs i = pqr (ps i) (qs i)
-
-------------------------------------------------------------------------
--- zip
-
-zip⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
-       All P xs → All Q ys → All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys)
-zip⁺ ps qs i = ps i , qs i
-
-zip⁻ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
-       All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys) → All P xs × All Q ys
-zip⁻ pqs = proj₁ ∘ pqs , proj₂ ∘ pqs
-
-------------------------------------------------------------------------
--- head
-
-head⁺ : ∀ (P : Pred A p) {n v} → All P v → P (head {n = n} v)
-head⁺ P ps = ps zero
-
-------------------------------------------------------------------------
--- tail
-
-tail⁺ : ∀ (P : Pred A p) {n v} → All P v → All P (tail {n = n} v)
-tail⁺ P ps = ps ∘ suc
-
-------------------------------------------------------------------------
 -- Properties of predicates preserved by All
 
 module _ {P : Pred A p} where
@@ -100,27 +45,4 @@ module _ {P : Pred A p} where
   universal uni xs i = uni (xs i)
 
   satisfiable : Satisfiable P → ∀ {n} → Satisfiable (All P {n = n})
-  satisfiable (x , px) = replicate x , replicate⁺ {P = P} px
-
-------------------------------------------------------------------------
--- ++
-
-++⁺ : ∀ (P : Pred A p) {m n xs ys} →
-      All P {n = m} xs → All P {n = n} ys → All P (xs ++ ys)
-++⁺ P {m = zero} pxs pys = pys
-++⁺ P {m = suc m} pxs pys zero = head⁺ P pxs
-++⁺ P {m = suc m} pxs pys (suc i) = ++⁺ P (tail⁺ P pxs) pys i
-
-++⁻ˡ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
-       All P (xs ++ ys) → All P xs
-++⁻ˡ P _ ps zero = head⁺ P ps
-++⁻ˡ P _ ps (suc i) = ++⁻ˡ P _ (tail⁺ P ps) i
-
-++⁻ʳ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
-       All P (xs ++ ys) → All P ys
-++⁻ʳ P {m = zero} _ ps = ps
-++⁻ʳ P {m = suc m} _ ps = ++⁻ʳ P _ (tail⁺ P ps)
-
-++⁻ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
-      All P (xs ++ ys) → All P xs × All P ys
-++⁻ P _ ps = ++⁻ˡ P _ ps , ++⁻ʳ P _ ps
+  satisfiable (x , px) = (λ _ → x) , (λ _ → px)

--- a/src/Data/Vec/Functional/Relation/Unary/All.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- All lifting of predicates to index notation vectors
+-- Universal lifting of predicates over Vectors
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -30,8 +30,10 @@ All P xs = ∀ i → P (xs i)
 ------------------------------------------------------------------------
 -- Operations
 
-map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → All P {n = n} ⊆ All Q
-map pq ps i = pq (ps i)
+module _ {P : Pred A p} {Q : Pred A q} where
+
+  map : P ⊆ Q → ∀ {n} → All P {n = n} ⊆ All Q
+  map pq ps i = pq (ps i)
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by All

--- a/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
@@ -29,42 +29,48 @@ private
 ------------------------------------------------------------------------
 -- map
 
-map⁺ : {P : Pred A p} {Q : Pred B q} {f : A → B} →
-       (∀ {x} → P x → Q (f x)) → ∀ {n} →
-       (∀ {xs} → All P {n = n} xs → All Q (VF.map f xs))
-map⁺ pq ps i = pq (ps i)
+module _ {P : Pred A p} {Q : Pred B q} {f : A → B} where
+
+  map⁺ :  (∀ {x} → P x → Q (f x)) →
+          ∀ {n xs} → All P {n = n} xs → All Q (VF.map f xs)
+  map⁺ pq ps i = pq (ps i)
 
 ------------------------------------------------------------------------
 -- replicate
 
-replicate⁺ : ∀ {P : Pred A p} {x n} → P x → All P (replicate {n = n} x)
-replicate⁺ = const
+module _ {P : Pred A p} {x : A} {n : ℕ} where
+
+  replicate⁺ : P x → All P (replicate {n = n} x)
+  replicate⁺ = const
 
 ------------------------------------------------------------------------
 -- _⊛_
 
-⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n} {fs : Vector (A → B) n} {xs} →
-     All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
-⊛⁺ pqs ps i = (pqs i) (ps i)
+module _ {P : Pred A p} {Q : Pred B q} where
+
+  ⊛⁺ : ∀ {n} {fs : Vector (A → B) n} {xs} →
+       All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
+  ⊛⁺ pqs ps i = (pqs i) (ps i)
 
 ------------------------------------------------------------------------
 -- zipWith
 
-zipWith⁺ : ∀ {P : Pred A p} {Q : Pred B q} {R : Pred C r} {n xs ys f} →
-           (∀ {x y} → P x → Q y → R (f x y)) →
-           All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
-zipWith⁺ pqr ps qs i = pqr (ps i) (qs i)
+module _ {P : Pred A p} {Q : Pred B q} {R : Pred C r} where
+
+  zipWith⁺ : ∀ {f} → (∀ {x y} → P x → Q y → R (f x y)) → ∀ {n xs ys} →
+             All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
+  zipWith⁺ pqr ps qs i = pqr (ps i) (qs i)
 
 ------------------------------------------------------------------------
 -- zip
 
-zip⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
-       All P xs → All Q ys → All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys)
-zip⁺ ps qs i = ps i , qs i
+module _ {P : Pred A p} {Q : Pred B q} {n} {xs : Vector A n} {ys} where
 
-zip⁻ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
-       All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys) → All P xs × All Q ys
-zip⁻ pqs = proj₁ ∘ pqs , proj₂ ∘ pqs
+  zip⁺ : All P xs → All Q ys → All (P ⟨×⟩ Q) (zip xs ys)
+  zip⁺ ps qs i = ps i , qs i
+
+  zip⁻ : All (P ⟨×⟩ Q) (zip xs ys) → All P xs × All Q ys
+  zip⁻ pqs = proj₁ ∘ pqs , proj₂ ∘ pqs
 
 ------------------------------------------------------------------------
 -- head
@@ -81,8 +87,8 @@ tail⁺ P ps = ps ∘ suc
 ------------------------------------------------------------------------
 -- ++
 
-++⁺ : ∀ (P : Pred A p) {m n xs ys} →
-      All P {n = m} xs → All P {n = n} ys → All P (xs ++ ys)
+++⁺ : ∀ (P : Pred A p) {m n} {xs : Vector A m} {ys : Vector A n} →
+      All P xs → All P ys → All P (xs ++ ys)
 ++⁺ P {m} {n} pxs pys i with splitAt m i
 ... | inj₁ i′ = pxs i′
 ... | inj₂ j′ = pys j′

--- a/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
@@ -83,19 +83,19 @@ tail⁺ P ps = ps ∘ suc
 
 ++⁺ : ∀ (P : Pred A p) {m n xs ys} →
       All P {n = m} xs → All P {n = n} ys → All P (xs ++ ys)
-++⁺ P {m} {n} pxs pys i with split+ m i
+++⁺ P {m} {n} pxs pys i with splitAt m i
 ... | inj₁ i′ = pxs i′
 ... | inj₂ j′ = pys j′
 
 ++⁻ˡ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
        All P (xs ++ ys) → All P xs
 ++⁻ˡ P {m} {n} _ ps i with ps (inject+ n i)
-... | p rewrite split+-inject+ m n i = p
+... | p rewrite splitAt-inject+ m n i = p
 
 ++⁻ʳ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
        All P (xs ++ ys) → All P ys
 ++⁻ʳ P {m} {n} _ ps i with ps (raise m i)
-... | p rewrite split+-raise m n i = p
+... | p rewrite splitAt-raise m n i = p
 
 ++⁻ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
       All P (xs ++ ys) → All P xs × All P ys

--- a/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
@@ -1,0 +1,100 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties related to All
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional.Relation.Unary.All.Properties where
+
+open import Data.Fin
+open import Data.Nat
+open import Data.Product as Σ using (_×_; _,_; proj₁; proj₂; uncurry)
+open import Data.Vec.Functional as VF hiding (map)
+open import Data.Vec.Functional.Relation.Unary.All
+open import Function
+open import Level using (Level)
+open import Relation.Unary
+
+private
+  variable
+    a b c p q r ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- map
+
+map⁺ : {P : Pred A p} {Q : Pred B q} {f : A → B} →
+       (∀ {x} → P x → Q (f x)) → ∀ {n} →
+       (∀ {xs} → All P {n = n} xs → All Q (VF.map f xs))
+map⁺ pq ps i = pq (ps i)
+
+------------------------------------------------------------------------
+-- replicate
+
+replicate⁺ : ∀ {P : Pred A p} {x n} → P x → All P (replicate {n = n} x)
+replicate⁺ = const
+
+------------------------------------------------------------------------
+-- _⊛_
+
+⊛⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n} {fs : Vector (A → B) n} {xs} →
+     All (λ f → ∀ {x} → P x → Q (f x)) fs → All P xs → All Q (fs ⊛ xs)
+⊛⁺ pqs ps i = (pqs i) (ps i)
+
+------------------------------------------------------------------------
+-- zipWith
+
+zipWith⁺ : ∀ {P : Pred A p} {Q : Pred B q} {R : Pred C r} {n xs ys f} →
+           (∀ {x y} → P x → Q y → R (f x y)) →
+           All P xs → All Q ys → All R (zipWith f {n = n} xs ys)
+zipWith⁺ pqr ps qs i = pqr (ps i) (qs i)
+
+------------------------------------------------------------------------
+-- zip
+
+zip⁺ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
+       All P xs → All Q ys → All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys)
+zip⁺ ps qs i = ps i , qs i
+
+zip⁻ : ∀ {P : Pred A p} {Q : Pred B q} {n xs ys} →
+       All (uncurry _×_ ∘ Σ.map P Q) (zip {n = n} xs ys) → All P xs × All Q ys
+zip⁻ pqs = proj₁ ∘ pqs , proj₂ ∘ pqs
+
+------------------------------------------------------------------------
+-- head
+
+head⁺ : ∀ (P : Pred A p) {n v} → All P v → P (head {n = n} v)
+head⁺ P ps = ps zero
+
+------------------------------------------------------------------------
+-- tail
+
+tail⁺ : ∀ (P : Pred A p) {n v} → All P v → All P (tail {n = n} v)
+tail⁺ P ps = ps ∘ suc
+
+------------------------------------------------------------------------
+-- ++
+
+++⁺ : ∀ (P : Pred A p) {m n xs ys} →
+      All P {n = m} xs → All P {n = n} ys → All P (xs ++ ys)
+++⁺ P {m = zero} pxs pys = pys
+++⁺ P {m = suc m} pxs pys zero = head⁺ P pxs
+++⁺ P {m = suc m} pxs pys (suc i) = ++⁺ P (tail⁺ P pxs) pys i
+
+++⁻ˡ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
+       All P (xs ++ ys) → All P xs
+++⁻ˡ P _ ps zero = head⁺ P ps
+++⁻ˡ P _ ps (suc i) = ++⁻ˡ P _ (tail⁺ P ps) i
+
+++⁻ʳ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
+       All P (xs ++ ys) → All P ys
+++⁻ʳ P {m = zero} _ ps = ps
+++⁻ʳ P {m = suc m} _ ps = ++⁻ʳ P _ (tail⁺ P ps)
+
+++⁻ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
+      All P (xs ++ ys) → All P xs × All P ys
+++⁻ P _ ps = ++⁻ˡ P _ ps , ++⁻ʳ P _ ps

--- a/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
@@ -9,8 +9,10 @@
 module Data.Vec.Functional.Relation.Unary.All.Properties where
 
 open import Data.Fin
+open import Data.Fin.Properties
 open import Data.Nat
 open import Data.Product as Σ using (_×_; _,_; proj₁; proj₂; uncurry)
+open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec.Functional as VF hiding (map)
 open import Data.Vec.Functional.Relation.Unary.All
 open import Function
@@ -81,19 +83,19 @@ tail⁺ P ps = ps ∘ suc
 
 ++⁺ : ∀ (P : Pred A p) {m n xs ys} →
       All P {n = m} xs → All P {n = n} ys → All P (xs ++ ys)
-++⁺ P {m = zero} pxs pys = pys
-++⁺ P {m = suc m} pxs pys zero = head⁺ P pxs
-++⁺ P {m = suc m} pxs pys (suc i) = ++⁺ P (tail⁺ P pxs) pys i
+++⁺ P {m} {n} pxs pys i with split+ m i
+... | inj₁ i′ = pxs i′
+... | inj₂ j′ = pys j′
 
 ++⁻ˡ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
        All P (xs ++ ys) → All P xs
-++⁻ˡ P _ ps zero = head⁺ P ps
-++⁻ˡ P _ ps (suc i) = ++⁻ˡ P _ (tail⁺ P ps) i
+++⁻ˡ P {m} {n} _ ps i with ps (inject+ n i)
+... | p rewrite split+-inject+ m n i = p
 
 ++⁻ʳ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
        All P (xs ++ ys) → All P ys
-++⁻ʳ P {m = zero} _ ps = ps
-++⁻ʳ P {m = suc m} _ ps = ++⁻ʳ P _ (tail⁺ P ps)
+++⁻ʳ P {m} {n} _ ps i with ps (raise m i)
+... | p rewrite split+-raise m n i = p
 
 ++⁻ : ∀ (P : Pred A p) {m n} (xs : Vector A m) {ys : Vector A n} →
       All P (xs ++ ys) → All P xs × All P ys

--- a/src/Data/Vec/Functional/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/Any.agda
@@ -27,13 +27,13 @@ private
 -- Definition
 
 Any : Pred A ℓ → ∀ {n} → Vector A n → Set ℓ
-Any P u = ∃ \ i → P (u i)
+Any P xs = ∃ \ i → P (xs i)
 
 ------------------------------------------------------------------------
 -- Operations
 
 map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → Any P {n = n} ⊆ Any Q
-map f = Σ.map id f
+map pq = Σ.map id pq
 
 here : ∀ {P : Pred A p} {x n} {v : Vector A n} → P x → Any P (x ∷ v)
 here px = zero , px
@@ -45,4 +45,4 @@ there = Σ.map suc id
 -- Properties of predicates preserved by Any
 
 any : {P : Pred A p} → Decidable P → ∀ {n} → Decidable (Any P {n = n})
-any p? u = any? \ i → p? (u i)
+any p? xs = any? \ i → p? (xs i)

--- a/src/Data/Vec/Functional/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/Any.agda
@@ -1,0 +1,51 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Existence of an index at which a predicate holds
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Functional.Relation.Unary.Any where
+
+open import Data.Fin
+open import Data.Fin.Properties
+open import Data.Nat
+open import Data.Product as Σ using (Σ; ∃; _×_; _,_; proj₁; proj₂)
+open import Data.Vec.Functional as VF hiding (map)
+open import Function
+open import Level using (Level)
+open import Relation.Unary
+
+private
+  variable
+    a b p q ℓ : Level
+    A : Set a
+    B : Set b
+    P : Pred A p
+    Q : Pred A q
+    m n : ℕ
+
+------------------------------------------------------------------------
+-- Definition
+
+Any : Pred A ℓ → Vector A n → Set ℓ
+Any P u = ∃ \ i → P (u i)
+
+------------------------------------------------------------------------
+-- Operations
+
+map : P ⊆ Q → Any {n = n} P ⊆ Any Q
+map f = Σ.map id f
+
+here : ∀ {x} {v : Vector A n} → P x → Any P (x ∷ v)
+here px = zero , px
+
+there : ∀ {x} {v : Vector A n} → Any P v → Any P (x ∷ v)
+there = Σ.map suc id
+
+------------------------------------------------------------------------
+-- Properties of predicates preserved by Any
+
+any : Decidable P → Decidable (Any {n = n} P)
+any p? u = any? \ i → p? (u i)

--- a/src/Data/Vec/Functional/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/Any.agda
@@ -27,7 +27,7 @@ private
 -- Definition
 
 Any : Pred A ℓ → ∀ {n} → Vector A n → Set ℓ
-Any P xs = ∃ \ i → P (xs i)
+Any P xs = ∃ λ i → P (xs i)
 
 ------------------------------------------------------------------------
 -- Operations
@@ -45,4 +45,4 @@ there = Σ.map suc id
 -- Properties of predicates preserved by Any
 
 any : {P : Pred A p} → Decidable P → ∀ {n} → Decidable (Any P {n = n})
-any p? xs = any? \ i → p? (xs i)
+any p? xs = any? λ i → p? (xs i)

--- a/src/Data/Vec/Functional/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/Any.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Existence of an index at which a predicate holds
+-- Existential lifting of predicates over Vectors
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -32,17 +32,23 @@ Any P xs = ∃ λ i → P (xs i)
 ------------------------------------------------------------------------
 -- Operations
 
-map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → Any P {n = n} ⊆ Any Q
-map pq = Σ.map id pq
+module _ {P : Pred A p} where
 
-here : ∀ {P : Pred A p} {x n} {v : Vector A n} → P x → Any P (x ∷ v)
-here px = zero , px
+  here : ∀ {x n} {v : Vector A n} → P x → Any P (x ∷ v)
+  here px = zero , px
 
-there : ∀ {P : Pred A p} {x n} {v : Vector A n} → Any P v → Any P (x ∷ v)
-there = Σ.map suc id
+  there : ∀ {x n} {v : Vector A n} → Any P v → Any P (x ∷ v)
+  there = Σ.map suc id
+
+module _ {P : Pred A p} {Q : Pred A q} where
+
+  map : P ⊆ Q → ∀ {n} → Any P {n = n} ⊆ Any Q
+  map pq = Σ.map id pq
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by Any
 
-any : {P : Pred A p} → Decidable P → ∀ {n} → Decidable (Any P {n = n})
-any p? xs = any? λ i → p? (xs i)
+module _ {P : Pred A p} where
+
+  any : Decidable P → ∀ {n} → Decidable (Any P {n = n})
+  any p? xs = any? λ i → p? (xs i)

--- a/src/Data/Vec/Functional/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/Any.agda
@@ -22,30 +22,27 @@ private
     a b p q ℓ : Level
     A : Set a
     B : Set b
-    P : Pred A p
-    Q : Pred A q
-    m n : ℕ
 
 ------------------------------------------------------------------------
 -- Definition
 
-Any : Pred A ℓ → Vector A n → Set ℓ
+Any : Pred A ℓ → ∀ {n} → Vector A n → Set ℓ
 Any P u = ∃ \ i → P (u i)
 
 ------------------------------------------------------------------------
 -- Operations
 
-map : P ⊆ Q → Any {n = n} P ⊆ Any Q
+map : {P : Pred A p} {Q : Pred A q} → P ⊆ Q → ∀ {n} → Any P {n = n} ⊆ Any Q
 map f = Σ.map id f
 
-here : ∀ {x} {v : Vector A n} → P x → Any P (x ∷ v)
+here : ∀ {P : Pred A p} {x n} {v : Vector A n} → P x → Any P (x ∷ v)
 here px = zero , px
 
-there : ∀ {x} {v : Vector A n} → Any P v → Any P (x ∷ v)
+there : ∀ {P : Pred A p} {x n} {v : Vector A n} → Any P v → Any P (x ∷ v)
 there = Σ.map suc id
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by Any
 
-any : Decidable P → Decidable (Any {n = n} P)
+any : {P : Pred A p} → Decidable P → ∀ {n} → Decidable (Any P {n = n})
 any p? u = any? \ i → p? (u i)


### PR DESCRIPTION
Motivation: #870

This pull request introduces vectors defined by index notation. That is, it defines vectors to be functions from `Fin n` to `A`. Assuming function extensionality, this is equivalent to `Vec A n`, but prioritises introduction and elimination via `tabulate` and `lookup`, rather than `[]`/`_∷_` and induction, respectively. This is the same as `Data.Table`, except for not having the unnecessary record wrapper (see #870 and the linked blog post for why it is unnecessary).

I'd like to have a somewhat complete collection of definitions and lemmas before this is merged. This should match use cases for functional vectors, rather than being a copy of what we have for inductive vectors. Remaining issues are as follows:

- [ ] What other type definitions/modules do we need?
- [ ] What other lemmas do we need?
- [ ] Does anything already done need modifying?

An important use case is vector/matrix calculus.

- [ ] Where do we put things about matrices?
- [ ] How do we organise all of the algebraic properties?
- [ ] Do we generalise to arbitrary tensors?