### PR TITLE
Added fixpoint proof for well-founded induction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@ Other minor additions
 
 * Added new proofs to `Induction.WellFounded`:
   ```agda
-  wfRecFixp : ∀ {x} → All.wfRec P f x ≡ f x λ y _ → All.wfRec P f y
+  someWfRecInvar : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
+  wfRecBuilder-wfRec : ∀ {x y} y<x → All.wfRecBuilder P f x y y<x ≡ All.wfRec P f y
+  wfRecFixpoint : ∀ {x} → All.wfRec P f x ≡ f x λ y _ → All.wfRec P f y
   ```
 
 * Added new proofs to `Algebra.Properties.Group`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@ Other minor additions
 
 * Added new proofs to `Induction.WellFounded`:
   ```agda
-  someWfRecInvar : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
-  wfRecBuilder-wfRec : ∀ {x y} y<x → All.wfRecBuilder P f x y y<x ≡ All.wfRec P f y
-  wfRecFixpoint : ∀ {x} → All.wfRec P f x ≡ f x λ y _ → All.wfRec P f y
+  some-wfRec-irrelevant : Some.wfRec P f x q ≡ Some.wfRec P f x q'
+  wfRecBuilder-wfRec    : All.wfRecBuilder P f x y y<x ≡ All.wfRec P f y
+  unfold-wfRec          : All.wfRec P f x ≡ f x λ y _ → All.wfRec P f y
   ```
 
 * Added new proofs to `Algebra.Properties.Group`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,8 @@ Other major additions
 
 Other minor additions
 ---------------------
+
+* Added new proofs to `Induction.WellFounded`
+  ```agda
+  wfRecFixp : ∀ {x} → All.wfRec P f x ≡ f x λ y _ → All.wfRec P f y
+  ```

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -14,6 +14,7 @@ open import Data.Product
 open import Function
 open import Induction
 open import Level
+open import Relation.Binary.PropositionalEquality hiding (trans)
 open import Relation.Unary
 
 -- When using well-founded recursion you can recurse arbitrarily, as
@@ -28,6 +29,10 @@ WfRec _<_ P x = ∀ y → y < x → P y
 
 data Acc {a ℓ} {A : Set a} (_<_ : Rel A ℓ) (x : A) : Set (a ⊔ ℓ) where
   acc : (rs : WfRec _<_ (Acc _<_) x) → Acc _<_ x
+
+acc-inv : ∀ {a ℓ} {A : Set a} {_<_ : Rel A ℓ} {x : A} (q : Acc _<_ x) →
+          {y : A} → y < x → Acc _<_ y
+acc-inv (acc rs) y<x = rs _ y<x
 
 -- The accessibility predicate encodes what it means to be
 -- well-founded; if all elements are accessible, then _<_ is
@@ -54,11 +59,16 @@ module Some {a lt} {A : Set a} {_<_ : Rel A lt} {ℓ} where
   wfRec : SubsetRecursor (Acc _<_) (WfRec _<_)
   wfRec = subsetBuild wfRecBuilder
 
+  wfRecFixp : (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P) {x : A} (q : Acc _<_ x) →
+              wfRec P f x q ≡ f x (λ y y<x → wfRec P f y (acc-inv q y<x))
+  wfRecFixp P f (acc rs) = refl
+
   wfRec-builder = wfRecBuilder
   {-# WARNING_ON_USAGE wfRec-builder
   "Warning: wfRec-builder was deprecated in v0.15.
   Please use wfRecBuilder instead."
   #-}
+
 
 ------------------------------------------------------------------------
 -- Well-founded induction for all elements, assuming they are all
@@ -78,6 +88,26 @@ module All {a lt} {A : Set a} {_<_ : Rel A lt}
   "Warning: wfRec-builder was deprecated in v0.15.
   Please use wfRecBuilder instead."
   #-}
+
+module FixPoint
+  {a ℓ} {A : Set a} {_<_ : Rel A ℓ} (wf : WellFounded _<_)
+  (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P)
+  (f-ext : (x : A) {IH IH' : WfRec _<_ P x} → (∀ y y<x → IH y y<x ≡ IH' y y<x) → f x IH ≡ f x IH')
+  where
+
+  someWfRecInv : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
+  someWfRecInv = All.wfRec wf (a ⊔ ℓ)
+                           (λ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q')
+                           (λ { x IH (acc rs) (acc rs') → f-ext x λ y y<x → IH y y<x (rs y y<x) (rs' y y<x) })
+
+  open All wf ℓ
+  wfRecFixpLemma : ∀ {x} y y<x → wfRecBuilder P f x y y<x ≡ wfRec P f y
+  wfRecFixpLemma {x} y y<x with wf x
+  wfRecFixpLemma {x} y y<x | acc rs = someWfRecInv y (rs y y<x) (wf y)
+
+  wfRecFixp : ∀ {x} → wfRec P f x ≡ f x λ y _ → wfRec P f y
+  wfRecFixp {x} = f-ext x wfRecFixpLemma
+
 
 ------------------------------------------------------------------------
 -- It might be useful to establish proofs of Acc or Well-founded using

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -59,9 +59,9 @@ module Some {a lt} {A : Set a} {_<_ : Rel A lt} {ℓ} where
   wfRec : SubsetRecursor (Acc _<_) (WfRec _<_)
   wfRec = subsetBuild wfRecBuilder
 
-  wfRecFixpoint : (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P) {x : A} (q : Acc _<_ x) →
-                  wfRec P f x q ≡ f x (λ y y<x → wfRec P f y (acc-inverse q y y<x))
-  wfRecFixpoint P f (acc rs) = refl
+  unfold-wfRec : (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P) {x : A} (q : Acc _<_ x) →
+                 wfRec P f x q ≡ f x (λ y y<x → wfRec P f y (acc-inverse q y y<x))
+  unfold-wfRec P f (acc rs) = refl
 
   wfRec-builder = wfRecBuilder
   {-# WARNING_ON_USAGE wfRec-builder
@@ -95,18 +95,18 @@ module FixPoint
   (f-ext : (x : A) {IH IH' : WfRec _<_ P x} → (∀ {y} y<x → IH y y<x ≡ IH' y y<x) → f x IH ≡ f x IH')
   where
 
-  someWfRecInvar : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
-  someWfRecInvar = All.wfRec wf (a ⊔ ℓ)
-                             (λ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q')
-                             (λ { x IH (acc rs) (acc rs') → f-ext x (λ y<x → IH _ y<x (rs _ y<x) (rs' _ y<x)) })
+  some-wfRec-irrelevant : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
+  some-wfRec-irrelevant = All.wfRec wf (a ⊔ ℓ)
+                                   (λ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q')
+                                   (λ { x IH (acc rs) (acc rs') → f-ext x (λ y<x → IH _ y<x (rs _ y<x) (rs' _ y<x)) })
 
   open All wf ℓ
   wfRecBuilder-wfRec : ∀ {x y} y<x → wfRecBuilder P f x y y<x ≡ wfRec P f y
   wfRecBuilder-wfRec {x} {y} y<x with wf x
-  ... | acc rs = someWfRecInvar y (rs y y<x) (wf y)
+  ... | acc rs = some-wfRec-irrelevant y (rs y y<x) (wf y)
 
-  wfRecFixpoint : ∀ {x} → wfRec P f x ≡ f x (λ y _ → wfRec P f y)
-  wfRecFixpoint {x} = f-ext x wfRecBuilder-wfRec
+  unfold-wfRec : ∀ {x} → wfRec P f x ≡ f x (λ y _ → wfRec P f y)
+  unfold-wfRec {x} = f-ext x wfRecBuilder-wfRec
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
`Fixpoint.wfRecFixp` proves that `All.wfRec` yields a fixpoint. This is especially useful when defining a type family (in contrast to proving a theorem) using well-founded induction.