### PR TITLE
remove `Level` import from `Data.Empty`

### DIFF
--- a/src/Data/Empty.agda
+++ b/src/Data/Empty.agda
@@ -8,8 +8,6 @@
 
 module Data.Empty where
 
-open import Level
-
 data ⊥ : Set where
 
 ⊥-elim : ∀ {w} {Whatever : Set w} → ⊥ → Whatever


### PR DESCRIPTION
Commit 907540c55c55d41ffa53330d2f3af16e1ed83899 added it, but it seems to not actually be needed or used. (Maybe I’m missing something, though — apologies in that case.)