### PR TITLE
Turn binary ++⁺ and related operators infix.

### DIFF
--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -308,18 +308,17 @@ _─_ : (xs : List A) → Fin (length xs) → List A
 ------------------------------------------------------------------------
 -- Operations for reversing lists
 
-reverseAcc : List A → List A → List A
-reverseAcc = foldl (flip _∷_)
-
-reverse : List A → List A
-reverse = reverseAcc []
-
 -- "Reverse append" xs ʳ++ ys = reverse xs ++ ys
 
 infixr 5 _ʳ++_
 
 _ʳ++_ : List A → List A → List A
-_ʳ++_ = flip reverseAcc
+xs ʳ++ ys = foldl (flip _∷_) ys xs
+
+-- Reverse.
+
+reverse : List A → List A
+reverse = _ʳ++ []
 
 -- Snoc.
 
@@ -390,3 +389,13 @@ boolSpan p (x ∷ xs) with p x
 
 boolBreak : (A → Bool) → List A → (List A × List A)
 boolBreak p = boolSpan (not ∘ p)
+
+-- Version 1.2
+
+reverseAcc : List A → List A → List A
+reverseAcc = foldl (flip _∷_)
+
+{-# WARNING_ON_USAGE reverseAcc
+"Warning: reverseAcc was deprecated in v1.2.
+Please use _ʳ++_ instead."
+#-}

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -103,8 +103,10 @@ module _ {v : A} where
   ∈-++⁺ˡ : ∀ {xs ys} → v ∈ xs → v ∈ xs ++ ys
   ∈-++⁺ˡ = Membershipₛ.∈-++⁺ˡ (P.setoid A)
 
-  ∈-++⁺ʳ : ∀ xs {ys} → v ∈ ys → v ∈ xs ++ ys
-  ∈-++⁺ʳ = Membershipₛ.∈-++⁺ʳ (P.setoid A)
+  infixr 5 _∈-++⁺ʳ_
+
+  _∈-++⁺ʳ_ : ∀ xs {ys} → v ∈ ys → v ∈ xs ++ ys
+  _∈-++⁺ʳ_ = Membershipₛ._∈-++⁺ʳ_ (P.setoid A)
 
   ∈-++⁻ : ∀ xs {ys} → v ∈ xs ++ ys → (v ∈ xs) ⊎ (v ∈ ys)
   ∈-++⁻ = Membershipₛ.∈-++⁻ (P.setoid A)

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -149,8 +149,10 @@ module _ {c ℓ} (S : Setoid c ℓ) where
   ∈-++⁺ˡ : ∀ {v xs ys} → v ∈ xs → v ∈ xs ++ ys
   ∈-++⁺ˡ = Any.++⁺ˡ
 
-  ∈-++⁺ʳ : ∀ {v} xs {ys} → v ∈ ys → v ∈ xs ++ ys
-  ∈-++⁺ʳ = Any.++⁺ʳ
+  infixr 5 _∈-++⁺ʳ_
+
+  _∈-++⁺ʳ_ : ∀ {v} xs {ys} → v ∈ ys → v ∈ xs ++ ys
+  _∈-++⁺ʳ_ = Any._++⁺ʳ_
 
   ∈-++⁻ : ∀ {v} xs {ys} → v ∈ xs ++ ys → (v ∈ xs) ⊎ (v ∈ ys)
   ∈-++⁻ = Any.++⁻

--- a/src/Data/List/Relation/Binary/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/Binary/BagAndSetEquality.agda
@@ -145,9 +145,12 @@ module _ {ℓ k} {A B : Set ℓ} {f g : A → B} {xs ys} where
 
 module _ {a k} {A : Set a} {xs₁ xs₂ ys₁ ys₂ : List A} where
 
-  ++-cong : xs₁ ∼[ k ] xs₂ → ys₁ ∼[ k ] ys₂ →
-            xs₁ ++ ys₁ ∼[ k ] xs₂ ++ ys₂
-  ++-cong xs₁≈xs₂ ys₁≈ys₂ {x} =
+  infixr 5 _++-cong_
+
+  _++-cong_ : xs₁ ∼[ k ] xs₂ →
+              ys₁ ∼[ k ] ys₂ →
+              xs₁ ++ ys₁ ∼[ k ] xs₂ ++ ys₂
+  _++-cong_ xs₁≈xs₂ ys₁≈ys₂ {x} =
     x ∈ xs₁ ++ ys₁       ↔⟨ SK-sym $ ++↔ ⟩
     (x ∈ xs₁ ⊎ x ∈ ys₁)  ∼⟨ xs₁≈xs₂ ⊎-cong ys₁≈ys₂ ⟩
     (x ∈ xs₂ ⊎ x ∈ ys₂)  ↔⟨ ++↔ ⟩
@@ -220,7 +223,7 @@ commutativeMonoid {a} k A = record
     { isSemigroup = record
       { isMagma = record
         { isEquivalence = Eq.isEquivalence
-        ; ∙-cong        = ++-cong
+        ; ∙-cong        = _++-cong_
         }
       ; assoc         = λ xs ys zs →
                           Eq.reflexive (LP.++-assoc xs ys zs)

--- a/src/Data/List/Relation/Binary/Equality/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Equality/Setoid.agda
@@ -85,8 +85,10 @@ module _ {b ℓ₂} (T : Setoid b ℓ₂) where
 ------------------------------------------------------------------------
 -- _++_
 
-++⁺ : ∀ {ws xs ys zs} → ws ≋ xs → ys ≋ zs → ws ++ ys ≋ xs ++ zs
-++⁺ = PW.++⁺
+infixr 5 _++⁺_
+
+_++⁺_ : ∀ {ws xs ys zs} → ws ≋ xs → ys ≋ zs → ws ++ ys ≋ xs ++ zs
+_++⁺_ = PW._++⁺_
 
 ++-cancelˡ : ∀ xs {ys zs} → xs ++ ys ≋ xs ++ zs → ys ≋ zs
 ++-cancelˡ = PW.++-cancelˡ
@@ -123,8 +125,10 @@ module _ {P : Pred A p} (P? : U.Decidable P) (resp : P Respects _≈_)
 ------------------------------------------------------------------------
 -- reverse
 
-ʳ++⁺ : ∀{xs xs′ ys ys′} → xs ≋ xs′ → ys ≋ ys′ → xs ʳ++ ys ≋ xs′ ʳ++ ys′
-ʳ++⁺ = PW.ʳ++⁺
+infixr 5 _ʳ++⁺_
+
+_ʳ++⁺_ : ∀{xs xs′ ys ys′} → xs ≋ xs′ → ys ≋ ys′ → xs ʳ++ ys ≋ xs′ ʳ++ ys′
+_ʳ++⁺_ = PW._ʳ++⁺_
 
 reverse⁺ : ∀ {xs ys} → xs ≋ ys → reverse xs ≋ reverse ys
 reverse⁺ = PW.reverse⁺

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -203,10 +203,14 @@ module _ {_∼_ : REL A B ℓ} where
 
 module _ {_∼_ : REL A B ℓ} where
 
-  ++⁺ : ∀ {ws xs ys zs} → Pointwise _∼_ ws xs → Pointwise _∼_ ys zs →
-        Pointwise _∼_ (ws ++ ys) (xs ++ zs)
-  ++⁺ []            ys∼zs = ys∼zs
-  ++⁺ (w∼x ∷ ws∼xs) ys∼zs = w∼x ∷ ++⁺ ws∼xs ys∼zs
+  infixr 5 _++⁺_
+
+  _++⁺_ : ∀ {ws xs ys zs} →
+          Pointwise _∼_ ws xs →
+          Pointwise _∼_ ys zs →
+          Pointwise _∼_ (ws ++ ys) (xs ++ zs)
+  []            ++⁺ ys∼zs = ys∼zs
+  (w∼x ∷ ws∼xs) ++⁺ ys∼zs = w∼x ∷ ws∼xs ++⁺ ys∼zs
 
 module _ {_∼_ : Rel₂ A ℓ} where
 
@@ -228,29 +232,28 @@ module _ {_∼_ : Rel₂ A ℓ} where
 
 module _ {_∼_ : REL A B ℓ} where
 
-  concat⁺ : ∀ {xss yss} → Pointwise (Pointwise _∼_) xss yss →
+  concat⁺ : ∀ {xss yss} →
+            Pointwise (Pointwise _∼_) xss yss →
             Pointwise _∼_ (concat xss) (concat yss)
   concat⁺ []                = []
-  concat⁺ (xs∼ys ∷ xss∼yss) = ++⁺ xs∼ys (concat⁺ xss∼yss)
+  concat⁺ (xs∼ys ∷ xss∼yss) = xs∼ys ++⁺ concat⁺ xss∼yss
 
 ------------------------------------------------------------------------
 -- reverse
 
 module _ {R : REL A B ℓ} where
 
-  reverseAcc⁺ : ∀ {as bs as′ bs′} → Pointwise R as′ bs′ → Pointwise R as bs →
-                Pointwise R (reverseAcc as′ as) (reverseAcc bs′ bs)
-  reverseAcc⁺ rs′ []       = rs′
-  reverseAcc⁺ rs′ (r ∷ rs) = reverseAcc⁺ (r ∷ rs′) rs
+  infixr 5 _ʳ++⁺_
 
-  ʳ++⁺ : ∀ {as bs as′ bs′} →
+  _ʳ++⁺_ : ∀ {as bs as′ bs′} →
            Pointwise R as bs →
            Pointwise R as′ bs′ →
            Pointwise R (as ʳ++ as′) (bs ʳ++ bs′)
-  ʳ++⁺ rs rs′ = reverseAcc⁺ rs′ rs
+  []       ʳ++⁺ rs′ = rs′
+  (r ∷ rs) ʳ++⁺ rs′ = rs ʳ++⁺ (r ∷ rs′)
 
   reverse⁺ : ∀ {as bs} → Pointwise R as bs → Pointwise R (reverse as) (reverse bs)
-  reverse⁺ = reverseAcc⁺ []
+  reverse⁺ = _ʳ++⁺ []
 
 ------------------------------------------------------------------------
 -- map
@@ -363,4 +366,17 @@ decidable-≡ = ≡-dec
 {-# WARNING_ON_USAGE decidable-≡
 "Warning: decidable-≡ was deprecated in v1.0.
 Please use ≡-dec from `Data.List.Properties` instead."
+#-}
+
+-- Version 1.2
+
+reverseAcc⁺ : ∀ {R : REL A B ℓ} {as bs as′ bs′} →
+              Pointwise R as′ bs′ →
+              Pointwise R as bs →
+              Pointwise R (as ʳ++ as′) (bs ʳ++ bs′)  -- Pointwise R (reverseAcc as′ as) (reverseAcc bs′ bs)
+reverseAcc⁺ rs′ = _ʳ++⁺ rs′
+
+{-# WARNING_ON_USAGE reverseAcc⁺
+"Warning: reverseAcc⁺ was deprecated in v1.2.
+Please use _ʳ++⁺_ instead."
 #-}

--- a/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
@@ -69,10 +69,14 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
-  ++⁺ : ∀ {as bs cs ds} → Pointwise R as bs →
-        Prefix R cs ds → Prefix R (as ++ cs) (bs ++ ds)
-  ++⁺ []       cs⊆ds = cs⊆ds
-  ++⁺ (r ∷ rs) cs⊆ds = r ∷ (++⁺ rs cs⊆ds)
+  infixr 5 _++⁺_
+
+  _++⁺_ : ∀ {as bs cs ds} →
+          Pointwise R as bs →
+          Prefix R cs ds →
+          Prefix R (as ++ cs) (bs ++ ds)
+  []       ++⁺ cs⊆ds = cs⊆ds
+  (r ∷ rs) ++⁺ cs⊆ds = r ∷ (rs ++⁺ cs⊆ds)
 
   ++⁻ : ∀ {as bs cs ds} → length as ≡ length bs →
         Prefix R (as ++ cs) (bs ++ ds) → Prefix R cs ds

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -176,34 +176,43 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 ------------------------------------------------------------------------
 -- _++_
 
-  ++⁺ : ∀ {as bs cs ds} → Sublist R as bs → Sublist R cs ds →
-        Sublist R (as ++ cs) (bs ++ ds)
-  ++⁺ []         cds = cds
-  ++⁺ (y ∷ʳ abs) cds = y ∷ʳ ++⁺ abs cds
-  ++⁺ (ab ∷ abs) cds = ab ∷ ++⁺ abs cds
+  infixr 5 _++⁺_ _++ʳ_ _++ˡ_
+
+  _++⁺_ : ∀ {as bs cs ds} →
+          Sublist R as bs →
+          Sublist R cs ds →
+          Sublist R (as ++ cs) (bs ++ ds)
+  []         ++⁺ cds = cds
+  (y ∷ʳ abs) ++⁺ cds = y ∷ʳ  abs ++⁺ cds
+  (ab ∷ abs) ++⁺ cds = ab ∷  abs ++⁺ cds
 
   ++⁻ : ∀ {as bs cs ds} → length as ≡ length bs →
         Sublist R (as ++ cs) (bs ++ ds) → Sublist R cs ds
   ++⁻ {[]}     {[]}     eq rs = rs
   ++⁻ {a ∷ as} {b ∷ bs} eq rs = ++⁻ (ℕₚ.suc-injective eq) (∷⁻ rs)
 
-  ++ˡ : ∀ {as bs} (cs : List B) → Sublist R as bs → Sublist R as (cs ++ bs)
-  ++ˡ zs = ++⁺ (minimum zs)
+  _++ˡ_ : ∀ {as bs} (cs : List B) →
+          Sublist R as bs →
+          Sublist R as (cs ++ bs)
+  _++ˡ_ zs = minimum zs ++⁺_
 
-  ++ʳ : ∀ {as bs} (cs : List B) → Sublist R as bs → Sublist R as (bs ++ cs)
-  ++ʳ cs []        = minimum cs
-  ++ʳ cs (y ∷ʳ rs) = y ∷ʳ ++ʳ cs rs
-  ++ʳ cs (r ∷ rs)  = r ∷ ++ʳ cs rs
+  _++ʳ_ : ∀ {as bs} →
+          Sublist R as bs → (cs : List B) →
+          Sublist R as (bs ++ cs)
+  []        ++ʳ cs = minimum cs
+  (y ∷ʳ rs) ++ʳ cs = y ∷ʳ rs ++ʳ cs
+  (r ∷  rs) ++ʳ cs = r ∷  rs ++ʳ cs
 
 
 ------------------------------------------------------------------------
 -- concat
 
-  concat⁺ : ∀ {ass bss} → Sublist (Sublist R) ass bss →
+  concat⁺ : ∀ {ass bss} →
+            Sublist (Sublist R) ass bss →
             Sublist R (concat ass) (concat bss)
   concat⁺ []          = []
-  concat⁺ (y  ∷ʳ rss) = ++ˡ y (concat⁺ rss)
-  concat⁺ (rs ∷  rss) = ++⁺ rs (concat⁺ rss)
+  concat⁺ (y  ∷ʳ rss) = y ++ˡ concat⁺ rss
+  concat⁺ (rs ∷  rss) = rs ++⁺ concat⁺ rss
 
 ------------------------------------------------------------------------
 -- take / drop
@@ -286,20 +295,18 @@ module _ {a r p} {A : Set a} {R : Rel A r} {P : Pred A p} (P? : U.Decidable P) w
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
-  reverseAcc⁺ : ∀ {as bs cs ds} → Sublist R as bs → Sublist R cs ds →
-                Sublist R (reverseAcc cs as) (reverseAcc ds bs)
-  reverseAcc⁺ []         cds = cds
-  reverseAcc⁺ (y ∷ʳ abs) cds = reverseAcc⁺ abs (y ∷ʳ cds)
-  reverseAcc⁺ (r ∷ abs)  cds = reverseAcc⁺ abs (r ∷ cds)
+  infixr 5 _ʳ++⁺_
 
-  ʳ++⁺ : ∀ {as bs cs ds} →
-         Sublist R as bs →
-         Sublist R cs ds →
-         Sublist R (as ʳ++ cs) (bs ʳ++ ds)
-  ʳ++⁺ = reverseAcc⁺
+  _ʳ++⁺_ : ∀ {as bs cs ds} →
+           Sublist R as bs →
+           Sublist R cs ds →
+           Sublist R (as ʳ++ cs) (bs ʳ++ ds)
+  []         ʳ++⁺ cds = cds
+  (y ∷ʳ abs) ʳ++⁺ cds = abs ʳ++⁺ (y ∷ʳ cds)
+  (r ∷  abs) ʳ++⁺ cds = abs ʳ++⁺ (r ∷  cds)
 
   reverse⁺ : ∀ {as bs} → Sublist R as bs → Sublist R (reverse as) (reverse bs)
-  reverse⁺ rs = reverseAcc⁺ rs []
+  reverse⁺ rs = rs ʳ++⁺ []
 
   reverse⁻ : ∀ {as bs} → Sublist R (reverse as) (reverse bs) → Sublist R as bs
   reverse⁻ {as} {bs} p = cast (reverse⁺ p) where
@@ -710,3 +717,18 @@ module DisjointnessMonotonicity
   shrinkDisjoint [] []         []         = []
 
 open DisjointnessMonotonicity public
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.2
+
+reverseAcc⁺ = _ʳ++⁺_
+{-# WARNING_ON_USAGE reverseAcc⁺
+"Warning: reverseAcc⁺ was deprecated in v1.2.
+Please use _ʳ++⁺_ instead."
+#-}

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Solver.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Solver.agda
@@ -113,11 +113,11 @@ flatten (t <> u) =
 private
 
   keep-it : ∀ {n a b} → a ⊆I b → (xs ys : RList n) → xs ⊆R ys → (a ∷ xs) ⊆R (b ∷ ys)
-  keep-it (var a≡b) xs ys hyp ρ = ++⁺ (reflexive R-refl (cong _ a≡b)) (hyp ρ)
+  keep-it (var a≡b) xs ys hyp ρ = reflexive R-refl (cong _ a≡b) ++⁺ hyp ρ
   keep-it (val rab) xs ys hyp ρ = rab ∷ hyp ρ
 
   skip-it : ∀ {n} it (d e : RList n) → d ⊆R e → d ⊆R (it ∷ e)
-  skip-it it d ys hyp ρ = ++ˡ (⟦ it ⟧I ρ) (hyp ρ)
+  skip-it it d ys hyp ρ = ⟦ it ⟧I ρ ++ˡ hyp ρ
 
 -- Solver for items
 solveI : ∀ {n} (a b : Item n) → Maybe (a ⊆I b)

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -124,14 +124,16 @@ module _ {b ℓ} (R : Setoid b ℓ) where
 
 module _ {as bs : List A} where
 
-  ++⁺ˡ : ∀ cs → as ⊆ bs → as ⊆ cs ++ bs
-  ++⁺ˡ = HeteroProperties.++ˡ
+  infixr 5 _++⁺ˡ_ _++⁺ʳ_ _++⁺_
 
-  ++⁺ʳ : ∀ cs → as ⊆ bs → as ⊆ bs ++ cs
-  ++⁺ʳ = HeteroProperties.++ʳ
+  _++⁺ˡ_ : ∀ cs → as ⊆ bs → as ⊆ cs ++ bs
+  _++⁺ˡ_ = HeteroProperties._++ˡ_
 
-  ++⁺ : ∀ {cs ds} → as ⊆ bs → cs ⊆ ds → as ++ cs ⊆ bs ++ ds
-  ++⁺ = HeteroProperties.++⁺
+  _++⁺ʳ_ : as ⊆ bs → ∀ cs → as ⊆ bs ++ cs
+  _++⁺ʳ_ = HeteroProperties._++ʳ_
+
+  _++⁺_ : ∀ {cs ds} → as ⊆ bs → cs ⊆ ds → as ++ cs ⊆ bs ++ ds
+  _++⁺_ = HeteroProperties._++⁺_
 
   ++⁻ : ∀ {cs ds} → length as ≡ length bs → as ++ cs ⊆ bs ++ ds → cs ⊆ ds
   ++⁻ = HeteroProperties.++⁻
@@ -191,15 +193,11 @@ module _ {p q} {P : Pred A p} {Q : Pred A q}
 
 module _ {as bs : List A} where
 
-  reverseAcc⁺ : ∀ {cs ds} → as ⊆ bs → cs ⊆ ds →
-                reverseAcc cs as ⊆ reverseAcc ds bs
-  reverseAcc⁺ = HeteroProperties.reverseAcc⁺
-
-  ʳ++⁺ : ∀ {cs ds} →
-         as ⊆ bs →
-         cs ⊆ ds →
-         as ʳ++ cs ⊆ bs ʳ++ ds
-  ʳ++⁺ = reverseAcc⁺
+  _ʳ++⁺_ : ∀ {cs ds} →
+           as ⊆ bs →
+           cs ⊆ ds →
+           as ʳ++ cs ⊆ bs ʳ++ ds
+  _ʳ++⁺_ = HeteroProperties._ʳ++⁺_
 
   reverse⁺ : as ⊆ bs → reverse as ⊆ reverse bs
   reverse⁺ = HeteroProperties.reverse⁺
@@ -291,3 +289,17 @@ shrinkDisjointʳ (v≈y ∷ σ)  (y≈z ∷ᵣ d) = trans v≈y y≈z ∷ᵣ shr
 -- Not in σ: drop y.
 shrinkDisjointʳ (y  ∷ʳ σ)  (y≈z ∷ᵣ d) = _             ∷ₙ shrinkDisjointʳ σ d
 shrinkDisjointʳ []         []         = []
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.2
+
+reverseAcc⁺ = _ʳ++⁺_
+{-# WARNING_ON_USAGE reverseAcc⁺
+"Warning: reverseAcc⁺ was deprecated in v1.2.
+Please use _ʳ++⁺_ instead."
+#-}

--- a/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
@@ -120,10 +120,14 @@ module _ {a b e r s} {A : Set a} {B : Set b}
 
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
-  ++⁺ : ∀ {as bs cs ds} → Suffix R as bs → Pointwise R cs ds →
-        Suffix R (as ++ cs) (bs ++ ds)
-  ++⁺ (here rs)   rs′ = here (Pw.++⁺ rs rs′)
-  ++⁺ (there suf) rs′ = there (++⁺ suf rs′)
+  infixr 5 _++⁺_
+
+  _++⁺_ : ∀ {as bs cs ds} →
+          Suffix R as bs →
+          Pointwise R cs ds →
+          Suffix R (as ++ cs) (bs ++ ds)
+  here rs   ++⁺ rs′ = here (rs Pw.++⁺ rs′)
+  there suf ++⁺ rs′ = there (suf ++⁺ rs′)
 
   ++⁻ : ∀ {as bs cs ds} → length cs ≡ length ds →
         Suffix R (as ++ cs) (bs ++ ds) → Pointwise R cs ds

--- a/src/Data/List/Relation/Ternary/Interleaving.agda
+++ b/src/Data/List/Relation/Ternary/Interleaving.agda
@@ -24,6 +24,8 @@ open import Relation.Binary.PropositionalEquality as P using (_≡_)
 module _ {a b c l r} {A : Set a} {B : Set b} {C : Set c}
          (L : REL A C l) (R : REL B C r) where
 
+  infixr 5 _∷ˡ_ _∷ʳ_
+
   data Interleaving : List A → List B → List C → Set (a ⊔ b ⊔ c ⊔ l ⊔ r) where
     []   : Interleaving [] [] []
     _∷ˡ_ : ∀ {a c l r cs} → L a c → Interleaving l r cs → Interleaving (a ∷ l) r (c ∷ cs)

--- a/src/Data/List/Relation/Ternary/Interleaving/Properties.agda
+++ b/src/Data/List/Relation/Ternary/Interleaving/Properties.agda
@@ -37,20 +37,22 @@ module _ {a b c l r} {A : Set a} {B : Set b} {C : Set c}
 ------------------------------------------------------------------------
 -- _++_
 
-  ++⁺ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
-        Interleaving L R as₁ l₁ r₁ →
-        Interleaving L R as₂ l₂ r₂ →
-        Interleaving L R (as₁ ++ as₂) (l₁ ++ l₂) (r₁ ++ r₂)
-  ++⁺ []         sp₂ = sp₂
-  ++⁺ (l ∷ˡ sp₁) sp₂ = l ∷ˡ (++⁺ sp₁ sp₂)
-  ++⁺ (r ∷ʳ sp₁) sp₂ = r ∷ʳ (++⁺ sp₁ sp₂)
+  infixr 5 _++⁺_ _++-disjoint_
 
-  ++-disjoint : ∀ {as₁ as₂ l₁ r₂} →
-                Interleaving L R l₁ [] as₁ →
-                Interleaving L R [] r₂ as₂ →
-                Interleaving L R l₁ r₂ (as₁ ++ as₂)
-  ++-disjoint []         sp₂ = sp₂
-  ++-disjoint (l ∷ˡ sp₁) sp₂ = l ∷ˡ ++-disjoint sp₁ sp₂
+  _++⁺_ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
+          Interleaving L R as₁ l₁ r₁ →
+          Interleaving L R as₂ l₂ r₂ →
+          Interleaving L R (as₁ ++ as₂) (l₁ ++ l₂) (r₁ ++ r₂)
+  []         ++⁺ sp₂ = sp₂
+  (l ∷ˡ sp₁) ++⁺ sp₂ = l ∷ˡ (sp₁ ++⁺ sp₂)
+  (r ∷ʳ sp₁) ++⁺ sp₂ = r ∷ʳ (sp₁ ++⁺ sp₂)
+
+  _++-disjoint_ : ∀ {as₁ as₂ l₁ r₂} →
+                  Interleaving L R l₁ [] as₁ →
+                  Interleaving L R [] r₂ as₂ →
+                  Interleaving L R l₁ r₂ (as₁ ++ as₂)
+  []         ++-disjoint sp₂ = sp₂
+  (l ∷ˡ sp₁) ++-disjoint sp₂ = l ∷ˡ (sp₁ ++-disjoint sp₂)
 
 ------------------------------------------------------------------------
 -- map
@@ -85,27 +87,46 @@ module _ {a b c l r} {A : Set a} {B : Set b} {C : Set c}
          {L : REL A C l} {R : REL B C r}
          where
 
-  reverseAcc⁺ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
-                Interleaving L R l₁ r₁ as₁ →
-                Interleaving L R l₂ r₂ as₂ →
-                Interleaving L R (reverseAcc l₁ l₂) (reverseAcc r₁ r₂) (reverseAcc as₁ as₂)
-  reverseAcc⁺ sp₁ []         = sp₁
-  reverseAcc⁺ sp₁ (l ∷ˡ sp₂) = reverseAcc⁺ (l ∷ˡ sp₁) sp₂
-  reverseAcc⁺ sp₁ (r ∷ʳ sp₂) = reverseAcc⁺ (r ∷ʳ sp₁) sp₂
+  infixr 5 _ʳ++⁺_
 
-  ʳ++⁺ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
-         Interleaving L R l₁ r₁ as₁ →
-         Interleaving L R l₂ r₂ as₂ →
-         Interleaving L R (l₁ ʳ++ l₂) (r₁ ʳ++ r₂) (as₁ ʳ++ as₂)
-  ʳ++⁺ sp₁ sp₂ = reverseAcc⁺ sp₂ sp₁
+  _ʳ++⁺_ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
+           Interleaving L R l₁ r₁ as₁ →
+           Interleaving L R l₂ r₂ as₂ →
+           Interleaving L R (l₁ ʳ++ l₂) (r₁ ʳ++ r₂) (as₁ ʳ++ as₂)
+  []         ʳ++⁺ sp₂ = sp₂
+  (l ∷ˡ sp₁) ʳ++⁺ sp₂ = sp₁ ʳ++⁺ (l ∷ˡ sp₂)
+  (r ∷ʳ sp₁) ʳ++⁺ sp₂ = sp₁ ʳ++⁺ (r ∷ʳ sp₂)
 
-  reverse⁺ : ∀ {as l r} → Interleaving L R l r as →
+  reverse⁺ : ∀ {as l r} →
+             Interleaving L R l r as →
              Interleaving L R (reverse l) (reverse r) (reverse as)
-  reverse⁺ = reverseAcc⁺ []
+  reverse⁺ sp = sp ʳ++⁺ []
 
-  reverse⁻ : ∀ {as l r} → Interleaving L R (reverse l) (reverse r) (reverse as) →
+  reverse⁻ : ∀ {as l r} →
+             Interleaving L R (reverse l) (reverse r) (reverse as) →
              Interleaving L R l r as
   reverse⁻ {as} {l} {r} sp with reverse⁺ sp
   ... | sp′ rewrite reverse-involutive as
                   | reverse-involutive l
                   | reverse-involutive r = sp′
+
+  ------------------------------------------------------------------------
+  -- DEPRECATED NAMES
+  ------------------------------------------------------------------------
+  -- Please use the new names as continuing support for the old names is
+  -- not guaranteed.
+
+  -- Version 1.2
+
+  reverseAcc⁺ : ∀ {as₁ as₂ l₁ l₂ r₁ r₂} →
+                Interleaving L R l₁ r₁ as₁ →
+                Interleaving L R l₂ r₂ as₂ →
+                Interleaving L R (l₂ ʳ++ l₁) (r₂ ʳ++ r₁) (as₂ ʳ++ as₁ )
+                -- Or: Interleaving L R (reverseAcc l₁ l₂) (reverseAcc r₁ r₂) (reverseAcc as₁ as₂)
+                -- but reverseAcc is deprecated itself.
+  reverseAcc⁺ sp₁ sp₂ = sp₂ ʳ++⁺ sp₁
+
+  {-# WARNING_ON_USAGE reverseAcc⁺
+  "Warning: reverseAcc⁺ was deprecated in v1.2.
+  Please use _ʳ++⁺_ instead."
+  #-}

--- a/src/Data/List/Relation/Ternary/Interleaving/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Ternary/Interleaving/Setoid/Properties.agda
@@ -30,7 +30,7 @@ open import Data.List.Relation.Ternary.Interleaving.Properties public
 -- _++_
 
 ++-linear : (xs ys : List A) → Interleaving xs ys (xs ++ ys)
-++-linear xs ys = ++-disjoint (left ≋-refl) (right ≋-refl)
+++-linear xs ys = (left ≋-refl) ++-disjoint (right ≋-refl)
 
 ------------------------------------------------------------------------
 -- filter

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -371,9 +371,11 @@ module _ (P : B → Set p) {f : A → Maybe B} where
 
 module _ {P : A → Set p} where
 
-  ++⁺ : ∀ {xs ys} → All P xs → All P ys → All P (xs ++ ys)
-  ++⁺ []         pys = pys
-  ++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
+  infixr 5 _++⁺_
+
+  _++⁺_ : ∀ {xs ys} → All P xs → All P ys → All P (xs ++ ys)
+  []         ++⁺ pys = pys
+  (px ∷ pxs) ++⁺ pys = px ∷ (pxs ++⁺ pys)
 
   ++⁻ˡ : ∀ xs {ys} → All P (xs ++ ys) → All P xs
   ++⁻ˡ []       p          = []
@@ -388,15 +390,15 @@ module _ {P : A → Set p} where
   ++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (px ∷_) id (++⁻ _ pxs)
 
   ++↔ : ∀ {xs ys} → (All P xs × All P ys) ↔ All P (xs ++ ys)
-  ++↔ {xs} = inverse (uncurry ++⁺) (++⁻ xs) ++⁻∘++⁺ (++⁺∘++⁻ xs)
+  ++↔ {xs} = inverse (uncurry _++⁺_) (++⁻ xs) ++⁻∘++⁺ (++⁺∘++⁻ xs)
     where
     ++⁺∘++⁻ : ∀ xs {ys} (p : All P (xs ++ ys)) →
-              uncurry′ ++⁺ (++⁻ xs p) ≡ p
+              uncurry′ _++⁺_ (++⁻ xs p) ≡ p
     ++⁺∘++⁻ []       p          = refl
     ++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
 
     ++⁻∘++⁺ : ∀ {xs ys} (p : All P xs × All P ys) →
-              ++⁻ xs (uncurry ++⁺ p) ≡ p
+              ++⁻ xs (uncurry _++⁺_ p) ≡ p
     ++⁻∘++⁺ ([]       , pys) = refl
     ++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = refl
 
@@ -407,7 +409,7 @@ module _ {P : A → Set p} where
 
   concat⁺ : ∀ {xss} → All (All P) xss → All P (concat xss)
   concat⁺ []           = []
-  concat⁺ (pxs ∷ pxss) = ++⁺ pxs (concat⁺ pxss)
+  concat⁺ (pxs ∷ pxss) = pxs ++⁺ concat⁺ pxss
 
   concat⁻ : ∀ {xss} → All P (concat xss) → All (All P) xss
   concat⁻ {[]}       []  = []
@@ -529,8 +531,10 @@ module _ {P : A → Set p} where
 
 module _ {P : A → Set p} {x xs} where
 
-  ∷ʳ⁺ : All P xs → P x → All P (xs ∷ʳ x)
-  ∷ʳ⁺ pxs px = ++⁺ pxs (px ∷ [])
+  infixl 5 _∷ʳ⁺_
+
+  _∷ʳ⁺_ : All P xs → P x → All P (xs ∷ʳ x)
+  pxs ∷ʳ⁺ px = pxs ++⁺ (px ∷ [])
 
   ∷ʳ⁻ : All P (xs ∷ʳ x) → All P xs × P x
   ∷ʳ⁻ pxs = Prod.map₂ singleton⁻ $ ++⁻ xs pxs

--- a/src/Data/List/Relation/Unary/AllPairs/Properties.agda
+++ b/src/Data/List/Relation/Unary/AllPairs/Properties.agda
@@ -42,7 +42,7 @@ module _ {a ℓ} {A : Set a} {R : Rel A ℓ} where
   ++⁺ : ∀ {xs ys} → AllPairs R xs → AllPairs R ys →
         All (λ x → All (R x) ys) xs → AllPairs R (xs ++ ys)
   ++⁺ []         Rys _              = Rys
-  ++⁺ (px ∷ Rxs) Rys (Rxys ∷ Rxsys) = All.++⁺ px Rxys ∷ ++⁺ Rxs Rys Rxsys
+  ++⁺ (px ∷ Rxs) Rys (Rxys ∷ Rxsys) = (px All.++⁺ Rxys) ∷ ++⁺ Rxs Rys Rxsys
 
 ------------------------------------------------------------------------
 -- concat

--- a/src/Data/List/Relation/Unary/First/Properties.agda
+++ b/src/Data/List/Relation/Unary/First/Properties.agda
@@ -38,13 +38,15 @@ module _ {a b p q} {A : Set a} {B : Set b} {P : Pred B p} {Q : Pred B q} where
 
 module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
 
-  ++⁺ : ∀ {xs ys} → All P xs → First P Q ys → First P Q (xs List.++ ys)
-  ++⁺ []         pqys = pqys
-  ++⁺ (px ∷ pxs) pqys = px ∷ ++⁺ pxs pqys
+  infixr 5 _++⁺_ _⁺++_
 
-  ⁺++ : ∀ {xs} → First P Q xs → ∀ ys → First P Q (xs List.++ ys)
-  ⁺++ [ qx ]      ys = [ qx ]
-  ⁺++ (px ∷ pqxs) ys = px ∷ ⁺++ pqxs ys
+  _++⁺_ : ∀ {xs ys} → All P xs → First P Q ys → First P Q (xs List.++ ys)
+  []         ++⁺ pqys = pqys
+  (px ∷ pxs) ++⁺ pqys = px ∷ (pxs ++⁺ pqys)
+
+  _⁺++_ : ∀ {xs} → First P Q xs → ∀ ys → First P Q (xs List.++ ys)
+  [ qx ]      ⁺++ ys = [ qx ]
+  (px ∷ pqxs) ⁺++ ys = px ∷ pqxs ⁺++ ys
 
 ------------------------------------------------------------------------
 -- Relationship to All
@@ -109,4 +111,4 @@ module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
   ... | pxs ++  qy ∷ ys = (px ∷ pxs) ++ qy ∷ ys
 
   fromView : ∀ {as} → FirstView P Q as → First P Q as
-  fromView (pxs ++ qy ∷ ys) = ++⁺ pxs [ qy ]
+  fromView (pxs ++ qy ∷ ys) = pxs ++⁺ [ qy ]

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -224,7 +224,7 @@ x≢0⇒x>0 {1+[2 _ ]} _   =  0<odd
 <-trans (odd<odd x<y) (odd<even (inj₂ refl))   =  odd<even (inj₁ x<y)
 <-trans (odd<odd x<y) (odd<odd y<z)            =  odd<odd (<-trans x<y y<z)
 
-<-cmp :  ∀ (x y) → Tri (x < y) (x ≡ y) (x > y)
+<-cmp : ∀ x y → Tri (x < y) (x ≡ y) (x > y)
 <-cmp zero     zero      = tri≈ x≮0    refl  x≮0
 <-cmp zero     2[1+ _ ]  = tri< 0<even (λ()) x≮0
 <-cmp zero     1+[2 _ ]  = tri< 0<odd  (λ()) x≮0
@@ -737,14 +737,14 @@ module _ where
 +-monoʳ-< :  ∀ x → (x +_) Preserves _<_ ⟶ _<_
 +-monoʳ-< x y<z =  +-mono-≤-< (≤-refl {x}) y<z
 
-x≤y+x :  ∀ (x y) → x ≤ y + x
+x≤y+x : ∀ x y → x ≤ y + x
 x≤y+x x y =  begin
   x        ≡⟨ sym (+-identityˡ x) ⟩
   0ᵇ + x   ≤⟨ +-monoˡ-≤ x (0≤x y) ⟩
   y + x    ∎
   where open ≤-Reasoning
 
-x≤x+y :  ∀ (x y) → x ≤ x + y
+x≤x+y : ∀ x y → x ≤ x + y
 x≤x+y x y =  begin
   x        ≤⟨ x≤y+x x y ⟩
   y + x    ≡⟨ +-comm y x ⟩
@@ -1272,7 +1272,7 @@ suc-* x y = begin
   x + x * y    ∎
   where open ≡-Reasoning
 
-x≤suc[y]*x :  ∀ (x y) → x ≤ (suc y) * x
+x≤suc[y]*x :  ∀ x y → x ≤ (suc y) * x
 x≤suc[y]*x x y =  begin
   x             ≤⟨ x≤x+y x (y * x) ⟩
   x + y * x     ≡⟨ sym (suc-* y x) ⟩

--- a/src/Data/Trie/NonEmpty.agda
+++ b/src/Data/Trie/NonEmpty.agda
@@ -45,7 +45,7 @@ Word = List Key
 
 eat : ∀ {v} → Value v → Word → Value v
 family   (eat V ks) = family   V ∘′ (ks ++_)
-respects (eat V ks) = respects V ∘′ ++⁺ ≋-refl
+respects (eat V ks) = respects V ∘′ (≋-refl ++⁺_)
 
 data Trie⁺ {v} (V : Value v) : Size → Set (v ⊔ k ⊔ e ⊔ r)
 Tries⁺ : ∀ {v} (V : Value v) (i : Size) → Set (v ⊔ k ⊔ e ⊔ r)


### PR DESCRIPTION
This is motivated by their proof-relevant use.  For instance
```agda    
      _++⁺_ : All P xs → All P ys → All P (xs ++ ys)
```
is the operation concatenating two well-typed environments, in case `xs` and `ys` are contexts (lists of types) and `P` is mapping a type to its set of values.

Also: deprecate `reverseAcc`.

This PR originated from https://github.com/agda/agda-stdlib/pull/899#discussion_r325096169