### PR TITLE
[ see #225 ] Redefine `Dec` for better computation

### DIFF
--- a/src/Category/Monad/Partiality.agda
+++ b/src/Category/Monad/Partiality.agda
@@ -910,9 +910,9 @@ private
   -- McCarthy's f91:
 
   f91′ : ℕ → ℕ ⊥P
-  f91′ n with n ≤? 100
-  ... | yes _ = later (♯ (f91′ (11 + n) >>= f91′))
-  ... | no  _ = now (n ∸ 10)
+  f91′ n with isYes (n ≤? 100)
+  ... | true  = later (♯ (f91′ (11 + n) >>= f91′))
+  ... | false = now (n ∸ 10)
 
   f91 : ℕ → ℕ ⊥
   f91 n = ⟦ f91′ n ⟧P

--- a/src/Codata/Cofin/Literals.agda
+++ b/src/Codata/Cofin/Literals.agda
@@ -17,7 +17,7 @@ open import Relation.Nullary.Decidable
 
 number : ∀ n → Number (Cofin n)
 number n = record
-  { Constraint = λ k → True (suc k ℕ≤? n)
-  ; fromNat    = λ n {{p}} → fromℕ< (toWitness p)
+  { Constraint = λ k → True! (suc k ℕ≤? n)
+  ; fromNat    = λ n {{p}} → fromℕ< (toWitness! p)
   }
 

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -11,7 +11,6 @@ module Data.Bool.Base where
 open import Data.Unit.Base using (⊤)
 open import Data.Empty
 open import Level using (Level)
-open import Relation.Nullary
 
 private
   variable

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -20,7 +20,7 @@ open import Function.Equivalence
 open import Level using (Level; 0ℓ)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality hiding ([_])
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (Dec; isYes; reflects; yes; no; true; false)
 open import Relation.Nullary.Decidable using (True)
 import Relation.Unary as U
 
@@ -626,8 +626,9 @@ T-irrelevant : U.Irrelevant T
 T-irrelevant {true}  _  _  = refl
 
 T? : U.Decidable T
-T? true  = yes _
-T? false = no (λ ())
+isYes (T? x) = x
+reflects (T? false) = false id
+reflects (T? true ) = true  _
 
 T?-diag : ∀ b → T b → True (T? b)
 T?-diag true  _ = _

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -16,7 +16,7 @@ import Data.Nat.Properties as ℕₚ
 
 open import Function
 open import Relation.Nullary using (yes; no)
-open import Relation.Nullary.Decidable using (map′; isYes)
+open import Relation.Nullary.Decidable using (map′; isYes!)
 open import Relation.Binary
   using ( _⇒_; Reflexive; Symmetric; Transitive; Substitutive
         ; Decidable; IsEquivalence; IsDecEquivalence
@@ -103,7 +103,7 @@ x ≟ y = map′ ≈⇒≡ ≈-reflexive (x ≈? y)
 
 infix 4 _==_
 _==_ : Char → Char → Bool
-c₁ == c₂ = isYes (c₁ ≟ c₂)
+c₁ == c₂ = isYes! (c₁ ≟ c₂)
 
 private
 

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -8,6 +8,7 @@
 
 module Data.Digit where
 
+open import Data.Bool.Base using (if_then_else_)
 open import Data.Nat
 open import Data.Nat.Properties
 open import Data.Nat.Solver
@@ -18,7 +19,7 @@ open import Data.Product
 open import Data.Vec as Vec using (Vec; _∷_; [])
 open import Data.Nat.DivMod
 open import Data.Nat.Induction
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (isYes)
 open import Relation.Nullary.Decidable
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
@@ -54,9 +55,9 @@ toNatDigits base@(suc (suc b)) n = aux (<-wellFounded n) []
   where
   aux : {n : ℕ} → Acc _<_ n → List ℕ → List ℕ
   aux {zero}        _        xs =  (0 ∷ xs)
-  aux {n@(suc n-1)} (acc wf) xs with 0 <? n / base
-  ... | no _    =  (n % base) ∷ xs
-  ... | yes 0<q =  aux (wf (n / base) q<n) ((n % base) ∷ xs)
+  aux {n@(suc n-1)} (acc wf) xs = if isYes (0 <? n / base)
+    then (n % base) ∷ xs
+    else aux (wf (n / base) q<n) ((n % base) ∷ xs)
     where
     q<n : n / base < n
     q<n = m/n<m n base (s≤s z≤n) (s≤s (s≤s z≤n))

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -48,7 +48,7 @@ Bit     = Digit 2
 ------------------------------------------------------------------------
 -- Converting between `ℕ` and `expansions of ℕ`
 
-toNatDigits : (base : ℕ) {base≤16 : True (1 ≤? base)} → ℕ → List ℕ
+toNatDigits : (base : ℕ) {base≤16 : True! (1 ≤? base)} → ℕ → List ℕ
 toNatDigits base@(suc zero)    n = replicate n 1
 toNatDigits base@(suc (suc b)) n = aux (<-wellFounded n) []
   where
@@ -80,7 +80,7 @@ fromDigits {base} (d ∷ ds) = toℕ d + fromDigits ds * base
 --
 -- Note that the list of digits is always non-empty.
 
-toDigits : (base : ℕ) {base≥2 : True (2 ≤? base)} (n : ℕ) →
+toDigits : (base : ℕ) {base≥2 : True! (2 ≤? base)} (n : ℕ) →
            ∃ λ (ds : Expansion base) → fromDigits ds ≡ n
 toDigits (suc (suc k)) n = <′-rec Pred helper n
   where
@@ -123,6 +123,6 @@ digitChars =
 
 -- showDigit shows digits in base ≤ 16.
 
-showDigit : ∀ {base} {base≤16 : True (base ≤? 16)} → Digit base → Char
+showDigit : ∀ {base} {base≤16 : True! (base ≤? 16)} → Digit base → Char
 showDigit {base≤16 = base≤16} d =
-  Vec.lookup digitChars (Fin.inject≤ d (toWitness base≤16))
+  Vec.lookup digitChars (Fin.inject≤ d (toWitness! base≤16))

--- a/src/Data/Fin.agda
+++ b/src/Data/Fin.agda
@@ -27,5 +27,5 @@ open import Data.Fin.Properties public
 
 infix 10 #_
 
-#_ : ∀ m {n} {m<n : True (suc m ℕₚ.≤? n)} → Fin n
-#_ _ {m<n = m<n} = fromℕ≤ (toWitness m<n)
+#_ : ∀ m {n} {m<n : True! (suc m ℕₚ.≤? n)} → Fin n
+#_ _ {m<n = m<n} = fromℕ≤ (toWitness! m<n)

--- a/src/Data/Fin/Literals.agda
+++ b/src/Data/Fin/Literals.agda
@@ -11,10 +11,10 @@ module Data.Fin.Literals where
 open import Agda.Builtin.FromNat
 open import Data.Nat using (suc; _≤?_)
 open import Data.Fin using (Fin ; #_)
-open import Relation.Nullary.Decidable using (True)
+open import Relation.Nullary.Decidable using (True!)
 
 number : ∀ n → Number (Fin n)
 number n = record
-  { Constraint = λ m → True (suc m ≤? n)
+  { Constraint = λ m → True! (suc m ≤? n)
   ; fromNat    = λ m {{pr}} → (# m) {n} {pr}
   }

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -8,12 +8,15 @@
 
 module Data.Fin.Permutation.Components where
 
+open import Data.Bool.Base using (true; false; if_then_else_)
 open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat as ℕ using (zero; suc; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Product using (proj₂)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (dec; isYes; yes; no)
+open import Relation.Nullary.Decidable using (dec-true; dec-false)
+open import Relation.Nullary.Reflects as Ref using (invert)
 open import Relation.Binary.PropositionalEquality
 open import Algebra.FunctionProperties using (Involutive)
 open ≡-Reasoning
@@ -25,11 +28,11 @@ open ≡-Reasoning
 -- 'tranpose i j' swaps the places of 'i' and 'j'.
 
 transpose : ∀ {n} → Fin n → Fin n → Fin n → Fin n
-transpose i j k with k ≟ i
-... | yes _ = j
-... | no  _ with k ≟ j
-...   | yes _ = i
-...   | no  _ = k
+transpose i j k = if isYes (k ≟ i)
+  then j
+  else if isYes (k ≟ j)
+    then i
+    else k
 
 -- reverse i = n ∸ 1 ∸ i
 
@@ -43,13 +46,13 @@ reverse {suc n} i  = inject≤ (n ℕ- i) (ℕₚ.n∸m≤n (toℕ i) (suc n))
 transpose-inverse : ∀ {n} (i j : Fin n) {k} →
                     transpose i j (transpose j i k) ≡ k
 transpose-inverse i j {k} with k ≟ j
-... | yes p rewrite ≡-≟-identity _≟_ {x = i} refl = sym p
-... | no ¬p with k ≟ i
-...   | no ¬q rewrite proj₂ (≢-≟-identity _≟_ ¬q)
-                    | proj₂ (≢-≟-identity _≟_ ¬p) = refl
-...   | yes q with j ≟ i
-...     | yes r = trans r (sym q)
-...     | no ¬r rewrite ≡-≟-identity _≟_ {x = j} refl = sym q
+... | dec true  [k=j] rewrite dec-true (i ≟ i) refl = sym (invert [k=j])
+... | dec false [k≠j] with k ≟ i
+...   | dec false [k≠i] rewrite dec-false (k ≟ i) (invert [k≠i])
+                              | dec-false (k ≟ j) (invert [k≠j]) = refl
+...   | dec true  [k=i] with j ≟ i
+...     | dec true  [j=i] = trans (invert [j=i]) (sym (invert [k=i]))
+...     | dec false [j≠i] rewrite dec-true (j ≟ j) refl = sym (invert [k=i])
 
 reverse-prop : ∀ {n} → (i : Fin n) → toℕ (reverse i) ≡ n ∸ suc (toℕ i)
 reverse-prop {suc n} i = begin

--- a/src/Data/Graph/Acyclic.agda
+++ b/src/Data/Graph/Acyclic.agda
@@ -21,7 +21,7 @@ open import Data.Fin as Fin
 import Data.Fin.Properties as FP
 import Data.Fin.Permutation.Components as PC
 open import Data.Product as Prod using (∃; _×_; _,_)
-open import Data.Maybe.Base using (Maybe; nothing; just)
+open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; decToMaybe)
 open import Data.Empty
 open import Data.Unit.Base using (⊤; tt)
 open import Data.Vec as Vec using (Vec; []; _∷_)
@@ -237,9 +237,7 @@ preds (c & g) (suc i) =
             (List.map (Prod.map suc id) $ preds g i)
   where
   p : ∀ {e} {E : Set e} {n} (i : Fin n) → E × Fin n → Maybe (Fin′ (suc i) × E)
-  p i (e , j)  with i ≟ j
-  p i (e , .i) | yes P.refl = just (zero , e)
-  p i (e , j)  | no _       = nothing
+  p i (e , j) = Maybe.map (λ { P.refl → zero , e }) (decToMaybe (i ≟ j))
 
 private
 

--- a/src/Data/Integer/DivMod.agda
+++ b/src/Data/Integer/DivMod.agda
@@ -22,22 +22,22 @@ open import Relation.Nullary.Decidable
 open import Relation.Binary.PropositionalEquality
 
 infixl 7 _divℕ_ _div_ _modℕ_ _mod_
-_divℕ_ : (dividend : ℤ) (divisor : ℕ) {≢0 : False (divisor ℕ.≟ 0)} → ℤ
+_divℕ_ : (dividend : ℤ) (divisor : ℕ) {≢0 : False! (divisor ℕ.≟ 0)} → ℤ
 (+ n      divℕ d) {d≠0} = + (n NDM./ d) {d≠0}
 (-[1+ n ] divℕ d) {d≠0} with (ℕ.suc n NDM.divMod d) {d≠0}
 ... | NDM.result q Fin.zero    eq = - (+ q)
 ... | NDM.result q (Fin.suc r) eq = -[1+ q ]
 
-_div_ : (dividend divisor : ℤ) {≢0 : False (∣ divisor ∣ ℕ.≟ 0)} → ℤ
+_div_ : (dividend divisor : ℤ) {≢0 : False! (∣ divisor ∣ ℕ.≟ 0)} → ℤ
 (n div d) {d≢0} = (sign d ◃ 1) ℤ.* (n divℕ ∣ d ∣) {d≢0}
 
-_modℕ_ : (dividend : ℤ) (divisor : ℕ) {≠0 : False (divisor ℕ.≟ 0)} → ℕ
+_modℕ_ : (dividend : ℤ) (divisor : ℕ) {≠0 : False! (divisor ℕ.≟ 0)} → ℕ
 (+ n      modℕ d) {d≠0} = (n NDM.% d) {d≠0}
 (-[1+ n ] modℕ d) {d≠0} with (ℕ.suc n NDM.divMod d) {d≠0}
 ... | NDM.result q Fin.zero    eq = 0
 ... | NDM.result q (Fin.suc r) eq = d ℕ.∸ ℕ.suc (Fin.toℕ r)
 
-_mod_ : (dividend divisor : ℤ) {≠0 : False (∣ divisor ∣ ℕ.≟ 0)} → ℕ
+_mod_ : (dividend divisor : ℤ) {≠0 : False! (∣ divisor ∣ ℕ.≟ 0)} → ℕ
 (n mod d) {d≢0} = (n modℕ ∣ d ∣) {d≢0}
 
 n%ℕd<d : ∀ n d {d≢0} → (n modℕ d) {d≢0} ℕ.< d

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -18,7 +18,7 @@ open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 open import Data.These.Base as These using (These; this; that; these)
 open import Function using (id; _∘_ ; _∘′_; const; flip)
 open import Level using (Level)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (isYes)
 open import Relation.Unary using (Pred; Decidable)
 open import Relation.Unary.Properties using (∁?)
 
@@ -258,33 +258,34 @@ splitAt (suc n) (x ∷ xs) with splitAt n xs
 
 takeWhile : ∀ {P : Pred A p} → Decidable P → List A → List A
 takeWhile P? []       = []
-takeWhile P? (x ∷ xs) with P? x
-... | yes _ = x ∷ takeWhile P? xs
-... | no  _ = []
+takeWhile P? (x ∷ xs) = if isYes (P? x)
+  then x ∷ takeWhile P? xs
+  else []
 
 dropWhile : ∀ {P : Pred A p} → Decidable P → List A → List A
 dropWhile P? []       = []
-dropWhile P? (x ∷ xs) with P? x
-... | yes _ = dropWhile P? xs
-... | no  _ = x ∷ xs
+dropWhile P? (x ∷ xs) = if isYes (P? x)
+  then dropWhile P? xs
+  else x ∷ xs
 
 filter : ∀ {P : Pred A p} → Decidable P → List A → List A
 filter P? [] = []
-filter P? (x ∷ xs) with P? x
-... | no  _ = filter P? xs
-... | yes _ = x ∷ filter P? xs
+filter P? (x ∷ xs) = if isYes (P? x)
+  then x ∷ filter P? xs
+  else filter P? xs
 
 partition : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 partition P? []       = ([] , [])
-partition P? (x ∷ xs) with P? x | partition P? xs
-... | yes _ | (ys , zs) = (x ∷ ys , zs)
-... | no  _ | (ys , zs) = (ys , x ∷ zs)
+partition P? (x ∷ xs) =
+  (if isYes (P? x) then Prod.map (x ∷_) id
+                   else Prod.map id (x ∷_))
+    (partition P? xs)
 
 span : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 span P? []       = ([] , [])
-span P? (x ∷ xs) with P? x
-... | yes _ = Prod.map (x ∷_) id (span P? xs)
-... | no  _ = ([] , x ∷ xs)
+span P? (x ∷ xs) = if isYes (P? x)
+  then Prod.map (x ∷_) id (span P? xs)
+  else ([] , x ∷ xs)
 
 break : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 break P? = span (∁? P?)

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -12,6 +12,7 @@ open import Relation.Binary
 
 module Data.List.Countdown (D : DecSetoid 0ℓ 0ℓ) where
 
+open import Data.Bool.Base using (true; false)
 open import Data.Empty
 open import Data.Fin using (Fin; zero; suc; punchOut)
 open import Data.Fin.Properties
@@ -46,8 +47,8 @@ private
   first-occurrence : ∀ {xs} x → x ∈ xs → x ∈ xs
   first-occurrence x (here x≈y)           = here x≈y
   first-occurrence x (there {x = y} x∈xs) with x ≟ y
-  ... | yes x≈y = here x≈y
-  ... | no  _   = there $ first-occurrence x x∈xs
+  ... | yes     x≈y = here x≈y
+  ... | dec false _ = there $ first-occurrence x x∈xs
 
   -- The index of the first occurrence of x in xs.
 
@@ -70,10 +71,10 @@ private
     ... | yes x₁≈x = refl
     ... | no  x₁≉x = ⊥-elim (x₁≉x (trans x₁≈x₂ x₂≈x))
     helper (there {x = x} x₁∈xs) (there x₂∈xs) with x₁ ≟ x | x₂ ≟ x
-    ... | yes x₁≈x | yes x₂≈x = refl
-    ... | yes x₁≈x | no  x₂≉x = ⊥-elim (x₂≉x (trans (sym x₁≈x₂) x₁≈x))
-    ... | no  x₁≉x | yes x₂≈x = ⊥-elim (x₁≉x (trans x₁≈x₂ x₂≈x))
-    ... | no  x₁≉x | no  x₂≉x = cong suc $ helper x₁∈xs x₂∈xs
+    ... | yes x₁≈x    | yes x₂≈x    = refl
+    ... | dec false _ | dec false _ = cong suc $ helper x₁∈xs x₂∈xs
+    ... | yes x₁≈x    | no  x₂≉x    = ⊥-elim (x₂≉x (trans (sym x₁≈x₂) x₁≈x))
+    ... | no  x₁≉x    | yes x₂≈x    = ⊥-elim (x₁≉x (trans x₁≈x₂ x₂≈x))
 
   -- first-index is injective in its first argument.
 
@@ -87,14 +88,10 @@ private
     helper (here x₁≈x) (here x₂≈x)             _  = trans x₁≈x (sym x₂≈x)
     helper (here x₁≈x) (there {x = x} x₂∈xs)   _  with x₂ ≟ x
     helper (here x₁≈x) (there {x = x} x₂∈xs)   _  | yes x₂≈x = trans x₁≈x (sym x₂≈x)
-    helper (here x₁≈x) (there {x = x} x₂∈xs)   () | no  x₂≉x
     helper (there {x = x} x₁∈xs) (here x₂≈x)   _  with x₁ ≟ x
     helper (there {x = x} x₁∈xs) (here x₂≈x)   _  | yes x₁≈x = trans x₁≈x (sym x₂≈x)
-    helper (there {x = x} x₁∈xs) (here x₂≈x)   () | no  x₁≉x
     helper (there {x = x} x₁∈xs) (there x₂∈xs) _  with x₁ ≟ x | x₂ ≟ x
     helper (there {x = x} x₁∈xs) (there x₂∈xs) _  | yes x₁≈x | yes x₂≈x = trans x₁≈x (sym x₂≈x)
-    helper (there {x = x} x₁∈xs) (there x₂∈xs) () | yes x₁≈x | no  x₂≉x
-    helper (there {x = x} x₁∈xs) (there x₂∈xs) () | no  x₁≉x | yes x₂≈x
     helper (there {x = x} x₁∈xs) (there x₂∈xs) eq | no  x₁≉x | no  x₂≉x =
       helper x₁∈xs x₂∈xs (suc-injective eq)
 
@@ -190,11 +187,7 @@ insert {counted} {n} counted⊕1+n x x∉counted =
   inj : ∀ {y z i} → kind′ y ≡ inj₂ i → kind′ z ≡ inj₂ i → y ≈ z
   inj {y} {z} eq₁ eq₂ with y ≟ x | z ≟ x | kind x | kind y | kind z
                          | helper x y | helper x z | helper y z
-  inj ()  _   | yes _ | _     | _              | _      | _      | _ | _ | _
-  inj _   ()  | _     | yes _ | _              | _      | _      | _ | _ | _
   inj _   _   | no  _ | no  _ | inj₁ x∈counted | _      | _      | _ | _ | _ = ⊥-elim (x∉counted x∈counted)
-  inj ()  _   | no  _ | no  _ | inj₂ _         | inj₁ _ | _      | _ | _ | _
-  inj _   ()  | no  _ | no  _ | inj₂ _         | _      | inj₁ _ | _ | _ | _
   inj eq₁ eq₂ | no  _ | no  _ | inj₂ i         | inj₂ _ | inj₂ _ | _ | _ | hlp =
     hlp _ refl refl $
       punchOut-injective {i = i} _ _ $

--- a/src/Data/List/Fresh.agda
+++ b/src/Data/List/Fresh.agda
@@ -11,6 +11,7 @@
 module Data.List.Fresh where
 
 open import Level using (Level; _⊔_; Lift)
+open import Data.Bool.Base
 open import Data.Unit.Base
 open import Data.Product using (∃; _×_; _,_; -,_; proj₁; proj₂)
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
@@ -18,7 +19,7 @@ open import Data.List.Relation.Unary.AllPairs using (AllPairs; []; _∷_)
 open import Data.Maybe.Base as Maybe using (Maybe; just; nothing)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Function using (_∘′_; flip; id; _on_)
-open import Relation.Nullary      using (yes; no)
+open import Relation.Nullary      using (isYes)
 open import Relation.Unary   as U using (Pred)
 open import Relation.Binary  as B using (Rel)
 open import Relation.Nary
@@ -156,33 +157,33 @@ module _ {P : Pred A p} (P? : U.Decidable P) where
   takeWhile-# : ∀ {R : Rel A r} a (as : List# A R) → a # as → a # takeWhile as
 
   takeWhile []             = []
-  takeWhile (cons a as ps) with P? a
-  ... | yes _ = cons a (takeWhile as) (takeWhile-# a as ps)
-  ... | no _  = []
+  takeWhile (cons a as ps) = if isYes (P? a)
+    then cons a (takeWhile as) (takeWhile-# a as ps)
+    else []
 
   takeWhile-# a []        _        = _
-  takeWhile-# a (x ∷# xs) (p , ps) with P? x
-  ... | yes _ = p , takeWhile-# a xs ps
-  ... | no _  = _
+  takeWhile-# a (x ∷# xs) (p , ps) with isYes (P? x)
+  ... | true  = p , takeWhile-# a xs ps
+  ... | false = _
 
   dropWhile : {R : Rel A r} → List# A R → List# A R
   dropWhile []            = []
-  dropWhile aas@(a ∷# as) with P? a
-  ... | yes _ = dropWhile as
-  ... | no _  = aas
+  dropWhile aas@(a ∷# as) = if isYes (P? a)
+    then dropWhile as
+    else aas
 
   filter   : {R : Rel A r} → List# A R → List# A R
   filter-# : ∀ {R : Rel A r} a (as : List# A R) → a # as → a # filter as
 
   filter []             = []
-  filter (cons a as ps) with P? a
-  ... | yes _ = cons a (filter as) (filter-# a as ps)
-  ... | no _  = filter as
+  filter (cons a as ps) = if isYes (P? a)
+    then cons a (filter as) (filter-# a as ps)
+    else filter as
 
   filter-# a []        _        = _
-  filter-# a (x ∷# xs) (p , ps) with P? x
-  ... | yes _ = p , filter-# a xs ps
-  ... | no _  = filter-# a xs ps
+  filter-# a (x ∷# xs) (p , ps) with isYes (P? x)
+  ... | true  = p , filter-# a xs ps
+  ... | false = filter-# a xs ps
 
 ------------------------------------------------------------------------
 -- Relationship to List and AllPairs

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -10,7 +10,7 @@ module Data.List.Membership.Propositional.Properties where
 
 open import Algebra.FunctionProperties using (Op₂; Selective)
 open import Category.Monad using (RawMonad)
-open import Data.Bool.Base using (Bool; false; true; T)
+open import Data.Bool.Base using (Bool; false; true; T; if_then_else_)
 open import Data.Fin using (Fin)
 open import Data.List as List
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
@@ -39,7 +39,7 @@ open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; trans; cong; subst; →-to-⟶; _≗_)
 import Relation.Binary.Properties.DecTotalOrder as DTOProperties
 open import Relation.Unary using (_⟨×⟩_; Decidable)
-open import Relation.Nullary using (¬_; Dec; yes; no)
+open import Relation.Nullary using (¬_; Dec; dec; isYes; yes; no)
 open import Relation.Nullary.Negation
 
 private
@@ -273,9 +273,9 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = excluded-middle helper
   helper (yes (i , fᵢ≡x)) = finite f′-inj xs f′ⱼ∈xs
     where
     f′ : ℕ → _
-    f′ j with i ≤? j
-    ... | yes i≤j = f (suc j)
-    ... | no  i≰j = f j
+    f′ j = if isYes (i ≤? j)
+      then f (suc j)
+      else f j
 
     ∈-if-not-i : ∀ {j} → i ≢ j → f j ∈ xs
     ∈-if-not-i i≢j = not-x (i≢j ∘ f-inj ∘ trans fᵢ≡x ∘ sym)
@@ -290,10 +290,10 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = excluded-middle helper
 
     f′-injective′ : Injective {B = P.setoid _} (→-to-⟶ f′)
     f′-injective′ {j} {k} eq with i ≤? j | i ≤? k
-    ... | yes _   | yes _   = P.cong pred (f-inj eq)
-    ... | yes i≤j | no  i≰k = contradiction (f-inj eq) (lemma i≤j i≰k)
-    ... | no  i≰j | yes i≤k = contradiction (f-inj eq) (lemma i≤k i≰j ∘ sym)
-    ... | no  _   | no  _   = f-inj eq
+    ... | dec true  _ | dec true  _ = P.cong pred (f-inj eq)
+    ... | dec false _ | dec false _ = f-inj eq
+    ... | yes i≤j     | no  i≰k     = contradiction (f-inj eq) (lemma i≤j i≰k)
+    ... | no  i≰j     | yes i≤k     = contradiction (f-inj eq) (lemma i≤k i≰j ∘ sym)
 
     f′-inj = record
       { to        = →-to-⟶ f′

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -9,6 +9,7 @@
 module Data.List.Membership.Setoid.Properties where
 
 open import Algebra.FunctionProperties using (Op₂; Selective)
+open import Data.Bool.Base using (true; false)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.List
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
@@ -25,7 +26,7 @@ open import Function using (_$_; flip; _∘_; id)
 open import Relation.Binary as B hiding (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Unary as U using (Decidable; Pred)
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary using (¬_; Dec; dec; isYes; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 open Setoid using (Carrier)
 
@@ -228,16 +229,16 @@ module _ {c ℓ p} (S : Setoid c ℓ) {P : Pred (Carrier S) p}
 
   ∈-filter⁺ : ∀ {v xs} → v ∈ xs → P v → v ∈ filter P? xs
   ∈-filter⁺ {xs = x ∷ _} (here v≈x) Pv with P? x
-  ... | yes _   = here v≈x
-  ... | no  ¬Px = contradiction (resp v≈x Pv) ¬Px
-  ∈-filter⁺ {xs = x ∷ _} (there v∈xs) Pv with P? x
-  ... | yes _ = there (∈-filter⁺ v∈xs Pv)
-  ... | no  _ = ∈-filter⁺ v∈xs Pv
+  ... | dec true _ = here v≈x
+  ... | no     ¬Px = contradiction (resp v≈x Pv) ¬Px
+  ∈-filter⁺ {xs = x ∷ _} (there v∈xs) Pv with isYes (P? x)
+  ... | true  = there (∈-filter⁺ v∈xs Pv)
+  ... | false = ∈-filter⁺ v∈xs Pv
 
   ∈-filter⁻ : ∀ {v xs} → v ∈ filter P? xs → v ∈ xs × P v
   ∈-filter⁻ {xs = x ∷ xs} v∈f[x∷xs] with P? x
-  ... | no  _  = Prod.map there id (∈-filter⁻ v∈f[x∷xs])
-  ... | yes Px with v∈f[x∷xs]
+  ... | dec false _ = Prod.map there id (∈-filter⁻ v∈f[x∷xs])
+  ... | yes      Px with v∈f[x∷xs]
   ...   | here  v≈x   = here v≈x , resp (sym v≈x) Px
   ...   | there v∈fxs = Prod.map there id (∈-filter⁻ v∈fxs)
 

--- a/src/Data/List/NonEmpty.agda
+++ b/src/Data/List/NonEmpty.agda
@@ -24,7 +24,7 @@ open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence
   using () renaming (module Equivalence to Eq)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; _≢_; refl)
-open import Relation.Nullary.Decidable using (isYes)
+open import Relation.Nullary using (isYes)
 
 ------------------------------------------------------------------------
 -- Non-empty lists

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -31,9 +31,8 @@ import Relation.Binary as B
 import Relation.Binary.Reasoning.Setoid as EqR
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; _≗_; refl ; sym ; cong)
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary using (¬_; yes; no; isYes)
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable using (isYes)
 open import Relation.Unary using (Pred; Decidable; ∁)
 open import Relation.Unary.Properties using (∁?)
 

--- a/src/Data/List/Relation/Binary/Lex/NonStrict.agda
+++ b/src/Data/List/Relation/Binary/Lex/NonStrict.agda
@@ -89,9 +89,9 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
     <-isStrictTotalOrder : Decidable _≈_ → IsTotalOrder _≈_ _≼_ →
                            IsStrictTotalOrder _≋_ _<_
-    <-isStrictTotalOrder dec tot =
+    <-isStrictTotalOrder _≟_ tot =
       Strict.<-isStrictTotalOrder
-        (Conv.<-isStrictTotalOrder₁ _ _ dec tot)
+        (Conv.<-isStrictTotalOrder₁ _ _ _≟_ tot)
 
 <-strictPartialOrder : ∀ {a ℓ₁ ℓ₂} → Poset a ℓ₁ ℓ₂ →
                        StrictPartialOrder _ _ _
@@ -163,9 +163,9 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 
     ≤-isTotalOrder : Decidable _≈_ → IsTotalOrder _≈_ _≼_ →
                      IsTotalOrder _≋_ _≤_
-    ≤-isTotalOrder dec tot =
+    ≤-isTotalOrder _≟_ tot =
       Strict.≤-isTotalOrder
-        (Conv.<-isStrictTotalOrder₁ _ _ dec tot)
+        (Conv.<-isStrictTotalOrder₁ _ _ _≟_ tot)
 
     ≤-isDecTotalOrder : IsDecTotalOrder _≈_ _≼_ →
                         IsDecTotalOrder _≋_ _≤_

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -10,6 +10,7 @@ module Data.List.Relation.Binary.Pointwise where
 
 open import Function.Core
 open import Function.Inverse using (Inverse)
+open import Data.Bool.Base using (true; false)
 open import Data.Product hiding (map)
 open import Data.List.Base as List hiding (map; head; tail)
 open import Data.List.Properties using (≡-dec; length-++)
@@ -284,10 +285,10 @@ module _ {R : REL A B ℓ} {P : Pred A p} {Q : Pred B q}
   filter⁺ : ∀ {as bs} → Pointwise R as bs → Pointwise R (filter P? as) (filter Q? bs)
   filter⁺ []       = []
   filter⁺ {a ∷ _} {b ∷ _} (r ∷ rs) with P? a | Q? b
-  ... | yes p | yes q = r ∷ filter⁺ rs
-  ... | yes p | no ¬q = contradiction (P⇒Q r p) ¬q
-  ... | no ¬p | yes q = contradiction (Q⇒P r q) ¬p
-  ... | no ¬p | no ¬q = filter⁺ rs
+  ... | dec true  _ | dec true  _ = r ∷ filter⁺ rs
+  ... | dec false _ | dec false _ = filter⁺ rs
+  ... | yes p       | no ¬q       = contradiction (P⇒Q r p) ¬q
+  ... | no ¬p       | yes q       = contradiction (Q⇒P r q) ¬p
 
 ------------------------------------------------------------------------
 -- replicate

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -18,8 +18,9 @@ open import Data.Nat using (ℕ; zero; suc)
 open import Data.Nat.Properties
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Nullary.Negation using (contradiction)
-import Relation.Nullary.Decidable as Dec using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary as U using (Pred)
 open import Relation.Binary renaming (Rel to Rel₂)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
@@ -112,15 +113,15 @@ respects₂ {_≈_ = _≈_} {_∼_} resp = respʳ , respˡ
   respˡ (x≈y ∷ xs≈ys) (x∼z ∷ xs∼zs) =
     proj₂ resp x≈y x∼z ∷ respˡ xs≈ys xs∼zs
 
-decidable : ∀ {_∼_ : REL A B ℓ} → Decidable _∼_ → Decidable (Pointwise _∼_)
-decidable dec []       []       = yes []
-decidable dec []       (y ∷ ys) = no (λ ())
-decidable dec (x ∷ xs) []       = no (λ ())
-decidable dec (x ∷ xs) (y ∷ ys) with dec x y
-... | no ¬x∼y = no (¬x∼y ∘ head)
-... | yes x∼y with decidable dec xs ys
-...   | no ¬xs∼ys = no (¬xs∼ys ∘ tail)
-...   | yes xs∼ys = yes (x∼y ∷ xs∼ys)
+module _ {_∼_ : REL A B ℓ} (_∼?_ : Decidable _∼_) where
+
+  decidable : Decidable (Pointwise _∼_)
+  decidable []       []       = yes []
+  decidable []       (y ∷ ys) = no (λ ())
+  decidable (x ∷ xs) []       = no (λ ())
+  decidable (x ∷ xs) (y ∷ ys) =
+    map′ (uncurry _∷_) (λ { (x∼y ∷ xs∼ys) → x∼y , xs∼ys })
+         (x ∼? y ×-dec decidable xs ys)
 
 module _ {_≈_ : Rel₂ A ℓ} where
 

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -17,7 +17,7 @@ import Data.List.Membership.Setoid as Membership
 open import Data.List.Membership.Setoid.Properties
 import Data.List.Relation.Binary.Subset.Setoid as Sublist
 import Data.List.Relation.Binary.Equality.Setoid as Equality
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary using (¬_; isYes)
 open import Relation.Unary using (Pred; Decidable)
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 
@@ -77,8 +77,8 @@ module _ {a p ℓ} (S : Setoid a ℓ)
   open Sublist S
 
   filter⁺ : ∀ xs → filter P? xs ⊆ xs
-  filter⁺ (x ∷ xs) y∈f[x∷xs] with P? x
-  ... | no  _ = there (filter⁺ xs y∈f[x∷xs])
-  ... | yes _ with y∈f[x∷xs]
+  filter⁺ (x ∷ xs) y∈f[x∷xs] with isYes (P? x)
+  ... | false = there (filter⁺ xs y∈f[x∷xs])
+  ... | true  with y∈f[x∷xs]
   ...   | here  y≈x     = here y≈x
   ...   | there y∈f[xs] = there (filter⁺ xs y∈f[xs])

--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -14,11 +14,13 @@ open import Data.Empty using (⊥)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional using (_∈_)
-open import Data.Product as Prod using (∃; -,_; _×_; _,_; proj₁; proj₂)
+open import Data.Product as Prod
+  using (∃; -,_; _×_; _,_; proj₁; proj₂; uncurry)
 open import Function
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary hiding (_∈_)
 open import Relation.Binary.PropositionalEquality as P
 
@@ -201,9 +203,7 @@ module _ {P : Pred A p} where
 
   all : Decidable P → Decidable (All P)
   all p []       = yes []
-  all p (x ∷ xs) with p x
-  ... | yes px = Dec.map′ (px ∷_) tail (all p xs)
-  ... | no ¬px = no (¬px ∘ head)
+  all p (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (p x ×-dec all p xs)
 
   universal : Universal P → Universal (All P)
   universal u []       = []

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -9,7 +9,7 @@
 module Data.List.Relation.Unary.All.Properties where
 
 open import Axiom.Extensionality.Propositional using (Extensionality)
-open import Data.Bool.Base using (Bool; T)
+open import Data.Bool.Base using (Bool; true; false; T)
 open import Data.Bool.Properties using (T-∧)
 open import Data.Empty
 open import Data.Fin using (Fin) renaming (zero to fzero; suc to fsuc)
@@ -93,11 +93,13 @@ module _ {P : A → Set p} where
   All¬⇒¬Any (¬p ∷ _)  (here  p) = ¬p p
   All¬⇒¬Any (_  ∷ ¬p) (there p) = All¬⇒¬Any ¬p p
 
-  ¬All⇒Any¬ : Decidable P → ∀ xs → ¬ All P xs → Any (¬_ ∘ P) xs
-  ¬All⇒Any¬ dec []       ¬∀ = ⊥-elim (¬∀ [])
-  ¬All⇒Any¬ dec (x ∷ xs) ¬∀ with dec x
-  ... | yes p = there (¬All⇒Any¬ dec xs (¬∀ ∘ _∷_ p))
-  ... | no ¬p = here ¬p
+  module _ (p? : Decidable P) where
+
+    ¬All⇒Any¬ : ∀ xs → ¬ All P xs → Any (¬_ ∘ P) xs
+    ¬All⇒Any¬ []       ¬∀ = ⊥-elim (¬∀ [])
+    ¬All⇒Any¬ (x ∷ xs) ¬∀ with p? x
+    ... | yes p = there (¬All⇒Any¬ xs (¬∀ ∘ (p ∷_)))
+    ... | no ¬p = here ¬p
 
   Any¬→¬All : ∀ {xs} → Any (¬_ ∘ P) xs → ¬ All P xs
   Any¬→¬All (here  ¬p) = ¬p           ∘ All.head
@@ -122,12 +124,12 @@ module _ {P : A → Set p} where
       }
 
   Any¬⇔¬All : ∀ {xs} → Decidable P → Any (¬_ ∘ P) xs ⇔ (¬ All P xs)
-  Any¬⇔¬All dec = equivalence Any¬→¬All (¬All⇒Any¬ dec _)
+  Any¬⇔¬All p? = equivalence Any¬→¬All (¬All⇒Any¬ p? _)
     where
     -- If equality of functions were extensional, then the logical
     -- equivalence could be strengthened to a surjection.
     to∘from : Extensionality _ _ →
-              ∀ {xs} (¬∀ : ¬ All P xs) → Any¬→¬All (¬All⇒Any¬ dec xs ¬∀) ≡ ¬∀
+              ∀ {xs} (¬∀ : ¬ All P xs) → Any¬→¬All (¬All⇒Any¬ p? xs ¬∀) ≡ ¬∀
     to∘from ext ¬∀ = ext (⊥-elim ∘ ¬∀)
 
 module _ {_~_ : REL (List A) B ℓ} where

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -495,16 +495,16 @@ module _ {P : A → Set p} (P? : Decidable P) where
   all-filter : ∀ xs → All P (filter P? xs)
   all-filter []       = []
   all-filter (x ∷ xs) with P? x
-  ... | yes Px = Px ∷ all-filter xs
-  ... | no  _  = all-filter xs
+  ... | yes      Px = Px ∷ all-filter xs
+  ... | dec false _ = all-filter xs
 
 module _ {P : A → Set p} {Q : A → Set q} (P? : Decidable P) where
 
   filter⁺ : ∀ {xs} → All Q xs → All Q (filter P? xs)
   filter⁺ {xs = _}     [] = []
   filter⁺ {xs = x ∷ _} (Qx ∷ Qxs) with P? x
-  ... | no  _ = filter⁺ Qxs
-  ... | yes _ = Qx ∷ filter⁺ Qxs
+  ... | dec false _ = filter⁺ Qxs
+  ... | dec true  _ = Qx ∷ filter⁺ Qxs
 
 ------------------------------------------------------------------------
 -- zipWith

--- a/src/Data/List/Relation/Unary/AllPairs/Properties.agda
+++ b/src/Data/List/Relation/Unary/AllPairs/Properties.agda
@@ -8,6 +8,7 @@
 
 module Data.List.Relation.Unary.AllPairs.Properties where
 
+open import Data.Bool.Base using (true; false)
 open import Data.List hiding (any)
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 import Data.List.Relation.Unary.All.Properties as All
@@ -20,7 +21,7 @@ open import Function using (_∘_; flip)
 open import Relation.Binary using (Rel; DecSetoid)
 open import Relation.Binary.PropositionalEquality using (_≢_)
 open import Relation.Unary using (Pred; Decidable)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (isYes)
 
 ------------------------------------------------------------------------
 -- Introduction (⁺) and elimination (⁻) rules for list operations
@@ -120,6 +121,6 @@ module _ {a ℓ p} {A : Set a} {R : Rel A ℓ}
 
   filter⁺ : ∀ {xs} → AllPairs R xs → AllPairs R (filter P? xs)
   filter⁺ {_}      []           = []
-  filter⁺ {x ∷ xs} (x∉xs ∷ xs!) with P? x
-  ... | no  _ = filter⁺ xs!
-  ... | yes _ = All.filter⁺ P? x∉xs ∷ filter⁺ xs!
+  filter⁺ {x ∷ xs} (x∉xs ∷ xs!) with isYes (P? x)
+  ... | false = filter⁺ xs!
+  ... | true  = All.filter⁺ P? x∉xs ∷ filter⁺ xs!

--- a/src/Data/Maybe/Base.agda
+++ b/src/Data/Maybe/Base.agda
@@ -48,8 +48,8 @@ is-nothing : Maybe A → Bool
 is-nothing = not ∘ is-just
 
 decToMaybe : Dec A → Maybe A
-decToMaybe (yes x) = just x
-decToMaybe (no _)  = nothing
+decToMaybe (yes       x) = just x
+decToMaybe (dec false _) = nothing
 
 -- A dependent eliminator.
 

--- a/src/Data/Maybe/Relation/Binary/Pointwise.agda
+++ b/src/Data/Maybe/Relation/Binary/Pointwise.agda
@@ -64,11 +64,11 @@ module _ {a b c r₁ r₂ r₃} {A : Set a} {B : Set b} {C : Set c}
 
 module _ {a r} {A : Set a} {R : Rel A r} where
 
-  dec : Decidable R → Decidable (Pointwise R)
-  dec R-dec (just x) (just y) = Dec.map just-equivalence (R-dec x y)
-  dec R-dec (just x) nothing  = no (λ ())
-  dec R-dec nothing  (just y) = no (λ ())
-  dec R-dec nothing  nothing  = yes nothing
+  decidable : Decidable R → Decidable (Pointwise R)
+  decidable R-dec (just x) (just y) = Dec.map just-equivalence (R-dec x y)
+  decidable R-dec (just x) nothing  = no (λ ())
+  decidable R-dec nothing  (just y) = no (λ ())
+  decidable R-dec nothing  nothing  = yes nothing
 
   isEquivalence : IsEquivalence R → IsEquivalence (Pointwise R)
   isEquivalence R-isEquivalence = record
@@ -80,7 +80,7 @@ module _ {a r} {A : Set a} {R : Rel A r} where
   isDecEquivalence : IsDecEquivalence R → IsDecEquivalence (Pointwise R)
   isDecEquivalence R-isDecEquivalence = record
     { isEquivalence = isEquivalence R.isEquivalence
-    ; _≟_           = dec R._≟_
+    ; _≟_           = decidable R._≟_
     } where module R = IsDecEquivalence R-isDecEquivalence
 
 module _ {c ℓ} where

--- a/src/Data/Maybe/Relation/Unary/All.agda
+++ b/src/Data/Maybe/Relation/Unary/All.agda
@@ -104,9 +104,9 @@ module _ {a} p {A : Set a} {P : Pred A (a ⊔ p)} {M}
 
 module _ {a p} {A : Set a} {P : Pred A p} where
 
-  dec : Decidable P → Decidable (All P)
-  dec P-dec nothing  = yes nothing
-  dec P-dec (just x) = Dec.map just-equivalence (P-dec x)
+  decidable : Decidable P → Decidable (All P)
+  decidable P-dec nothing  = yes nothing
+  decidable P-dec (just x) = Dec.map just-equivalence (P-dec x)
 
   universal : Universal P → Universal (All P)
   universal P-universal (just x) = just (P-universal x)

--- a/src/Data/Maybe/Relation/Unary/Any.agda
+++ b/src/Data/Maybe/Relation/Unary/Any.agda
@@ -65,9 +65,9 @@ module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
 
 module _ {a p} {A : Set a} {P : Pred A p} where
 
-  dec : Decidable P → Decidable (Any P)
-  dec P-dec nothing  = no λ ()
-  dec P-dec (just x) = Dec.map just-equivalence (P-dec x)
+  decidable : Decidable P → Decidable (Any P)
+  decidable P-dec nothing  = no λ ()
+  decidable P-dec (just x) = Dec.map just-equivalence (P-dec x)
 
   irrelevant : Irrelevant P → Irrelevant (Any P)
   irrelevant P-irrelevant (just p) (just q) = cong just (P-irrelevant p q)

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -17,7 +17,7 @@ open import Data.Nat.DivMod.Core
 open import Data.Nat.Divisibility.Core
 open import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary.Decidable using (False)
+open import Relation.Nullary.Decidable using (False!)
 
 open ≤-Reasoning
 
@@ -36,12 +36,12 @@ infixl 7 _/_ _%_
 
 -- Natural division
 
-_/_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → ℕ
+_/_ : (dividend divisor : ℕ) .{≢0 : False! (divisor ≟ 0)} → ℕ
 m / (suc n) = div-helper 0 n m n
 
 -- Natural remainder/modulus
 
-_%_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → ℕ
+_%_ : (dividend divisor : ℕ) .{≢0 : False! (divisor ≟ 0)} → ℕ
 m % (suc n) = mod-helper 0 n m n
 
 ------------------------------------------------------------------------
@@ -196,13 +196,13 @@ record DivMod (dividend divisor : ℕ) : Set where
 
 infixl 7 _div_ _mod_ _divMod_
 
-_div_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → ℕ
+_div_ : (dividend divisor : ℕ) .{≢0 : False! (divisor ≟ 0)} → ℕ
 _div_ = _/_
 
-_mod_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} → Fin divisor
+_mod_ : (dividend divisor : ℕ) .{≢0 : False! (divisor ≟ 0)} → Fin divisor
 m mod (suc n) = fromℕ≤ (m%n<n m n)
 
-_divMod_ : (dividend divisor : ℕ) .{≢0 : False (divisor ≟ 0)} →
+_divMod_ : (dividend divisor : ℕ) .{≢0 : False! (divisor ≟ 0)} →
            DivMod dividend divisor
 m divMod n@(suc n-1) = result (m / n) (m mod n) (begin-equality
   m                                     ≡⟨ m≡m%n+[m/n]*n m n-1 ⟩

--- a/src/Data/Nat/LCM.agda
+++ b/src/Data/Nat/LCM.agda
@@ -22,13 +22,13 @@ open import Function
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; refl; sym; trans; cong; cong₂; module ≡-Reasoning)
 open import Relation.Binary
-open import Relation.Nullary.Decidable using (False; fromWitnessFalse)
+open import Relation.Nullary.Decidable using (False!; fromWitnessFalse!)
 
 open +-*-Solver
 
 private
-  gcd≢0′ : ∀ m n → False (gcd (suc m) n ≟ 0)
-  gcd≢0′ m n = fromWitnessFalse (gcd[m,n]≢0 (suc m) n (inj₁ (λ())))
+  gcd≢0′ : ∀ m n → False! (gcd (suc m) n ≟ 0)
+  gcd≢0′ m n = fromWitnessFalse! (gcd[m,n]≢0 (suc m) n (inj₁ (λ())))
 
 ------------------------------------------------------------------------
 -- Definition

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -148,10 +148,8 @@ m ≟ n = map′ (≡ᵇ⇒≡ m n) (≡⇒≡ᵇ m n) (T? (m ≡ᵇ n))
 infix 4 _≤?_ _≥?_
 
 _≤?_ : Decidable _≤_
-zero  ≤? _     = yes z≤n
-suc m ≤? n with T? (m <ᵇ n)
-... | yes m<n = yes (<ᵇ⇒< m n m<n)
-... | no  m≮n = no  (m≮n ∘ <⇒<ᵇ)
+zero  ≤? _ = yes z≤n
+suc m ≤? n = map′ (<ᵇ⇒< m n) <⇒<ᵇ (T? (m <ᵇ n))
 
 _≥?_ : Decidable _≥_
 _≥?_ = flip _≤?_

--- a/src/Data/Nat/Show.agda
+++ b/src/Data/Nat/Show.agda
@@ -15,7 +15,7 @@ open import Data.List using (List; []; _∷_; map; reverse)
 open import Data.Nat
 open import Data.Product using (proj₁)
 open import Data.String as String using (String)
-open import Relation.Nullary.Decidable using (True)
+open import Relation.Nullary.Decidable using (True!)
 
 ------------------------------------------------------------------------
 -- Conversion from unary representation to the representation by the
@@ -39,8 +39,8 @@ show = String.fromList ∘ toDecimalChars
 -- O(n) instead of the expected O(log(n)).
 
 showInBase : (base : ℕ)
-             {base≥2 : True (2 ≤? base)}
-             {base≤16 : True (base ≤? 16)} →
+             {base≥2 : True! (2 ≤? base)}
+             {base≤16 : True! (base ≤? 16)} →
              ℕ → String
 showInBase base {base≥2} {base≤16} n =
   String.fromList $

--- a/src/Data/Record.agda
+++ b/src/Data/Record.agda
@@ -9,7 +9,7 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Data.Bool.Base using (if_then_else_)
+open import Data.Bool.Base using (Bool; true; false; if_then_else_)
 open import Data.Empty
 open import Data.List.Base
 open import Data.Product hiding (proj₁; proj₂)
@@ -102,12 +102,12 @@ _∈_ : ∀ {s} → Label → Signature s → Set
 Restrict : ∀ {s} (Sig : Signature s) (ℓ : Label) → ℓ ∈ Sig →
            Signature s
 Restrict ∅              ℓ ()
-Restrict (Sig , ℓ′ ∶ A) ℓ ℓ∈ with ℓ ≟ ℓ′
-... | yes _ = Sig
-... | no  _ = Restrict Sig ℓ ℓ∈
-Restrict (Sig , ℓ′ ≔ a) ℓ ℓ∈ with ℓ ≟ ℓ′
-... | yes _ = Sig
-... | no  _ = Restrict Sig ℓ ℓ∈
+Restrict (Sig , ℓ′ ∶ A) ℓ ℓ∈ with isYes (ℓ ≟ ℓ′)
+... | true  = Sig
+... | false = Restrict Sig ℓ ℓ∈
+Restrict (Sig , ℓ′ ≔ a) ℓ ℓ∈ with isYes (ℓ ≟ ℓ′)
+... | true  = Sig
+... | false = Restrict Sig ℓ ℓ∈
 
 Restricted : ∀ {s} (Sig : Signature s) (ℓ : Label) → ℓ ∈ Sig → Set s
 Restricted Sig ℓ ℓ∈ = Record (Restrict Sig ℓ ℓ∈)
@@ -115,12 +115,12 @@ Restricted Sig ℓ ℓ∈ = Record (Restrict Sig ℓ ℓ∈)
 Proj : ∀ {s} (Sig : Signature s) (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
        Restricted Sig ℓ ℓ∈ → Set s
 Proj ∅              ℓ {}
-Proj (Sig , ℓ′ ∶ A) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = A
-... | no  _ = Proj Sig ℓ {ℓ∈}
-Proj (_,_≔_ Sig ℓ′ {A = A} a) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = A
-... | no  _ = Proj Sig ℓ {ℓ∈}
+Proj (Sig , ℓ′ ∶ A) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = A
+... | false = Proj Sig ℓ {ℓ∈}
+Proj (_,_≔_ Sig ℓ′ {A = A} a) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = A
+... | false = Proj Sig ℓ {ℓ∈}
 
 -- Record restriction and projection.
 
@@ -129,12 +129,12 @@ infixl 5 _∣_
 _∣_ : ∀ {s} {Sig : Signature s} → Record Sig →
       (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} → Restricted Sig ℓ ℓ∈
 _∣_ {Sig = ∅}            r       ℓ {}
-_∣_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Σ.proj₁ r
-... | no  _ = _∣_ (Σ.proj₁ r) ℓ {ℓ∈}
-_∣_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Manifest-Σ.proj₁ r
-... | no  _ = _∣_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
+_∣_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = Σ.proj₁ r
+... | false = _∣_ (Σ.proj₁ r) ℓ {ℓ∈}
+_∣_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = Manifest-Σ.proj₁ r
+... | false = _∣_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
 
 infixl 5 _·_
 
@@ -142,12 +142,12 @@ _·_ : ∀ {s} {Sig : Signature s} (r : Record Sig)
       (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
       Proj Sig ℓ {ℓ∈} (r ∣ ℓ)
 _·_ {Sig = ∅}            r       ℓ {}
-_·_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Σ.proj₂ r
-... | no  _ = _·_ (Σ.proj₁ r) ℓ {ℓ∈}
-_·_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Manifest-Σ.proj₂ r
-... | no  _ = _·_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
+_·_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = Σ.proj₂ r
+... | false = _·_ (Σ.proj₁ r) ℓ {ℓ∈}
+_·_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with isYes (ℓ ≟ ℓ′)
+... | true  = Manifest-Σ.proj₂ r
+... | false = _·_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
 
 ------------------------------------------------------------------------
 -- With
@@ -161,20 +161,20 @@ mutual
   _With_≔_ : ∀ {s} (Sig : Signature s) (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
              ((r : Restricted Sig ℓ ℓ∈) → Proj Sig ℓ r) → Signature s
   _With_≔_ ∅ ℓ {} a
-  _With_≔_ (Sig , ℓ′ ∶ A)   ℓ {ℓ∈} a with ℓ ≟ ℓ′
-  ... | yes _ = Sig                   , ℓ′ ≔ a
-  ... | no  _ = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ∶ A ∘ drop-With
-  _With_≔_  (Sig , ℓ′ ≔ a′) ℓ {ℓ∈} a with ℓ ≟ ℓ′
-  ... | yes _ = Sig                   , ℓ′ ≔ a
-  ... | no  _ = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ≔ a′ ∘ drop-With
+  _With_≔_ (Sig , ℓ′ ∶ A)   ℓ {ℓ∈} a with isYes (ℓ ≟ ℓ′)
+  ... | true  = Sig                   , ℓ′ ≔ a
+  ... | false = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ∶ A ∘ drop-With
+  _With_≔_  (Sig , ℓ′ ≔ a′) ℓ {ℓ∈} a with isYes (ℓ ≟ ℓ′)
+  ... | true  = Sig                   , ℓ′ ≔ a
+  ... | false = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ≔ a′ ∘ drop-With
 
   drop-With : ∀ {s} {Sig : Signature s} {ℓ : Label} {ℓ∈ : ℓ ∈ Sig}
               {a : (r : Restricted Sig ℓ ℓ∈) → Proj Sig ℓ r} →
               Record (_With_≔_ Sig ℓ {ℓ∈} a) → Record Sig
   drop-With {Sig = ∅} {ℓ∈ = ()}      r
-  drop-With {Sig = Sig , ℓ′ ∶ A} {ℓ} (rec r) with ℓ ≟ ℓ′
-  ... | yes _ = rec (Manifest-Σ.proj₁ r , Manifest-Σ.proj₂ r)
-  ... | no  _ = rec (drop-With (Σ.proj₁ r) , Σ.proj₂ r)
-  drop-With {Sig = Sig , ℓ′ ≔ a} {ℓ} (rec r) with ℓ ≟ ℓ′
-  ... | yes _ = rec (Manifest-Σ.proj₁ r ,)
-  ... | no  _ = rec (drop-With (Manifest-Σ.proj₁ r) ,)
+  drop-With {Sig = Sig , ℓ′ ∶ A} {ℓ} (rec r) with isYes (ℓ ≟ ℓ′)
+  ... | true  = rec (Manifest-Σ.proj₁ r , Manifest-Σ.proj₂ r)
+  ... | false = rec (drop-With (Σ.proj₁ r) , Σ.proj₂ r)
+  drop-With {Sig = Sig , ℓ′ ≔ a} {ℓ} (rec r) with isYes (ℓ ≟ ℓ′)
+  ... | true  = rec (Manifest-Σ.proj₁ r ,)
+  ... | false = rec (drop-With (Manifest-Σ.proj₁ r) ,)

--- a/src/Data/String/Properties.agda
+++ b/src/Data/String/Properties.agda
@@ -16,7 +16,7 @@ import Data.List.Relation.Binary.Lex.Strict as StrictLex
 open import Data.String.Base
 open import Function
 open import Relation.Nullary using (yes; no)
-open import Relation.Nullary.Decidable using (map′; isYes)
+open import Relation.Nullary.Decidable using (map′; isYes!)
 open import Relation.Binary
   using ( _⇒_; Reflexive; Symmetric; Transitive; Substitutive
         ; Decidable; IsEquivalence; IsDecEquivalence
@@ -120,7 +120,7 @@ x <? y = StrictLex.<-decidable Charₚ._≈?_ Charₚ._<?_ (toList x) (toList y)
 
 infix 4 _==_
 _==_ : String → String → Bool
-s₁ == s₂ = isYes (s₁ ≟ s₂)
+s₁ == s₂ = isYes! (s₁ ≟ s₂)
 
 private
 

--- a/src/Data/Table.agda
+++ b/src/Data/Table.agda
@@ -12,11 +12,11 @@ module Data.Table where
 
 open import Data.Table.Base public
 
-open import Data.Bool using (true; false)
+open import Data.Bool using (true; false; if_then_else_)
 open import Data.Fin using (Fin; _≟_)
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Inverse using (Inverse; _↔_)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (isYes)
 open import Relation.Nullary.Decidable using (⌊_⌋)
 
 --------------------------------------------------------------------------------
@@ -33,6 +33,6 @@ permute π = rearrange (Inverse.to π ⟨$⟩_)
 -- and 'z' everywhere else.
 
 select : ∀ {n} {a} {A : Set a} → A → Fin n → Table A n → Table A n
-lookup (select z i t) j with j ≟ i
-... | yes _ = lookup t i
-... | no  _ = z
+lookup (select z i t) j = if isYes (j ≟ i)
+  then lookup t i
+  else z

--- a/src/Data/Table/Properties.agda
+++ b/src/Data/Table/Properties.agda
@@ -28,7 +28,7 @@ open import Function.Core using (_∘_; flip)
 open import Function.Inverse using (Inverse)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; cong)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (dec; isYes; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 
 private
@@ -43,9 +43,9 @@ private
 
 select-const : ∀ {n} (z : A) (i : Fin n) t →
                select z i t ≗ select z i (replicate (lookup t i))
-select-const z i t j with j ≟ i
-... | yes _ = refl
-... | no  _ = refl
+select-const z i t j with isYes (j ≟ i)
+... | true  = refl
+... | false = refl
 
 -- Selecting an element from a table then looking it up is the same as looking
 -- up the index in the original table
@@ -53,8 +53,8 @@ select-const z i t j with j ≟ i
 select-lookup : ∀ {n x i} (t : Table A n) →
                 lookup (select x i t) i ≡ lookup t i
 select-lookup {i = i} t with i ≟ i
-... | yes _  = refl
-... | no i≢i = contradiction refl i≢i
+... | dec true _ = refl
+... | no     i≢i = contradiction refl i≢i
 
 -- Selecting an element from a table then removing the same element produces a
 -- constant table
@@ -62,8 +62,8 @@ select-lookup {i = i} t with i ≟ i
 select-remove : ∀ {n x} i (t : Table A (suc n)) →
                 remove i (select x i t) ≗ replicate {n = n} x
 select-remove i t j with punchIn i j ≟ i
-... | yes p = contradiction p (FP.punchInᵢ≢i _ _)
-... | no ¬p = refl
+... | yes       p = contradiction p (FP.punchInᵢ≢i _ _)
+... | dec false _ = refl
 
 
 ------------------------------------------------------------------------

--- a/src/Data/These/Properties.agda
+++ b/src/Data/These/Properties.agda
@@ -8,11 +8,14 @@
 
 module Data.These.Properties where
 
+open import Data.Product
 open import Data.These
 open import Function using (_∘_)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- Equality
@@ -31,6 +34,9 @@ module _ {a b} {A : Set a} {B : Set b} where
   these-injectiveʳ : ∀ {x y : A} {a b : B} → these x a ≡ these y b → a ≡ b
   these-injectiveʳ refl = refl
 
+  these-injective : ∀ {x y : A} {a b : B} → these x a ≡ these y b → x ≡ y × a ≡ b
+  these-injective = < these-injectiveˡ , these-injectiveʳ >
+
   ≡-dec : Decidable _≡_ → Decidable _≡_ → Decidable {A = These A B} _≡_
   ≡-dec dec₁ dec₂ (this x)    (this y)    with dec₁ x y
   ... | yes refl = yes refl
@@ -44,7 +50,5 @@ module _ {a b} {A : Set a} {B : Set b} where
   ≡-dec dec₁ dec₂ (that x)    (these y b) = no λ()
   ≡-dec dec₁ dec₂ (these x a) (this y)    = no λ()
   ≡-dec dec₁ dec₂ (these x a) (that y)    = no λ()
-  ≡-dec dec₁ dec₂ (these x a) (these y b) with dec₁ x y | dec₂ a b
-  ... | yes refl | yes refl = yes refl
-  ... | no  x≢y  | _        = no (x≢y ∘ these-injectiveˡ)
-  ... | yes _    | no  a≢b  = no (a≢b ∘ these-injectiveʳ)
+  ≡-dec dec₁ dec₂ (these x a) (these y b) =
+    map′ (uncurry (cong₂ these)) these-injective (dec₁ x y ×-dec dec₂ a b)

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -8,6 +8,7 @@
 
 module Data.Vec.Base where
 
+open import Data.Bool.Base using (if_then_else_)
 open import Data.Nat.Base
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List)
@@ -16,7 +17,7 @@ open import Data.These.Base as These using (These; this; that; these)
 open import Function
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (isYes)
 open import Relation.Unary using (Pred; Decidable)
 
 private
@@ -194,9 +195,9 @@ sum = foldr _ _+_ 0
 
 count : ∀ {P : Pred A p} → Decidable P → ∀ {n} → Vec A n → ℕ
 count P? []       = zero
-count P? (x ∷ xs) with P? x
-... | yes _ = suc (count P? xs)
-... | no  _ = count P? xs
+count P? (x ∷ xs) = if isYes (P? x)
+  then suc (count P? xs)
+  else count P? xs
 
 ------------------------------------------------------------------------
 -- Operations for building vectors

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -107,11 +107,12 @@ trans : ∀ {P : REL A B ℓ} {Q : REL B C ℓ} {R : REL A C ℓ} {n} →
 trans trns xs∼ys ys∼zs = ext λ i →
   trns (Pointwise.app xs∼ys i) (Pointwise.app ys∼zs i)
 
-decidable : ∀ {_∼_ : REL A B ℓ} →
-            Decidable _∼_ → ∀ {n} → Decidable (Pointwise _∼_ {n = n})
-decidable dec xs ys = Dec.map
-  (Setoid.sym (⇔-setoid _) equivalent)
-  (Inductive.decidable dec xs ys)
+module _ {_∼_ : REL A B ℓ} (_∼?_ : Decidable _∼_) where
+
+  decidable : ∀ {n} → Decidable (Pointwise _∼_ {n = n})
+  decidable xs ys = Dec.map
+    (Setoid.sym (⇔-setoid _) equivalent)
+    (Inductive.decidable _∼?_ xs ys)
 
 isEquivalence : ∀ {_∼_ : Rel A ℓ} {n} →
                 IsEquivalence _∼_ → IsEquivalence (Pointwise _∼_ {n = n})

--- a/src/Data/Vec/Relation/Unary/All.agda
+++ b/src/Data/Vec/Relation/Unary/All.agda
@@ -10,12 +10,13 @@ module Data.Vec.Relation.Unary.All where
 
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (Fin; zero; suc)
-open import Data.Product as Prod using (_,_)
+open import Data.Product as Prod using (_×_; _,_; uncurry; <_,_>)
 open import Data.Vec as Vec using (Vec; []; _∷_)
 open import Function using (_∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary hiding (Irrelevant)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary
 open import Relation.Binary.PropositionalEquality as P using (subst)
 
@@ -45,6 +46,9 @@ module _ {P : Pred A p} where
 
   tail : ∀ {n x} {xs : Vec A n} → All P (x ∷ xs) → All P xs
   tail (px ∷ pxs) = pxs
+
+  uncons : ∀ {n x} {xs : Vec A n} → All P (x ∷ xs) → P x × All P xs
+  uncons = < head , tail >
 
   lookup : ∀ {n} {xs : Vec A n} (i : Fin n) →
            All P xs → P (Vec.lookup xs i)
@@ -86,9 +90,7 @@ module _ {P : Pred A p} where
 
   all : ∀ {n} → Decidable P → Decidable (All P {n})
   all P? []       = yes []
-  all P? (x ∷ xs) with P? x
-  ... | yes px = Dec.map′ (px ∷_) tail (all P? xs)
-  ... | no ¬px = no (¬px ∘ head)
+  all P? (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (P? x ×-dec all P? xs)
 
   universal : Universal P → ∀ {n} → Universal (All P {n})
   universal u []       = []

--- a/src/Data/Vec/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Relation/Unary/Any.agda
@@ -18,6 +18,7 @@ open import Level using (_⊔_)
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary
 
 ------------------------------------------------------------------------
@@ -72,9 +73,7 @@ module _ {p} {P : A → Set p} where
 
   any : Decidable P → ∀ {n} → Decidable (Any P {n})
   any P? []       = no λ()
-  any P? (x ∷ xs) with P? x
-  ... | yes px = yes (here px)
-  ... | no ¬px = Dec.map′ there (tail ¬px) (any P? xs)
+  any P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any P? xs)
 
   satisfiable : Satisfiable P → ∀ {n} → Satisfiable (Any P {suc n})
   satisfiable (x , p) {zero}  = x ∷ [] , here p

--- a/src/Data/Word/Unsafe.agda
+++ b/src/Data/Word/Unsafe.agda
@@ -11,6 +11,7 @@ module Data.Word.Unsafe where
 import Data.Nat as ℕ
 open import Data.Word using (Word64; toℕ)
 open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 open import Relation.Binary.PropositionalEquality.TrustMe
 
@@ -18,7 +19,5 @@ open import Relation.Binary.PropositionalEquality.TrustMe
 -- An informative equality test.
 
 _≟_ : (a b : Word64) → Dec (a ≡ b)
-a ≟ b with toℕ a ℕ.≟ toℕ b
-... | yes _ = yes trustMe
-... | no  _ = no whatever
+a ≟ b = map′ (λ _ → trustMe) whatever (toℕ a ℕ.≟ toℕ b)
   where postulate whatever : _

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -8,7 +8,7 @@
 
 module Relation.Binary.Consequences where
 
-open import Data.Maybe.Base using (just; nothing)
+open import Data.Maybe.Base using (just; nothing; decToMaybe)
 open import Data.Sum as Sum using (inj₁; inj₂)
 open import Data.Product using (_,_)
 open import Data.Empty.Irrelevant using (⊥-elim)
@@ -17,6 +17,7 @@ open import Level using (Level)
 open import Relation.Binary.Core
 open import Relation.Binary.Definitions
 open import Relation.Nullary using (yes; no; recompute)
+open import Relation.Nullary.Decidable.Core using (map′)
 open import Relation.Unary using (∁)
 
 private
@@ -59,9 +60,7 @@ module _ {_≈_ : Rel A ℓ₁} {_≤_ : Rel A ℓ₂} where
                   Total _≤_ → Decidable _≈_ → Decidable _≤_
   total+dec⟶dec refl antisym total _≟_ x y with total x y
   ... | inj₁ x≤y = yes x≤y
-  ... | inj₂ y≤x with x ≟ y
-  ...   | yes x≈y = yes (refl x≈y)
-  ...   | no  x≉y = no (λ x≤y → x≉y (antisym x≤y y≤x))
+  ... | inj₂ y≤x = map′ refl (flip antisym y≤x) (x ≟ y)
 
 ------------------------------------------------------------------------
 -- Proofs for strict orders
@@ -151,9 +150,7 @@ module _  {_R_ : Rel A ℓ₁} {Q : Rel A ℓ₂} where
 module _ {P : REL A B p} where
 
   dec⟶weaklyDec : Decidable P → WeaklyDecidable P
-  dec⟶weaklyDec dec x y with dec x y
-  ... | yes p = just p
-  ... | no _ = nothing
+  dec⟶weaklyDec dec x y = decToMaybe (dec x y)
 
 module _ {P : REL A B ℓ₁} {Q : REL A B ℓ₂} where
 

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -15,7 +15,7 @@ open import Level
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.Reflexive
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_; refl)
-open import Relation.Nullary
+open import Relation.Nullary hiding (dec)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Unary using (Pred)
 

--- a/src/Relation/Binary/Construct/Intersection.agda
+++ b/src/Relation/Binary/Construct/Intersection.agda
@@ -14,6 +14,7 @@ open import Function using (_∘_)
 open import Level using (_⊔_)
 open import Relation.Binary
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -77,10 +78,7 @@ module _ {a ℓ₁ ℓ₂ ℓ₃} {A : Set a}
 module _ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} {L : REL A B ℓ₁} {R : REL A B ℓ₂} where
 
   decidable : Decidable L → Decidable R → Decidable (L ∩ R)
-  decidable L? R? x y with L? x y | R? x y
-  ... | no ¬Lxy | _       = no (¬Lxy ∘ proj₁)
-  ... | yes _   | no ¬Rxy = no (¬Rxy ∘ proj₂)
-  ... | yes Lxy | yes Rxy = yes (Lxy , Rxy)
+  decidable L? R? x y = L? x y ×-dec R? x y
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Relation/Binary/Construct/Union.agda
+++ b/src/Relation/Binary/Construct/Union.agda
@@ -14,6 +14,7 @@ open import Function using (_∘_)
 open import Level using (_⊔_)
 open import Relation.Binary
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Sum using (_⊎-dec_)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -62,7 +63,4 @@ module _ {a b ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b}
 module _ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} {L : REL A B ℓ₁} {R : REL A B ℓ₂} where
 
   decidable : Decidable L → Decidable R → Decidable (L ∪ R)
-  decidable L? R? x y with L? x y | R? x y
-  ... | yes Lxy | _       = yes (inj₁ Lxy)
-  ... | no  _   | yes Rxy = yes (inj₂ Rxy)
-  ... | no ¬Lxy | no ¬Rxy = no [ ¬Lxy , ¬Rxy ]
+  decidable L? R? x y = L? x y ⊎-dec R? x y

--- a/src/Relation/Binary/HeterogeneousEquality.agda
+++ b/src/Relation/Binary/HeterogeneousEquality.agda
@@ -186,11 +186,11 @@ indexedSetoid B = record
 
 decSetoid : Decidable {A = A} {B = A} (λ x y → x ≅ y) →
             DecSetoid _ _
-decSetoid dec = record
+decSetoid _≟_ = record
   { _≈_              = λ x y → x ≅ y
   ; isDecEquivalence = record
       { isEquivalence = isEquivalence
-      ; _≟_           = dec
+      ; _≟_           = _≟_
       }
   }
 

--- a/src/Relation/Binary/Reasoning/Base/Double.agda
+++ b/src/Relation/Binary/Reasoning/Base/Double.agda
@@ -22,7 +22,7 @@ open import Function using (case_of_; id)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; sym)
 open import Relation.Nullary using (Dec; yes; no)
-open import Relation.Nullary.Decidable using (True; toWitness)
+open import Relation.Nullary.Decidable using (True!; toWitness!)
 
 open IsPreorder isPreorder
 
@@ -68,8 +68,8 @@ begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ∼ y
 begin (nonstrict x∼y) = x∼y
 begin (equals    x≈y) = reflexive x≈y
 
-begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsEquality? r)} → x ≈ y
-begin-equality_ r {s} = extractEquality (toWitness s)
+begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True! (IsEquality? r)} → x ≈ y
+begin-equality_ r {s} = extractEquality (toWitness! s)
 
 _∼⟨_⟩_ : ∀ (x : A) {y z} → x ∼ y → y IsRelatedTo z → x IsRelatedTo z
 x ∼⟨ x∼y ⟩ nonstrict y∼z = nonstrict (trans x∼y y∼z)

--- a/src/Relation/Binary/Reasoning/Base/Triple.agda
+++ b/src/Relation/Binary/Reasoning/Base/Triple.agda
@@ -25,7 +25,7 @@ open import Level using (Level; _⊔_; Lift; lift)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; sym)
 open import Relation.Nullary using (Dec; yes; no)
-open import Relation.Nullary.Decidable using (True; toWitness)
+open import Relation.Nullary.Decidable using (True!; toWitness!)
 
 open IsPreorder isPreorder
   renaming
@@ -82,11 +82,11 @@ begin (strict    x<y) = <⇒≤ x<y
 begin (nonstrict x≤y) = x≤y
 begin (equals    x≈y) = ≤-reflexive x≈y
 
-begin-strict_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsStrict? r)} → x < y
-begin-strict_ r {s} = extractStrict (toWitness s)
+begin-strict_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True! (IsStrict? r)} → x < y
+begin-strict_ r {s} = extractStrict (toWitness! s)
 
-begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsEquality? r)} → x ≈ y
-begin-equality_ r {s} = extractEquality (toWitness s)
+begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True! (IsEquality? r)} → x ≈ y
+begin-equality_ r {s} = extractEquality (toWitness! s)
 
 _<⟨_⟩_ : ∀ (x : A) {y z} → x < y → y IsRelatedTo z → x IsRelatedTo z
 x <⟨ x<y ⟩ strict    y<z = strict (<-trans x<y y<z)

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -12,6 +12,7 @@ module Relation.Nullary where
 
 open import Agda.Builtin.Equality
 
+open import Data.Bool.Base
 open import Data.Empty hiding (⊥-elim)
 open import Data.Empty.Irrelevant
 open import Level
@@ -23,11 +24,29 @@ infix 3 ¬_
 ¬_ : ∀ {ℓ} → Set ℓ → Set ℓ
 ¬ P = P → ⊥
 
--- Decidable relations.
+-- `Reflects` idiom.
+-- The truth value of P is reflected by a boolean value.
 
-data Dec {p} (P : Set p) : Set p where
-  yes : ( p :   P) → Dec P
-  no  : (¬p : ¬ P) → Dec P
+data Reflects {p} (P : Set p) : Bool → Set p where
+  true  : ( p :   P) → Reflects P true
+  false : (¬p : ¬ P) → Reflects P false
+
+-- Decidable relations.
+-- This version of `Dec` allows the boolean portion of the
+-- value to compute independently from the proof portion.
+-- This often allows good computational properties when we
+-- only care about the boolean portion.
+
+record Dec {p} (P : Set p) : Set p where
+  constructor dec
+  field
+    isYes : Bool
+    reflects : Reflects P isYes
+
+open Dec public
+
+pattern yes p = dec true (true p)
+pattern no ¬p = dec false (false ¬p)
 
 -- Given an irrelevant proof of a decidable type, a proof can
 -- be recomputed and subsequently used in relevant contexts.

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -31,8 +31,9 @@ open import Relation.Nullary.Decidable.Core public
 -- Maps
 
 map : P ⇔ Q → Dec P → Dec Q
-map P⇔Q (yes p) = yes (Equivalence.to P⇔Q ⟨$⟩ p)
-map P⇔Q (no ¬p) = no (¬p ∘ _⟨$⟩_ (Equivalence.from P⇔Q))
+isYes (map P⇔Q p?) = isYes p?
+reflects (map P⇔Q (yes p)) = true (Equivalence.to P⇔Q ⟨$⟩ p)
+reflects (map P⇔Q (no ¬p)) = false (¬p ∘ (Equivalence.from P⇔Q ⟨$⟩_))
 
 map′ : (P → Q) → (Q → P) → Dec P → Dec Q
 map′ P→Q Q→P = map (equivalence P→Q Q→P)
@@ -48,6 +49,6 @@ module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} whe
   -- equivalence relation is also decidable.
 
   via-injection : Injection A B → Decidable _≈B_ → Decidable _≈A_
-  via-injection inj dec x y with dec (to inj ⟨$⟩ x) (to inj ⟨$⟩ y)
-  ... | yes injx≈injy = yes (Injection.injective inj injx≈injy)
-  ... | no  injx≉injy = no (λ x≈y → injx≉injy (Π.cong (to inj) x≈y))
+  via-injection inj _≟_ x y =
+    map′ (Injection.injective inj) (Π.cong (to inj))
+         ((to inj ⟨$⟩ x) ≟ (to inj ⟨$⟩ y))

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -28,15 +28,11 @@ private
 open import Relation.Nullary.Decidable.Core public
 
 ------------------------------------------------------------------------
--- Maps
+-- Preserve the boolean content non-strictly, but change the proofs
 
 map : P ⇔ Q → Dec P → Dec Q
-isYes (map P⇔Q p?) = isYes p?
-reflects (map P⇔Q (yes p)) = true (Equivalence.to P⇔Q ⟨$⟩ p)
-reflects (map P⇔Q (no ¬p)) = false (¬p ∘ (Equivalence.from P⇔Q ⟨$⟩_))
-
-map′ : (P → Q) → (Q → P) → Dec P → Dec Q
-map′ P→Q Q→P = map (equivalence P→Q Q→P)
+map P⇔Q = map′ (to P⇔Q ⟨$⟩_) (from P⇔Q ⟨$⟩_)
+  where open Equivalence
 
 module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} where
 

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -25,42 +25,71 @@ private
   variable
     p q : Level
     P : Set p
-    Q : Set q
+    p? : Set q
 
-isYes : Dec P → Bool
-isYes (yes _) = true
-isYes (no _)  = false
+-- `isYes!` is a stricter version of `isYes`, a field of `Dec`.
+-- Notice:
+--   isYes P? =η= isYes (dec b r) =β= b
+--   isYes! P? =η= isYes! (dec b r) ─β↛
+-- In these, `r : Respects P b` saves `P`, so we need to keep it to use
+-- `toWitness` &c. On the other hand, when we want to do branching,
+-- `isYes` will compute more easily.
+
+isYes! : Dec P → Bool
+isYes! (dec true  _) = true
+isYes! (dec false _) = false
 
 isNo : Dec P → Bool
 isNo = not ∘ isYes
 
+isNo! : Dec P → Bool
+isNo! = not ∘ isYes!
+
 True : Dec P → Set
-True Q = T (isYes Q)
+True p? = T (isYes p?)
+
+True! : Dec P → Set
+True! p? = T (isYes! p?)
 
 False : Dec P → Set
-False Q = T (isNo Q)
+False p? = T (isNo p?)
+
+False! : Dec P → Set
+False! p? = T (isNo! p?)
 
 -- Gives a witness to the "truth".
 
-toWitness : {Q : Dec P} → True Q → P
-toWitness {Q = yes p} _  = p
-toWitness {Q = no  _} ()
+toWitness : (p? : Dec P) → {_ : True p?} → P
+toWitness (yes p) = p
+
+toWitness! : {p? : Dec P} → True! p? → P
+toWitness! {p? = yes p} _ = p
 
 -- Establishes a "truth", given a witness.
 
-fromWitness : {Q : Dec P} → P → True Q
-fromWitness {Q = yes p} = const _
-fromWitness {Q = no ¬p} = ¬p
+fromWitness : (p? : Dec P) → P → True p?
+fromWitness (dec true _) = const _
+fromWitness (no      ¬p) = ¬p
 
--- Variants for False.
+fromWitness! : {p? : Dec P} → P → True! p?
+fromWitness! {p? = dec true _} = const _
+fromWitness! {p? = no      ¬p} = ¬p
 
-toWitnessFalse : {Q : Dec P} → False Q → ¬ P
-toWitnessFalse {Q = yes _}  ()
-toWitnessFalse {Q = no  ¬p} _  = ¬p
+-- Variants for False!.
 
-fromWitnessFalse : {Q : Dec P} → ¬ P → False Q
-fromWitnessFalse {Q = yes p} = flip _$_ p
-fromWitnessFalse {Q = no ¬p} = const _
+toWitnessFalse : (p? : Dec P) → {_ : False p?} → ¬ P
+toWitnessFalse (no ¬p) = ¬p
+
+toWitnessFalse! : {p? : Dec P} → False! p? → ¬ P
+toWitnessFalse! {p? = no ¬p} _ = ¬p
+
+fromWitnessFalse : (p? : Dec P) → ¬ P → False p?
+fromWitnessFalse (dec false _) = const _
+fromWitnessFalse (yes       p) = flip _$_ p
+
+fromWitnessFalse! : {p? : Dec P} → ¬ P → False! p?
+fromWitnessFalse! {p? = dec false _} = const _
+fromWitnessFalse! {p? = yes       p} = flip _$_ p
 
 -- If a decision procedure returns "yes", then we can extract the
 -- proof using from-yes.
@@ -68,39 +97,46 @@ fromWitnessFalse {Q = no ¬p} = const _
 module _ {p} {P : Set p} where
 
   From-yes : Dec P → Set p
-  From-yes (yes _) = P
-  From-yes (no  _) = Lift p ⊤
+  From-yes (dec true  _) = P
+  From-yes (dec false _) = Lift p ⊤
 
   from-yes : (p : Dec P) → From-yes p
-  from-yes (yes p) = p
-  from-yes (no  _) = _
+  from-yes (yes       p) = p
+  from-yes (dec false _) = _
 
 -- If a decision procedure returns "no", then we can extract the proof
 -- using from-no.
 
   From-no : Dec P → Set p
-  From-no (no  _) = ¬ P
-  From-no (yes _) = Lift p ⊤
+  From-no (dec false _) = ¬ P
+  From-no (dec true  _) = Lift p ⊤
 
   from-no : (p : Dec P) → From-no p
-  from-no (no ¬p) = ¬p
-  from-no (yes _) = _
+  from-no (no      ¬p) = ¬p
+  from-no (dec true _) = _
 
 ------------------------------------------------------------------------
 -- Result of decidability
 
 dec-yes : (p? : Dec P) → P → ∃ λ p′ → p? ≡ yes p′
+dec-yes (no ¬p ) p = ⊥-elim (¬p p)
 dec-yes (yes p′) p = p′ , refl
-dec-yes (no ¬p) p = ⊥-elim (¬p p)
+
+dec-true : (p? : Dec P) → P → isYes p? ≡ true
+dec-true (dec true _) _ = refl
+dec-true (no      ¬p) p = ⊥-elim (¬p p)
 
 dec-no : (p? : Dec P) → ¬ P → ∃ λ ¬p′ → p? ≡ no ¬p′
-dec-no (yes p) ¬p  = ¬p , ⊥-elim (¬p p)
 dec-no (no ¬p′) ¬p = ¬p′ , refl
+dec-no (yes p) ¬p = ⊥-elim (¬p p)
+
+dec-false : (p? : Dec P) → ¬ P → isYes p? ≡ false
+dec-false (yes       p) ¬p = ⊥-elim (¬p p)
+dec-false (dec false _)  _ = refl
 
 dec-yes-irr : (p? : Dec P) → Irrelevant P → (p : P) → p? ≡ yes p
 dec-yes-irr p? irr p with dec-yes p? p
 ... | p′ , eq rewrite irr p p′ = eq
-
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
@@ -110,8 +146,8 @@ dec-yes-irr p? irr p with dec-yes p? p
 
 -- Version 1.2
 
-⌊_⌋ = isYes
+⌊_⌋ = isYes!
 {-# WARNING_ON_USAGE ⌊_⌋
 "Warning: ⌊_⌋ was deprecated in v1.2.
-Please use isYes instead."
+Please use isYes! instead."
 #-}

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -25,6 +25,7 @@ private
   variable
     p q : Level
     P : Set p
+    Q : Set q
     p? : Set q
 
 -- `isYes!` is a stricter version of `isYes`, a field of `Dec`.
@@ -137,6 +138,14 @@ dec-false (dec false _)  _ = refl
 dec-yes-irr : (p? : Dec P) → Irrelevant P → (p : P) → p? ≡ yes p
 dec-yes-irr p? irr p with dec-yes p? p
 ... | p′ , eq rewrite irr p p′ = eq
+
+------------------------------------------------------------------------
+-- Preserve the boolean content non-strictly, but change the proofs
+
+map′ : (P → Q) → (Q → P) → Dec P → Dec Q
+isYes (map′ P→Q Q→P p?) = isYes p?
+reflects (map′ P→Q Q→P (yes p)) = true (P→Q p)
+reflects (map′ P→Q Q→P (no ¬p)) = false (¬p ∘ Q→P)
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Relation/Nullary/Implication.agda
+++ b/src/Relation/Nullary/Implication.agda
@@ -8,7 +8,9 @@
 
 module Relation.Nullary.Implication where
 
+open import Data.Bool.Base
 open import Data.Empty
+open import Function using (_∘_; _$_)
 open import Relation.Nullary
 open import Level
 
@@ -24,6 +26,7 @@ private
 infixr 2 _→-dec_
 
 _→-dec_ : Dec P → Dec Q → Dec (P → Q)
-yes p →-dec no ¬q = no  (λ f → ¬q (f p))
-yes p →-dec yes q = yes (λ _ → q)
-no ¬p →-dec _     = yes (λ p → ⊥-elim (¬p p))
+isYes (p? →-dec q?) = not (isYes p?) ∨ isYes q?
+reflects (yes p →-dec yes q) = true (λ _ → q)
+reflects (yes p →-dec no ¬q) = false (¬q ∘ (_$ p))
+reflects (no ¬p →-dec q?) = true (⊥-elim ∘ ¬p)

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -9,13 +9,14 @@
 module Relation.Nullary.Negation where
 
 open import Category.Monad
-open import Data.Bool.Base using (Bool; false; true; if_then_else_)
+open import Data.Bool.Base using (Bool; false; true; if_then_else_; not)
 open import Data.Empty
 open import Data.Product as Prod
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Function
 open import Level
 open import Relation.Nullary
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Unary
 
 private
@@ -45,8 +46,9 @@ private
 -- If we can decide P, then we can decide its negation.
 
 ¬? : Dec P → Dec (¬ P)
-¬? (yes p) = no (λ ¬p → ¬p p)
-¬? (no ¬p) = yes ¬p
+isYes (¬? p?) = not (isYes p?)
+reflects (¬? (yes p)) = false (contradiction p)
+reflects (¬? (no ¬p)) = true ¬p
 
 ------------------------------------------------------------------------
 -- Quantifier juggling
@@ -96,8 +98,7 @@ decidable-stable (yes p) ¬¬p = p
 decidable-stable (no ¬p) ¬¬p = ⊥-elim (¬¬p ¬p)
 
 ¬-drop-Dec : Dec (¬ ¬ P) → Dec (¬ P)
-¬-drop-Dec (yes ¬¬p) = no ¬¬p
-¬-drop-Dec (no ¬¬¬p) = yes (negated-stable ¬¬¬p)
+¬-drop-Dec ¬¬p? = map′ negated-stable contradiction (¬? ¬¬p?)
 
 -- Double-negation is a monad (if we assume that all elements of ¬ ¬ P
 -- are equal).

--- a/src/Relation/Nullary/Product.agda
+++ b/src/Relation/Nullary/Product.agda
@@ -8,6 +8,7 @@
 
 module Relation.Nullary.Product where
 
+open import Data.Bool.Base using (Bool; true; false; _∧_)
 open import Data.Product
 open import Function
 open import Level
@@ -25,6 +26,7 @@ private
 infixr 2 _×-dec_
 
 _×-dec_ : Dec P → Dec Q → Dec (P × Q)
-yes p ×-dec yes q = yes (p , q)
-no ¬p ×-dec _     = no (¬p ∘ proj₁)
-_     ×-dec no ¬q = no (¬q ∘ proj₂)
+isYes (p? ×-dec q?) = isYes p? ∧ isYes q?
+reflects (yes p ×-dec yes q) = true (p , q)
+reflects (yes p ×-dec no ¬q) = false (¬q ∘ proj₂)
+reflects (no ¬p ×-dec q?) = false (¬p ∘ proj₁)

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -1,0 +1,27 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of the `Reflects` construct
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Nullary.Reflects where
+
+open import Data.Bool.Base
+open import Level
+open import Relation.Nullary
+
+variable
+  p : Level
+  P : Set p
+
+invert-true : Reflects P true → P
+invert-true (true p) = p
+
+invert-false : Reflects P false → ¬ P
+invert-false (false ¬p) = ¬p
+
+invert : ∀ {b} → Reflects P b → if b then P else ¬ P
+invert (true   p) = p
+invert (false ¬p) = ¬p

--- a/src/Relation/Nullary/Sum.agda
+++ b/src/Relation/Nullary/Sum.agda
@@ -8,6 +8,7 @@
 
 module Relation.Nullary.Sum where
 
+open import Data.Bool.Base using (Bool; true; false; _∨_)
 open import Data.Sum
 open import Data.Empty
 open import Level
@@ -29,10 +30,7 @@ _¬-⊎_ : ¬ P → ¬ Q → ¬ (P ⊎ Q)
 (¬p ¬-⊎ ¬q) (inj₂ q) = ¬q q
 
 _⊎-dec_ : Dec P → Dec Q → Dec (P ⊎ Q)
-yes p ⊎-dec _     = yes (inj₁ p)
-_     ⊎-dec yes q = yes (inj₂ q)
-no ¬p ⊎-dec no ¬q = no helper
-  where
-  helper : _ ⊎ _ → ⊥
-  helper (inj₁ p) = ¬p p
-  helper (inj₂ q) = ¬q q
+isYes (p? ⊎-dec q?) = isYes p? ∨ isYes q?
+reflects (yes p ⊎-dec q?) = true (inj₁ p)
+reflects (no ¬p ⊎-dec yes q) = true (inj₂ q)
+reflects (no ¬p ⊎-dec no ¬q) = false [ ¬p , ¬q ]

--- a/src/Relation/Unary.agda
+++ b/src/Relation/Unary.agda
@@ -15,6 +15,7 @@ open import Data.Sum using (_⊎_; [_,_])
 open import Function.Core
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
+open import Relation.Nullary.Decidable.Core using (True!)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_)
 
 private
@@ -165,9 +166,7 @@ Decidable P = ∀ x → Dec (P x)
 -- amenable to η-expansion
 
 ⌊_⌋ : {P : Pred A ℓ} → Decidable P → Pred A ℓ
-⌊ P? ⌋ a with P? a
-... | yes _ = Lift _ ⊤
-... | no _  = Lift _ ⊥
+⌊ P? ⌋ a = Lift _ (True! (P? a))
 
 -- Irrelevance - any two proofs that an element satifies P are
 -- indistinguishable.


### PR DESCRIPTION
Motivation
===

As proposed [here-ish](https://github.com/agda/agda-stdlib/issues/225#issuecomment-525622181), this pull request redefines `Dec` in terms of `Reflects`. The actual series of definitions is the following (`Relation.Nullary`).

```agda
data Reflects {p} (P : Set p) : Bool → Set p where
  true  : ( p :   P) → Reflects P true
  false : (¬p : ¬ P) → Reflects P false

record Dec {p} (P : Set p) : Set p where
  constructor dec
  field
    isYes : Bool
    reflects : Reflects P isYes

open Dec public

pattern yes p = dec true (true p)
pattern no ¬p = dec false (false ¬p)
```

`Reflects P b` is the graph of `if b then P else ¬ P`. A `Dec` value contains a boolean `isYes`, along with a proof that `isYes` reflects the proposition `P` that we're deciding. We are able to branch on `isYes` without pattern matching on `reflects`, which is where the computational advantages of this definition come from.

With the pattern declarations, pretty much everything in the standard library still works if the only change we make is the redefinition of `Dec`. However, this way, all definitions are as strict as they were before, and we gain no benefit.

We can often gain something in decidable equality proofs. For example, consider a standard current definition of decidable equality on natural numbers, and how it interacts with the current `isYes` (recently renamed from `⌊_⌋`). The definition is equivalent to:

```agda
_≟_ : Decidable {A = ℕ} _≡_
zero ≟ zero = yes refl
zero ≟ suc n = no λ ()
suc m ≟ zero = no λ ()
suc m ≟ suc n with m ≟ n
... | yes p = yes (cong suc p)
... | no ¬p = no (¬p ∘ suc-injective)
```

In the `suc`-`suc` case, before we can say what the result is, we must be able to get the full proof coming from `m ≟ n`. We can try getting an answer:

```agda
run : (m n : ℕ) → Set
run m n = {!isYes (3 + m ≟ 2 + n)!}
```

But normalising this expression does not give us anything much simpler.

In contrast, we can now make the following definition also.

```agda
_≟_ : Decidable {A = ℕ} _≡_
zero ≟ zero = yes refl
zero ≟ suc n = no λ ()
suc m ≟ zero = no λ ()
isYes (suc m ≟ suc n) = isYes (m ≟ n)
reflects (suc m ≟ suc n) with m ≟ n
... | yes p = true (cong suc p)
... | no ¬p = false (¬p ∘ suc-injective)
```

Now, we can follow the test case again, and it normalises to `isYes (1 + m ≟ n)`. This behaviour can be useful for functions like `filter` from `Data.List`, which require a decidable proposition but don't actually use the proposition part.

Work done
===

The most interesting changes are in the `Relation.Nullary` hierarchy. In `Relation.Nullary.Decidable.Core`, the closest equivalent to the old `isYes` is `isYes!`. As documented in the file, `isYes` is intended for branching, whereas `isYes!` is intended for proof automation (assuming concrete values). `Relation.Nullary.Reflects` has been introduced, containing some inversion lemmas. The proofs of decidability for logical connectives (`¬?`, `_×-dec_`, `_⊎-dec_`, and `_→-dec_`) have been rewritten to make the connection to the corresponding boolean functions explicit.

Elsewhere, functions branching on decisions (like `filter`) and recursive decision procedures have been rewritten to be less strict. A lot of the time for decision procedures, the tactic has been to rewrite `with` clauses to some combination of `map′` and `_×-dec_`, which would have been a stylistic improvement with the current definition of `Dec`. In addition, lemmas about decision-using functions have also been made less strict, which seems more idiomatic.

I don't have any good way to know whether I've caught every overly strict usage of `Dec` in the library. I have so far been guided by grepping for `yes  *_` and `no  *_`, which suggest only the branching is important and not the proofs. There are probably more things that could be improved. The `Everything` file checks successfully, so at least nothing that is used in the library is broken (proof automation, for example).