### PR TITLE
Add `Reflects` and define `Dec` in terms of it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,47 @@ from `_↞_` to `_↩_` in order to make room for the new package for right inve
 * The existing modules `Data.Bin` and `Data.Bin.Properties` still exist but have been
   deprecated and may be removed in some future release of the library.
 
+### Addition of the `Reflects` idiom
+
+* A version of the `Reflects` idiom, as seen in SSReflect, has been introduced
+in `Relation.Nullary`. Some properties of it have been added in
+`Relation.Nullary.Reflects`. The definition is as follows
+  ```agda
+  data Reflects {p} (P : Set p) : Bool → Set p where
+    ofʸ : ( p :   P) → Reflects P true
+    ofⁿ : (¬p : ¬ P) → Reflects P false
+  ```
+
+* `Dec` has been redefined in terms of `Reflects`.
+  ```agda
+  record Dec {p} (P : Set p) : Set p where
+    constructor _because_
+    field
+      does : Bool
+      proof : Reflects P does
+
+  open Dec public
+
+  pattern yes p =  true because ofʸ  p
+  pattern no ¬p = false because ofⁿ ¬p
+  ```
+This change should be backwards compatible thanks to the pattern synonyms.
+However, decision procedures can now be built in such a way that a boolean
+result is given independently of the proof that it is the correct decision.
+See, for example, this proof of decidability of _≤_ on natural numbers.
+  ```agda
+  _≤?_ : (m n : ℕ) → Dec (m ≤ n)
+  zero  ≤?    n = yes z≤n
+  suc m ≤? zero = no λ ()
+  does  (suc m ≤? suc n) = does (m ≤? n)
+  proof (suc m ≤? suc n) with m ≤? n
+  ... | yes p = ofʸ (s≤s p)
+  ... | no ¬p = ofⁿ (¬p ∘ ≤-pred)
+  ```
+Notice that if we project the `does` field, we get a function which behaves
+identically to what we would expect of a boolean test. This can have
+advantages for both performance and reasoning.
+
 ### Other breaking changes
 
 #### Harmonizing `List.All` and `Vec` in their role as finite maps.
@@ -181,6 +222,8 @@ The following new modules have been added to the library:
   Relation.Binary.Properties.Setoid
   Relation.Binary.Reasoning.Base.Partial
   Relation.Binary.Reasoning.PartialSetoid
+
+  Relation.Nullary.Reflects
   ```
 
 Relocated modules

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -11,7 +11,6 @@ module Data.Bool.Base where
 open import Data.Unit.Base using (⊤)
 open import Data.Empty
 open import Level using (Level)
-open import Relation.Nullary
 
 private
   variable

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -12,6 +12,7 @@ module Relation.Nullary where
 
 open import Agda.Builtin.Equality
 
+open import Data.Bool.Base
 open import Data.Empty hiding (⊥-elim)
 open import Data.Empty.Irrelevant
 open import Level
@@ -19,15 +20,34 @@ open import Level
 -- Negation.
 
 infix 3 ¬_
+infix 2 _because_
 
 ¬_ : ∀ {ℓ} → Set ℓ → Set ℓ
 ¬ P = P → ⊥
 
--- Decidable relations.
+-- `Reflects` idiom.
+-- The truth value of P is reflected by a boolean value.
 
-data Dec {p} (P : Set p) : Set p where
-  yes : ( p :   P) → Dec P
-  no  : (¬p : ¬ P) → Dec P
+data Reflects {p} (P : Set p) : Bool → Set p where
+  ofʸ : ( p :   P) → Reflects P true
+  ofⁿ : (¬p : ¬ P) → Reflects P false
+
+-- Decidable relations.
+-- This version of `Dec` allows the boolean portion of the
+-- value to compute independently from the proof portion.
+-- This often allows good computational properties when we
+-- only care about the boolean portion.
+
+record Dec {p} (P : Set p) : Set p where
+  constructor _because_
+  field
+    does : Bool
+    proof : Reflects P does
+
+open Dec public
+
+pattern yes p =  true because ofʸ  p
+pattern no ¬p = false because ofⁿ ¬p
 
 -- Given an irrelevant proof of a decidable type, a proof can
 -- be recomputed and subsequently used in relevant contexts.

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -1,0 +1,28 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of the `Reflects` construct
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Nullary.Reflects where
+
+open import Data.Bool.Base
+open import Level
+open import Relation.Nullary
+
+variable
+  p : Level
+  P : Set p
+
+------------------------------------------------------------------------
+-- `Reflects P b` is equivalent to `if b then P else ¬ P`.
+
+of : ∀ {b} → if b then P else ¬ P → Reflects P b
+of {b = false} ¬p = ofⁿ ¬p
+of {b = true }  p = ofʸ p
+
+invert : ∀ {b} → Reflects P b → if b then P else ¬ P
+invert (ofʸ  p) = p
+invert (ofⁿ ¬p) = ¬p

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -9,7 +9,9 @@
 module Relation.Nullary.Reflects where
 
 open import Data.Bool.Base
+open import Data.Empty
 open import Level
+open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
 
 variable
@@ -32,3 +34,13 @@ of {b = true }  p = ofʸ p
 invert : ∀ {b} → Reflects P b → if b then P else ¬ P
 invert (ofʸ  p) = p
 invert (ofⁿ ¬p) = ¬p
+
+------------------------------------------------------------------------
+-- Other lemmas
+
+-- `Reflects` is deterministic.
+det : ∀ {b b′} → Reflects P b → Reflects P b′ → b ≡ b′
+det (ofʸ  p) (ofʸ  p′) = refl
+det (ofʸ  p) (ofⁿ ¬p′) = ⊥-elim (¬p′ p)
+det (ofⁿ ¬p) (ofʸ  p′) = ⊥-elim (¬p p′)
+det (ofⁿ ¬p) (ofⁿ ¬p′) = refl

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -19,6 +19,12 @@ variable
 ------------------------------------------------------------------------
 -- `Reflects P b` is equivalent to `if b then P else ¬ P`.
 
+-- These lemmas are intended to be used mostly when `b` is a value, so
+-- that the `if` expressions have already been evaluated away.
+-- In this case, `of` works like the relevant constructor (`ofⁿ` or
+-- `ofʸ`), and `invert` strips off the constructor to just give either
+-- the proof of `P` or the proof of `¬ P`.
+
 of : ∀ {b} → if b then P else ¬ P → Reflects P b
 of {b = false} ¬p = ofⁿ ¬p
 of {b = true }  p = ofʸ p


### PR DESCRIPTION
This pull request contains the first steps of #929. It introduces `Reflects` and the module `Relation.Nullary.Reflects`, which at the moment just contains lemmas converting between `Reflects P b` and `if b then P else ¬ P`. It redefines `Dec` to contain a boolean value and a `Reflects` proof of it. There are patterns `yes` and `no`, which have behaviour similar to the old constructors of `Dec`. The rest of the library checks without modification. Finally, a bit about all of this has been added to the changelog.

I think with this new set of names (in particular `_because_` and `does`), breaking changes should not be necessary. Some of the existing names may look a bit strange (`isYes`, `True`, `toWitness`, and the corresponding negative definitions are more special-purpose than their names suggest), but they can be dealt with via deprecation if necessary. This leaves just a few more tasks to do to catch up to #929:

1. Reprove `map′` in `Relation.Nullary.Decidable` so that the `does` field is a pass-through.
2. Reprove the decidability of logical connectives in `Relation.Nullary.*` so that the `does` field uses named boolean functions. Maybe there should also be `Reflects` proofs, for example, `×-reflects : Reflects P x → Reflects Q y → Reflects (P × Q) (x ∧ y)` in `Relation.Nullary.Product`. If `×-reflects` exists, `_×-dec_` can then use it, in a relationship similar to `isMonoid` and `monoid` in various places.
3. Reprove recursive decision procedures throughout the library (mostly in `Data`). This mostly (but not entirely) consists of rephrasing `with` clauses to applications of `map′`, possibly on `_×-dec_`, `_⊎-dec_`, &c, which could be done independently of even this pull request.
4. Reimplement functions which use `Dec` values for the boolean content only, e.g. `filter`.
5. Reprove lemmas to be only as strict as necessary. This is least important, unless someone is going to depend computationally on these proofs.

All of these changes should only improve definitional equality while not causing any new unification issues or name clashes (this was my experience in #929), so should be safe to do.