### PR TITLE
Redo Dec-related lemmas in the `Relation.Nullary` hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,25 @@ Notice that if we project the `does` field, we get a function which behaves
 identically to what we would expect of a boolean test. This can have
 advantages for both performance and reasoning.
 
+* Functions and lemmas about `Dec` have been rewritten to reflect the changes to
+  its definition.
+  In particular, `map′` and `map` produce their `does` result without any
+  pattern matching, and `isYes` matches only on the `does` field, and not the
+  `proof` field.
+  The change to `map′` and `map` means that `does (map q X?)` is definitionally
+  equal to `does X?`, which is a useful property whenever a computation depends
+  only on the yes/no result.
+  The function `isYes` still exists to be used in conjunction with `toWitness`
+  and similar (in proof automation), but doesn't require evaluation of the
+  `proof` part straight away.
+
+* The rest of the `Relation.Nullary` subtree has been updated to reflect the
+  changes to `Dec`.
+  All of the connective lemmas like `_×-dec_` have a `does` field written in
+  terms of boolean functions like `_∧_`.
+  As well as being less strict than the previous definitions, this should
+  improve readability when only the `does` field is involved.
+
 ### Other breaking changes
 
 #### Harmonizing `List.All` and `Vec` in their role as finite maps.
@@ -657,4 +676,30 @@ Other minor additions
   fromSum :  a ≡ b ⊎ a ~ b  → Refl _~_ a b
   toSum   :  Refl _~_ a b   → a ≡ b ⊎ a ~ b
   ⊎⇔Refl  : (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
+  ```
+
+* Added new definitions to `Relation.Nullary.Decidable`:
+  ```agda
+  dec-true  : (p? : Dec P) →   P → does p? ≡ true
+  dec-false : (p? : Dec P) → ¬ P → does p? ≡ false
+  ```
+
+* Added new definitions to `Relation.Nullary.Implication`:
+  ```agda
+  _→-reflects_ : Reflects P bp → Reflects Q bq → Reflects (P → Q) (not bp ∨ bq)
+  ```
+
+* Added new definitions to `Relation.Nullary.Negation`:
+  ```agda
+  ¬-reflects : Reflects P b → Reflects (¬ P) (not b)
+  ```
+
+* Added new definitions to `Relation.Nullary.Product`:
+  ```agda
+  _×-reflects_ : Reflects P bp → Reflects Q bq → Reflects (P × Q) (bp ∧ bq)
+  ```
+
+* Added new definitions to `Relation.Nullary.Sum`:
+  ```agda
+  _⊎-reflects_ : Reflects P bp → Reflects Q bq → Reflects (P ⊎ Q) (bp ∨ bq)
   ```

--- a/README/Dec.agda
+++ b/README/Dec.agda
@@ -24,6 +24,7 @@ open import Data.Product
 open import Data.Unit
 open import Function
 open import Relation.Binary.PropositionalEquality
+open import Relation.Nary
 open import Relation.Nullary.Product
 
 infix 4 _≟₀_ _≟₁_ _≟₂_
@@ -106,7 +107,7 @@ _ = λ m n → refl
 -- `map′` can be used in conjunction with combinators such as `_⊎-dec_` and
 -- `_×-dec_` to build complex (simply typed) decision procedures.
 
-module ListDecEq {a} {A : Set a} (_≟ᴬ_ : (x y : A) → Dec (x ≡ y)) where
+module ListDecEq₀ {a} {A : Set a} (_≟ᴬ_ : (x y : A) → Dec (x ≡ y)) where
 
   _≟ᴸᴬ_ : (xs ys : List A) → Dec (xs ≡ ys)
   []       ≟ᴸᴬ []       = yes refl
@@ -117,3 +118,15 @@ module ListDecEq {a} {A : Set a} (_≟ᴬ_ : (x y : A) → Dec (x ≡ y)) where
 
 -- The final case says that `x ∷ xs ≡ y ∷ ys` exactly when `x ≡ y` *and*
 -- `xs ≡ ys`. The proofs are updated by the first two arguments to `map′`.
+
+-- In the case of ≡-equality tests, the pattern
+-- `map′ (congₙ c) c-injective (x₀ ≟ y₀ ×-dec ... ×-dec xₙ₋₁ ≟ yₙ₋₁)`
+-- is captured by `≟-mapₙ n c c-injective (x₀ ≟ y₀) ... (xₙ₋₁ ≟ yₙ₋₁)`.
+
+module ListDecEq₁ {a} {A : Set a} (_≟ᴬ_ : (x y : A) → Dec (x ≡ y)) where
+
+  _≟ᴸᴬ_ : (xs ys : List A) → Dec (xs ≡ ys)
+  []       ≟ᴸᴬ []       = yes refl
+  []       ≟ᴸᴬ (y ∷ ys) = no λ ()
+  (x ∷ xs) ≟ᴸᴬ []       = no λ ()
+  (x ∷ xs) ≟ᴸᴬ (y ∷ ys) = ≟-mapₙ 2 _∷_ ∷-injective (x ≟ᴬ y) (xs ≟ᴸᴬ ys)

--- a/README/Dec.agda
+++ b/README/Dec.agda
@@ -1,0 +1,119 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Examples of decision procedures and how to use them
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module README.Dec where
+
+-- Reflects and Dec are defined in Relation.Nullary, and operations on them can
+-- be found in Relation.Nullary.Reflects and Relation.Nullary.Decidable.
+
+open import Relation.Nullary as Nullary
+open import Relation.Nullary.Reflects
+open import Relation.Nullary.Decidable
+
+open import Data.Bool
+open import Data.List
+open import Data.List.Properties using (∷-injective)
+open import Data.Nat
+open import Data.Nat.Properties using (suc-injective)
+open import Data.Product
+open import Data.Unit
+open import Function
+open import Relation.Binary.PropositionalEquality
+open import Relation.Nullary.Product
+
+infix 4 _≟₀_ _≟₁_ _≟₂_
+
+-- A proof of `Reflects P b` shows that a proposition `P` has the truth value of
+-- the boolean `b`. A proof of `Reflects P true` amounts to a proof of `P`, and
+-- a proof of `Reflects P false` amounts to a refutation of `P`.
+
+ex₀ : (n : ℕ) → Reflects (n ≡ n) true
+ex₀ n = ofʸ refl
+
+ex₁ : (n : ℕ) → Reflects (zero ≡ suc n) false
+ex₁ n = ofⁿ λ ()
+
+ex₂ : (b : Bool) → Reflects (T b) b
+ex₂ false = ofⁿ id
+ex₂ true  = ofʸ tt
+
+-- A proof of `Dec P` is a proof of `Reflects P b` for some `b`.
+-- `Dec P` is declared as a record, with fields:
+--   does : Bool
+--   proof : Reflects P does
+
+ex₃ : (b : Bool) → Dec (T b)
+does  (ex₃ b) = b
+proof (ex₃ b) = ex₂ b
+
+-- We also have pattern synonyms `yes` and `no`, allowing both fields to be
+-- given at once.
+
+ex₄ : (n : ℕ) → Dec (zero ≡ suc n)
+ex₄ n = no λ ()
+
+-- It is possible, but not ideal, to define recursive decision procedures using
+-- only the `yes` and `no` patterns. The following procedure decides whether two
+-- given natural numbers are equal.
+
+_≟₀_ : (m n : ℕ) → Dec (m ≡ n)
+zero  ≟₀ zero  = yes refl
+zero  ≟₀ suc n = no λ ()
+suc m ≟₀ zero  = no λ ()
+suc m ≟₀ suc n with m ≟₀ n
+... | yes p = yes (cong suc p)
+... | no ¬p = no (¬p ∘ suc-injective)
+
+-- In this case, we can see that `does (suc m ≟ suc n)` should be equal to
+-- `does (m ≟ n)`, because a `yes` from `m ≟ n` gives rise to a `yes` from the
+-- result, and similarly for `no`. However, in the above definition, this
+-- equality does not hold definitionally, because we always do a case split
+-- before returning a result. To avoid this, we can return the `does` part
+-- separately, before any pattern matching.
+
+_≟₁_ : (m n : ℕ) → Dec (m ≡ n)
+zero  ≟₁ zero  = yes refl
+zero  ≟₁ suc n = no λ ()
+suc m ≟₁ zero  = no λ ()
+does  (suc m ≟₁ suc n) = does (m ≟₁ n)
+proof (suc m ≟₁ suc n) with m ≟₁ n
+... | yes p = ofʸ (cong suc p)
+... | no ¬p = ofⁿ (¬p ∘ suc-injective)
+
+-- We now get definitional equalities such as the following.
+
+_ : (m n : ℕ) → does (5 + m ≟₁ 3 + n) ≡ does (2 + m ≟₁ n)
+_ = λ m n → refl
+
+-- Even better, from a maintainability point of view, is to use `map` or `map′`,
+-- both of which capture the pattern of the `does` field remaining the same, but
+-- the `proof` field being updated.
+
+_≟₂_ : (m n : ℕ) → Dec (m ≡ n)
+zero  ≟₂ zero  = yes refl
+zero  ≟₂ suc n = no λ ()
+suc m ≟₂ zero  = no λ ()
+suc m ≟₂ suc n = map′ (cong suc) suc-injective (m ≟₂ n)
+
+_ : (m n : ℕ) → does (5 + m ≟₂ 3 + n) ≡ does (2 + m ≟₂ n)
+_ = λ m n → refl
+
+-- `map′` can be used in conjunction with combinators such as `_⊎-dec_` and
+-- `_×-dec_` to build complex (simply typed) decision procedures.
+
+module ListDecEq {a} {A : Set a} (_≟ᴬ_ : (x y : A) → Dec (x ≡ y)) where
+
+  _≟ᴸᴬ_ : (xs ys : List A) → Dec (xs ≡ ys)
+  []       ≟ᴸᴬ []       = yes refl
+  []       ≟ᴸᴬ (y ∷ ys) = no λ ()
+  (x ∷ xs) ≟ᴸᴬ []       = no λ ()
+  (x ∷ xs) ≟ᴸᴬ (y ∷ ys) =
+    map′ (uncurry (cong₂ _∷_)) ∷-injective (x ≟ᴬ y ×-dec xs ≟ᴸᴬ ys)
+
+-- The final case says that `x ∷ xs ≡ y ∷ ys` exactly when `x ≡ y` *and*
+-- `xs ≡ ys`. The proofs are updated by the first two arguments to `map′`.

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -19,6 +19,7 @@ open import Data.Product
 open import Function.Core
 
 open import Agda.Builtin.Equality
+open import Relation.Nullary.Reflects
 open import Relation.Nullary
 
 private
@@ -27,9 +28,13 @@ private
     P : Set p
     Q : Set q
 
+-- `isYes` is a stricter version of `does`. The lack of computation means that
+-- we can recover the proposition `P` from `isYes P?` by unification. This is
+-- useful when we are using the decision procedure for proof automation.
+
 isYes : Dec P → Bool
-isYes (yes _) = true
-isYes (no _)  = false
+isYes ( true because _) = true
+isYes (false because _)  = false
 
 -- The traditional name for isYes is ⌊_⌋, indicating the stripping of evidence.
 ⌊_⌋ = isYes
@@ -46,24 +51,24 @@ False Q = T (isNo Q)
 -- Gives a witness to the "truth".
 
 toWitness : {Q : Dec P} → True Q → P
-toWitness {Q = yes p} _  = p
-toWitness {Q = no  _} ()
+toWitness {Q =  true because [p]} _  = invert [p]
+toWitness {Q = false because  _ } ()
 
 -- Establishes a "truth", given a witness.
 
 fromWitness : {Q : Dec P} → P → True Q
-fromWitness {Q = yes p} = const _
-fromWitness {Q = no ¬p} = ¬p
+fromWitness {Q =  true because   _ } = const _
+fromWitness {Q = false because [¬p]} = invert [¬p]
 
 -- Variants for False.
 
 toWitnessFalse : {Q : Dec P} → False Q → ¬ P
-toWitnessFalse {Q = yes _}  ()
-toWitnessFalse {Q = no  ¬p} _  = ¬p
+toWitnessFalse {Q =  true because   _ }  ()
+toWitnessFalse {Q = false because [¬p]} _  = invert [¬p]
 
 fromWitnessFalse : {Q : Dec P} → ¬ P → False Q
-fromWitnessFalse {Q = yes p} = flip _$_ p
-fromWitnessFalse {Q = no ¬p} = const _
+fromWitnessFalse {Q =  true because [p]} = flip _$_ (invert [p])
+fromWitnessFalse {Q = false because  _ } = const _
 
 -- If a decision procedure returns "yes", then we can extract the
 -- proof using from-yes.
@@ -71,34 +76,42 @@ fromWitnessFalse {Q = no ¬p} = const _
 module _ {p} {P : Set p} where
 
   From-yes : Dec P → Set p
-  From-yes (yes _) = P
-  From-yes (no  _) = Lift p ⊤
+  From-yes ( true because _) = P
+  From-yes (false because _) = Lift p ⊤
 
   from-yes : (p : Dec P) → From-yes p
-  from-yes (yes p) = p
-  from-yes (no  _) = _
+  from-yes (true because [p]) = invert [p]
+  from-yes (false because _ ) = _
 
 -- If a decision procedure returns "no", then we can extract the proof
 -- using from-no.
 
   From-no : Dec P → Set p
-  From-no (no  _) = ¬ P
-  From-no (yes _) = Lift p ⊤
+  From-no (false because _) = ¬ P
+  From-no ( true because _) = Lift p ⊤
 
   from-no : (p : Dec P) → From-no p
-  from-no (no ¬p) = ¬p
-  from-no (yes _) = _
+  from-no (false because [¬p]) = invert [¬p]
+  from-no ( true because   _ ) = _
 
 ------------------------------------------------------------------------
 -- Result of decidability
 
+dec-true : (p? : Dec P) → P → does p? ≡ true
+dec-true ( true because   _ ) p = refl
+dec-true (false because [¬p]) p = ⊥-elim (invert [¬p] p)
+
+dec-false : (p? : Dec P) → ¬ P → does p? ≡ false
+dec-false (false because  _ ) ¬p = refl
+dec-false ( true because [p]) ¬p = ⊥-elim (¬p (invert [p]))
+
 dec-yes : (p? : Dec P) → P → ∃ λ p′ → p? ≡ yes p′
-dec-yes (yes p′) p = p′ , refl
-dec-yes (no ¬p) p = ⊥-elim (¬p p)
+dec-yes p? p with dec-true p? p
+dec-yes (yes p′) p | refl = p′ , refl
 
 dec-no : (p? : Dec P) → ¬ P → ∃ λ ¬p′ → p? ≡ no ¬p′
-dec-no (yes p) ¬p  = ¬p , ⊥-elim (¬p p)
-dec-no (no ¬p′) ¬p = ¬p′ , refl
+dec-no p? ¬p with dec-false p? ¬p
+dec-no (no ¬p′) ¬p | refl = ¬p′ , refl
 
 dec-yes-irr : (p? : Dec P) → Irrelevant P → (p : P) → p? ≡ yes p
 dec-yes-irr p? irr p with dec-yes p? p
@@ -108,5 +121,6 @@ dec-yes-irr p? irr p with dec-yes p? p
 -- Maps
 
 map′ : (P → Q) → (Q → P) → Dec P → Dec Q
-map′ P→Q Q→P (yes p) = yes (P→Q p)
-map′ P→Q Q→P (no ¬p) = no (¬p ∘ Q→P)
+does  (map′ P→Q Q→P p?) = does p?
+proof (map′ P→Q Q→P ( true because  [p])) = ofʸ (P→Q (invert [p]))
+proof (map′ P→Q Q→P (false because [¬p])) = ofⁿ (invert [¬p] ∘ Q→P)

--- a/src/Relation/Nullary/Implication.agda
+++ b/src/Relation/Nullary/Implication.agda
@@ -8,7 +8,9 @@
 
 module Relation.Nullary.Implication where
 
+open import Data.Bool.Base
 open import Data.Empty
+open import Function.Core
 open import Relation.Nullary
 open import Level
 
@@ -21,9 +23,14 @@ private
 ------------------------------------------------------------------------
 -- Some properties which are preserved by _→_.
 
-infixr 2 _→-dec_
+infixr 2 _→-reflects_ _→-dec_
+
+_→-reflects_ : ∀ {bp bq} → Reflects P bp → Reflects Q bq →
+                           Reflects (P → Q) (not bp ∨ bq)
+ofʸ  p →-reflects ofʸ  q = ofʸ (const q)
+ofʸ  p →-reflects ofⁿ ¬q = ofⁿ (¬q ∘ (_$ p))
+ofⁿ ¬p →-reflects _      = ofʸ (⊥-elim ∘ ¬p)
 
 _→-dec_ : Dec P → Dec Q → Dec (P → Q)
-yes p →-dec no ¬q = no  (λ f → ¬q (f p))
-yes p →-dec yes q = yes (λ _ → q)
-no ¬p →-dec _     = yes (λ p → ⊥-elim (¬p p))
+does  (p? →-dec q?) = not (does p?) ∨ does q?
+proof (p? →-dec q?) = proof p? →-reflects proof q?

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -9,13 +9,14 @@
 module Relation.Nullary.Negation where
 
 open import Category.Monad
-open import Data.Bool.Base using (Bool; false; true; if_then_else_)
+open import Data.Bool.Base using (Bool; false; true; if_then_else_; not)
 open import Data.Empty
 open import Data.Product as Prod
 open import Data.Sum as Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Function
 open import Level
 open import Relation.Nullary
+open import Relation.Nullary.Decidable
 open import Relation.Unary
 
 private
@@ -44,9 +45,13 @@ private
 
 -- If we can decide P, then we can decide its negation.
 
+¬-reflects : ∀ {b} → Reflects P b → Reflects (¬ P) (not b)
+¬-reflects (ofʸ  p) = ofⁿ (_$ p)
+¬-reflects (ofⁿ ¬p) = ofʸ ¬p
+
 ¬? : Dec P → Dec (¬ P)
-¬? (yes p) = no (λ ¬p → ¬p p)
-¬? (no ¬p) = yes ¬p
+does  (¬? p?) = not (does p?)
+proof (¬? p?) = ¬-reflects (proof p?)
 
 ------------------------------------------------------------------------
 -- Quantifier juggling
@@ -96,8 +101,7 @@ decidable-stable (yes p) ¬¬p = p
 decidable-stable (no ¬p) ¬¬p = ⊥-elim (¬¬p ¬p)
 
 ¬-drop-Dec : Dec (¬ ¬ P) → Dec (¬ P)
-¬-drop-Dec (yes ¬¬p) = no ¬¬p
-¬-drop-Dec (no ¬¬¬p) = yes (negated-stable ¬¬¬p)
+¬-drop-Dec ¬¬p? = map′ negated-stable contradiction (¬? ¬¬p?)
 
 -- Double-negation is a monad (if we assume that all elements of ¬ ¬ P
 -- are equal).

--- a/src/Relation/Nullary/Product.agda
+++ b/src/Relation/Nullary/Product.agda
@@ -8,9 +8,11 @@
 
 module Relation.Nullary.Product where
 
+open import Data.Bool.Base
 open import Data.Product
 open import Function
 open import Level
+open import Relation.Nullary.Reflects
 open import Relation.Nullary
 
 private
@@ -22,9 +24,14 @@ private
 ------------------------------------------------------------------------
 -- Some properties which are preserved by _×_.
 
-infixr 2 _×-dec_
+infixr 2 _×-reflects_ _×-dec_
+
+_×-reflects_ : ∀ {bp bq} → Reflects P bp → Reflects Q bq →
+                           Reflects (P × Q) (bp ∧ bq)
+ofʸ  p ×-reflects ofʸ  q = ofʸ (p , q)
+ofʸ  p ×-reflects ofⁿ ¬q = ofⁿ (¬q ∘ proj₂)
+ofⁿ ¬p ×-reflects _      = ofⁿ (¬p ∘ proj₁)
 
 _×-dec_ : Dec P → Dec Q → Dec (P × Q)
-yes p ×-dec yes q = yes (p , q)
-no ¬p ×-dec _     = no (¬p ∘ proj₁)
-_     ×-dec no ¬q = no (¬q ∘ proj₂)
+does  (p? ×-dec q?) = does p? ∧ does q?
+proof (p? ×-dec q?) = proof p? ×-reflects proof q?

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -8,15 +8,16 @@
 
 module Relation.Nullary.Reflects where
 
+open import Agda.Builtin.Equality
 open import Data.Bool.Base
 open import Data.Empty
 open import Level
-open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary
 
-variable
-  p : Level
-  P : Set p
+private
+  variable
+    p : Level
+    P : Set p
 
 ------------------------------------------------------------------------
 -- `Reflects P b` is equivalent to `if b then P else ¬ P`.

--- a/src/Relation/Nullary/Sum.agda
+++ b/src/Relation/Nullary/Sum.agda
@@ -8,9 +8,11 @@
 
 module Relation.Nullary.Sum where
 
+open import Data.Bool.Base
 open import Data.Sum
 open import Data.Empty
 open import Level
+open import Relation.Nullary.Reflects
 open import Relation.Nullary
 
 private
@@ -22,17 +24,17 @@ private
 ------------------------------------------------------------------------
 -- Some properties which are preserved by _⊎_.
 
-infixr 1 _¬-⊎_ _⊎-dec_
+infixr 1 _¬-⊎_ _⊎-reflects_ _⊎-dec_
 
 _¬-⊎_ : ¬ P → ¬ Q → ¬ (P ⊎ Q)
-(¬p ¬-⊎ ¬q) (inj₁ p) = ¬p p
-(¬p ¬-⊎ ¬q) (inj₂ q) = ¬q q
+_¬-⊎_ = [_,_]
+
+_⊎-reflects_ : ∀ {bp bq} → Reflects P bp → Reflects Q bq →
+                           Reflects (P ⊎ Q) (bp ∨ bq)
+ofʸ  p ⊎-reflects      _ = ofʸ (inj₁ p)
+ofⁿ ¬p ⊎-reflects ofʸ  q = ofʸ (inj₂ q)
+ofⁿ ¬p ⊎-reflects ofⁿ ¬q = ofⁿ (¬p ¬-⊎ ¬q)
 
 _⊎-dec_ : Dec P → Dec Q → Dec (P ⊎ Q)
-yes p ⊎-dec _     = yes (inj₁ p)
-_     ⊎-dec yes q = yes (inj₂ q)
-no ¬p ⊎-dec no ¬q = no helper
-  where
-  helper : _ ⊎ _ → ⊥
-  helper (inj₁ p) = ¬p p
-  helper (inj₂ q) = ¬q q
+does  (p? ⊎-dec q?) = does p? ∨ does q?
+proof (p? ⊎-dec q?) = proof p? ⊎-reflects proof q?


### PR DESCRIPTION
This pull request addresses points 1 and 2 of the plan laid out in #932. The key changes are as follows.

1. `map′` now has definition
```agda
map′ : (P → Q) → (Q → P) → Dec P → Dec Q
does  (map′ P→Q Q→P p?) = does p?
proof (map′ P→Q Q→P ( true because  [p])) = ofʸ (P→Q (invert [p]))
proof (map′ P→Q Q→P (false because [¬p])) = ofⁿ (invert [¬p] ∘ Q→P)
```
This is maximally non-strict, and the `does` half is branch-free. Additionally (I don't know whether this is good or bad) when `b` is a value, `proof (map′ id id (b because r))` will reduce to `of (invert r)`. This is a form of η-expansion. If we wanted to avoid this, the proof of `map′` would pattern match on `[p]` and `[¬p]`, instead of using `invert` below the `ofʸ` and `ofⁿ` constructors.

2. `isYes` (with alias `⌊_⌋`) has definition
```agda
isYes : Dec P → Bool
isYes ( true because _) = true
isYes (false because _)  = false
```
I have added a comment above it explaining what it would be used for (i.e, proof automation). Not destructing the proof portion should bring performance improvements to code that doesn't need the proofs.

3. There are two new proofs in `Relation.Nullary.Decidable`.
```agda
dec-true : (p? : Dec P) → P → does p? ≡ true
dec-false : (p? : Dec P) → ¬ P → does p? ≡ false
```
These will now generally be more useful than `dec-yes` and `dec-no`.

4. Each logical connective has a new lemma like
```agda
_×-reflects_ : ∀ {bp bq} → Reflects P bp → Reflects Q bq → Reflects (P × Q) (bp ∧ bq)
```
which is used to prove the corresponding `_×-dec_`. These are proved by pattern matching on the `Reflects` proofs rather than the `Bool`s, which may be inconsistent with how `map′` was proved.

I'll update the changelog, but I'm not sure which of these changes changes should be noted, and to what level of detail. Definitely the new lemmas are included, but the change to `map′` feels like part of the whole `Dec` changes. The rest of the changes I think are unimportant.

I'll address the rest of the hierarchy in a separate pull request. Note, though, that, given #935, most of the decision procedures in the library will already have the improved behaviour after this pull request. IIRC, only a few more complicated decision procedures remain to be redone.