### PR TITLE
Rewrite definitions that use Dec to be less strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Bug-fixes
 Non-backwards compatible changes
 --------------------------------
 
+* The following lemmas may have breaking changes in their computational
+  behaviour.
+  - `Data.Fin.Permutation.Components`: `transpose-inverse`
+  - `Data.Fin.Properties`: `decFinSubset`, `all?`
+
+  Definitions that are sensitive to the behaviour of these lemmas, rather than
+  just their existence, may need to be revised.
+
 Other major additions
 ---------------------
 
@@ -39,4 +47,59 @@ Other minor additions
   x∈∁s⇒x∉s : x ∈ ∁ s → x ∉ s
   x∉∁s⇒x∈s : x ∉ ∁ s → x ∈ s
   x∉s⇒x∈∁s : x ∉ s → x ∈ ∁ s
+
+* Added a new proof to `Relation.Nullary.Decidable`:
+  ```agda
+  isYes≗does : (P? : Dec P) → isYes P? ≡ does P?
+  ```
+
+* Rewrote definitions branching on a `Dec` value to branch only on the boolean
+  `does` field, wherever possible. Furthermore, branching on the `proof` field
+  has been made as late as possible, using the `invert` lemma from
+  `Relation.Nullary.Reflects`.
+  
+  For example, the old definition of `filter` in `Data.List.Base` used the
+  `yes` and `no` patterns, which desugared to the following.
+  
+  ```agda
+  filter : ∀ {P : Pred A p} → Decidable P → List A → List A
+  filter P? [] = []
+  filter P? (x ∷ xs) with P? x
+  ... | false because ofⁿ _ = filter P? xs
+  ... |  true because ofʸ _ = x ∷ filter P? xs
+  ```
+  
+  Because the proofs (`ofⁿ _` and `ofʸ _`) are not giving us any information,
+  we do not need to match on them. We end up with the following definition,
+  where the `proof` field has been projected away.
+
+  ```agda
+  filter : ∀ {P : Pred A p} → Decidable P → List A → List A
+  filter P? [] = []
+  filter P? (x ∷ xs) with does (P? x)
+  ... | false = filter P? xs
+  ... | true  = x ∷ filter P? xs
+  ```
+  
+  Correspondingly, when proving a property of `filter`, we can often make a
+  similar change, but sometimes need the proof eventually. The following
+  example is adapted from `Data.List.Membership.Setoid.Properties`.
+  
+  ```agda
+  module _ {c ℓ p} (S : Setoid c ℓ) {P : Pred (Carrier S) p}
+           (P? : Decidable P) (resp : P Respects (Setoid._≈_ S)) where
+  
+    open Membership S using (_∈_)
+  
+    ∈-filter⁺ : ∀ {v xs} → v ∈ xs → P v → v ∈ filter P? xs
+    ∈-filter⁺ {xs = x ∷ _} (here v≈x) Pv with P? x
+    -- There is no matching on the proof, so we can emit the result without
+    -- computing the proof at all.
+    ... |  true because   _   = here v≈x
+    -- `invert` is used to get the proof just when it is needed.
+    ... | false because [¬Px] = contradiction (resp v≈x Pv) (invert [¬Px])
+    -- In the remaining cases, we make no use of the proof.
+    ∈-filter⁺ {xs = x ∷ _} (there v∈xs) Pv with does (P? x)
+    ... | true  = there (∈-filter⁺ v∈xs Pv)
+    ... | false = ∈-filter⁺ v∈xs Pv
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,10 @@ Other minor additions
   `does` field, wherever possible. Furthermore, branching on the `proof` field
   has been made as late as possible, using the `invert` lemma from
   `Relation.Nullary.Reflects`.
-  
+
   For example, the old definition of `filter` in `Data.List.Base` used the
   `yes` and `no` patterns, which desugared to the following.
-  
+
   ```agda
   filter : ∀ {P : Pred A p} → Decidable P → List A → List A
   filter P? [] = []
@@ -68,7 +68,7 @@ Other minor additions
   ... | false because ofⁿ _ = filter P? xs
   ... |  true because ofʸ _ = x ∷ filter P? xs
   ```
-  
+
   Because the proofs (`ofⁿ _` and `ofʸ _`) are not giving us any information,
   we do not need to match on them. We end up with the following definition,
   where the `proof` field has been projected away.
@@ -80,17 +80,17 @@ Other minor additions
   ... | false = filter P? xs
   ... | true  = x ∷ filter P? xs
   ```
-  
+
   Correspondingly, when proving a property of `filter`, we can often make a
   similar change, but sometimes need the proof eventually. The following
   example is adapted from `Data.List.Membership.Setoid.Properties`.
-  
+
   ```agda
   module _ {c ℓ p} (S : Setoid c ℓ) {P : Pred (Carrier S) p}
            (P? : Decidable P) (resp : P Respects (Setoid._≈_ S)) where
-  
+
     open Membership S using (_∈_)
-  
+
     ∈-filter⁺ : ∀ {v xs} → v ∈ xs → P v → v ∈ filter P? xs
     ∈-filter⁺ {xs = x ∷ _} (here v≈x) Pv with P? x
     -- There is no matching on the proof, so we can emit the result without

--- a/src/Algebra/Properties/CommutativeMonoid.agda
+++ b/src/Algebra/Properties/CommutativeMonoid.agda
@@ -17,6 +17,7 @@ open import Relation.Binary as B using (_Preserves_⟶_)
 open import Function
 open import Function.Equality using (_⟨$⟩_)
 open import Data.Product
+open import Data.Bool.Base using (Bool; true; false)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.List as List using ([]; _∷_)
@@ -28,9 +29,10 @@ open import Data.Table.Relation.Binary.Equality as TE using (_≗_)
 open import Data.Unit using (tt)
 import Data.Table.Properties as TP
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary as Nullary using (¬_; does; _because_)
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable using (⌊_⌋)
+open import Relation.Nullary.Decidable using (⌊_⌋; dec-true; dec-false)
+open import Relation.Nullary.Reflects using (invert)
 
 open CommutativeMonoid M
   renaming
@@ -147,13 +149,17 @@ sumₜ-permute {suc m} {suc n} t π = begin
 -- If the function takes the same value at 'i' and 'j', then transposing 'i' and
 -- 'j' then selecting 'j' is the same as selecting 'i'.
 
-select-transpose : ∀ {n} t (i j : Fin n) → lookup t i ≈ lookup t j → ∀ k → (lookup (select 0# j t) ∘ PermC.transpose i j) k ≈ lookup (select 0# i t) k
+select-transpose :
+  ∀ {n} t (i j : Fin n) → lookup t i ≈ lookup t j →
+  ∀ k → (lookup (select 0# j t) ∘ PermC.transpose i j) k
+      ≈  lookup (select 0# i t) k
 select-transpose _ i j e k with k FP.≟ i
-... | yes p rewrite P.≡-≟-identity FP._≟_ {j} P.refl = sym e
-... | no ¬p with k FP.≟ j
-...   | no ¬q rewrite proj₂ (P.≢-≟-identity FP._≟_ ¬q) = refl
-...   | yes q rewrite proj₂ (P.≢-≟-identity FP._≟_
-                               (¬p ∘ P.trans q ∘ P.sym)) = refl
+... | true  because _ rewrite dec-true (j FP.≟ j) P.refl = sym e
+... | false because [k≢i] with k FP.≟ j
+...   | true  because [k≡j]
+  rewrite dec-false (i FP.≟ j) (invert [k≢i] ∘ P.trans (invert [k≡j]) ∘ P.sym)
+        = refl
+...   | false because [k≢j] rewrite dec-false (k FP.≟ j) (invert [k≢j]) = refl
 
 -- Summing over a pulse gives you the single value picked out by the pulse.
 

--- a/src/Axiom/UniquenessOfIdentityProofs.agda
+++ b/src/Axiom/UniquenessOfIdentityProofs.agda
@@ -8,7 +8,9 @@
 
 module Axiom.UniquenessOfIdentityProofs where
 
+open import Data.Bool.Base using (true; false)
 open import Data.Empty
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary hiding (Irrelevant)
 open import Relation.Binary.Core
 open import Relation.Binary.Definitions
@@ -62,13 +64,13 @@ module Decidable⇒UIP
 
   ≡-normalise : _≡_ {A = A} ⇒ _≡_
   ≡-normalise {a} {b} a≡b with a ≟ b
-  ... | yes p = p
-  ... | no ¬p = ⊥-elim (¬p a≡b)
+  ... | true  because  [p] = invert [p]
+  ... | false because [¬p] = ⊥-elim (invert [¬p] a≡b)
 
   ≡-normalise-constant : ∀ {a b} (p q : a ≡ b) → ≡-normalise p ≡ ≡-normalise q
   ≡-normalise-constant {a} {b} p q with a ≟ b
-  ... | yes _ = refl
-  ... | no ¬p = ⊥-elim (¬p p)
+  ... | true  because   _  = refl
+  ... | false because [¬p] = ⊥-elim (invert [¬p] p)
 
   ≡-irrelevant : UIP A
   ≡-irrelevant = Constant⇒UIP.≡-irrelevant ≡-normalise ≡-normalise-constant

--- a/src/Category/Monad/Partiality.agda
+++ b/src/Category/Monad/Partiality.agda
@@ -910,9 +910,9 @@ private
   -- McCarthy's f91:
 
   f91′ : ℕ → ℕ ⊥P
-  f91′ n with n ≤? 100
-  ... | yes _ = later (♯ (f91′ (11 + n) >>= f91′))
-  ... | no  _ = now (n ∸ 10)
+  f91′ n with does (n ≤? 100)
+  ... | true  = later (♯ (f91′ (11 + n) >>= f91′))
+  ... | false = now (n ∸ 10)
 
   f91 : ℕ → ℕ ⊥
   f91 n = ⟦ f91′ n ⟧P

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -32,6 +32,7 @@ import Relation.Binary.Construct.FromRel as Ind
 import Relation.Binary.Reasoning.Preorder as PreR
 import Relation.Binary.Reasoning.PartialOrder as POR
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Nullary.Negation
 
@@ -527,8 +528,9 @@ finite-or-infinite :
 finite-or-infinite xs = helper <$> excluded-middle
   where
   helper : Dec (Finite xs) → Finite xs ⊎ Infinite xs
-  helper (yes fin) = inj₁ fin
-  helper (no ¬fin) = inj₂ $ not-finite-is-infinite xs ¬fin
+  helper ( true because  [fin]) = inj₁ (invert [fin])
+  helper (false because [¬fin]) =
+    inj₂ $ not-finite-is-infinite xs (invert [¬fin])
 
 -- Colists are not both finite and infinite.
 

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -20,7 +20,7 @@ open import Function.Equivalence
 open import Level using (Level; 0ℓ)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality hiding ([_])
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (ofʸ; ofⁿ; does; proof; yes; no)
 open import Relation.Nullary.Decidable using (True)
 import Relation.Unary as U
 
@@ -630,8 +630,9 @@ T-irrelevant : U.Irrelevant T
 T-irrelevant {true}  _  _  = refl
 
 T? : U.Decidable T
-T? true  = yes _
-T? false = no (λ ())
+does  (T? b) = b
+proof (T? true ) = ofʸ _
+proof (T? false) = ofⁿ λ()
 
 T?-diag : ∀ b → T b → True (T? b)
 T?-diag true  _ = _

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -12,13 +12,14 @@ open import Data.Nat
 open import Data.Nat.Properties
 open import Data.Nat.Solver
 open import Data.Fin as Fin using (Fin; zero; suc; toℕ)
+open import Data.Bool.Base using (Bool; true; false)
 open import Data.Char using (Char)
 open import Data.List.Base
 open import Data.Product
 open import Data.Vec as Vec using (Vec; _∷_; [])
 open import Data.Nat.DivMod
 open import Data.Nat.Induction
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 open import Relation.Nullary.Decidable
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; refl)
@@ -54,9 +55,9 @@ toNatDigits base@(suc (suc b)) n = aux (<-wellFounded n) []
   where
   aux : {n : ℕ} → Acc _<_ n → List ℕ → List ℕ
   aux {zero}        _        xs =  (0 ∷ xs)
-  aux {n@(suc n-1)} (acc wf) xs with 0 <? n / base
-  ... | no _    =  (n % base) ∷ xs
-  ... | yes 0<q =  aux (wf (n / base) q<n) ((n % base) ∷ xs)
+  aux {n@(suc n-1)} (acc wf) xs with does (0 <? n / base)
+  ... | false =  (n % base) ∷ xs
+  ... | true  =  aux (wf (n / base) q<n) ((n % base) ∷ xs)
     where
     q<n : n / base < n
     q<n = m/n<m n base (s≤s z≤n) (s≤s (s≤s z≤n))

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -47,13 +47,14 @@ reverse {suc n} i  = inject≤ (n ℕ- i) (ℕₚ.m∸n≤m (suc n) (toℕ i))
 transpose-inverse : ∀ {n} (i j : Fin n) {k} →
                     transpose i j (transpose j i k) ≡ k
 transpose-inverse i j {k} with k ≟ j
-... | yes p rewrite ≡-≟-identity _≟_ {x = i} refl = sym p
-... | no ¬p with k ≟ i
-...   | no ¬q rewrite proj₂ (≢-≟-identity _≟_ ¬q)
-                    | proj₂ (≢-≟-identity _≟_ ¬p) = refl
-...   | yes q with j ≟ i
-...     | yes r = trans r (sym q)
-...     | no ¬r rewrite ≡-≟-identity _≟_ {x = j} refl = sym q
+... | true  because [k≡j] rewrite dec-true (i ≟ i) refl = sym (invert [k≡j])
+... | false because [k≢j] with k ≟ i
+...   | true  because [k≡i]
+        rewrite dec-false (j ≟ i) (invert [k≢j] ∘ trans (invert [k≡i]) ∘ sym)
+                | dec-true (j ≟ j) refl
+                = sym (invert [k≡i])
+...   | false because [k≢i] rewrite dec-false (k ≟ i) (invert [k≢i])
+                                  | dec-false (k ≟ j) (invert [k≢j]) = refl
 
 reverse-prop : ∀ {n} → (i : Fin n) → toℕ (reverse i) ≡ n ∸ suc (toℕ i)
 reverse-prop {suc n} i = begin

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -14,7 +14,7 @@ open import Data.Fin.Properties
 open import Data.Nat as ℕ using (zero; suc; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Product using (proj₂)
-open import Function.Core using (_∘_)
+open import Function.Base using (_∘_)
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary using (does; _because_; yes; no)
 open import Relation.Nullary.Decidable using (dec-true; dec-false)

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -8,12 +8,16 @@
 
 module Data.Fin.Permutation.Components where
 
+open import Data.Bool.Base using (Bool; true; false)
 open import Data.Fin
 open import Data.Fin.Properties
 open import Data.Nat as ℕ using (zero; suc; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Product using (proj₂)
-open import Relation.Nullary using (yes; no)
+open import Function.Core using (_∘_)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (does; _because_; yes; no)
+open import Relation.Nullary.Decidable using (dec-true; dec-false)
 open import Relation.Binary.PropositionalEquality
 open import Algebra.Definitions using (Involutive)
 open ≡-Reasoning
@@ -25,11 +29,11 @@ open ≡-Reasoning
 -- 'tranpose i j' swaps the places of 'i' and 'j'.
 
 transpose : ∀ {n} → Fin n → Fin n → Fin n → Fin n
-transpose i j k with k ≟ i
-... | yes _ = j
-... | no  _ with k ≟ j
-...   | yes _ = i
-...   | no  _ = k
+transpose i j k with does (k ≟ i)
+... | true  = j
+... | false with does (k ≟ j)
+...   | true  = i
+...   | false = k
 
 -- reverse i = n ∸ 1 ∸ i
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -11,8 +11,10 @@ module Data.Fin.Properties where
 
 open import Category.Applicative using (RawApplicative)
 open import Category.Functor using (RawFunctor)
+open import Data.Bool.Base using (Bool; true; false; not; _∧_; _∨_)
 open import Data.Empty using (⊥-elim)
 open import Data.Fin.Base
+open import Data.Fin.Patterns
 open import Data.Nat as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
@@ -25,8 +27,10 @@ open import Relation.Binary as B hiding (Decidable)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; trans; cong; subst; module ≡-Reasoning)
 open import Relation.Nullary.Decidable as Dec using (map′)
+open import Relation.Nullary.Reflects
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary
+  using (Reflects; ofʸ; ofⁿ; Dec; _because_; does; proof; yes; no; ¬_)
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary as U
@@ -553,14 +557,17 @@ module _ {n p} {P : Pred (Fin (suc n)) p} where
 
 decFinSubset : ∀ {n p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
                Decidable Q → (∀ {f} → Q f → Dec (P f)) → Dec (Q ⊆ P)
-decFinSubset {zero}  {_}     {_} _  _  = yes λ{}
-decFinSubset {suc n} {P = P} {Q} Q? P? with decFinSubset (Q? ∘ suc) P?
-... | no ¬q⟶p = no (λ q⟶p → ¬q⟶p (q⟶p))
-... | yes q⟶p with Q? zero
-...   | no ¬q₀ = yes (∀-cons {P = Q U.⇒ P} (⊥-elim ∘ ¬q₀) (λ _ → q⟶p) _)
-...   | yes q₀ with P? q₀
-...     | no ¬p₀ = no (λ q⟶p → ¬p₀ (q⟶p q₀))
-...     | yes p₀ = yes (∀-cons {P = Q U.⇒ P} (λ _ → p₀) (λ _ → q⟶p) _)
+decFinSubset {zero} Q? P? = yes λ {}
+decFinSubset {suc n} {P = P} {Q} Q? P?
+  with Q? zero | ∀-cons {P = λ x → Q x → P x}
+... | false because [¬Q0] | cons =
+  map′ (λ f {x} → cons (⊥-elim ∘ invert [¬Q0]) (λ x → f {x}) x)
+       (λ f {x} → f {suc x})
+       (decFinSubset (Q? ∘ suc) P?)
+... | true  because  [Q0] | cons =
+  map′ (uncurry λ P0 rec {x} → cons (λ _ → P0) (λ x → rec {x}) x)
+       < _$ invert [Q0] , (λ f {x} → f {suc x}) >
+       (P? (invert [Q0]) ×-dec decFinSubset (Q? ∘ suc) P?)
 
 any? : ∀ {n p} {P : Fin n → Set p} → Decidable P → Dec (∃ P)
 any? {zero}  {P = _} P? = no λ { (() , _) }
@@ -571,6 +578,15 @@ all? : ∀ {n p} {P : Pred (Fin n) p} →
 all? P? = map′ (λ ∀p f → ∀p tt) (λ ∀p {x} _ → ∀p x)
                (decFinSubset U? (λ {f} _ → P? f))
 
+private
+  -- A nice computational property of `all?`:
+  -- The boolean component of the result is exactly the
+  -- obvious fold of boolean tests (`foldr _∧_ true`).
+  note : ∀ {p} {P : Pred (Fin 3) p} (P? : Decidable P) →
+         ∃ λ z → does (all? P?) ≡ z
+  note P? = does (P? 0F) ∧ does (P? 1F) ∧ does (P? 2F) ∧ true
+          , refl
+
 -- If a decidable predicate P over a finite set is sometimes false,
 -- then we can find the smallest value for which this is the case.
 
@@ -578,9 +594,9 @@ all? P? = map′ (λ ∀p f → ∀p tt) (λ ∀p {x} _ → ∀p x)
                  ¬ (∀ i → P i) → ∃ λ i → ¬ P i × ((j : Fin′ i) → P (inject j))
 ¬∀⟶∃¬-smallest zero    P P? ¬∀P = contradiction (λ()) ¬∀P
 ¬∀⟶∃¬-smallest (suc n) P P? ¬∀P with P? zero
-... | no ¬P₀ = (zero , ¬P₀ , λ ())
-... | yes P₀ = map suc (map id (∀-cons P₀))
-  (¬∀⟶∃¬-smallest n (P ∘ suc) (P? ∘ suc) (¬∀P ∘ (∀-cons P₀)))
+... | false because [¬P₀] = (zero , invert [¬P₀] , λ ())
+... |  true because  [P₀] = map suc (map id (∀-cons (invert [P₀])))
+  (¬∀⟶∃¬-smallest n (P ∘ suc) (P? ∘ suc) (¬∀P ∘ (∀-cons (invert [P₀]))))
 
 -- When P is a decidable predicate over a finite set the following
 -- lemma can be proved.

--- a/src/Data/Graph/Acyclic.agda
+++ b/src/Data/Graph/Acyclic.agda
@@ -21,7 +21,7 @@ open import Data.Fin as Fin
 import Data.Fin.Properties as FP
 import Data.Fin.Permutation.Components as PC
 open import Data.Product as Prod using (∃; _×_; _,_)
-open import Data.Maybe.Base using (Maybe; nothing; just)
+open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; decToMaybe)
 open import Data.Empty
 open import Data.Unit.Base using (⊤; tt)
 open import Data.Vec as Vec using (Vec; []; _∷_)
@@ -237,9 +237,7 @@ preds (c & g) (suc i) =
             (List.map (Prod.map suc id) $ preds g i)
   where
   p : ∀ {e} {E : Set e} {n} (i : Fin n) → E × Fin n → Maybe (Fin′ (suc i) × E)
-  p i (e , j)  with i ≟ j
-  p i (e , .i) | yes P.refl = just (zero , e)
-  p i (e , j)  | no _       = nothing
+  p i (e , j) = Maybe.map (λ{ P.refl → zero , e }) (decToMaybe (i ≟ j))
 
 private
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -21,7 +21,7 @@ open import Data.Sum as Sum using (_⊎_; inj₁; inj₂)
 open import Data.These.Base as These using (These; this; that; these)
 open import Function using (id; _∘_ ; _∘′_; const; flip)
 open import Level using (Level)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 open import Relation.Unary using (Pred; Decidable)
 open import Relation.Unary.Properties using (∁?)
 
@@ -261,33 +261,33 @@ splitAt (suc n) (x ∷ xs) with splitAt n xs
 
 takeWhile : ∀ {P : Pred A p} → Decidable P → List A → List A
 takeWhile P? []       = []
-takeWhile P? (x ∷ xs) with P? x
-... | yes _ = x ∷ takeWhile P? xs
-... | no  _ = []
+takeWhile P? (x ∷ xs) with does (P? x)
+... | true  = x ∷ takeWhile P? xs
+... | false = []
 
 dropWhile : ∀ {P : Pred A p} → Decidable P → List A → List A
 dropWhile P? []       = []
-dropWhile P? (x ∷ xs) with P? x
-... | yes _ = dropWhile P? xs
-... | no  _ = x ∷ xs
+dropWhile P? (x ∷ xs) with does (P? x)
+... | true  = dropWhile P? xs
+... | false = x ∷ xs
 
 filter : ∀ {P : Pred A p} → Decidable P → List A → List A
 filter P? [] = []
-filter P? (x ∷ xs) with P? x
-... | no  _ = filter P? xs
-... | yes _ = x ∷ filter P? xs
+filter P? (x ∷ xs) with does (P? x)
+... | false = filter P? xs
+... | true  = x ∷ filter P? xs
 
 partition : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 partition P? []       = ([] , [])
-partition P? (x ∷ xs) with P? x | partition P? xs
-... | yes _ | (ys , zs) = (x ∷ ys , zs)
-... | no  _ | (ys , zs) = (ys , x ∷ zs)
+partition P? (x ∷ xs) with does (P? x) | partition P? xs
+... | true  | (ys , zs) = (x ∷ ys , zs)
+... | false | (ys , zs) = (ys , x ∷ zs)
 
 span : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 span P? []       = ([] , [])
-span P? (x ∷ xs) with P? x
-... | yes _ = Prod.map (x ∷_) id (span P? xs)
-... | no  _ = ([] , x ∷ xs)
+span P? (x ∷ xs) with does (P? x)
+... | true  = Prod.map (x ∷_) id (span P? xs)
+... | false = ([] , x ∷ xs)
 
 break : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 break P? = span (∁? P?)

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -66,17 +66,17 @@ private
     helper : ∀ {xs} (x₁∈xs : x₁ ∈ xs) (x₂∈xs : x₂ ∈ xs) →
              first-index x₁ x₁∈xs ≡ first-index x₂ x₂∈xs
     helper (here x₁≈x) (here x₂≈x)           = refl
-    helper (here x₁≈x) (there {x = x} x₂∈xs) with x₂ ≟ x
-    ... | yes x₂≈x = refl
-    ... | no  x₂≉x = ⊥-elim (x₂≉x (trans (sym x₁≈x₂) x₁≈x))
-    helper (there {x = x} x₁∈xs) (here x₂≈x) with x₁ ≟ x
-    ... | yes x₁≈x = refl
-    ... | no  x₁≉x = ⊥-elim (x₁≉x (trans x₁≈x₂ x₂≈x))
+    helper (here x₁≈x) (there {x = x} x₂∈xs)
+      with x₂ ≟ x | dec-true (x₂ ≟ x) (trans (sym x₁≈x₂) x₁≈x)
+    ... | _ | refl = refl
+    helper (there {x = x} x₁∈xs) (here x₂≈x)
+      with x₁ ≟ x | dec-true (x₁ ≟ x) (trans x₁≈x₂ x₂≈x)
+    ... | _ | refl = refl
     helper (there {x = x} x₁∈xs) (there x₂∈xs) with x₁ ≟ x | x₂ ≟ x
-    ... | yes x₁≈x | yes x₂≈x = refl
+    ... | true  because _ | true  because _ = refl
+    ... | false because _ | false because _ = cong suc $ helper x₁∈xs x₂∈xs
     ... | yes x₁≈x | no  x₂≉x = ⊥-elim (x₂≉x (trans (sym x₁≈x₂) x₁≈x))
     ... | no  x₁≉x | yes x₂≈x = ⊥-elim (x₁≉x (trans x₁≈x₂ x₂≈x))
-    ... | no  x₁≉x | no  x₂≉x = cong suc $ helper x₁∈xs x₂∈xs
 
   -- first-index is injective in its first argument.
 

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -20,13 +20,16 @@ open import Function.Base
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Injection
   using (Injection; module Injection)
+open import Data.Bool.Base using (true; false)
 open import Data.List hiding (lookup)
 open import Data.List.Relation.Unary.Any as Any using (here; there)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Product
 open import Data.Sum
 open import Data.Sum.Properties
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
+open import Relation.Nullary.Decidable using (dec-true; dec-false)
 open import Relation.Binary.PropositionalEquality as PropEq
   using (_≡_; _≢_; refl; cong)
 open PropEq.≡-Reasoning
@@ -46,8 +49,8 @@ private
   first-occurrence : ∀ {xs} x → x ∈ xs → x ∈ xs
   first-occurrence x (here x≈y)           = here x≈y
   first-occurrence x (there {x = y} x∈xs) with x ≟ y
-  ... | yes x≈y = here x≈y
-  ... | no  _   = there $ first-occurrence x x∈xs
+  ... | true  because [x≈y] = here (invert [x≈y])
+  ... | false because   _   = there $ first-occurrence x x∈xs
 
   -- The index of the first occurrence of x in xs.
 

--- a/src/Data/List/Fresh.agda
+++ b/src/Data/List/Fresh.agda
@@ -14,6 +14,7 @@
 module Data.List.Fresh where
 
 open import Level using (Level; _⊔_; Lift)
+open import Data.Bool.Base using (true; false)
 open import Data.Unit.Base
 open import Data.Product using (∃; _×_; _,_; -,_; proj₁; proj₂)
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
@@ -21,7 +22,7 @@ open import Data.List.Relation.Unary.AllPairs using (AllPairs; []; _∷_)
 open import Data.Maybe.Base as Maybe using (Maybe; just; nothing)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Function using (_∘′_; flip; id; _on_)
-open import Relation.Nullary      using (yes; no)
+open import Relation.Nullary      using (does)
 open import Relation.Unary   as U using (Pred)
 open import Relation.Binary  as B using (Rel)
 open import Relation.Nary
@@ -159,33 +160,33 @@ module _ {P : Pred A p} (P? : U.Decidable P) where
   takeWhile-# : ∀ {R : Rel A r} a (as : List# A R) → a # as → a # takeWhile as
 
   takeWhile []             = []
-  takeWhile (cons a as ps) with P? a
-  ... | yes _ = cons a (takeWhile as) (takeWhile-# a as ps)
-  ... | no _  = []
+  takeWhile (cons a as ps) with does (P? a)
+  ... | true  = cons a (takeWhile as) (takeWhile-# a as ps)
+  ... | false = []
 
   takeWhile-# a []        _        = _
-  takeWhile-# a (x ∷# xs) (p , ps) with P? x
-  ... | yes _ = p , takeWhile-# a xs ps
-  ... | no _  = _
+  takeWhile-# a (x ∷# xs) (p , ps) with does (P? x)
+  ... | true  = p , takeWhile-# a xs ps
+  ... | false = _
 
   dropWhile : {R : Rel A r} → List# A R → List# A R
   dropWhile []            = []
-  dropWhile aas@(a ∷# as) with P? a
-  ... | yes _ = dropWhile as
-  ... | no _  = aas
+  dropWhile aas@(a ∷# as) with does (P? a)
+  ... | true  = dropWhile as
+  ... | false = aas
 
   filter   : {R : Rel A r} → List# A R → List# A R
   filter-# : ∀ {R : Rel A r} a (as : List# A R) → a # as → a # filter as
 
   filter []             = []
-  filter (cons a as ps) with P? a
-  ... | yes _ = cons a (filter as) (filter-# a as ps)
-  ... | no _  = filter as
+  filter (cons a as ps) with does (P? a)
+  ... | true  = cons a (filter as) (filter-# a as ps)
+  ... | false = filter as
 
   filter-# a []        _        = _
-  filter-# a (x ∷# xs) (p , ps) with P? x
-  ... | yes _ = p , filter-# a xs ps
-  ... | no _  = filter-# a xs ps
+  filter-# a (x ∷# xs) (p , ps) with does (P? x)
+  ... | true  = p , filter-# a xs ps
+  ... | false = filter-# a xs ps
 
 ------------------------------------------------------------------------
 -- Relationship to List and AllPairs

--- a/src/Data/List/Fresh/Relation/Unary/Any/Properties.agda
+++ b/src/Data/List/Fresh/Relation/Unary/Any/Properties.agda
@@ -9,11 +9,13 @@
 module Data.List.Fresh.Relation.Unary.Any.Properties where
 
 open import Level using (Level; _⊔_; Lift)
+open import Data.Bool.Base using (true; false)
 open import Data.Empty
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Product using (_,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Function using (_∘′_)
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Unary  as U using (Pred)
 open import Relation.Binary as B using (Rel)
@@ -56,14 +58,14 @@ module _ {R : Rel A r} {P : Pred A p} {Q : Pred A q} (P? : Decidable P) where
   ¬All⇒Any : {xs : List# A R} → ¬ (All P xs) → Any (∁ P) xs
   ¬All⇒Any {xs = []}      ¬ps = ⊥-elim (¬ps [])
   ¬All⇒Any {xs = x ∷# xs} ¬ps with P? x
-  ... | yes p = there (¬All⇒Any (¬ps ∘′ (p ∷_)))
-  ... | no ¬p = here ¬p
+  ... |  true because  [p] = there (¬All⇒Any (¬ps ∘′ (invert [p] ∷_)))
+  ... | false because [¬p] = here (invert [¬p])
 
   ¬Any⇒All : {xs : List# A R} → ¬ (Any P xs) → All (∁ P) xs
   ¬Any⇒All {xs = []}      ¬ps = []
   ¬Any⇒All {xs = x ∷# xs} ¬ps with P? x
-  ... | yes p = ⊥-elim (¬ps (here p))
-  ... | no ¬p = ¬p ∷ ¬Any⇒All (¬ps ∘′ there)
+  ... |  true because  [p] = ⊥-elim (¬ps (here (invert [p])))
+  ... | false because [¬p] = invert [¬p] ∷ ¬Any⇒All (¬ps ∘′ there)
 
 ------------------------------------------------------------------------
 -- remove

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -39,7 +39,8 @@ open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; trans; cong; subst; →-to-⟶; _≗_)
 import Relation.Binary.Properties.DecTotalOrder as DTOProperties
 open import Relation.Unary using (_⟨×⟩_; Decidable)
-open import Relation.Nullary using (¬_; Dec; yes; no)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (¬_; Dec; does; yes; no)
 open import Relation.Nullary.Negation
 
 private
@@ -273,9 +274,9 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = excluded-middle helper
   helper (yes (i , fᵢ≡x)) = finite f′-inj xs f′ⱼ∈xs
     where
     f′ : ℕ → _
-    f′ j with i ≤? j
-    ... | yes i≤j = f (suc j)
-    ... | no  i≰j = f j
+    f′ j with does (i ≤? j)
+    ... | true  = f (suc j)
+    ... | false = f j
 
     ∈-if-not-i : ∀ {j} → i ≢ j → f j ∈ xs
     ∈-if-not-i i≢j = not-x (i≢j ∘ f-inj ∘ trans fᵢ≡x ∘ sym)

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -9,6 +9,7 @@
 module Data.List.Membership.Setoid.Properties where
 
 open import Algebra using (Op₂; Selective)
+open import Data.Bool.Base using (true; false)
 open import Data.Fin using (Fin; zero; suc)
 open import Data.List
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
@@ -25,7 +26,8 @@ open import Function using (_$_; flip; _∘_; id)
 open import Relation.Binary as B hiding (Decidable)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Unary as U using (Decidable; Pred)
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (¬_; does; _because_)
 open import Relation.Nullary.Negation using (contradiction)
 open Setoid using (Carrier)
 
@@ -228,17 +230,17 @@ module _ {c ℓ p} (S : Setoid c ℓ) {P : Pred (Carrier S) p}
 
   ∈-filter⁺ : ∀ {v xs} → v ∈ xs → P v → v ∈ filter P? xs
   ∈-filter⁺ {xs = x ∷ _} (here v≈x) Pv with P? x
-  ... | yes _   = here v≈x
-  ... | no  ¬Px = contradiction (resp v≈x Pv) ¬Px
-  ∈-filter⁺ {xs = x ∷ _} (there v∈xs) Pv with P? x
-  ... | yes _ = there (∈-filter⁺ v∈xs Pv)
-  ... | no  _ = ∈-filter⁺ v∈xs Pv
+  ... |  true because   _   = here v≈x
+  ... | false because [¬Px] = contradiction (resp v≈x Pv) (invert [¬Px])
+  ∈-filter⁺ {xs = x ∷ _} (there v∈xs) Pv with does (P? x)
+  ... | true  = there (∈-filter⁺ v∈xs Pv)
+  ... | false = ∈-filter⁺ v∈xs Pv
 
   ∈-filter⁻ : ∀ {v xs} → v ∈ filter P? xs → v ∈ xs × P v
   ∈-filter⁻ {xs = x ∷ xs} v∈f[x∷xs] with P? x
-  ... | no  _  = Prod.map there id (∈-filter⁻ v∈f[x∷xs])
-  ... | yes Px with v∈f[x∷xs]
-  ...   | here  v≈x   = here v≈x , resp (sym v≈x) Px
+  ... | false because  _   = Prod.map there id (∈-filter⁻ v∈f[x∷xs])
+  ... |  true because [Px] with v∈f[x∷xs]
+  ...   | here  v≈x   = here v≈x , resp (sym v≈x) (invert [Px])
   ...   | there v∈fxs = Prod.map there id (∈-filter⁻ v∈fxs)
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -30,7 +30,8 @@ open import Level using (Level)
 import Relation.Binary as B
 import Relation.Binary.Reasoning.Setoid as EqR
 open import Relation.Binary.PropositionalEquality as P hiding ([_])
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (¬_; does; _because_; yes; no)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Nullary.Decidable using (isYes; map′)
 open import Relation.Nullary.Product using (_×-dec_)
@@ -1000,8 +1001,8 @@ module _ (P : A → Set p) (P? : Decidable P) where
   boolFilter-filters : ∀ xs → All P (boolFilter (isYes ∘ P?) xs)
   boolFilter-filters []       = []
   boolFilter-filters (x ∷ xs) with P? x
-  ... | yes px = px ∷ boolFilter-filters xs
-  ... | no ¬px = boolFilter-filters xs
+  ... | true  because [px] = invert [px] ∷ boolFilter-filters xs
+  ... | false because  _   = boolFilter-filters xs
   {-# WARNING_ON_USAGE boolFilter-filters
   "Warning: boolFilter was deprecated in v0.16.
   Please use filter instead."

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -10,6 +10,7 @@ module Data.List.Relation.Binary.Pointwise where
 
 open import Function.Base
 open import Function.Inverse using (Inverse)
+open import Data.Bool.Base using (true; false)
 open import Data.Product hiding (map)
 open import Data.List.Base as List hiding (map; head; tail; uncons)
 open import Data.List.Properties using (≡-dec; length-++)
@@ -287,10 +288,10 @@ module _ {R : REL A B ℓ} {P : Pred A p} {Q : Pred B q}
   filter⁺ : ∀ {as bs} → Pointwise R as bs → Pointwise R (filter P? as) (filter Q? bs)
   filter⁺ []       = []
   filter⁺ {a ∷ _} {b ∷ _} (r ∷ rs) with P? a | Q? b
-  ... | yes p | yes q = r ∷ filter⁺ rs
+  ... | true  because _ | true  because _ = r ∷ filter⁺ rs
+  ... | false because _ | false because _ = filter⁺ rs
   ... | yes p | no ¬q = contradiction (P⇒Q r p) ¬q
   ... | no ¬p | yes q = contradiction (Q⇒P r q) ¬p
-  ... | no ¬p | no ¬q = filter⁺ rs
 
 ------------------------------------------------------------------------
 -- replicate

--- a/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
@@ -8,6 +8,7 @@
 
 module Data.List.Relation.Binary.Prefix.Heterogeneous.Properties where
 
+open import Data.Bool.Base using (true; false)
 open import Data.Empty
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 import Data.List.Relation.Unary.All.Properties as All
@@ -20,7 +21,7 @@ open import Data.Nat.Properties using (suc-injective)
 open import Data.Product as Prod using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Function
 
-open import Relation.Nullary using (yes; no; ¬_)
+open import Relation.Nullary using (yes; no; ¬_; _because_)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary as U using (Pred)
@@ -108,10 +109,10 @@ module _ {a b r p q} {A : Set a} {B : Set b} {R : REL A B r}
   filter⁺ : ∀ {as bs} → Prefix R as bs → Prefix R (filter P? as) (filter Q? bs)
   filter⁺ [] = []
   filter⁺ {a ∷ as} {b ∷ bs} (r ∷ rs) with P? a | Q? b
-  ... | yes pa | yes qb = r ∷ filter⁺ rs
-  ... | yes pa | no ¬qb = ⊥-elim (¬qb (P⇒Q r pa))
-  ... | no ¬pa | yes qb = ⊥-elim (¬pa (Q⇒P r qb))
-  ... | no ¬pa | no ¬qb = filter⁺ rs
+  ... |  true because _ |  true because _ = r ∷ filter⁺ rs
+  ... | yes pa          | no ¬qb          = ⊥-elim (¬qb (P⇒Q r pa))
+  ... | no ¬pa          | yes qb          = ⊥-elim (¬pa (Q⇒P r qb))
+  ... | false because _ | false because _ = filter⁺ rs
 
 ------------------------------------------------------------------------
 -- take

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -17,7 +17,7 @@ import Data.List.Membership.Setoid as Membership
 open import Data.List.Membership.Setoid.Properties
 import Data.List.Relation.Binary.Subset.Setoid as Sublist
 import Data.List.Relation.Binary.Equality.Setoid as Equality
-open import Relation.Nullary using (¬_; yes; no)
+open import Relation.Nullary using (¬_; does)
 open import Relation.Unary using (Pred; Decidable)
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 
@@ -77,8 +77,8 @@ module _ {a p ℓ} (S : Setoid a ℓ)
   open Sublist S
 
   filter⁺ : ∀ xs → filter P? xs ⊆ xs
-  filter⁺ (x ∷ xs) y∈f[x∷xs] with P? x
-  ... | no  _ = there (filter⁺ xs y∈f[x∷xs])
-  ... | yes _ with y∈f[x∷xs]
+  filter⁺ (x ∷ xs) y∈f[x∷xs] with does (P? x)
+  ... | false = there (filter⁺ xs y∈f[x∷xs])
+  ... | true  with y∈f[x∷xs]
   ...   | here  y≈x     = here y≈x
   ...   | there y∈f[xs] = there (filter⁺ xs y∈f[xs])

--- a/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
@@ -8,6 +8,7 @@
 
 module Data.List.Relation.Binary.Suffix.Heterogeneous.Properties where
 
+open import Data.Bool.Base using (true; false)
 open import Data.List as List
   using (List; []; _∷_; _++_; length; filter; replicate; reverse; reverseAcc)
 open import Data.List.Relation.Binary.Pointwise as Pw
@@ -19,7 +20,7 @@ open import Data.List.Relation.Binary.Prefix.Heterogeneous as Prefix
 open import Data.Nat
 open import Data.Nat.Properties
 open import Function using (_$_; flip)
-open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary using (Dec; does; ¬_)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Unary as U using (Pred)
 open import Relation.Nullary.Negation using (contradiction)
@@ -174,9 +175,9 @@ module _ {a b r p q} {A : Set a} {B : Set b} {R : REL A B r}
   filter⁺ : ∀ {as bs} → Suffix R as bs →
             Suffix R (filter P? as) (filter Q? bs)
   filter⁺ (here rs) = here (Pw.filter⁺ P? Q? P⇒Q Q⇒P rs)
-  filter⁺ (there {a} suf) with Q? a
-  ... | yes q = there (filter⁺ suf)
-  ... | no ¬q = filter⁺ suf
+  filter⁺ (there {a} suf) with does (Q? a)
+  ... | true  = there (filter⁺ suf)
+  ... | false = filter⁺ suf
 
 ------------------------------------------------------------------------
 -- replicate

--- a/src/Data/List/Relation/Ternary/Interleaving/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Ternary/Interleaving/Setoid/Properties.agda
@@ -12,8 +12,9 @@ module Data.List.Relation.Ternary.Interleaving.Setoid.Properties
   {c ℓ} (S : Setoid c ℓ) where
 
 open import Data.List.Base using (List; []; _∷_; filter; _++_)
+open import Data.Bool.Base using (true; false)
 open import Relation.Unary using (Decidable)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 open import Relation.Nullary.Negation using (¬?)
 open import Function
 
@@ -39,6 +40,6 @@ module _ {p} {P : A → Set p} (P? : Decidable P) where
 
   filter⁺ : ∀ xs → Interleaving (filter P? xs) (filter (¬? ∘ P?) xs) xs
   filter⁺ []       = []
-  filter⁺ (x ∷ xs) with P? x
-  ... | yes px = refl ∷ˡ filter⁺ xs
-  ... | no ¬px = refl ∷ʳ filter⁺ xs
+  filter⁺ (x ∷ xs) with does (P? x)
+  ... | true  = refl ∷ˡ filter⁺ xs
+  ... | false = refl ∷ʳ filter⁺ xs

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -9,7 +9,7 @@
 module Data.List.Relation.Unary.All.Properties where
 
 open import Axiom.Extensionality.Propositional using (Extensionality)
-open import Data.Bool.Base using (Bool; T)
+open import Data.Bool.Base using (Bool; T; true; false)
 open import Data.Bool.Properties using (T-∧)
 open import Data.Empty
 open import Data.Fin using (Fin) renaming (zero to fzero; suc to fsuc)
@@ -43,6 +43,7 @@ open import Level using (Level)
 open import Relation.Binary using (REL; Setoid; _Respects_)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; cong; cong₂; _≗_)
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Unary
   using (Decidable; Pred; Universal) renaming (_⊆_ to _⋐_)
@@ -96,8 +97,8 @@ module _ {P : A → Set p} where
   ¬All⇒Any¬ : Decidable P → ∀ xs → ¬ All P xs → Any (¬_ ∘ P) xs
   ¬All⇒Any¬ dec []       ¬∀ = ⊥-elim (¬∀ [])
   ¬All⇒Any¬ dec (x ∷ xs) ¬∀ with dec x
-  ... | yes p = there (¬All⇒Any¬ dec xs (¬∀ ∘ _∷_ p))
-  ... | no ¬p = here ¬p
+  ... |  true because  [p] = there (¬All⇒Any¬ dec xs (¬∀ ∘ _∷_ (invert [p])))
+  ... | false because [¬p] = here (invert [¬p])
 
   Any¬→¬All : ∀ {xs} → Any (¬_ ∘ P) xs → ¬ All P xs
   Any¬→¬All (here  ¬p) = ¬p           ∘ All.head
@@ -493,16 +494,16 @@ module _ {P : A → Set p} (P? : Decidable P) where
   all-filter : ∀ xs → All P (filter P? xs)
   all-filter []       = []
   all-filter (x ∷ xs) with P? x
-  ... | yes Px = Px ∷ all-filter xs
-  ... | no  _  = all-filter xs
+  ... |  true because [Px] = invert [Px] ∷ all-filter xs
+  ... | false because  _   = all-filter xs
 
 module _ {P : A → Set p} {Q : A → Set q} (P? : Decidable P) where
 
   filter⁺ : ∀ {xs} → All Q xs → All Q (filter P? xs)
   filter⁺ {xs = _}     [] = []
-  filter⁺ {xs = x ∷ _} (Qx ∷ Qxs) with P? x
-  ... | no  _ = filter⁺ Qxs
-  ... | yes _ = Qx ∷ filter⁺ Qxs
+  filter⁺ {xs = x ∷ _} (Qx ∷ Qxs) with does (P? x)
+  ... | false = filter⁺ Qxs
+  ... | true  = Qx ∷ filter⁺ Qxs
 
 ------------------------------------------------------------------------
 -- zipWith

--- a/src/Data/List/Relation/Unary/AllPairs/Properties.agda
+++ b/src/Data/List/Relation/Unary/AllPairs/Properties.agda
@@ -12,6 +12,7 @@ open import Data.List hiding (any)
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 import Data.List.Relation.Unary.All.Properties as All
 open import Data.List.Relation.Unary.AllPairs as AllPairs using (AllPairs; []; _∷_)
+open import Data.Bool.Base using (true; false)
 open import Data.Fin using (Fin)
 open import Data.Fin.Properties using (suc-injective)
 open import Data.Nat using (zero; suc; _<_; z≤n; s≤s)
@@ -20,7 +21,7 @@ open import Function using (_∘_; flip)
 open import Relation.Binary using (Rel; DecSetoid)
 open import Relation.Binary.PropositionalEquality using (_≢_)
 open import Relation.Unary using (Pred; Decidable)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 
 ------------------------------------------------------------------------
 -- Introduction (⁺) and elimination (⁻) rules for list operations
@@ -120,6 +121,6 @@ module _ {a ℓ p} {A : Set a} {R : Rel A ℓ}
 
   filter⁺ : ∀ {xs} → AllPairs R xs → AllPairs R (filter P? xs)
   filter⁺ {_}      []           = []
-  filter⁺ {x ∷ xs} (x∉xs ∷ xs!) with P? x
-  ... | no  _ = filter⁺ xs!
-  ... | yes _ = All.filter⁺ P? x∉xs ∷ filter⁺ xs!
+  filter⁺ {x ∷ xs} (x∉xs ∷ xs!) with does (P? x)
+  ... | false = filter⁺ xs!
+  ... | true  = All.filter⁺ P? x∉xs ∷ filter⁺ xs!

--- a/src/Data/List/Relation/Unary/Linked.agda
+++ b/src/Data/List/Relation/Unary/Linked.agda
@@ -10,7 +10,7 @@ module Data.List.Relation.Unary.Linked {a} {A : Set a} where
 
 open import Data.List using (List; []; _∷_)
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
-open import Data.Product as Prod using (_,_; _×_)
+open import Data.Product as Prod using (_,_; _×_; uncurry; <_,_>)
 open import Function using (id; _∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Binary as B using (Rel; _⇒_)
@@ -18,7 +18,8 @@ open import Relation.Binary.Construct.Intersection renaming (_∩_ to _∩ᵇ_)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Unary as U renaming (_∩_ to _∩ᵘ_) hiding (_⇒_)
 open import Relation.Nullary using (yes; no)
-import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Decidable as Dec using (map′)
+open import Relation.Nullary.Product using (_×-dec_)
 
 private
   variable
@@ -83,10 +84,8 @@ module _ {R : Rel A ℓ} where
   linked? : B.Decidable R → U.Decidable (Linked R)
   linked? R? []           = yes []
   linked? R? (x ∷ [])     = yes [-]
-  linked? R? (x ∷ y ∷ xs) with R? x y | linked? R? (y ∷ xs)
-  ... | yes Rxy | yes Rxs = yes (Rxy ∷ Rxs)
-  ... | no ¬Rxy | _       = no (¬Rxy ∘ head)
-  ... | _       | no ¬Rxs = no (¬Rxs ∘ tail)
+  linked? R? (x ∷ y ∷ xs) =
+    map′ (uncurry _∷_) < head , tail > (R? x y ×-dec linked? R? (y ∷ xs))
 
   irrelevant : B.Irrelevant R → U.Irrelevant (Linked R)
   irrelevant irr []           []           = refl

--- a/src/Data/Maybe/Base.agda
+++ b/src/Data/Maybe/Base.agda
@@ -16,6 +16,7 @@ open import Data.Unit.Base using (⊤)
 open import Data.These.Base using (These; this; that; these)
 open import Data.Product as Prod using (_×_; _,_)
 open import Function.Base
+open import Relation.Nullary.Reflects
 open import Relation.Nullary
 
 private
@@ -48,8 +49,8 @@ is-nothing : Maybe A → Bool
 is-nothing = not ∘ is-just
 
 decToMaybe : Dec A → Maybe A
-decToMaybe (yes x) = just x
-decToMaybe (no _)  = nothing
+decToMaybe ( true because [a]) = just (invert [a])
+decToMaybe (false because  _ ) = nothing
 
 -- A dependent eliminator.
 

--- a/src/Data/Product/Properties/WithK.agda
+++ b/src/Data/Product/Properties/WithK.agda
@@ -8,12 +8,14 @@
 
 module Data.Product.Properties.WithK where
 
+open import Data.Bool.Base
 open import Data.Product
 open import Data.Product.Properties using (,-injectiveˡ)
 open import Function
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Reflects
+open import Relation.Nullary using (Dec; _because_; yes; no)
 open import Relation.Nullary.Decidable using (map′)
 
 ------------------------------------------------------------------------
@@ -34,5 +36,5 @@ module _ {a b} {A : Set a} {B : A → Set b} where
   ≡-dec : Decidable _≡_ → (∀ {a} → Decidable {A = B a} _≡_) →
           Decidable {A = Σ A B} _≡_
   ≡-dec dec₁ dec₂ (a , x) (b , y) with dec₁ a b
-  ... | no  a≢b  = no (a≢b ∘ ,-injectiveˡ)
+  ... | false because [a≢b] = no (invert [a≢b] ∘ ,-injectiveˡ)
   ... | yes refl = map′ (cong (a ,_)) ,-injectiveʳ (dec₂ x y)

--- a/src/Data/Record.agda
+++ b/src/Data/Record.agda
@@ -9,7 +9,7 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Data.Bool.Base using (if_then_else_)
+open import Data.Bool.Base using (true; false; if_then_else_)
 open import Data.Empty
 open import Data.List.Base
 open import Data.Product hiding (proj₁; proj₂)
@@ -91,7 +91,7 @@ infix 4 _∈_
 
 _∈_ : ∀ {s} → Label → Signature s → Set
 ℓ ∈ Sig =
-  foldr (λ ℓ′ → if isYes (ℓ ≟ ℓ′) then (λ _ → ⊤) else id) ⊥ (labels Sig)
+  foldr (λ ℓ′ → if does (ℓ ≟ ℓ′) then (λ _ → ⊤) else id) ⊥ (labels Sig)
 
 ------------------------------------------------------------------------
 -- Projections
@@ -102,12 +102,12 @@ _∈_ : ∀ {s} → Label → Signature s → Set
 Restrict : ∀ {s} (Sig : Signature s) (ℓ : Label) → ℓ ∈ Sig →
            Signature s
 Restrict ∅              ℓ ()
-Restrict (Sig , ℓ′ ∶ A) ℓ ℓ∈ with ℓ ≟ ℓ′
-... | yes _ = Sig
-... | no  _ = Restrict Sig ℓ ℓ∈
-Restrict (Sig , ℓ′ ≔ a) ℓ ℓ∈ with ℓ ≟ ℓ′
-... | yes _ = Sig
-... | no  _ = Restrict Sig ℓ ℓ∈
+Restrict (Sig , ℓ′ ∶ A) ℓ ℓ∈ with does (ℓ ≟ ℓ′)
+... | true  = Sig
+... | false = Restrict Sig ℓ ℓ∈
+Restrict (Sig , ℓ′ ≔ a) ℓ ℓ∈ with does (ℓ ≟ ℓ′)
+... | true  = Sig
+... | false = Restrict Sig ℓ ℓ∈
 
 Restricted : ∀ {s} (Sig : Signature s) (ℓ : Label) → ℓ ∈ Sig → Set s
 Restricted Sig ℓ ℓ∈ = Record (Restrict Sig ℓ ℓ∈)
@@ -115,12 +115,12 @@ Restricted Sig ℓ ℓ∈ = Record (Restrict Sig ℓ ℓ∈)
 Proj : ∀ {s} (Sig : Signature s) (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
        Restricted Sig ℓ ℓ∈ → Set s
 Proj ∅              ℓ {}
-Proj (Sig , ℓ′ ∶ A) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = A
-... | no  _ = Proj Sig ℓ {ℓ∈}
-Proj (_,_≔_ Sig ℓ′ {A = A} a) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = A
-... | no  _ = Proj Sig ℓ {ℓ∈}
+Proj (Sig , ℓ′ ∶ A) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = A
+... | false = Proj Sig ℓ {ℓ∈}
+Proj (_,_≔_ Sig ℓ′ {A = A} a) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = A
+... | false = Proj Sig ℓ {ℓ∈}
 
 -- Record restriction and projection.
 
@@ -129,12 +129,12 @@ infixl 5 _∣_
 _∣_ : ∀ {s} {Sig : Signature s} → Record Sig →
       (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} → Restricted Sig ℓ ℓ∈
 _∣_ {Sig = ∅}            r       ℓ {}
-_∣_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Σ.proj₁ r
-... | no  _ = _∣_ (Σ.proj₁ r) ℓ {ℓ∈}
-_∣_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Manifest-Σ.proj₁ r
-... | no  _ = _∣_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
+_∣_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = Σ.proj₁ r
+... | false = _∣_ (Σ.proj₁ r) ℓ {ℓ∈}
+_∣_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = Manifest-Σ.proj₁ r
+... | false = _∣_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
 
 infixl 5 _·_
 
@@ -142,12 +142,12 @@ _·_ : ∀ {s} {Sig : Signature s} (r : Record Sig)
       (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
       Proj Sig ℓ {ℓ∈} (r ∣ ℓ)
 _·_ {Sig = ∅}            r       ℓ {}
-_·_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Σ.proj₂ r
-... | no  _ = _·_ (Σ.proj₁ r) ℓ {ℓ∈}
-_·_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with ℓ ≟ ℓ′
-... | yes _ = Manifest-Σ.proj₂ r
-... | no  _ = _·_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
+_·_ {Sig = Sig , ℓ′ ∶ A} (rec r) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = Σ.proj₂ r
+... | false = _·_ (Σ.proj₁ r) ℓ {ℓ∈}
+_·_ {Sig = Sig , ℓ′ ≔ a} (rec r) ℓ {ℓ∈} with does (ℓ ≟ ℓ′)
+... | true  = Manifest-Σ.proj₂ r
+... | false = _·_ (Manifest-Σ.proj₁ r) ℓ {ℓ∈}
 
 ------------------------------------------------------------------------
 -- With
@@ -161,20 +161,20 @@ mutual
   _With_≔_ : ∀ {s} (Sig : Signature s) (ℓ : Label) {ℓ∈ : ℓ ∈ Sig} →
              ((r : Restricted Sig ℓ ℓ∈) → Proj Sig ℓ r) → Signature s
   _With_≔_ ∅ ℓ {} a
-  _With_≔_ (Sig , ℓ′ ∶ A)   ℓ {ℓ∈} a with ℓ ≟ ℓ′
-  ... | yes _ = Sig                   , ℓ′ ≔ a
-  ... | no  _ = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ∶ A ∘ drop-With
-  _With_≔_  (Sig , ℓ′ ≔ a′) ℓ {ℓ∈} a with ℓ ≟ ℓ′
-  ... | yes _ = Sig                   , ℓ′ ≔ a
-  ... | no  _ = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ≔ a′ ∘ drop-With
+  _With_≔_ (Sig , ℓ′ ∶ A)   ℓ {ℓ∈} a with does (ℓ ≟ ℓ′)
+  ... | true  = Sig                   , ℓ′ ≔ a
+  ... | false = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ∶ A ∘ drop-With
+  _With_≔_  (Sig , ℓ′ ≔ a′) ℓ {ℓ∈} a with does (ℓ ≟ ℓ′)
+  ... | true  = Sig                   , ℓ′ ≔ a
+  ... | false = _With_≔_ Sig ℓ {ℓ∈} a , ℓ′ ≔ a′ ∘ drop-With
 
   drop-With : ∀ {s} {Sig : Signature s} {ℓ : Label} {ℓ∈ : ℓ ∈ Sig}
               {a : (r : Restricted Sig ℓ ℓ∈) → Proj Sig ℓ r} →
               Record (_With_≔_ Sig ℓ {ℓ∈} a) → Record Sig
   drop-With {Sig = ∅} {ℓ∈ = ()}      r
-  drop-With {Sig = Sig , ℓ′ ∶ A} {ℓ} (rec r) with ℓ ≟ ℓ′
-  ... | yes _ = rec (Manifest-Σ.proj₁ r , Manifest-Σ.proj₂ r)
-  ... | no  _ = rec (drop-With (Σ.proj₁ r) , Σ.proj₂ r)
-  drop-With {Sig = Sig , ℓ′ ≔ a} {ℓ} (rec r) with ℓ ≟ ℓ′
-  ... | yes _ = rec (Manifest-Σ.proj₁ r ,)
-  ... | no  _ = rec (drop-With (Manifest-Σ.proj₁ r) ,)
+  drop-With {Sig = Sig , ℓ′ ∶ A} {ℓ} (rec r) with does (ℓ ≟ ℓ′)
+  ... | true  = rec (Manifest-Σ.proj₁ r , Manifest-Σ.proj₂ r)
+  ... | false = rec (drop-With (Σ.proj₁ r) , Σ.proj₂ r)
+  drop-With {Sig = Sig , ℓ′ ≔ a} {ℓ} (rec r) with does (ℓ ≟ ℓ′)
+  ... | true  = rec (Manifest-Σ.proj₁ r ,)
+  ... | false = rec (drop-With (Manifest-Σ.proj₁ r) ,)

--- a/src/Data/Sum/Base.agda
+++ b/src/Data/Sum/Base.agda
@@ -8,8 +8,10 @@
 
 module Data.Sum.Base where
 
+open import Data.Bool.Base using (true; false)
 open import Function.Base using (_∘_; _-[_]-_ ; id)
-open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (Dec; yes; no; _because_; ¬_)
 open import Level using (Level; _⊔_)
 
 private
@@ -67,8 +69,8 @@ f -⊎- g = f -[ _⊎_ ]- g
 -- Conversion back and forth with Dec
 
 fromDec : Dec A → A ⊎ ¬ A
-fromDec (yes p) = inj₁ p
-fromDec (no ¬p) = inj₂ ¬p
+fromDec ( true because  [p]) = inj₁ (invert  [p])
+fromDec (false because [¬p]) = inj₂ (invert [¬p])
 
 toDec : A ⊎ ¬ A → Dec A
 toDec (inj₁ p)  = yes p

--- a/src/Data/Table.agda
+++ b/src/Data/Table.agda
@@ -14,7 +14,7 @@ open import Data.Bool using (true; false)
 open import Data.Fin using (Fin; _≟_)
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Inverse using (Inverse; _↔_)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 open import Relation.Nullary.Decidable using (⌊_⌋)
 
 --------------------------------------------------------------------------------
@@ -31,6 +31,6 @@ permute π = rearrange (Inverse.to π ⟨$⟩_)
 -- and 'z' everywhere else.
 
 select : ∀ {n} {a} {A : Set a} → A → Fin n → Table A n → Table A n
-lookup (select z i t) j with j ≟ i
-... | yes _ = lookup t i
-... | no  _ = z
+lookup (select z i t) j with does (j ≟ i)
+... | true  = lookup t i
+... | false = z

--- a/src/Data/Table/Properties.agda
+++ b/src/Data/Table/Properties.agda
@@ -28,7 +28,8 @@ open import Function.Base using (_∘_; flip)
 open import Function.Inverse using (Inverse)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; cong)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
+open import Relation.Nullary.Decidable using (dec-true; dec-false)
 open import Relation.Nullary.Negation using (contradiction)
 
 private
@@ -43,27 +44,24 @@ private
 
 select-const : ∀ {n} (z : A) (i : Fin n) t →
                select z i t ≗ select z i (replicate (lookup t i))
-select-const z i t j with j ≟ i
-... | yes _ = refl
-... | no  _ = refl
+select-const z i t j with does (j ≟ i)
+... | true  = refl
+... | false = refl
 
 -- Selecting an element from a table then looking it up is the same as looking
 -- up the index in the original table
 
 select-lookup : ∀ {n x i} (t : Table A n) →
                 lookup (select x i t) i ≡ lookup t i
-select-lookup {i = i} t with i ≟ i
-... | yes _  = refl
-... | no i≢i = contradiction refl i≢i
+select-lookup {i = i} t rewrite dec-true (i ≟ i) refl = refl
 
 -- Selecting an element from a table then removing the same element produces a
 -- constant table
 
 select-remove : ∀ {n x} i (t : Table A (suc n)) →
                 remove i (select x i t) ≗ replicate {n = n} x
-select-remove i t j with punchIn i j ≟ i
-... | yes p = contradiction p (FP.punchInᵢ≢i _ _)
-... | no ¬p = refl
+select-remove i t j rewrite dec-false (punchIn i j ≟ i) (FP.punchInᵢ≢i _ _)
+                          = refl
 
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec.agda
+++ b/src/Data/Vec.agda
@@ -17,6 +17,7 @@
 module Data.Vec where
 
 open import Level
+open import Data.Bool.Base
 import Data.Nat.Properties as ℕₚ
 open import Data.Vec.Bounded.Base as Vec≤
   using (Vec≤; ≤-cast; fromVec)
@@ -40,18 +41,18 @@ module _ {P : A → Set p} (P? : Decidable P) where
 
   filter : ∀ {n} → Vec A n → Vec≤ A n
   filter []       = Vec≤.[]
-  filter (a ∷ as) with P? a
-  ... | yes p = a Vec≤.∷ filter as
-  ... | no ¬p = ≤-cast (ℕₚ.n≤1+n _) (filter as)
+  filter (a ∷ as) with does (P? a)
+  ... | true  = a Vec≤.∷ filter as
+  ... | false = ≤-cast (ℕₚ.n≤1+n _) (filter as)
 
   takeWhile : ∀ {n} → Vec A n → Vec≤ A n
   takeWhile []       = Vec≤.[]
-  takeWhile (a ∷ as) with P? a
-  ... | yes p = a Vec≤.∷ takeWhile as
-  ... | no ¬p = Vec≤.[]
+  takeWhile (a ∷ as) with does (P? a)
+  ... | true  = a Vec≤.∷ takeWhile as
+  ... | false = Vec≤.[]
 
   dropWhile : ∀ {n} → Vec A n → Vec≤ A n
   dropWhile Vec.[]       = Vec≤.[]
-  dropWhile (a Vec.∷ as) with P? a
-  ... | yes p = ≤-cast (ℕₚ.n≤1+n _) (dropWhile as)
-  ... | no ¬p = fromVec (a Vec.∷ as)
+  dropWhile (a Vec.∷ as) with does (P? a)
+  ... | true  = ≤-cast (ℕₚ.n≤1+n _) (dropWhile as)
+  ... | false = fromVec (a Vec.∷ as)

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -8,6 +8,7 @@
 
 module Data.Vec.Base where
 
+open import Data.Bool.Base
 open import Data.Nat.Base
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List)
@@ -16,7 +17,7 @@ open import Data.These.Base as These using (These; this; that; these)
 open import Function
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl)
-open import Relation.Nullary using (yes; no)
+open import Relation.Nullary using (does)
 open import Relation.Unary using (Pred; Decidable)
 
 private
@@ -194,9 +195,9 @@ sum = foldr _ _+_ 0
 
 count : ∀ {P : Pred A p} → Decidable P → ∀ {n} → Vec A n → ℕ
 count P? []       = zero
-count P? (x ∷ xs) with P? x
-... | yes _ = suc (count P? xs)
-... | no  _ = count P? xs
+count P? (x ∷ xs) with does (P? x)
+... | true  = suc (count P? xs)
+... | false = count P? xs
 
 ------------------------------------------------------------------------
 -- Operations for building vectors

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -9,6 +9,7 @@
 module Data.Vec.Properties where
 
 open import Algebra.Definitions
+open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
 open import Data.Fin as Fin using (Fin; zero; suc; toℕ; fromℕ)
 open import Data.List.Base as List using (List)
@@ -24,7 +25,7 @@ open import Relation.Binary as B hiding (Decidable)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; _≗_; cong₂)
 open import Relation.Unary using (Pred; Decidable)
-open import Relation.Nullary using (Dec; yes; no)
+open import Relation.Nullary using (Dec; does; yes; no)
 open import Relation.Nullary.Decidable using (map′)
 open import Relation.Nullary.Product using (_×-dec_)
 
@@ -651,9 +652,9 @@ module _ {P : Pred A p} (P? : Decidable P) where
 
   count≤n : ∀ {n} (xs : Vec A n) → count P? xs ≤ n
   count≤n []       = z≤n
-  count≤n (x ∷ xs) with P? x
-  ... | yes _ = s≤s (count≤n xs)
-  ... | no  _ = ≤-step (count≤n xs)
+  count≤n (x ∷ xs) with does (P? x)
+  ... | true  = s≤s (count≤n xs)
+  ... | false = ≤-step (count≤n xs)
 
 ------------------------------------------------------------------------
 -- insert

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -11,6 +11,7 @@ module Function.Related.TypeIsomorphisms where
 
 open import Algebra
 open import Axiom.Extensionality.Propositional using (Extensionality)
+open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Product as Prod hiding (swap)
 open import Data.Product.Function.NonDependent.Propositional
@@ -26,7 +27,8 @@ open import Function.Inverse as Inv using (_↔_; Inverse; inverse)
 open import Function.Related
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_; _≗_)
-open import Relation.Nullary using (Dec; ¬_; yes; no)
+open import Relation.Nullary.Reflects using (invert)
+open import Relation.Nullary using (Dec; ¬_; _because_)
 open import Relation.Nullary.Decidable using (True)
 
 ------------------------------------------------------------------------
@@ -332,8 +334,10 @@ Related-cong {A = A} {B} {C} {D} A≈B C≈D =
 
 True↔ : ∀ {p} {P : Set p}
         (dec : Dec P) → ((p₁ p₂ : P) → p₁ ≡ p₂) → True dec ↔ P
-True↔ (yes p) irr = inverse (λ _ → p) (λ _ → _) (λ _ → P.refl) (irr p)
-True↔ (no ¬p) _   = inverse (λ()) ¬p (λ()) (⊥-elim ∘ ¬p)
+True↔ ( true because  [p]) irr =
+  inverse (λ _ → invert [p]) (λ _ → _) (λ _ → P.refl) (irr _)
+True↔ (false because [¬p]) _   =
+  inverse (λ()) (invert [¬p]) (λ()) (⊥-elim ∘ invert [¬p])
 
 ------------------------------------------------------------------------
 -- Equality between pairs can be expressed as a pair of equalities

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -16,6 +16,7 @@ module Relation.Nary where
 
 open import Level using (Level; _⊔_; Lift)
 open import Data.Unit.Base
+open import Data.Bool.Base using (true; false)
 open import Data.Empty
 open import Data.Nat.Base using (zero; suc)
 open import Data.Product as Prod using (_×_; _,_)
@@ -23,7 +24,7 @@ open import Data.Product.Nary.NonDependent
 open import Data.Sum using (_⊎_)
 open import Function using (_$_; _∘′_)
 open import Function.Nary.NonDependent
-open import Relation.Nullary using (¬_; Dec; yes; no)
+open import Relation.Nullary using (¬_; Dec; yes; no; _because_)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Product using (_×-dec_)
 import Relation.Unary as Unary
@@ -187,9 +188,7 @@ Decidable R = Π[ mapₙ _ Dec R ]
 -- erasure
 
 ⌊_⌋ : ∀ {n ls r} {as : Sets n ls} {R : as ⇉ Set r} → Decidable R → as ⇉ Set r
-⌊_⌋ {zero}  R? with R?
-... | yes _ = Lift _ ⊤
-... | no  _ = Lift _ ⊥
+⌊_⌋ {zero}  R? = Lift _ (Dec.True R?)
 ⌊_⌋ {suc n} R? a = ⌊ R? a ⌋
 
 -- equivalence between R and its erasure
@@ -197,13 +196,13 @@ Decidable R = Π[ mapₙ _ Dec R ]
 fromWitness : ∀ {n ls r} {as : Sets n ls} (R : as ⇉ Set r) (R? : Decidable R) →
               ∀[ ⌊ R? ⌋ ⇒ R ]
 fromWitness {zero} R R? with R?
-... | yes r = λ _ → r
-... | no _  = λ ()
+... | yes           r = λ _ → r
+... | false because _ = λ ()
 fromWitness {suc n} R R? = fromWitness (R _) (R? _)
 
 toWitness : ∀ {n ls r} {as : Sets n ls} (R : as ⇉ Set r) (R? : Decidable R) →
               ∀[ R ⇒ ⌊ R? ⌋ ]
 toWitness {zero} R R? with R?
-... | yes _ = _
-... | no ¬r = ⊥-elim ∘′ ¬r
+... | true because _ = _
+... | no          ¬r = ⊥-elim ∘′ ¬r
 toWitness {suc n} R R? = toWitness (R _) (R? _)

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -36,6 +36,10 @@ isYes : Dec P → Bool
 isYes ( true because _) = true
 isYes (false because _) = false
 
+isYes≗does : (P? : Dec P) → isYes P? ≡ does P?
+isYes≗does ( true because _) = refl
+isYes≗does (false because _) = refl
+
 -- The traditional name for isYes is ⌊_⌋, indicating the stripping of evidence.
 ⌊_⌋ = isYes
 

--- a/src/Relation/Unary.agda
+++ b/src/Relation/Unary.agda
@@ -15,6 +15,7 @@ open import Data.Sum using (_⊎_; [_,_])
 open import Function.Base
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
+open import Relation.Nullary.Decidable.Core using (True)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_)
 
 private
@@ -165,9 +166,7 @@ Decidable P = ∀ x → Dec (P x)
 -- amenable to η-expansion
 
 ⌊_⌋ : {P : Pred A ℓ} → Decidable P → Pred A ℓ
-⌊ P? ⌋ a with P? a
-... | yes _ = Lift _ ⊤
-... | no _  = Lift _ ⊥
+⌊ P? ⌋ a = Lift _ (True (P? a))
 
 -- Irrelevance - any two proofs that an element satifies P are
 -- indistinguishable.


### PR DESCRIPTION
This pull request addresses points 4 and 5 from #932. I found that distinguishing programs from proofs (the difference between 4 and 5) was fairly difficult, so I put them all into one PR. The general principles have been:

1. If possible, factor through `does`.
2. If the proof part is needed, try to localise pattern matching as much as possible using `invert`.
3. In cases where (AFAICT) computation doesn't matter, keep with `yes` and `no`. This is mostly proofs via `⊥`.