### PR TITLE
[ refactor ] change decision procedures to use more combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -440,3 +440,64 @@ Other minor additions
   ```agda
   _⊔ˢ_ : Size → Size → Size
   ```
+
+* Added new definitions to `Data.Fin.Properties`:
+  ```agda
+  ∀-cons-⇔ : (P zero × Π[ P ∘ suc ]) ⇔ Π[ P ]
+  ∃-here   : P zero → ∃⟨ P ⟩
+  ∃-there  : ∃⟨ P ∘ suc ⟩ → ∃⟨ P ⟩
+  ∃-toSum  : ∃⟨ P ⟩ → P zero ⊎ ∃⟨ P ∘ suc ⟩
+  ⊎⇔∃      : (P zero ⊎ ∃⟨ P ∘ suc ⟩) ⇔ ∃⟨ P ⟩
+  ```
+
+* Added new definitions to `Data.Fin.Subset.Properties`:
+  ```agda
+  out⊆    : p ⊆ q → outside ∷ p ⊆      y ∷ q
+  out⊆-⇔  : p ⊆ q ⇔ outside ∷ p ⊆      y ∷ q
+  in⊆in   : p ⊆ q →  inside ∷ p ⊆ inside ∷ q
+  in⊆in-⇔ : p ⊆ q ⇔  inside ∷ p ⊆ inside ∷ q
+
+  ∃-Subset-zero : ∃⟨ P ⟩ → P []
+  ∃-Subset-[]-⇔ : P [] ⇔ ∃⟨ P ⟩
+  ∃-Subset-suc  : ∃⟨ P ⟩ → ∃⟨ P ∘ (inside ∷_) ⟩ ⊎ ∃⟨ P ∘ (outside ∷_) ⟩
+  ∃-Subset-∷-⇔  : (∃⟨ P ∘ (inside ∷_) ⟩ ⊎ ∃⟨ P ∘ (outside ∷_) ⟩) ⇔ ∃⟨ P ⟩
+  ```
+
+* Added new definitions to `Data.List.Relation.Binary.Lex.Core`:
+  ```agda
+  []<[]-⇔ : P ⇔ [] < []
+  toSum   : (x ∷ xs) < (y ∷ ys) → (x ≺ y ⊎ (x ≈ y × xs < ys))
+  ∷<∷-⇔   : (x ≺ y ⊎ (x ≈ y × xs < ys)) ⇔ (x ∷ xs) < (y ∷ ys)
+  ```
+
+* Added new definitions to `Data.List.Relation.Binary.Pointwise`:
+  ```agda
+  uncons : Pointwise _∼_ (x ∷ xs) (y ∷ ys) → x ∼ y × Pointwise _∼_ xs ys
+  ```
+
+* Added new definitions to `Data.List.Relation.Unary.AllPairs`:
+  ```agda
+  uncons : AllPairs R (x ∷ xs) → All (R x) xs × AllPairs R xs
+  ```
+
+* Added new definitions to `Data.These.Properties`:
+  ```agda
+  these-injective : these x a ≡ these y b → x ≡ y × a ≡ b
+  ```
+
+* Added new definitions to `Data.Vec.Relation.Binary.Pointwise.Inductive`:
+  ```agda
+  uncons : Pointwise _∼_ (x ∷ xs) (y ∷ ys) → x ∼ y × Pointwise _∼_ xs ys
+  ```
+
+* Added new definitions to `Data.Vec.Relation.Unary.All`:
+  ```agda
+  uncons : All P (x ∷ xs) → P x × All P xs
+  ```
+
+* Added new definitions to `Relation.Binary.Construct.Closure.Reflexive.Properties`:
+  ```agda
+  fromSum :  a ≡ b ⊎ a ~ b  → Refl _~_ a b
+  toSum   :  Refl _~_ a b   → a ≡ b ⊎ a ~ b
+  ⊎⇔Refl  : (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
+  ```

--- a/src/Codata/Conat/Properties.agda
+++ b/src/Codata/Conat/Properties.agda
@@ -14,17 +14,16 @@ open import Codata.Conat
 open import Codata.Conat.Bisimilarity
 open import Function
 open import Relation.Nullary
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Binary
 
 sℕ≤s⁻¹ : ∀ {m n} → suc m ℕ≤ suc n → m ℕ≤ n .force
 sℕ≤s⁻¹ (sℕ≤s p) = p
 
 _ℕ≤?_ : Decidable _ℕ≤_
-zero  ℕ≤? n       = yes zℕ≤n
-suc m ℕ≤? zero    = no (λ ())
-suc m ℕ≤? suc n with m ℕ≤? n .force
-... | yes p = yes (sℕ≤s p)
-... | no ¬p = no (¬p ∘′ sℕ≤s⁻¹)
+zero  ℕ≤? n     = yes zℕ≤n
+suc m ℕ≤? zero  = no (λ ())
+suc m ℕ≤? suc n = map′ sℕ≤s sℕ≤s⁻¹ (m ℕ≤? n .force)
 
 0ℕ+-identity : ∀ {i n} → i ⊢ 0 ℕ+ n ≈ n
 0ℕ+-identity = refl

--- a/src/Data/Bin/Properties.agda
+++ b/src/Data/Bin/Properties.agda
@@ -18,13 +18,15 @@ open import Data.Nat
   using (ℕ; zero; z≤n; s≤s)
   renaming (suc to 1+_; _+_ to _+ℕ_; _*_ to _*ℕ_; _≤_ to _≤ℕ_)
 import Data.Nat.Properties as ℕₚ
-open import Data.Product using (proj₁; proj₂)
+open import Data.Product using (proj₁; proj₂; uncurry)
 open import Function using (_∘_)
 open import Relation.Binary
 open import Relation.Binary.Consequences
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; refl; sym; isEquivalence; resp₂; decSetoid)
+  using (_≡_; _≢_; refl; sym; isEquivalence; resp₂; decSetoid; cong; cong₂)
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- (Bin, _≡_) is a decidable setoid
@@ -38,18 +40,14 @@ _≟ₑ_ : ∀ {base} → Decidable (_≡_ {A = Expansion base})
 _≟ₑ_ []       []       = yes refl
 _≟ₑ_ []       (_ ∷ _)  = no λ()
 _≟ₑ_ (_ ∷ _) []        = no λ()
-_≟ₑ_ (x ∷ xs) (y ∷ ys) with x Fin.≟ y | xs ≟ₑ ys
-... | _        | no xs≢ys = no (xs≢ys ∘ proj₂ ∘ ∷-injective)
-... | no  x≢y  | _        = no (x≢y   ∘ proj₁ ∘ ∷-injective)
-... | yes refl | yes refl = yes refl
+_≟ₑ_ (x ∷ xs) (y ∷ ys) =
+  map′ (uncurry (cong₂ _∷_)) ∷-injective (x Fin.≟ y ×-dec xs ≟ₑ ys)
 
 _≟_ : Decidable {A = Bin} _≡_
 0#    ≟ 0#    = yes refl
 0#    ≟ bs 1# = no λ()
 as 1# ≟ 0#    = no λ()
-as 1# ≟ bs 1# with as ≟ₑ bs
-... | yes refl  = yes refl
-... | no  as≢bs = no (as≢bs ∘ 1#-injective)
+as 1# ≟ bs 1# = map′ (cong _1#) 1#-injective (as ≟ₑ bs)
 
 ≡-isDecEquivalence : IsDecEquivalence _≡_
 ≡-isDecEquivalence = record

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -35,7 +35,8 @@ open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary using (Dec; yes; no; ¬_)
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Nullary.Sum using (_⊎-dec_)
-open import Relation.Unary as U using (U; Pred; Decidable; _⊆_)
+open import Relation.Unary as U
+  using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
 open import Relation.Unary.Properties using (U?)
 
 ------------------------------------------------------------------------
@@ -495,25 +496,25 @@ punchOut-punchIn (suc i) {suc j} = cong suc (begin
 
 module _ {n p} {P : Pred (Fin (suc n)) p} where
 
-  ∀-cons : P zero → (∀ i → P (suc i)) → (∀ i → P i)
+  ∀-cons : P zero → Π[ P ∘ suc ] → Π[ P ]
   ∀-cons z s zero    = z
   ∀-cons z s (suc i) = s i
 
-  ∀-cons-⇔ : (P zero × (∀ i → P (suc i))) ⇔ (∀ i → P i)
+  ∀-cons-⇔ : (P zero × Π[ P ∘ suc ]) ⇔ Π[ P ]
   ∀-cons-⇔ = equivalence (uncurry ∀-cons) < _$ zero , _∘ suc >
 
-  ∃-here : P zero → ∃ P
+  ∃-here : P zero → ∃⟨ P ⟩
   ∃-here = zero ,_
 
-  ∃-there : ∃ (P ∘ suc) → ∃ P
+  ∃-there : ∃⟨ P ∘ suc ⟩ → ∃⟨ P ⟩
   ∃-there = map suc id
 
-  ∃-toSum : ∃ P → P zero ⊎ ∃ (P ∘ suc)
+  ∃-toSum : ∃⟨ P ⟩ → P zero ⊎ ∃⟨ P ∘ suc ⟩
   ∃-toSum ( zero , P₀ ) = inj₁ P₀
   ∃-toSum (suc f , P₁₊) = inj₂ (f , P₁₊)
 
-  ∃-cons-⇔ : (P zero ⊎ ∃ (P ∘ suc)) ⇔ ∃ P
-  ∃-cons-⇔ = equivalence [ ∃-here , ∃-there ] ∃-toSum
+  ⊎⇔∃ : (P zero ⊎ ∃⟨ P ∘ suc ⟩) ⇔ ∃⟨ P ⟩
+  ⊎⇔∃ = equivalence [ ∃-here , ∃-there ] ∃-toSum
 
 decFinSubset : ∀ {n p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
                Decidable Q → (∀ {f} → Q f → Dec (P f)) → Dec (Q ⊆ P)
@@ -528,7 +529,7 @@ decFinSubset {suc n} {P = P} {Q} Q? P? with decFinSubset (Q? ∘ suc) P?
 
 any? : ∀ {n p} {P : Fin n → Set p} → Decidable P → Dec (∃ P)
 any? {zero}  {P = _} P? = no λ { (() , _) }
-any? {suc n} {P = P} P? = Dec.map ∃-cons-⇔ (P? zero ⊎-dec any? (P? ∘ suc))
+any? {suc n} {P = P} P? = Dec.map ⊎⇔∃ (P? zero ⊎-dec any? (P? ∘ suc))
 
 all? : ∀ {n p} {P : Pred (Fin n) p} →
        Decidable P → Dec (∀ f → P f)

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -508,12 +508,12 @@ module _ {n p} {P : Pred (Fin (suc n)) p} where
   ∃-there : ∃ (P ∘ suc) → ∃ P
   ∃-there = map suc id
 
+  ∃-toSum : ∃ P → P zero ⊎ ∃ (P ∘ suc)
+  ∃-toSum ( zero , P₀ ) = inj₁ P₀
+  ∃-toSum (suc f , P₁₊) = inj₂ (f , P₁₊)
+
   ∃-cons-⇔ : (P zero ⊎ ∃ (P ∘ suc)) ⇔ ∃ P
-  ∃-cons-⇔ = equivalence
-    [ ∃-here , ∃-there ]
-    λ { (zero  , P₀ ) → inj₁ P₀
-      ; (suc f , P₁₊) → inj₂ (f , P₁₊)
-      }
+  ∃-cons-⇔ = equivalence [ ∃-here , ∃-there ] ∃-toSum
 
 decFinSubset : ∀ {n p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
                Decidable Q → (∀ {f} → Q f → Dec (P f)) → Dec (Q ⊆ P)

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -33,7 +33,7 @@ open import Relation.Nullary using (Dec; yes; no)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary.Sum using (_⊎-dec_)
-open import Relation.Unary using (Pred; Decidable)
+open import Relation.Unary using (Pred; Decidable; Satisfiable)
 
 ------------------------------------------------------------------------
 -- Constructor mangling
@@ -588,24 +588,24 @@ Lift? P? p = decFinSubset (_∈? p) (λ {x} _ → P? x)
 
 module _ {p} {P : Pred (Subset zero) p} where
 
-  ∃-Subset-zero : ∃ P → P []
+  ∃-Subset-zero : ∃⟨ P ⟩ → P []
   ∃-Subset-zero ([] , P[]) = P[]
 
-  ∃-Subset-[]-⇔ : P [] ⇔ ∃ P
+  ∃-Subset-[]-⇔ : P [] ⇔ ∃⟨ P ⟩
   ∃-Subset-[]-⇔ = equivalence ([] ,_) ∃-Subset-zero
 
 module _ {p n} {P : Pred (Subset (suc n)) p} where
 
-  ∃-Subset-suc : ∃ P → ∃ (P ∘ (inside ∷_)) ⊎ ∃ (P ∘ (outside ∷_))
+  ∃-Subset-suc : ∃⟨ P ⟩ → ∃⟨ P ∘ (inside ∷_) ⟩ ⊎ ∃⟨ P ∘ (outside ∷_) ⟩
   ∃-Subset-suc (outside ∷ p , Pop) = inj₂ (p , Pop)
   ∃-Subset-suc ( inside ∷ p , Pip) = inj₁ (p , Pip)
 
-  ∃-Subset-∷-⇔ : (∃ (P ∘ (inside ∷_)) ⊎ ∃ (P ∘ (outside ∷_))) ⇔ ∃ P
+  ∃-Subset-∷-⇔ : (∃⟨ P ∘ (inside ∷_) ⟩ ⊎ ∃⟨ P ∘ (outside ∷_) ⟩) ⇔ ∃⟨ P ⟩
   ∃-Subset-∷-⇔ = equivalence
     [ Product.map _ id , Product.map _ id ]′
     ∃-Subset-suc
 
-anySubset? : ∀ {p n} {P : Pred (Subset n) p} → Decidable P → Dec (∃ P)
+anySubset? : ∀ {p n} {P : Pred (Subset n) p} → Decidable P → Dec ∃⟨ P ⟩
 anySubset? {n = zero}  P? = Dec.map ∃-Subset-[]-⇔ (P? [])
 anySubset? {n = suc n} P? =
   Dec.map ∃-Subset-∷-⇔ (anySubset? (P? ∘ ( inside ∷_)) ⊎-dec

--- a/src/Data/List/Fresh/Relation/Unary/Any.agda
+++ b/src/Data/List/Fresh/Relation/Unary/Any.agda
@@ -69,6 +69,6 @@ module _ {R : Rel A r} {P : Pred A p} (P? : Decidable P) where
 
   any? : (xs : List# A R) → Dec (Any P xs)
   any? []        = no (λ ())
-  any? (x ∷# xs) with P? x
-  ... | yes p = yes (here p)
-  ... | no ¬p = Dec.map′ there (tail ¬p) (any? xs)
+  any? (x ∷# xs) =
+    Dec.map′ [ here , there ]′ (λ{ (here x) → inj₁ x ; (there z) → inj₂ z })
+             (P? x ⊎-dec any? xs)

--- a/src/Data/List/Fresh/Relation/Unary/Any.agda
+++ b/src/Data/List/Fresh/Relation/Unary/Any.agda
@@ -42,10 +42,15 @@ module _ {R : Rel A r} {P : Pred A p} {x} {xs : List# A R} {pr} where
   tail ¬head (here p)   = ⊥-elim (¬head p)
   tail ¬head (there ps) = ps
 
-  Any-cons-⇔ : (P x ⊎ Any P xs) ⇔ Any P (cons x xs pr)
-  Any-cons-⇔ = equivalence
-    [ here , there ]′
-    (λ{ (here x) → inj₁ x ; (there z) → inj₂ z })
+  toSum : Any P (cons x xs pr) → P x ⊎ Any P xs
+  toSum (here p) = inj₁ p
+  toSum (there ps) = inj₂ ps
+
+  fromSum : P x ⊎ Any P xs → Any P (cons x xs pr)
+  fromSum = [ here , there ]′
+
+  ⊎⇔Any : (P x ⊎ Any P xs) ⇔ Any P (cons x xs pr)
+  ⊎⇔Any = equivalence fromSum toSum
 
 module _ {R : Rel A r} {P : Pred A p} {Q : Pred A q} where
 
@@ -75,4 +80,4 @@ module _ {R : Rel A r} {P : Pred A p} (P? : Decidable P) where
 
   any? : (xs : List# A R) → Dec (Any P xs)
   any? []        = no (λ ())
-  any? (x ∷# xs) = Dec.map Any-cons-⇔ (P? x ⊎-dec any? xs)
+  any? (x ∷# xs) = Dec.map ⊎⇔Any (P? x ⊎-dec any? xs)

--- a/src/Data/List/Fresh/Relation/Unary/Any.agda
+++ b/src/Data/List/Fresh/Relation/Unary/Any.agda
@@ -12,6 +12,7 @@ open import Level using (Level; _⊔_; Lift)
 open import Data.Empty
 open import Data.Product using (∃; _,_; -,_)
 open import Data.Sum.Base using (_⊎_; [_,_]′; inj₁; inj₂)
+open import Function.Equivalence using (_⇔_; equivalence)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Sum using (_⊎-dec_)
@@ -41,6 +42,11 @@ module _ {R : Rel A r} {P : Pred A p} {x} {xs : List# A R} {pr} where
   tail ¬head (here p)   = ⊥-elim (¬head p)
   tail ¬head (there ps) = ps
 
+  Any-cons-⇔ : (P x ⊎ Any P xs) ⇔ Any P (cons x xs pr)
+  Any-cons-⇔ = equivalence
+    [ here , there ]′
+    (λ{ (here x) → inj₁ x ; (there z) → inj₂ z })
+
 module _ {R : Rel A r} {P : Pred A p} {Q : Pred A q} where
 
   map : {xs : List# A R} → ∀[ P ⇒ Q ] → Any P xs → Any Q xs
@@ -69,6 +75,4 @@ module _ {R : Rel A r} {P : Pred A p} (P? : Decidable P) where
 
   any? : (xs : List# A R) → Dec (Any P xs)
   any? []        = no (λ ())
-  any? (x ∷# xs) =
-    Dec.map′ [ here , there ]′ (λ{ (here x) → inj₁ x ; (there z) → inj₂ z })
-             (P? x ⊎-dec any? xs)
+  any? (x ∷# xs) = Dec.map Any-cons-⇔ (P? x ⊎-dec any? xs)

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -30,10 +30,11 @@ open import Level using (Level)
 import Relation.Binary as B
 import Relation.Binary.Reasoning.Setoid as EqR
 open import Relation.Binary.PropositionalEquality as P
-  using (_≡_; _≢_; _≗_; refl ; sym ; cong)
+  using (_≡_; _≢_; _≗_; refl ; sym ; cong; cong₂)
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable using (isYes)
+open import Relation.Nullary.Decidable using (isYes; map′)
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary using (Pred; Decidable; ∁)
 open import Relation.Unary.Properties using (∁?)
 
@@ -60,14 +61,14 @@ module _ {x y : A} {xs ys : List A} where
   ∷-injectiveʳ : x ∷ xs ≡ y List.∷ ys → xs ≡ ys
   ∷-injectiveʳ refl = refl
 
-≡-dec : B.Decidable _≡_ → B.Decidable {A = List A} _≡_
-≡-dec _≟_ []       []       = yes refl
-≡-dec _≟_ (x ∷ xs) []       = no λ()
-≡-dec _≟_ []       (y ∷ ys) = no λ()
-≡-dec _≟_ (x ∷ xs) (y ∷ ys) with x ≟ y | ≡-dec _≟_ xs ys
-... | no  x≢y  | _        = no (x≢y   ∘ ∷-injectiveˡ)
-... | yes _    | no xs≢ys = no (xs≢ys ∘ ∷-injectiveʳ)
-... | yes refl | yes refl = yes refl
+module _ (_≟_ : B.Decidable {A = A} _≡_) where
+
+  ≡-dec : B.Decidable {A = List A} _≡_
+  ≡-dec []       []       = yes refl
+  ≡-dec (x ∷ xs) []       = no λ()
+  ≡-dec []       (y ∷ ys) = no λ()
+  ≡-dec (x ∷ xs) (y ∷ ys) =
+    map′ (uncurry (cong₂ _∷_)) ∷-injective (x ≟ y ×-dec ≡-dec xs ys)
 
 ------------------------------------------------------------------------
 -- map

--- a/src/Data/List/Relation/Binary/Lex/Core.agda
+++ b/src/Data/List/Relation/Binary/Lex/Core.agda
@@ -11,10 +11,14 @@ module Data.List.Relation.Binary.Lex.Core where
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤; tt)
 open import Function using (_∘_; flip; id)
-open import Data.Product using (_,_; proj₁; proj₂)
+open import Data.Product using (_,_; proj₁; proj₂; uncurry)
 open import Data.List.Base using (List; []; _∷_)
+open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Level using (_⊔_)
 open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
+open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Binary
 open import Data.List.Relation.Binary.Pointwise
    using (Pointwise; []; _∷_; head; tail)
@@ -94,15 +98,16 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
     resp² (x≈z ∷ xs≋zs) (next x≈y xs<ys) =
       next (trans (sym x≈z) x≈y) (resp² xs≋zs xs<ys)
 
-  decidable : Dec P → Decidable _≈_ → Decidable _≺_ → Decidable _<_
-  decidable (yes p) dec-≈ dec-≺ []       []       = yes (base p)
-  decidable (no ¬p) dec-≈ dec-≺ []       []       = no λ{(base p) → ¬p p}
-  decidable dec-P   dec-≈ dec-≺ []       (y ∷ ys) = yes halt
-  decidable dec-P   dec-≈ dec-≺ (x ∷ xs) []       = no λ()
-  decidable dec-P   dec-≈ dec-≺ (x ∷ xs) (y ∷ ys) with dec-≺ x y
-  ... | yes x≺y = yes (this x≺y)
-  ... | no x≮y with dec-≈ x y
-  ...   | no x≉y = no (¬≤-this x≉y x≮y)
-  ...   | yes x≈y with decidable dec-P dec-≈ dec-≺ xs ys
-  ...     | yes xs<ys = yes (next x≈y xs<ys)
-  ...     | no  xs≮ys = no (¬≤-next x≮y xs≮ys)
+  module _ (dec-P : Dec P) (dec-≈ : Decidable _≈_) (dec-≺ : Decidable _≺_)
+    where
+
+    decidable : Decidable _<_
+    decidable []       []       =
+      map′ base (λ{ (base p) → p }) dec-P
+    decidable []       (y ∷ ys) = yes halt
+    decidable (x ∷ xs) []       = no λ()
+    decidable (x ∷ xs) (y ∷ ys) =
+      map′ [ this , uncurry next ] (λ { (this x≺y) → inj₁ x≺y
+                                      ; (next x≈y z) → inj₂ (x≈y , z)
+                                      })
+           (dec-≺ x y ⊎-dec (dec-≈ x y ×-dec decidable xs ys))

--- a/src/Data/List/Relation/Binary/Lex/Core.agda
+++ b/src/Data/List/Relation/Binary/Lex/Core.agda
@@ -102,12 +102,12 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
   []<[]-⇔ : P ⇔ [] < []
   []<[]-⇔ = equivalence base (λ { (base p) → p })
 
+  toSum : ∀ {x y xs ys} → (x ∷ xs) < (y ∷ ys) → (x ≺ y ⊎ (x ≈ y × xs < ys))
+  toSum (this x≺y) = inj₁ x≺y
+  toSum (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
+
   ∷<∷-⇔ : ∀ {x y xs ys} → (x ≺ y ⊎ (x ≈ y × xs < ys)) ⇔ (x ∷ xs) < (y ∷ ys)
-  ∷<∷-⇔ = equivalence
-    [ this , uncurry next ]
-    (λ { (this x≺y      ) → inj₁ x≺y
-       ; (next x≈y xs<ys) → inj₂ (x≈y , xs<ys)
-       })
+  ∷<∷-⇔ = equivalence [ this , uncurry next ] toSum
 
   module _ (dec-P : Dec P) (dec-≈ : Decidable _≈_) (dec-≺ : Decidable _≺_)
     where

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -117,12 +117,14 @@ respects₂ {_≈_ = _≈_} {_∼_} resp = respʳ , respˡ
   respˡ (x≈y ∷ xs≈ys) (x∼z ∷ xs∼zs) =
     proj₂ resp x≈y x∼z ∷ respˡ xs≈ys xs∼zs
 
-decidable : ∀ {_∼_ : REL A B ℓ} → Decidable _∼_ → Decidable (Pointwise _∼_)
-decidable dec []       []       = yes []
-decidable dec []       (y ∷ ys) = no (λ ())
-decidable dec (x ∷ xs) []       = no (λ ())
-decidable dec (x ∷ xs) (y ∷ ys) =
-  Dec.map′ (uncurry _∷_) uncons (dec x y ×-dec decidable dec xs ys)
+module _ {_∼_ : REL A B ℓ} (dec : Decidable _∼_) where
+
+  decidable : Decidable (Pointwise _∼_)
+  decidable []       []       = yes []
+  decidable []       (y ∷ ys) = no (λ ())
+  decidable (x ∷ xs) []       = no (λ ())
+  decidable (x ∷ xs) (y ∷ ys) =
+    Dec.map′ (uncurry _∷_) uncons (dec x y ×-dec decidable xs ys)
 
 module _ {_≈_ : Rel₂ A ℓ} where
 

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -488,16 +488,13 @@ module Disjointness {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   -- Present in both sublists: not disjoint.
   ⊆-disjoint? (x≈z ∷ τ₁) (y≈z ∷ τ₂) = no λ()
   -- Present in either sublist: ok.
-  ⊆-disjoint? (y ∷ʳ τ₁) (x≈y ∷ τ₂) with ⊆-disjoint? τ₁ τ₂
-  ... | yes d = yes (x≈y ∷ᵣ d)
-  ... | no ¬d = no λ{ (_ ∷ᵣ d) → ¬d d }
-  ⊆-disjoint? (x≈y ∷ τ₁) (y ∷ʳ τ₂) with ⊆-disjoint? τ₁ τ₂
-  ... | yes d = yes (x≈y ∷ₗ d)
-  ... | no ¬d = no λ{ (_ ∷ₗ d) → ¬d d }
+  ⊆-disjoint? (y ∷ʳ τ₁) (x≈y ∷ τ₂) =
+    Dec.map′ (x≈y ∷ᵣ_) (λ{ (_ ∷ᵣ d) → d }) (⊆-disjoint? τ₁ τ₂)
+  ⊆-disjoint? (x≈y ∷ τ₁) (y ∷ʳ τ₂) =
+    Dec.map′ (x≈y ∷ₗ_) (λ{ (_ ∷ₗ d) → d }) (⊆-disjoint? τ₁ τ₂)
   -- Present in neither sublist: ok.
-  ⊆-disjoint? (y ∷ʳ τ₁) (.y ∷ʳ τ₂) with ⊆-disjoint? τ₁ τ₂
-  ... | yes d = yes (y ∷ₙ d)
-  ... | no ¬d = no λ{ (_ ∷ₙ d) → ¬d d }
+  ⊆-disjoint? (y ∷ʳ τ₁) (.y ∷ʳ τ₂) =
+    Dec.map′ (y ∷ₙ_) (λ{ (_ ∷ₙ d) → d }) (⊆-disjoint? τ₁ τ₂)
 
   -- Disjoint is proof-irrelevant
 

--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -14,11 +14,13 @@ open import Data.Empty using (⊥)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional using (_∈_)
-open import Data.Product as Prod using (∃; -,_; _×_; _,_; proj₁; proj₂)
+open import Data.Product as Prod
+  using (∃; -,_; _×_; _,_; proj₁; proj₂; uncurry)
 open import Function
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary hiding (_∈_)
 open import Relation.Binary.PropositionalEquality as P
 
@@ -201,9 +203,7 @@ module _ {P : Pred A p} where
 
   all : Decidable P → Decidable (All P)
   all p []       = yes []
-  all p (x ∷ xs) with p x
-  ... | yes px = Dec.map′ (px ∷_) tail (all p xs)
-  ... | no ¬px = no (¬px ∘ head)
+  all p (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (p x ×-dec all p xs)
 
   universal : Universal P → Universal (All P)
   universal u []       = []

--- a/src/Data/List/Relation/Unary/AllPairs.agda
+++ b/src/Data/List/Relation/Unary/AllPairs.agda
@@ -13,7 +13,7 @@ module Data.List.Relation.Unary.AllPairs
 
 open import Data.List using (List; []; _∷_)
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
-open import Data.Product as Prod using (_,_; _×_)
+open import Data.Product as Prod using (_,_; _×_; uncurry; <_,_>)
 open import Function using (id; _∘_)
 open import Level using (_⊔_)
 open import Relation.Binary as B using (Rel; _⇒_)
@@ -22,6 +22,7 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Unary as U renaming (_∩_ to _∩ᵘ_) hiding (_⇒_)
 open import Relation.Nullary using (yes; no)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -36,6 +37,9 @@ head (px ∷ pxs) = px
 
 tail : ∀ {x xs} → AllPairs R (x ∷ xs) → AllPairs R xs
 tail (px ∷ pxs) = pxs
+
+uncons : ∀ {x xs} → AllPairs R (x ∷ xs) → All (R x) xs × AllPairs R xs
+uncons = < head , tail >
 
 module _ {q} {S : Rel A q} where
 
@@ -66,9 +70,8 @@ module _ {s} {S : Rel A s} where
 
 allPairs? : B.Decidable R → U.Decidable (AllPairs R)
 allPairs? R? []       = yes []
-allPairs? R? (x ∷ xs) with All.all (R? x) xs
-... | yes px = Dec.map′ (px ∷_) tail (allPairs? R? xs)
-... | no ¬px = no (¬px ∘ head)
+allPairs? R? (x ∷ xs) =
+  Dec.map′ (uncurry _∷_) uncons (All.all (R? x) xs ×-dec allPairs? R? xs)
 
 irrelevant : B.Irrelevant R → U.Irrelevant (AllPairs R)
 irrelevant irr []           []           = refl

--- a/src/Data/List/Relation/Unary/Any.agda
+++ b/src/Data/List/Relation/Unary/Any.agda
@@ -17,6 +17,7 @@ open import Level using (Level; _⊔_)
 open import Relation.Nullary using (¬_; yes; no)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary hiding (_∈_)
 
 private
@@ -95,9 +96,7 @@ module _ {P : Pred A p} where
 
   any : Decidable P → Decidable (Any P)
   any P? []       = no λ()
-  any P? (x ∷ xs) with P? x
-  ... | yes px = yes (here px)
-  ... | no ¬px = Dec.map′ there (tail ¬px) (any P? xs)
+  any P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any P? xs)
 
   satisfiable : Satisfiable P → Satisfiable (Any P)
   satisfiable (x , Px) = [ x ] , here Px

--- a/src/Data/Maybe/Properties.agda
+++ b/src/Data/Maybe/Properties.agda
@@ -19,6 +19,7 @@ open import Level using (Level)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
 
 private
   variable
@@ -37,9 +38,7 @@ just-injective refl = refl
 ≡-dec _≟_ nothing  nothing  = yes refl
 ≡-dec _≟_ (just x) nothing  = no λ()
 ≡-dec _≟_ nothing  (just y) = no λ()
-≡-dec _≟_ (just x) (just y) with x ≟ y
-... | yes refl = yes refl
-... | no  x≢y  = no (x≢y ∘ just-injective)
+≡-dec _≟_ (just x) (just y) = map′ (cong just) just-injective (x ≟ y)
 
 ------------------------------------------------------------------------
 -- map

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -24,7 +24,7 @@ open import Induction.Lexicographic using (_⊗_; [_⊗_])
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; subst; cong)
-open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary using (Dec)
 open import Relation.Nullary.Negation using (contradiction)
 import Relation.Nullary.Decidable as Dec
 
@@ -201,9 +201,9 @@ mkGCD m n = gcd m n , gcd-GCD m n
 -- gcd as a proposition is decidable
 
 gcd? : (m n d : ℕ) → Dec (GCD m n d)
-gcd? m n d with gcd m n ≟ d
-... | yes P.refl = yes (gcd-GCD m n)
-... | no  gcd≢d  = no (gcd≢d ∘ GCD.unique (gcd-GCD m n))
+gcd? m n d =
+  Dec.map′ (λ { P.refl → gcd-GCD m n }) (GCD.unique (gcd-GCD m n))
+           (gcd m n ≟ d)
 
 ------------------------------------------------------------------------
 -- Calculating the gcd

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -148,10 +148,8 @@ m ≟ n = map′ (≡ᵇ⇒≡ m n) (≡⇒≡ᵇ m n) (T? (m ≡ᵇ n))
 infix 4 _≤?_ _≥?_
 
 _≤?_ : Decidable _≤_
-zero  ≤? _     = yes z≤n
-suc m ≤? n with T? (m <ᵇ n)
-... | yes m<n = yes (<ᵇ⇒< m n m<n)
-... | no  m≮n = no  (m≮n ∘ <⇒<ᵇ)
+zero  ≤? _ = yes z≤n
+suc m ≤? n = map′ (<ᵇ⇒< m n) <⇒<ᵇ (T? (m <ᵇ n))
 
 _≥?_ : Decidable _≥_
 _≥?_ = flip _≤?_

--- a/src/Data/Product/Properties/WithK.agda
+++ b/src/Data/Product/Properties/WithK.agda
@@ -14,6 +14,7 @@ open import Function
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
 
 ------------------------------------------------------------------------
 -- Equality
@@ -28,10 +29,10 @@ module _ {a b} {A : Set a} {B : A → Set b} where
   ,-injectiveʳ : ∀ {a} {b c : B a} → (Σ A B ∋ (a , b)) ≡ (a , c) → b ≡ c
   ,-injectiveʳ refl = refl
 
+  -- Note: this is not an instance of `_×-dec_`, because we need `x` and `y`
+  -- to have the same type before we can test them for equality.
   ≡-dec : Decidable _≡_ → (∀ {a} → Decidable {A = B a} _≡_) →
           Decidable {A = Σ A B} _≡_
   ≡-dec dec₁ dec₂ (a , x) (b , y) with dec₁ a b
   ... | no  a≢b  = no (a≢b ∘ ,-injectiveˡ)
-  ... | yes refl with dec₂ x y
-  ...   | no x≢y   = no (x≢y ∘ ,-injectiveʳ)
-  ...   | yes refl = yes refl
+  ... | yes refl = map′ (cong (a ,_)) ,-injectiveʳ (dec₂ x y)

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -17,13 +17,14 @@ open import Data.Nat as ℕ using (ℕ; zero; suc)
 import Data.Nat.Properties as ℕ
 open import Data.Nat.Coprimality as C using (Coprime; coprime?)
 open import Data.Nat.Divisibility hiding (/-cong)
-open import Data.Product using (_,_)
+open import Data.Product using (_×_; _,_)
 open import Data.Sum
 open import Level using (0ℓ)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no; recompute)
-open import Relation.Nullary.Decidable as Dec using (True; fromWitness)
+open import Relation.Nullary.Decidable as Dec using (True; fromWitness; map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 open import Algebra.FunctionProperties {A = ℚ} _≡_
 open import Algebra.FunctionProperties.Consequences.Propositional
@@ -40,13 +41,16 @@ private
 -- Propositional equality
 ------------------------------------------------------------------------
 
+mkℚ-injective : ∀ {n₁ n₂ d₁ d₂} .{c₁ : Coprime ∣ n₁ ∣ (suc d₁)}
+                                .{c₂ : Coprime ∣ n₂ ∣ (suc d₂)} →
+                mkℚ n₁ d₁ c₁ ≡ mkℚ n₂ d₂ c₂ → n₁ ≡ n₂ × d₁ ≡ d₂
+mkℚ-injective refl = refl , refl
+
 infix 4 _≟_
 
 _≟_ : Decidable {A = ℚ} _≡_
-mkℚ n₁ d₁ _ ≟ mkℚ n₂ d₂ _ with n₁ ℤ.≟ n₂ | d₁ ℕ.≟ d₂
-... | yes refl | yes refl = yes refl
-... | no n₁≢n₂ | _        = no λ { refl → n₁≢n₂ refl }
-... | _        | no d₁≢d₂ = no λ { refl → d₁≢d₂ refl }
+mkℚ n₁ d₁ _ ≟ mkℚ n₂ d₂ _ =
+  map′ (λ { (refl , refl) → refl }) mkℚ-injective (n₁ ℤ.≟ n₂ ×-dec d₁ ℕ.≟ d₂)
 
 ≡-setoid : Setoid 0ℓ 0ℓ
 ≡-setoid = setoid ℚ

--- a/src/Data/Sum/Properties.agda
+++ b/src/Data/Sum/Properties.agda
@@ -23,13 +23,13 @@ module _ {a b} {A : Set a} {B : Set b} where
   inj₂-injective : ∀ {x y} → (A ⊎ B ∋ inj₂ x) ≡ inj₂ y → x ≡ y
   inj₂-injective refl = refl
 
-  ≡-dec : Decidable _≡_ → Decidable _≡_ → Decidable {A = A ⊎ B} _≡_
-  ≡-dec dec₁ dec₂ (inj₁ x) (inj₁ y) =
-    map′ (cong inj₁) inj₁-injective (dec₁ x y)
-  ≡-dec dec₁ dec₂ (inj₁ x) (inj₂ y) = no λ()
-  ≡-dec dec₁ dec₂ (inj₂ x) (inj₁ y) = no λ()
-  ≡-dec dec₁ dec₂ (inj₂ x) (inj₂ y) =
-    map′ (cong inj₂) inj₂-injective (dec₂ x y)
+  module _ (dec₁ : Decidable _≡_) (dec₂ : Decidable _≡_) where
+
+    ≡-dec : Decidable {A = A ⊎ B} _≡_
+    ≡-dec (inj₁ x) (inj₁ y) = map′ (cong inj₁) inj₁-injective (dec₁ x y)
+    ≡-dec (inj₁ x) (inj₂ y) = no λ()
+    ≡-dec (inj₂ x) (inj₁ y) = no λ()
+    ≡-dec (inj₂ x) (inj₂ y) = map′ (cong inj₂) inj₂-injective (dec₂ x y)
 
   swap-involutive : swap {A = A} {B = B} ∘ swap ≗ id
   swap-involutive = [ (λ _ → refl) , (λ _ → refl) ]

--- a/src/Data/Sum/Properties.agda
+++ b/src/Data/Sum/Properties.agda
@@ -13,6 +13,7 @@ open import Function
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
 
 module _ {a b} {A : Set a} {B : Set b} where
 
@@ -23,14 +24,12 @@ module _ {a b} {A : Set a} {B : Set b} where
   inj₂-injective refl = refl
 
   ≡-dec : Decidable _≡_ → Decidable _≡_ → Decidable {A = A ⊎ B} _≡_
-  ≡-dec dec₁ dec₂ (inj₁ x) (inj₁ y) with dec₁ x y
-  ... | yes refl = yes refl
-  ... | no  x≢y  = no (x≢y ∘ inj₁-injective)
+  ≡-dec dec₁ dec₂ (inj₁ x) (inj₁ y) =
+    map′ (cong inj₁) inj₁-injective (dec₁ x y)
   ≡-dec dec₁ dec₂ (inj₁ x) (inj₂ y) = no λ()
   ≡-dec dec₁ dec₂ (inj₂ x) (inj₁ y) = no λ()
-  ≡-dec dec₁ dec₂ (inj₂ x) (inj₂ y) with dec₂ x y
-  ... | yes refl = yes refl
-  ... | no  x≢y  = no (x≢y ∘ inj₂-injective)
+  ≡-dec dec₁ dec₂ (inj₂ x) (inj₂ y) =
+    map′ (cong inj₂) inj₂-injective (dec₂ x y)
 
   swap-involutive : swap {A = A} {B = B} ∘ swap ≗ id
   swap-involutive = [ (λ _ → refl) , (λ _ → refl) ]

--- a/src/Data/These/Properties.agda
+++ b/src/Data/These/Properties.agda
@@ -8,11 +8,14 @@
 
 module Data.These.Properties where
 
+open import Data.Product
 open import Data.These
 open import Function using (_∘_)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- Equality
@@ -31,20 +34,19 @@ module _ {a b} {A : Set a} {B : Set b} where
   these-injectiveʳ : ∀ {x y : A} {a b : B} → these x a ≡ these y b → a ≡ b
   these-injectiveʳ refl = refl
 
+  these-injective : ∀ {x y : A} {a b : B} → these x a ≡ these y b → x ≡ y × a ≡ b
+  these-injective = < these-injectiveˡ , these-injectiveʳ >
+
   ≡-dec : Decidable _≡_ → Decidable _≡_ → Decidable {A = These A B} _≡_
-  ≡-dec dec₁ dec₂ (this x)    (this y)    with dec₁ x y
-  ... | yes refl = yes refl
-  ... | no  x≢y  = no (x≢y ∘ this-injective)
+  ≡-dec dec₁ dec₂ (this x)    (this y) =
+    map′ (cong this) this-injective (dec₁ x y)
   ≡-dec dec₁ dec₂ (this x)    (that y)    = no λ()
   ≡-dec dec₁ dec₂ (this x)    (these y b) = no λ()
   ≡-dec dec₁ dec₂ (that x)    (this y)    = no λ()
-  ≡-dec dec₁ dec₂ (that x)    (that y)    with dec₂ x y
-  ... | yes refl = yes refl
-  ... | no  x≢y  = no (x≢y ∘ that-injective)
+  ≡-dec dec₁ dec₂ (that x)    (that y) =
+    map′ (cong that) that-injective (dec₂ x y)
   ≡-dec dec₁ dec₂ (that x)    (these y b) = no λ()
   ≡-dec dec₁ dec₂ (these x a) (this y)    = no λ()
   ≡-dec dec₁ dec₂ (these x a) (that y)    = no λ()
-  ≡-dec dec₁ dec₂ (these x a) (these y b) with dec₁ x y | dec₂ a b
-  ... | yes refl | yes refl = yes refl
-  ... | no  x≢y  | _        = no (x≢y ∘ these-injectiveˡ)
-  ... | yes _    | no  a≢b  = no (a≢b ∘ these-injectiveʳ)
+  ≡-dec dec₁ dec₂ (these x a) (these y b) =
+    map′ (uncurry (cong₂ these)) these-injective (dec₁ x y ×-dec dec₂ a b)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -22,9 +22,11 @@ open import Function.Inverse using (_↔_; inverse)
 open import Level using (Level)
 open import Relation.Binary as B hiding (Decidable)
 open import Relation.Binary.PropositionalEquality as P
-  using (_≡_; _≢_; refl; _≗_)
+  using (_≡_; _≢_; refl; _≗_; cong₂)
 open import Relation.Unary using (Pred; Decidable)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 private
   variable
@@ -50,10 +52,9 @@ module _ {n} {x y : A} {xs ys : Vec A n} where
 
 ≡-dec : B.Decidable _≡_ → ∀ {n} → B.Decidable {A = Vec A n} _≡_
 ≡-dec _≟_ []       []       = yes refl
-≡-dec _≟_ (x ∷ xs) (y ∷ ys) with x ≟ y | ≡-dec _≟_ xs ys
-... | yes refl | yes refl = yes refl
-... | no  x≢y  | _        = no (x≢y   ∘ ∷-injectiveˡ)
-... | yes _    | no xs≢ys = no (xs≢ys ∘ ∷-injectiveʳ)
+≡-dec _≟_ (x ∷ xs) (y ∷ ys) =
+  map′ (uncurry (cong₂ _∷_)) ∷-injective
+       (x ≟ y ×-dec ≡-dec _≟_ xs ys)
 
 ------------------------------------------------------------------------
 -- _[_]=_

--- a/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
@@ -11,7 +11,7 @@ module Data.Vec.Relation.Binary.Pointwise.Inductive where
 open import Algebra.FunctionProperties
 open import Data.Fin using (Fin; zero; suc)
 open import Data.Nat using (ℕ; zero; suc)
-open import Data.Product using (_×_; _,_)
+open import Data.Product using (_×_; _,_; uncurry; <_,_>)
 open import Data.Vec as Vec hiding ([_]; head; tail; map; lookup)
 open import Data.Vec.Relation.Unary.All using (All; []; _∷_)
 open import Level using (Level; _⊔_)
@@ -20,6 +20,8 @@ open import Function.Equivalence using (_⇔_; equivalence)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
+open import Relation.Nullary.Decidable using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary using (Pred)
 
 private
@@ -64,6 +66,10 @@ module _ {_∼_ : REL A B ℓ} where
          Pointwise _∼_ (x ∷ xs) (y ∷ ys) → Pointwise _∼_ xs ys
   tail (x∼y ∷ xs∼ys) = xs∼ys
 
+  uncons : ∀ {m n x y} {xs : Vec A m} {ys : Vec B n} →
+           Pointwise _∼_ (x ∷ xs) (y ∷ ys) → x ∼ y × Pointwise _∼_ xs ys
+  uncons = < head , tail >
+
   lookup : ∀ {n} {xs : Vec A n} {ys : Vec B n} → Pointwise _∼_ xs ys →
            ∀ i → (Vec.lookup xs i) ∼ (Vec.lookup ys i)
   lookup (x∼y ∷ _)     zero    = x∼y
@@ -99,11 +105,8 @@ decidable : ∀ {_∼_ : REL A B ℓ} →
 decidable dec []       []       = yes []
 decidable dec []       (y ∷ ys) = no λ()
 decidable dec (x ∷ xs) []       = no λ()
-decidable dec (x ∷ xs) (y ∷ ys) with dec x y
-... | no ¬x∼y = no (¬x∼y ∘ head)
-... | yes x∼y with decidable dec xs ys
-...   | no ¬xs∼ys = no (¬xs∼ys ∘ tail)
-...   | yes xs∼ys = yes (x∼y ∷ xs∼ys)
+decidable dec (x ∷ xs) (y ∷ ys) =
+  map′ (uncurry _∷_) uncons (dec x y ×-dec decidable dec xs ys)
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Data/Vec/Relation/Unary/All.agda
+++ b/src/Data/Vec/Relation/Unary/All.agda
@@ -10,12 +10,13 @@ module Data.Vec.Relation.Unary.All where
 
 open import Data.Nat using (zero; suc)
 open import Data.Fin using (Fin; zero; suc)
-open import Data.Product as Prod using (_,_)
+open import Data.Product as Prod using (_×_; _,_; uncurry; <_,_>)
 open import Data.Vec as Vec using (Vec; []; _∷_)
 open import Function using (_∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary hiding (Irrelevant)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary
 open import Relation.Binary.PropositionalEquality as P using (subst)
 
@@ -45,6 +46,9 @@ module _ {P : Pred A p} where
 
   tail : ∀ {n x} {xs : Vec A n} → All P (x ∷ xs) → All P xs
   tail (px ∷ pxs) = pxs
+
+  uncons : ∀ {n x} {xs : Vec A n} → All P (x ∷ xs) → P x × All P xs
+  uncons = < head , tail >
 
   lookup : ∀ {n} {xs : Vec A n} (i : Fin n) →
            All P xs → P (Vec.lookup xs i)
@@ -86,9 +90,7 @@ module _ {P : Pred A p} where
 
   all : ∀ {n} → Decidable P → Decidable (All P {n})
   all P? []       = yes []
-  all P? (x ∷ xs) with P? x
-  ... | yes px = Dec.map′ (px ∷_) tail (all P? xs)
-  ... | no ¬px = no (¬px ∘ head)
+  all P? (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (P? x ×-dec all P? xs)
 
   universal : Universal P → ∀ {n} → Universal (All P {n})
   universal u []       = []

--- a/src/Data/Vec/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Relation/Unary/Any.agda
@@ -18,6 +18,7 @@ open import Level using (_⊔_)
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary
 
 ------------------------------------------------------------------------
@@ -72,9 +73,7 @@ module _ {p} {P : A → Set p} where
 
   any : Decidable P → ∀ {n} → Decidable (Any P {n})
   any P? []       = no λ()
-  any P? (x ∷ xs) with P? x
-  ... | yes px = yes (here px)
-  ... | no ¬px = Dec.map′ there (tail ¬px) (any P? xs)
+  any P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any P? xs)
 
   satisfiable : Satisfiable P → ∀ {n} → Satisfiable (Any P {suc n})
   satisfiable (x , p) {zero}  = x ∷ [] , here p

--- a/src/Data/Word/Unsafe.agda
+++ b/src/Data/Word/Unsafe.agda
@@ -11,6 +11,7 @@ module Data.Word.Unsafe where
 import Data.Nat as ℕ
 open import Data.Word using (Word64; toℕ)
 open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
 open import Relation.Binary.PropositionalEquality.TrustMe
 
@@ -18,7 +19,5 @@ open import Relation.Binary.PropositionalEquality.TrustMe
 -- An informative equality test.
 
 _≟_ : (a b : Word64) → Dec (a ≡ b)
-a ≟ b with toℕ a ℕ.≟ toℕ b
-... | yes _ = yes trustMe
-... | no  _ = no whatever
+a ≟ b = map′ (λ _ → trustMe) whatever (toℕ a ℕ.≟ toℕ b)
   where postulate whatever : _

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -8,7 +8,7 @@
 
 module Relation.Binary.Consequences where
 
-open import Data.Maybe.Base using (just; nothing)
+open import Data.Maybe.Base using (just; nothing; decToMaybe)
 open import Data.Sum as Sum using (inj₁; inj₂)
 open import Data.Product using (_,_)
 open import Data.Empty.Irrelevant using (⊥-elim)
@@ -17,6 +17,7 @@ open import Level using (Level)
 open import Relation.Binary.Core
 open import Relation.Binary.Definitions
 open import Relation.Nullary using (yes; no; recompute)
+open import Relation.Nullary.Decidable.Core using (map′)
 open import Relation.Unary using (∁)
 
 private
@@ -59,9 +60,7 @@ module _ {_≈_ : Rel A ℓ₁} {_≤_ : Rel A ℓ₂} where
                   Total _≤_ → Decidable _≈_ → Decidable _≤_
   total+dec⟶dec refl antisym total _≟_ x y with total x y
   ... | inj₁ x≤y = yes x≤y
-  ... | inj₂ y≤x with x ≟ y
-  ...   | yes x≈y = yes (refl x≈y)
-  ...   | no  x≉y = no (λ x≤y → x≉y (antisym x≤y y≤x))
+  ... | inj₂ y≤x = map′ refl (flip antisym y≤x) (x ≟ y)
 
 ------------------------------------------------------------------------
 -- Proofs for strict orders
@@ -151,9 +150,7 @@ module _  {_R_ : Rel A ℓ₁} {Q : Rel A ℓ₂} where
 module _ {P : REL A B p} where
 
   dec⟶weaklyDec : Decidable P → WeaklyDecidable P
-  dec⟶weaklyDec dec x y with dec x y
-  ... | yes p = just p
-  ... | no _ = nothing
+  dec⟶weaklyDec dec x y = decToMaybe (dec x y)
 
 module _ {P : REL A B ℓ₁} {Q : REL A B ℓ₂} where
 

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -61,13 +61,19 @@ module _ {_~_ : Rel A ℓ} where
   ... | tri≈ _ refl _ = inj₁ refl
   ... | tri> _ _    c = inj₂ [ c ]
 
-  Refl-⇔ : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
-  Refl-⇔ = equivalence
-    [ (λ { refl → refl }) , [_] ]′
-    (λ { refl → inj₁ refl ; [ x∼y ] → inj₂ x∼y })
+  fromSum : ∀ {a b} → a ≡ b ⊎ a ~ b → Refl _~_ a b
+  fromSum (inj₁ refl) = refl
+  fromSum (inj₂ y) = [ y ]
+
+  toSum : ∀ {a b} → Refl _~_ a b → a ≡ b ⊎ a ~ b
+  toSum [ x∼y ] = inj₂ x∼y
+  toSum refl = inj₁ refl
+
+  ⊎⇔Refl : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
+  ⊎⇔Refl = equivalence fromSum toSum
 
   dec : Decidable {A = A} _≡_ → Decidable _~_ → Decidable (Refl _~_)
-  dec ≡-dec ~-dec a b = Dec.map Refl-⇔ (≡-dec a b ⊎-dec ~-dec a b)
+  dec ≡-dec ~-dec a b = Dec.map ⊎⇔Refl (≡-dec a b ⊎-dec ~-dec a b)
 
   decidable : Trichotomous _≡_ _~_ → Decidable (Refl _~_)
   decidable ~-tri a b with ~-tri a b

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -10,13 +10,14 @@ module Relation.Binary.Construct.Closure.Reflexive.Properties where
 
 open import Data.Product as Prod
 open import Data.Sum as Sum
-open import Function
+open import Function.Equivalence using (_⇔_; equivalence)
+open import Function using (id)
 open import Level
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.Reflexive
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_; refl)
 open import Relation.Nullary
-open import Relation.Nullary.Decidable using (map′)
+import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary using (Pred)
@@ -60,11 +61,13 @@ module _ {_~_ : Rel A ℓ} where
   ... | tri≈ _ refl _ = inj₁ refl
   ... | tri> _ _    c = inj₂ [ c ]
 
+  Refl-⇔ : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
+  Refl-⇔ = equivalence
+    [ (λ { refl → refl }) , [_] ]′
+    (λ { refl → inj₁ refl ; [ x∼y ] → inj₂ x∼y })
+
   dec : Decidable {A = A} _≡_ → Decidable _~_ → Decidable (Refl _~_)
-  dec ≡-dec ~-dec a b =
-    map′ Sum.[ (λ { refl → refl }) , [_] ]
-         (λ { refl → inj₁ refl ; [ x∼y ] → inj₂ x∼y })
-         (≡-dec a b ⊎-dec ~-dec a b)
+  dec ≡-dec ~-dec a b = Dec.map Refl-⇔ (≡-dec a b ⊎-dec ~-dec a b)
 
   decidable : Trichotomous _≡_ _~_ → Decidable (Refl _~_)
   decidable ~-tri a b with ~-tri a b

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -9,14 +9,16 @@
 module Relation.Binary.Construct.Closure.Reflexive.Properties where
 
 open import Data.Product as Prod
-open import Data.Sum
+open import Data.Sum as Sum
 open import Function
 open import Level
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.Reflexive
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_; refl)
 open import Relation.Nullary
+open import Relation.Nullary.Decidable using (map′)
 open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary using (Pred)
 
 private
@@ -59,10 +61,10 @@ module _ {_~_ : Rel A ℓ} where
   ... | tri> _ _    c = inj₂ [ c ]
 
   dec : Decidable {A = A} _≡_ → Decidable _~_ → Decidable (Refl _~_)
-  dec ≡-dec ~-dec a b with ≡-dec a b | ~-dec a b
-  ... | _        | yes q = yes [ q ]
-  ... | yes refl | _     = yes refl
-  ... | no ¬p    | no ¬q = no λ { refl → ¬p refl; [ p ] → ¬q p }
+  dec ≡-dec ~-dec a b =
+    map′ Sum.[ (λ { refl → refl }) , [_] ]
+         (λ { refl → inj₁ refl ; [ x∼y ] → inj₂ x∼y })
+         (≡-dec a b ⊎-dec ~-dec a b)
 
   decidable : Trichotomous _≡_ _~_ → Decidable (Refl _~_)
   decidable ~-tri a b with ~-tri a b

--- a/src/Relation/Binary/Construct/Intersection.agda
+++ b/src/Relation/Binary/Construct/Intersection.agda
@@ -14,6 +14,7 @@ open import Function using (_∘_)
 open import Level using (_⊔_)
 open import Relation.Binary
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Product using (_×-dec_)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -77,10 +78,7 @@ module _ {a ℓ₁ ℓ₂ ℓ₃} {A : Set a}
 module _ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} {L : REL A B ℓ₁} {R : REL A B ℓ₂} where
 
   decidable : Decidable L → Decidable R → Decidable (L ∩ R)
-  decidable L? R? x y with L? x y | R? x y
-  ... | no ¬Lxy | _       = no (¬Lxy ∘ proj₁)
-  ... | yes _   | no ¬Rxy = no (¬Rxy ∘ proj₂)
-  ... | yes Lxy | yes Rxy = yes (Lxy , Rxy)
+  decidable L? R? x y = L? x y ×-dec R? x y
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Relation/Binary/Construct/NonStrictToStrict.agda
+++ b/src/Relation/Binary/Construct/NonStrictToStrict.agda
@@ -15,7 +15,8 @@ open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum using (inj₁; inj₂)
 open import Function using (_∘_; flip)
 open import Relation.Nullary using (¬_; yes; no)
-open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Negation using (contradiction; ¬?)
+open import Relation.Nullary.Product using (_×-dec_)
 
 private
   _≉_ : Rel A ℓ₁
@@ -106,10 +107,7 @@ x < y = x ≤ y × x ≉ y
 ...   | inj₂ y≤x = tri> (x≉y ∘ flip antisym y≤x ∘ proj₁) x≉y (y≤x , x≉y ∘ ≈-sym)
 
 <-decidable : Decidable _≈_ → Decidable _≤_ → Decidable _<_
-<-decidable _≟_ _≤?_ x y with x ≟ y | x ≤? y
-... | yes x≈y | _       = no  (flip proj₂ x≈y)
-... | no  x≉y | yes x≤y = yes (x≤y , x≉y)
-... | no  x≉y | no  x≰y = no  (x≰y ∘ proj₁)
+<-decidable _≟_ _≤?_ x y = x ≤? y ×-dec ¬? (x ≟ y)
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Relation/Binary/Construct/StrictToNonStrict.agda
+++ b/src/Relation/Binary/Construct/StrictToNonStrict.agda
@@ -17,12 +17,13 @@ module Relation.Binary.Construct.StrictToNonStrict
   (_≈_ : Rel A ℓ₁) (_<_ : Rel A ℓ₂)
   where
 
-open import Relation.Nullary
-open import Relation.Binary.Consequences
-open import Function
 open import Data.Product
 open import Data.Sum
 open import Data.Empty
+open import Function
+open import Relation.Binary.Consequences
+open import Relation.Nullary
+open import Relation.Nullary.Sum using (_⊎-dec_)
 
 ------------------------------------------------------------------------
 -- Conversion
@@ -93,10 +94,7 @@ total <-tri x y with <-tri x y
 ... | tri> x≮y x≉y x>y = inj₂ (inj₁ x>y)
 
 decidable : Decidable _≈_ → Decidable _<_ → Decidable _≤_
-decidable ≈-dec <-dec x y with ≈-dec x y | <-dec x y
-... | yes x≈y | _       = yes (inj₂ x≈y)
-... | no  x≉y | yes x<y = yes (inj₁ x<y)
-... | no  x≉y | no  x≮y = no [ x≮y , x≉y ]′
+decidable ≈-dec <-dec x y = <-dec x y ⊎-dec ≈-dec x y
 
 decidable' : Trichotomous _≈_ _<_ → Decidable _≤_
 decidable' compare x y with compare x y

--- a/src/Relation/Binary/Construct/Union.agda
+++ b/src/Relation/Binary/Construct/Union.agda
@@ -14,6 +14,7 @@ open import Function using (_∘_)
 open import Level using (_⊔_)
 open import Relation.Binary
 open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Sum using (_⊎-dec_)
 
 ------------------------------------------------------------------------
 -- Definition
@@ -62,7 +63,4 @@ module _ {a b ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b}
 module _ {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b} {L : REL A B ℓ₁} {R : REL A B ℓ₂} where
 
   decidable : Decidable L → Decidable R → Decidable (L ∪ R)
-  decidable L? R? x y with L? x y | R? x y
-  ... | yes Lxy | _       = yes (inj₁ Lxy)
-  ... | no  _   | yes Rxy = yes (inj₂ Rxy)
-  ... | no ¬Lxy | no ¬Rxy = no [ ¬Lxy , ¬Rxy ]
+  decidable L? R? x y = L? x y ⊎-dec R? x y

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -34,9 +34,11 @@ map : P ⇔ Q → Dec P → Dec Q
 map P⇔Q = map′ (to ⟨$⟩_) (from ⟨$⟩_)
   where open Equivalence P⇔Q
 
-module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} where
+module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
+         (inj : Injection A B)
+  where
 
-  open Injection
+  open Injection inj
   open Setoid A using () renaming (_≈_ to _≈A_)
   open Setoid B using () renaming (_≈_ to _≈B_)
 
@@ -44,7 +46,6 @@ module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} whe
   -- latter's equivalence relation is decidable, then the former's
   -- equivalence relation is also decidable.
 
-  via-injection : Injection A B → Decidable _≈B_ → Decidable _≈A_
-  via-injection inj dec x y with dec (to inj ⟨$⟩ x) (to inj ⟨$⟩ y)
-  ... | yes injx≈injy = yes (Injection.injective inj injx≈injy)
-  ... | no  injx≉injy = no (λ x≈y → injx≉injy (Π.cong (to inj) x≈y))
+  via-injection : Decidable _≈B_ → Decidable _≈A_
+  via-injection dec x y =
+    map′ injective (Π.cong to) (dec (to ⟨$⟩ x) (to ⟨$⟩ y))

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -31,11 +31,8 @@ open import Relation.Nullary.Decidable.Core public
 -- Maps
 
 map : P ⇔ Q → Dec P → Dec Q
-map P⇔Q (yes p) = yes (Equivalence.to P⇔Q ⟨$⟩ p)
-map P⇔Q (no ¬p) = no (¬p ∘ _⟨$⟩_ (Equivalence.from P⇔Q))
-
-map′ : (P → Q) → (Q → P) → Dec P → Dec Q
-map′ P→Q Q→P = map (equivalence P→Q Q→P)
+map P⇔Q = map′ (to ⟨$⟩_) (from ⟨$⟩_)
+  where open Equivalence P⇔Q
 
 module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂} where
 

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -103,3 +103,10 @@ dec-no (no ¬p′) ¬p = ¬p′ , refl
 dec-yes-irr : (p? : Dec P) → Irrelevant P → (p : P) → p? ≡ yes p
 dec-yes-irr p? irr p with dec-yes p? p
 ... | p′ , eq rewrite irr p p′ = eq
+
+------------------------------------------------------------------------
+-- Maps
+
+map′ : (P → Q) → (Q → P) → Dec P → Dec Q
+map′ P→Q Q→P (yes p) = yes (P→Q p)
+map′ P→Q Q→P (no ¬p) = no (¬p ∘ Q→P)


### PR DESCRIPTION
This pull request addresses point 3 of #932. Specifically, I've tried to find all instances where a decision procedure could be stated using `map′`, `_×-dec_`, `_⊎-dec_`, &c, and stated them that way. For example, suppose we started with:

```agda
  any : Decidable P → Decidable (Any P)
  any P? []       = no λ()
  any P? (x ∷ xs) with P? x
  ... | yes px = yes (here px)
  ... | no ¬px with any P? xs
  ...   | yes pxs = yes (there pxs)
  ...   | no ¬pxs = no λ { (here px) → ¬px px
                         ; (there pxs) → ¬pxs pxs
                         }
```

This would become:

```agda
  any : Decidable P → Decidable (Any P)
  any P? []       = no λ()
  any P? (x ∷ xs) =
    Dec.map′ [ here , there ]′ (λ { (here px) → inj₁ px
                                  ; (there pxs) → inj₂ pxs
                                  })
             (P? x ⊎-dec any P? xs)
```

In some cases, there are generally useful existing or new lemmas to fill the two directions of the `map′`. In the case of the example, we actually have

```agda
  toSum : Any P (x ∷ xs) → P x ⊎ Any P xs
  fromSum : P x ⊎ Any P xs → Any P (x ∷ xs)
```

This cuts the decision procedure down to just

```agda
  any : Decidable P → Decidable (Any P)
  any P? []       = no λ()
  any P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any P? xs)
```

All of these changes should be entirely backwards compatible, and for now not change the definitional behaviour of these procedures at all. The view is towards changing the implementation of `Dec` and the combinators, at which point the behaviour will be better. Nevertheless, I think these changes can be defended just from a stylistic point of view, in that they make clearer the logical operations that happen in the procedure.

Not in scope are complex procedures like `decFinSubset` from `Data.Fin.Properties`, which will require a more thorough rewrite to get the desired behaviour on the `does` field of new `Dec`.

A potential extension is to use `map` instead of `map′`, and state as lemmas all of the equivalences that get used by `map`. For example, we should be able to roll together `toSum` and `fromSum` into a proof of `Any P (x ∷ xs) ⇔ P x ⊎ Any P xs` (and I suppose even `Any P (x ∷ xs) ↔ P x ⊎ Any P xs`).