### PR TITLE
[ #917 ] Do not deprecate ⌊_⌋, the traditional name of isYes.

### DIFF
--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -31,6 +31,9 @@ isYes : Dec P → Bool
 isYes (yes _) = true
 isYes (no _)  = false
 
+-- The traditional name for isYes is ⌊_⌋, indicating the stripping of evidence.
+⌊_⌋ = isYes
+
 isNo : Dec P → Bool
 isNo = not ∘ isYes
 
@@ -100,18 +103,3 @@ dec-no (no ¬p′) ¬p = ¬p′ , refl
 dec-yes-irr : (p? : Dec P) → Irrelevant P → (p : P) → p? ≡ yes p
 dec-yes-irr p? irr p with dec-yes p? p
 ... | p′ , eq rewrite irr p p′ = eq
-
-
-------------------------------------------------------------------------
--- DEPRECATED NAMES
-------------------------------------------------------------------------
--- Please use the new names as continuing support for the old names is
--- not guaranteed.
-
--- Version 1.2
-
-⌊_⌋ = isYes
-{-# WARNING_ON_USAGE ⌊_⌋
-"Warning: ⌊_⌋ was deprecated in v1.2.
-Please use isYes instead."
-#-}


### PR DESCRIPTION
Undo the recent deprecation of  ⌊_⌋.