### PR TITLE
Refactor reflection in new RingSolver and MonoidSolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,9 @@ Other major additions
   Data.Word.Base
   Data.Word.Properties
   
+  Data.Nat.Reflection
+  Data.Fin.Reflection
+  
   Reflection.Abstraction
   Reflection.Argument
   Reflection.Argument.Information

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -636,14 +636,15 @@ Other minor additions
 
 * Added new functions to `Data.String.Base`:
   ```agda
-  parens      : String → String
-  braces      : String → String
-  intersperse : String → List String → String
-  unwords     : List String → String
-  _<+>_       : String → String → String
-  padLeft     : Char → ℕ → String → String
-  padRight    : Char → ℕ → String → String
-  padBoth     : Char → Char → ℕ → String → String
+  parens        : String → String
+  parensIfSpace : String → String
+  braces        : String → String
+  intersperse   : String → List String → String
+  unwords       : List String → String
+  _<+>_         : String → String → String
+  padLeft       : Char → ℕ → String → String
+  padRight      : Char → ℕ → String → String
+  padBoth       : Char → Char → ℕ → String → String
 
   data Alignment : Set where Left Center Right : Alignment
   fromAlignment  : Alignment → ℕ → String → String

--- a/README.agda
+++ b/README.agda
@@ -312,6 +312,7 @@ import README.Text.Tree
 -- Explaining how to use the automatic solvers
 
 import README.Tactic.MonoidSolver
+import README.Tactic.RingSolver
 
 -- Explaining how the Haskell FFI works
 

--- a/README/Tactic/RingSolver.agda
+++ b/README/Tactic/RingSolver.agda
@@ -1,0 +1,112 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Examples showing how the reflective ring solver may be used.
+------------------------------------------------------------------------
+
+module README.Tactic.RingSolver where
+
+-- You can ignore this bit! We're just overloading the literals Agda uses for
+-- numbers. This bit isn't necessary if you're just using Nats, or if you
+-- construct your type directly. We only really do it here so that we can use
+-- different numeric types in the same file.
+
+open import Agda.Builtin.FromNat
+open import Data.Nat using (ℕ)
+open import Data.Integer using (ℤ)
+import Data.Nat.Literals as ℕ
+import Data.Integer.Literals as ℤ
+
+instance
+  numberNat : Number ℕ
+  numberNat = ℕ.number
+
+instance
+  numberInt : Number ℤ
+  numberInt = ℤ.number
+
+------------------------------------------------------------------------------
+-- Imports!
+
+open import Data.List as List using (List; _∷_; [])
+open import Function
+open import Relation.Binary.PropositionalEquality as ≡
+  using (subst; _≡_; module ≡-Reasoning)
+open import Data.Bool as Bool using (Bool; true; false; if_then_else_)
+open import Data.Unit using (⊤; tt)
+
+open import Tactic.RingSolver.Core.AlmostCommutativeRing using (AlmostCommutativeRing)
+
+------------------------------------------------------------------------------
+-- Integer examples
+------------------------------------------------------------------------------
+
+module IntegerExamples where
+  open import Data.Integer.Tactic.RingSolver
+
+  open AlmostCommutativeRing ring
+
+  -- Everything is automatic: you just ask Agda to solve it and it does!
+  lemma₁ : ∀ x y → x + y * 1 + 3 ≈ 3 + 1 + y + x + - 1
+  lemma₁ = solve-∀
+
+  lemma₂ : ∀ x y → (x + y) ^ 2 ≈ x ^ 2 + 2 * x * y + y ^ 2
+  lemma₂ = solve-∀
+
+  -- It can interact with manual proofs as well.
+  lemma₃ : ∀ x y → x + y * 1 + 3 ≈ 2 + 1 + y + x
+  lemma₃ x y = begin
+    x + y * 1 + 3 ≡⟨ +-comm x (y * 1) ⟨ +-cong ⟩ refl ⟩
+    y * 1 + x + 3 ≡⟨ solve (x ∷ y ∷ []) ⟩
+    3 + y + x     ≡⟨⟩
+    2 + 1 + y + x ∎
+    where open ≡-Reasoning
+
+------------------------------------------------------------------------------
+-- Natural examples
+------------------------------------------------------------------------------
+
+module NaturalExamples where
+  open import Data.Nat.Tactic.RingSolver
+
+  open AlmostCommutativeRing ring
+
+  -- The solver is flexible enough to work with ℕ (even though it asks
+  -- for rings!)
+  lemma₁ : ∀ x y → x + y * 1 + 3 ≈ 2 + 1 + y + x
+  lemma₁ = solve-∀
+
+------------------------------------------------------------------------------
+-- Checking invariants
+------------------------------------------------------------------------------
+-- The solver makes it easy to prove invariants, without having to rewrite
+-- proof code every time something changes in the data structure.
+
+module _ {a} {A : Set a} (_≤_ : A → A → Bool) where
+  open import Data.Nat.Tactic.RingSolver
+  open AlmostCommutativeRing ring
+
+  -- A Skew Heap, indexed by its size.
+  data Tree : ℕ → Set a where
+    leaf : Tree 0
+    node : ∀ {n m} → A → Tree n → Tree m → Tree (1 + n + m)
+
+  -- A substitution operator, to clean things up.
+  infixr 1 _⇒_
+  _⇒_ : ∀ {n} → Tree n → ∀ {m} → n ≈ m → Tree m
+  x ⇒ n≈m  = subst Tree n≈m x
+
+  open ≡-Reasoning
+
+  _∪_ : ∀ {n m} → Tree n → Tree m → Tree (n + m)
+  leaf                 ∪ ys                   = ys
+  node {a} {b} x xl xr ∪ leaf                 =
+    node x xl xr ⇒ solve (a ∷ b ∷ [])
+  node {a} {b} x xl xr ∪ node {c} {d} y yl yr =
+      if x ≤ y
+        then node x (node y yl yr ∪ xr) xl ⇒ begin
+          1 + (1 + c + d + b) + a ≡⟨ solve (a ∷ b ∷ c ∷ d ∷ []) ⟩
+          1 + a + b + (1 + c + d) ∎
+        else node y (node x xl xr ∪ yr) yl ⇒ begin
+          1 + (1 + a + b + d) + c ≡⟨ solve (a ∷ b ∷ c ∷ d ∷ []) ⟩
+          1 + a + b + (1 + c + d) ∎

--- a/src/Data/Fin/Reflection.agda
+++ b/src/Data/Fin/Reflection.agda
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Reflection utilities for Fin
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Fin.Reflection where
+
+open import Data.Nat.Base as ℕ hiding (module ℕ)
+open import Data.Fin.Base as Fin hiding (module Fin)
+open import Data.List.Base
+open import Reflection.Term
+open import Reflection.Argument
+
+------------------------------------------------------------------------
+-- Term
+
+toTerm : ∀ {n} → Fin n → Term
+toTerm zero    = con (quote Fin.zero) (1 ⋯⟅∷⟆ [])
+toTerm (suc i) = con (quote Fin.suc)  (1 ⋯⟅∷⟆ toTerm i ⟨∷⟩ [])

--- a/src/Data/Nat/Reflection.agda
+++ b/src/Data/Nat/Reflection.agda
@@ -1,0 +1,26 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Reflection utilities for ℕ
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Nat.Reflection where
+
+open import Data.Nat.Base as ℕ
+open import Data.Fin.Base as Fin
+open import Data.List.Base using ([])
+open import Reflection.Term
+open import Reflection.Argument
+
+------------------------------------------------------------------------
+-- Term
+
+toTerm : ℕ → Term
+toTerm zero    = con (quote ℕ.zero) []
+toTerm (suc i) = con (quote ℕ.suc)  (toTerm i ⟨∷⟩ [])
+
+toFinTerm : ℕ → Term
+toFinTerm zero    = con (quote Fin.zero) (1 ⋯⟅∷⟆ [])
+toFinTerm (suc i) = con (quote Fin.suc)  (1 ⋯⟅∷⟆ toFinTerm i ⟨∷⟩ [])

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -9,6 +9,7 @@
 module Data.String.Base where
 
 open import Level using (zero)
+open import Data.Bool using (true; false)
 open import Data.Nat.Base as ℕ using (ℕ; _∸_; ⌊_/2⌋; ⌈_/2⌉)
 import Data.Nat.Properties as ℕₚ
 open import Data.List.Base as List using (List; [_])
@@ -18,8 +19,12 @@ open import Data.List.Relation.Binary.Pointwise using (Pointwise)
 open import Data.List.Relation.Binary.Lex.Strict using (Lex-<)
 open import Data.Vec.Base as Vec using (Vec)
 open import Data.Char.Base as Char using (Char)
+import Data.Char.Properties as Char using (_≟_)
 open import Function
 open import Relation.Binary using (Rel)
+open import Relation.Nullary using (does)
+
+open import Data.List.Membership.DecPropositional Char._≟_
 
 ------------------------------------------------------------------------
 -- From Agda.Builtin: type and renamed primitives
@@ -90,6 +95,12 @@ unwords = intersperse " "
 
 parens : String → String
 parens s = "(" ++ s ++ ")"
+
+-- enclose string with parens if it contains a space character
+parensIfSpace : String → String
+parensIfSpace s with does (' ' ∈? toList s)
+... | true  = parens s
+... | false = s
 
 braces : String → String
 braces s = "{" ++ s ++ "}"

--- a/src/Data/Word/Base.agda
+++ b/src/Data/Word/Base.agda
@@ -15,7 +15,7 @@ open import Relation.Binary using (Rel)
 open import Relation.Binary.PropositionalEquality
 
 ------------------------------------------------------------------------
--- Re-export built-ins publically
+-- Re-export built-ins publicly
 
 open import Agda.Builtin.Word public
   using (Word64)

--- a/src/Reflection.agda
+++ b/src/Reflection.agda
@@ -8,61 +8,49 @@
 
 module Reflection where
 
-open import Data.List.Base using (List); open List
-
-open import Data.Nat    as ℕ      using (ℕ)
-open import Data.String as String using (String)
-
-open import Data.Product
-open import Function
-open import Level
-open import Relation.Binary
-open import Relation.Binary.PropositionalEquality
-open import Relation.Nullary hiding (module Dec)
-open import Relation.Nullary.Decidable as Dec
-open import Relation.Nullary.Product
-
 import Agda.Builtin.Reflection as Builtin
 
-private
-  variable
-    a b c d : Level
-    A B C D : Set a
-
 ------------------------------------------------------------------------
--- Names, Metas, and Literals re-exported publically
+-- Names, Metas, and Literals re-exported publicly
 
-open import Reflection.Name as Name using (Name; Names) public
-open import Reflection.Meta as Meta using (Meta) public
-open import Reflection.Literal as Literal using (Literal) public
-open Literal.Literal public
+open import Reflection.Abstraction as Abstraction public
+  using (Abs; abs)
 open import Reflection.Argument as Argument public
-  using ( Arg; arg; Args
-        ; vArg; hArg; iArg
-        ) public
+  using (Arg; arg; Args; vArg; hArg; iArg)
+open import Reflection.Definition as Definition  public
+  using (Definition)
+open import Reflection.Meta as Meta public
+  using (Meta)
+open import Reflection.Name as Name public
+  using (Name; Names)
+open import Reflection.Literal as Literal public
+  using (Literal)
+open import Reflection.Pattern as Pattern public
+  using (Pattern)
+open import Reflection.Term as Term public
+  using (Term; Type; Clause; Clauses; Sort)
+
 import Reflection.Argument.Relevance as Relevance
-open Relevance.Relevance public
 import Reflection.Argument.Visibility as Visibility
-open Visibility.Visibility public
 import Reflection.Argument.Information as Information
-open Information.ArgInfo public
 
-open import Reflection.Pattern as Pattern using (Pattern) public
-open import Reflection.Abstraction as Abstraction using (Abs; abs) public
-
-open import Reflection.Term as Term using (Term; Type; Clause; Clauses; Sort) public
-open Term.Term public
-
-open import Reflection.Definition as Definition using (Definition) public
 open Definition.Definition public
+open Information.ArgInfo public
+open Literal.Literal public
+open Relevance.Relevance public
+open Term.Term public
+open Visibility.Visibility public
 
 ------------------------------------------------------------------------
 -- Fixity
 
-open Builtin public using (non-assoc; related; unrelated; fixity)
-  renaming ( left-assoc  to assocˡ
-           ; right-assoc to assocʳ
-           ; primQNameFixity to getFixity)
+open Builtin public
+  using (non-assoc; related; unrelated; fixity)
+  renaming
+  ( left-assoc      to assocˡ
+  ; right-assoc     to assocʳ
+  ; primQNameFixity to getFixity
+  )
 
 ------------------------------------------------------------------------
 -- Type checking monad
@@ -90,6 +78,13 @@ newMeta : Type → TC Term
 newMeta = checkType unknown
 
 ------------------------------------------------------------------------
+-- Show
+
+open import Reflection.Show public
+
+
+
+------------------------------------------------------------------------
 -- DEPRECATED NAMES
 ------------------------------------------------------------------------
 -- Please use the new names as continuing support for the old names is
@@ -103,9 +98,11 @@ returnTC = return
 Please use return instead."
 #-}
 
+-- Version 1.3
+
 Arg-info = Information.ArgInfo
 {-# WARNING_ON_USAGE Arg-info
-"Warning: Arg-info was deprecated in v1.1.
+"Warning: Arg-info was deprecated in v1.3.
 Please use Reflection.Argument.Information's ArgInfo instead."
 #-}
 
@@ -114,97 +111,79 @@ infix 4 _≟-Lit_ _≟-Name_ _≟-Meta_ _≟-Visibility_ _≟-Relevance_ _≟-Ar
 
 _≟-Lit_ = Literal._≟_
 {-# WARNING_ON_USAGE _≟-Lit_
-"Warning: _≟-Lit_ was deprecated in v1.1.
+"Warning: _≟-Lit_ was deprecated in v1.3.
 Please use Reflection.Literal's _≟_ instead."
 #-}
 
 _≟-Name_ = Name._≟_
 {-# WARNING_ON_USAGE _≟-Name_
-"Warning: _≟-Name_ was deprecated in v1.1.
+"Warning: _≟-Name_ was deprecated in v1.3.
 Please use Reflection.Name's _≟_ instead."
 #-}
 
 _≟-Meta_ = Meta._≟_
 {-# WARNING_ON_USAGE _≟-Meta_
-"Warning: _≟-Meta_ was deprecated in v1.1.
+"Warning: _≟-Meta_ was deprecated in v1.3.
 Please use Reflection.Meta's _≟_ instead."
 #-}
 
 _≟-Visibility_ = Visibility._≟_
 {-# WARNING_ON_USAGE _≟-Visibility_
-"Warning: _≟-Visibility_ was deprecated in v1.1.
+"Warning: _≟-Visibility_ was deprecated in v1.3.
 Please use Reflection.Argument.Visibility's _≟_ instead."
 #-}
 
 _≟-Relevance_ = Relevance._≟_
 {-# WARNING_ON_USAGE _≟-Relevance_
-"Warning: _≟-Relevance_ was deprecated in v1.1.
+"Warning: _≟-Relevance_ was deprecated in v1.3.
 Please use Reflection.Argument.Relevance's _≟_ instead."
 #-}
 
 _≟-Arg-info_ = Information._≟_
 {-# WARNING_ON_USAGE _≟-Arg-info_
-"Warning: _≟-Arg-info_ was deprecated in v1.1.
+"Warning: _≟-Arg-info_ was deprecated in v1.3.
 Please use Reflection.Argument.Information's _≟_ instead."
 #-}
 
 _≟-Pattern_ = Pattern._≟_
 {-# WARNING_ON_USAGE _≟-Pattern_
-"Warning: _≟-Pattern_ was deprecated in v1.1.
+"Warning: _≟-Pattern_ was deprecated in v1.3.
 Please use Reflection.Pattern's _≟_ instead."
 #-}
 
 _≟-ArgPatterns_ = Pattern._≟s_
 {-# WARNING_ON_USAGE _≟-ArgPatterns_
-"Warning: _≟-ArgPatterns_ was deprecated in v1.1.
+"Warning: _≟-ArgPatterns_ was deprecated in v1.3.
 Please use Reflection.Pattern's _≟s_ instead."
-#-}
-
-showLiteral = Literal.show
-{-# WARNING_ON_USAGE showLiteral
-"Warning: showLiteral was deprecated in v1.1.
-Please use Reflection.Literal's show instead."
-#-}
-
-showName = Name.show
-{-# WARNING_ON_USAGE showName
-"Warning: showName was deprecated in v1.1.
-Please use Reflection.Name's show instead."
-#-}
-
-showMeta = Meta.show
-{-# WARNING_ON_USAGE showMeta
-"Warning: showMeta was deprecated in v1.1.
-Please use Reflection.Meta's show instead."
 #-}
 
 map-Abs = Abstraction.map
 {-# WARNING_ON_USAGE map-Abs
-"Warning: map-Abs was deprecated in v1.1.
+"Warning: map-Abs was deprecated in v1.3.
 Please use Reflection.Abstraction's map instead."
 #-}
 
 map-Arg = Argument.map
 {-# WARNING_ON_USAGE map-Arg
-"Warning: map-Arg was deprecated in v1.1.
+"Warning: map-Arg was deprecated in v1.3.
 Please use Reflection.Argument's map instead."
 #-}
 
 map-Args = Argument.map-Args
 {-# WARNING_ON_USAGE map-Args
-"Warning: map-Args was deprecated in v1.1.
+"Warning: map-Args was deprecated in v1.3.
 Please use Reflection.Argument's map-Args instead."
 #-}
 
 visibility = Information.visibility
 {-# WARNING_ON_USAGE visibility
-"Warning: visibility was deprecated in v1.1.
+"Warning: visibility was deprecated in v1.3.
 Please use Reflection.Argument.Information's visibility instead."
 #-}
 
 relevance = Information.relevance
 {-# WARNING_ON_USAGE relevance
-"Warning: relevance was deprecated in v1.1.
+"Warning: relevance was deprecated in v1.3.
 Please use Reflection.Argument.Information's relevance instead."
 #-}
 
@@ -214,54 +193,54 @@ infix 4 _≟-AbsTerm_ _≟-AbsType_ _≟-ArgTerm_ _≟-ArgType_ _≟-Args_
 
 _≟-AbsTerm_ = Term._≟-AbsTerm_
 {-# WARNING_ON_USAGE _≟-AbsTerm_
-"Warning: _≟-AbsTerm_ was deprecated in v1.1.
+"Warning: _≟-AbsTerm_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-AbsTerm_ instead."
 #-}
 
 _≟-AbsType_ = Term._≟-AbsType_
 {-# WARNING_ON_USAGE _≟-AbsType_
-"Warning: _≟-AbsType_ was deprecated in v1.1.
+"Warning: _≟-AbsType_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-AbsType_ instead."
 #-}
 
 _≟-ArgTerm_ = Term._≟-ArgTerm_
 {-# WARNING_ON_USAGE _≟-ArgTerm_
-"Warning: _≟-ArgTerm_ was deprecated in v1.1.
+"Warning: _≟-ArgTerm_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-ArgTerm_ instead."
 #-}
 
 _≟-ArgType_ = Term._≟-ArgType_
 {-# WARNING_ON_USAGE _≟-ArgType_
-"Warning: _≟-ArgType_ was deprecated in v1.1.
+"Warning: _≟-ArgType_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-ArgType_ instead."
 #-}
 
 _≟-Args_    = Term._≟-Args_
 {-# WARNING_ON_USAGE _≟-Args_
-"Warning: _≟-Args_ was deprecated in v1.1.
+"Warning: _≟-Args_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-Args_ instead."
 #-}
 
 _≟-Clause_  = Term._≟-Clause_
 {-# WARNING_ON_USAGE _≟-Clause_
-"Warning: _≟-Clause_ was deprecated in v1.1.
+"Warning: _≟-Clause_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-Clause_ instead."
 #-}
 
 _≟-Clauses_ = Term._≟-Clauses_
 {-# WARNING_ON_USAGE _≟-Clauses_
-"Warning: _≟-Clauses_ was deprecated in v1.1.
+"Warning: _≟-Clauses_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-Clauses_ instead."
 #-}
 
 _≟_         = Term._≟_
 {-# WARNING_ON_USAGE _≟_
-"Warning: _≟_ was deprecated in v1.1.
+"Warning: _≟_ was deprecated in v1.3.
 Please use Reflection.Term's _≟_ instead."
 #-}
 
 _≟-Sort_    = Term._≟-Sort_
 {-# WARNING_ON_USAGE _≟-Sort_
-"Warning: _≟-Sort_ was deprecated in v1.1.
+"Warning: _≟-Sort_ was deprecated in v1.3.
 Please use Reflection.Term's _≟-Sort_ instead."
 #-}

--- a/src/Reflection/Argument.agda
+++ b/src/Reflection/Argument.agda
@@ -8,8 +8,9 @@
 
 module Reflection.Argument where
 
-open import Data.List.Base as List using (List)
+open import Data.List.Base as List using (List; []; _∷_)
 open import Data.Product using (_×_; _,_; uncurry; <_,_>)
+open import Data.Nat using (ℕ)
 open import Reflection.Argument.Visibility
 open import Reflection.Argument.Relevance
 open import Reflection.Argument.Information as Information
@@ -26,7 +27,7 @@ private
     A B : Set a
 
 ------------------------------------------------------------------------
--- Re-exporting the builtins publically
+-- Re-exporting the builtins publicly
 
 open import Agda.Builtin.Reflection public using (Arg)
 open Arg public
@@ -38,13 +39,20 @@ pattern hArg ty = arg (arg-info hidden relevant)    ty
 pattern iArg ty = arg (arg-info instance′ relevant) ty
 
 ------------------------------------------------------------------------
+-- Lists of arguments
+
+Args : {a : Level} (A : Set a) → Set a
+Args A = List (Arg A)
+
+infixr 5 _⟨∷⟩_ _⟅∷⟆_
+pattern _⟨∷⟩_ x xs = vArg x ∷ xs
+pattern _⟅∷⟆_ x xs = hArg x ∷ xs
+
+------------------------------------------------------------------------
 -- Operations
 
 map : (A → B) → Arg A → Arg B
 map f (arg i x) = arg i (f x)
-
-Args : {a : Level} (A : Set a) → Set a
-Args A = List (Arg A)
 
 map-Args : (A → B) → Args A → Args B
 map-Args f xs = List.map (map f) xs

--- a/src/Reflection/Argument/Relevance.agda
+++ b/src/Reflection/Argument/Relevance.agda
@@ -8,7 +8,6 @@
 
 module Reflection.Argument.Relevance where
 
-open import Data.String as String using (String)
 open import Relation.Nullary
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
@@ -18,13 +17,6 @@ open import Relation.Binary.PropositionalEquality
 
 open import Agda.Builtin.Reflection public using (Relevance)
 open Relevance public
-
-------------------------------------------------------------------------
--- Showing
-
-show : Relevance → String
-show relevant   = "relevant"
-show irrelevant = "irrelevant"
 
 ------------------------------------------------------------------------
 -- Decidable equality

--- a/src/Reflection/Argument/Visibility.agda
+++ b/src/Reflection/Argument/Visibility.agda
@@ -20,14 +20,6 @@ open import Agda.Builtin.Reflection public using (Visibility)
 open Visibility public
 
 ------------------------------------------------------------------------
--- Showing
-
-show : Visibility → String
-show visible   = "visible"
-show hidden    = "hidden"
-show instance′ = "instance"
-
-------------------------------------------------------------------------
 -- Decidable equality
 
 _≟_ : DecidableEquality Visibility

--- a/src/Reflection/Definition.agda
+++ b/src/Reflection/Definition.agda
@@ -39,19 +39,6 @@ open import Agda.Builtin.Reflection public
            ; prim-fun    to primitive′ )
 
 ------------------------------------------------------------------------
--- Showing
-
-show : Definition → String
-show (function cs)       = "function" <+> braces (Term.showClauses cs)
-show (data-type pars cs) =
- "datatype" <+> NatShow.show pars <+> braces (intersperse ", " (map Name.show cs))
-show (record′ c fs)      =
- "record" <+> Name.show c <+> braces (intersperse ", " (map (Name.show ∘′ Arg.unArg) fs))
-show (constructor′ d)    = "constructor" <+> Name.show d
-show axiom               = "axiom"
-show primitive′          = "primitive"
-
-------------------------------------------------------------------------
 -- Decidable equality
 
 function-injective : ∀ {cs cs′} → function cs ≡ function cs′ → cs ≡ cs′

--- a/src/Reflection/Literal.agda
+++ b/src/Reflection/Literal.agda
@@ -11,7 +11,6 @@ module Reflection.Literal where
 import Data.Char as Char
 import Data.Float as Float
 import Data.Nat as ℕ
-import Data.Nat.Show as ℕ
 open import Data.String as String using (String)
 import Data.Word as Word
 import Reflection.Meta as Meta
@@ -27,18 +26,6 @@ open import Relation.Binary.PropositionalEquality
 open import Agda.Builtin.Reflection public
   using ( Literal )
 open Literal public
-
-------------------------------------------------------------------------
--- Showing
-
-show : Literal → String
-show (nat x)    = ℕ.show x
-show (word64 x) = ℕ.show (Word.toℕ x)
-show (float x)  = Float.show x
-show (char x)   = Char.show x
-show (string x) = String.show x
-show (name x)   = Name.show x
-show (meta x)   = Meta.show x
 
 ------------------------------------------------------------------------
 -- Decidable equality

--- a/src/Reflection/Meta.agda
+++ b/src/Reflection/Meta.agda
@@ -16,13 +16,10 @@ import Relation.Binary.Construct.On as On
 open import Relation.Binary.PropositionalEquality
 
 open import Agda.Builtin.Reflection public
-  using (Meta)
-  renaming ( primShowMeta to show
-           ; primMetaToNat to toℕ
-           )
+  using (Meta) renaming (primMetaToNat to toℕ)
 
 open import Agda.Builtin.Reflection.Properties public
-  renaming ( primMetaToNatInjective to toℕ-injective )
+  renaming (primMetaToNatInjective to toℕ-injective)
 
 -- Equality of metas is decidable.
 

--- a/src/Reflection/Name.agda
+++ b/src/Reflection/Name.agda
@@ -21,13 +21,10 @@ open import Relation.Binary.PropositionalEquality
 -- Re-export built-ins
 
 open import Agda.Builtin.Reflection public
-  using (Name) renaming
-  ( primShowQName to show
-  ; primQNameToWord64s to toWords
-  )
+  using (Name) renaming (primQNameToWord64s to toWords)
 
 open import Agda.Builtin.Reflection.Properties public
-  renaming ( primQNameToWord64sInjective to toWords-injective )
+  renaming (primQNameToWord64sInjective to toWords-injective)
 
 ----------------------------------------------------------------------
 -- More definitions

--- a/src/Reflection/Name.agda
+++ b/src/Reflection/Name.agda
@@ -17,19 +17,28 @@ open import Relation.Binary
 import Relation.Binary.Construct.On as On
 open import Relation.Binary.PropositionalEquality
 
+----------------------------------------------------------------------
+-- Re-export built-ins
+
 open import Agda.Builtin.Reflection public
-  using (Name)
-  renaming ( primShowQName to show
-           ; primQNameToWord64s to toWords
-           )
+  using (Name) renaming
+  ( primShowQName to show
+  ; primQNameToWord64s to toWords
+  )
 
 open import Agda.Builtin.Reflection.Properties public
   renaming ( primQNameToWord64sInjective to toWords-injective )
 
+----------------------------------------------------------------------
+-- More definitions
+----------------------------------------------------------------------
+
 Names : Set
 Names = List Name
 
--- Equality of names is decidable.
+----------------------------------------------------------------------
+-- Decidable equality for names
+----------------------------------------------------------------------
 
 _≈_ : Rel Name _
 _≈_ = _≡_ on toWords

--- a/src/Reflection/Pattern.agda
+++ b/src/Reflection/Pattern.agda
@@ -32,34 +32,6 @@ open import Agda.Builtin.Reflection public using (Pattern)
 open Pattern public
 
 ------------------------------------------------------------------------
--- Showing
-
-mutual
-
-  showPatterns : List (Arg Pattern) → String
-  showPatterns []       = ""
-  showPatterns (a ∷ ps) = showArg a <+> showPatterns ps
-    where
-      showRel : Relevance → String
-      showRel relevant   = ""
-      showRel irrelevant = "."
-
-      showArg : Arg Pattern → String
-      showArg (arg (arg-info visible r) p)   = showRel r ++ show p
-      showArg (arg (arg-info hidden r) p)    = braces (showRel r ++ show p)
-      showArg (arg (arg-info instance′ r) p) = braces (braces (showRel r ++ show p))
-
-
-  show : Pattern → String
-  show (con c []) = Name.show c
-  show (con c ps) = parens (Name.show c <+> showPatterns ps)
-  show dot        = "._"
-  show (var s)    = s
-  show (lit l)    = Literal.show l
-  show (proj f)   = Name.show f
-  show absurd     = "()"
-
-------------------------------------------------------------------------
 -- Decidable equality
 
 con-injective₁ : ∀ {c c′ args args′} → con c args ≡ con c′ args′ → c ≡ c′

--- a/src/Reflection/Show.agda
+++ b/src/Reflection/Show.agda
@@ -1,0 +1,137 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Converting reflection machinery to strings
+------------------------------------------------------------------------
+
+-- Note that Reflection.termErr can also be used directly in tactic
+-- error messages.
+
+{-# OPTIONS --without-K --safe #-}
+
+module Reflection.Show where
+
+import Data.Char as Char
+import Data.Float as Float
+open import Data.List hiding (_++_; intersperse)
+import Data.Nat as ℕ
+import Data.Nat.Show as ℕ
+open import Data.String as String
+import Data.Word as Word
+open import Relation.Nullary using (yes; no)
+open import Function.Base using (_∘′_)
+
+open import Reflection.Abstraction hiding (map)
+open import Reflection.Argument hiding (map)
+open import Reflection.Argument.Relevance
+open import Reflection.Argument.Visibility
+open import Reflection.Argument.Information
+open import Reflection.Definition
+open import Reflection.Literal
+open import Reflection.Pattern
+open import Reflection.Term
+
+------------------------------------------------------------------------
+-- Re-export primitive show functions
+
+open import Agda.Builtin.Reflection public
+  using () renaming
+  ( primShowMeta  to showMeta
+  ; primShowQName to showName
+  )
+
+------------------------------------------------------------------------
+-- Non-primitive show functions
+
+showRelevance : Relevance → String
+showRelevance relevant   = "relevant"
+showRelevance irrelevant = "irrelevant"
+
+showRel : Relevance → String
+showRel relevant   = ""
+showRel irrelevant = "."
+
+showVisibility : Visibility → String
+showVisibility visible   = "visible"
+showVisibility hidden    = "hidden"
+showVisibility instance′ = "instance"
+
+showLiteral : Literal → String
+showLiteral (nat x)    = ℕ.show x
+showLiteral (word64 x) = ℕ.show (Word.toℕ x)
+showLiteral (float x)  = Float.show x
+showLiteral (char x)   = Char.show x
+showLiteral (string x) = String.show x
+showLiteral (name x)   = showName x
+showLiteral (meta x)   = showMeta x
+
+mutual
+
+  showPatterns : List (Arg Pattern) → String
+  showPatterns []       = ""
+  showPatterns (a ∷ ps) = showArg a <+> showPatterns ps
+    where
+    showArg : Arg Pattern → String
+    showArg (arg (arg-info visible r) p)   = showRel r ++ showPattern p
+    showArg (arg (arg-info hidden r) p)    = braces (showRel r ++ showPattern p)
+    showArg (arg (arg-info instance′ r) p) = braces (braces (showRel r ++ showPattern p))
+
+  showPattern : Pattern → String
+  showPattern (con c []) = showName c
+  showPattern (con c ps) = parens (showName c <+> showPatterns ps)
+  showPattern dot        = "._"
+  showPattern (var s)    = s
+  showPattern (lit l)    = showLiteral l
+  showPattern (proj f)   = showName f
+  showPattern absurd     = "()"
+
+private
+  -- add appropriate parens depending on the given visibility
+  visibilityParen : Visibility → String → String
+  visibilityParen visible   s = parensIfSpace s
+  visibilityParen hidden    s = braces s
+  visibilityParen instance′ s = braces (braces s)
+
+mutual
+
+  showTerms : List (Arg Term) → String
+  showTerms []             = ""
+  showTerms (arg i t ∷ ts) = visibilityParen (visibility i) (showTerm t) <+> showTerms ts
+
+  showTerm : Term → String
+  showTerm (var x args)         = "var" <+> ℕ.show x <+> showTerms args
+  showTerm (con c args)         = showName c <+> showTerms args
+  showTerm (def f args)         = showName f <+> showTerms args
+  showTerm (lam v (abs s x))    = "λ" <+> visibilityParen v s <+> "→" <+> showTerm x
+  showTerm (pat-lam cs args)    =
+    "λ {" <+> showClauses cs <+> "}" <+> showTerms args
+  showTerm (Π[ x ∶ arg i a ] b) =
+    "Π (" ++ visibilityParen (visibility i) x <+> ":" <+>
+    parensIfSpace (showTerm a) ++ ")" <+> parensIfSpace (showTerm b)
+  showTerm (sort s)             = showSort s
+  showTerm (lit l)              = showLiteral l
+  showTerm (meta x args)        = showMeta x <+> showTerms args
+  showTerm unknown              = "unknown"
+
+  showSort : Sort → String
+  showSort (set t) = "Set" <+> parensIfSpace (showTerm t)
+  showSort (lit n) = "Set" ++ ℕ.show n -- no space to disambiguate from set t
+  showSort unknown = "unknown"
+
+  showClause : Clause → String
+  showClause (clause ps t)      = showPatterns ps <+> "→" <+> showTerm t
+  showClause (absurd-clause ps) = showPatterns ps
+
+  showClauses : List Clause → String
+  showClauses []       = ""
+  showClauses (c ∷ cs) = showClause c <+> ";" <+> showClauses cs
+
+showDefinition : Definition → String
+showDefinition (function cs)       = "function" <+> braces (showClauses cs)
+showDefinition (data-type pars cs) =
+ "datatype" <+> ℕ.show pars <+> braces (intersperse ", " (map showName cs))
+showDefinition (record′ c fs)      =
+ "record" <+> showName c <+> braces (intersperse ", " (map (showName ∘′ unArg) fs))
+showDefinition (constructor′ d)    = "constructor" <+> showName d
+showDefinition axiom               = "axiom"
+showDefinition primitive′          = "primitive"

--- a/src/Reflection/Term.agda
+++ b/src/Reflection/Term.agda
@@ -12,17 +12,18 @@ import Data.Char.Properties as CP using (_≟_)
 open import Data.List.Base hiding (_++_)
 import Data.List.Membership.DecPropositional as ListMembership
 import Data.List.Properties as Lₚ
-import Data.Nat as ℕ
+open import Data.Nat as ℕ using (ℕ; zero; suc)
 import Data.Nat.Show as NatShow
 open import Data.Product
 open import Data.String as String using (String; braces; parens; _++_; _<+>_)
+open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Reflection.Abstraction
 open import Reflection.Argument
 open import Reflection.Argument.Information using (visibility)
 import Reflection.Argument.Visibility as Visibility; open Visibility.Visibility
 import Reflection.Literal as Literal
 import Reflection.Meta as Meta
-import Reflection.Name as Name
+open import Reflection.Name as Name using (Name)
 import Reflection.Pattern as Pattern
 open import Relation.Nullary
 open import Relation.Nullary.Product using (_×-dec_)
@@ -33,7 +34,8 @@ open import Relation.Binary.PropositionalEquality
 ------------------------------------------------------------------------
 -- Re-exporting the builtin type and constructors
 
-open import Agda.Builtin.Reflection as Builtin public using (Sort; Type; Term; Clause)
+open import Agda.Builtin.Reflection as Builtin public
+  using (Sort; Type; Term; Clause)
 open Sort public
 open Term public renaming (agda-sort to sort)
 open Clause public
@@ -53,6 +55,32 @@ pattern Π[_∶_]_ s a ty     = pi a (abs s ty)
 pattern vΠ[_∶_]_ s a ty    = Π[ s ∶ (vArg a) ] ty
 pattern hΠ[_∶_]_ s a ty    = Π[ s ∶ (hArg a) ] ty
 pattern iΠ[_∶_]_ s a ty    = Π[ s ∶ (iArg a) ] ty
+
+----------------------------------------------------------------------
+-- Utility functions
+
+getName : Term → Maybe Name
+getName (con c args) = just c
+getName (def f args) = just f
+getName _            = nothing
+
+-- "n ⋯⟅∷⟆ xs" prepends "n" visible unknown arguments to the list of
+-- arguments. Useful when constructing the list of arguments for a
+-- function with initial inferable arguments.
+infixr 5 _⋯⟨∷⟩_
+_⋯⟨∷⟩_ : ℕ → Args Term → Args Term
+zero  ⋯⟨∷⟩ xs = xs
+suc i ⋯⟨∷⟩ xs = unknown ⟨∷⟩ (i ⋯⟨∷⟩ xs)
+{-# INLINE _⋯⟨∷⟩_ #-}
+
+-- "n ⋯⟅∷⟆ xs" prepends "n" hidden unknown arguments to the list of
+-- arguments. Useful when constructing the list of arguments for a
+-- function with initial implicit arguments.
+infixr 5 _⋯⟅∷⟆_
+_⋯⟅∷⟆_ : ℕ → Args Term → Args Term
+zero  ⋯⟅∷⟆ xs = xs
+suc i ⋯⟅∷⟆ xs = unknown ⟅∷⟆ (i ⋯⟅∷⟆ xs)
+{-# INLINE _⋯⟅∷⟆_ #-}
 
 ------------------------------------------------------------------------
 -- Showing

--- a/src/Reflection/Term.agda
+++ b/src/Reflection/Term.agda
@@ -8,14 +8,10 @@
 
 module Reflection.Term where
 
-import Data.Char.Properties as CP using (_≟_)
 open import Data.List.Base hiding (_++_)
-import Data.List.Membership.DecPropositional as ListMembership
 import Data.List.Properties as Lₚ
 open import Data.Nat as ℕ using (ℕ; zero; suc)
-import Data.Nat.Show as NatShow
 open import Data.Product
-open import Data.String as String using (String; braces; parens; _++_; _<+>_)
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Reflection.Abstraction
 open import Reflection.Argument
@@ -81,61 +77,6 @@ _⋯⟅∷⟆_ : ℕ → Args Term → Args Term
 zero  ⋯⟅∷⟆ xs = xs
 suc i ⋯⟅∷⟆ xs = unknown ⟅∷⟆ (i ⋯⟅∷⟆ xs)
 {-# INLINE _⋯⟅∷⟆_ #-}
-
-------------------------------------------------------------------------
--- Showing
-
--- Note that Reflection.termErr can also be used directly in tactic error
--- messages.
-
-private
-  open ListMembership CP._≟_
-
-  -- enclose string with parens if it contains a space character
-  parensIfSpace : String -> String
-  parensIfSpace s with ' ' ∈? String.toList s
-  ... | yes _ = parens s
-  ... | no _  = s
-
-  -- add appropriate parens depending on the given visibility
-  visibilityParen : Builtin.Visibility → String → String
-  visibilityParen visible   s = parensIfSpace s
-  visibilityParen hidden    s = braces s
-  visibilityParen instance′ s = braces (braces s)
-
-mutual
-
-  showTerms : List (Arg Term) → String
-  showTerms []             = ""
-  showTerms (arg i t ∷ ts) = visibilityParen (visibility i) (show t) <+> showTerms ts
-
-  show : Term → String
-  show (var x args)         = "var" <+> NatShow.show x <+> showTerms args
-  show (con c args)         = Name.show c <+> showTerms args
-  show (def f args)         = Name.show f <+> showTerms args
-  show (lam v (abs s x))    = "λ" <+> visibilityParen v s <+> "→" <+> show x
-  show (pat-lam cs args)    =
-    "λ {" <+> showClauses cs <+> "}" <+> showTerms args
-  show (Π[ x ∶ arg i a ] b) =
-    "Π (" ++ visibilityParen (visibility i) x <+> ":" <+>
-    parensIfSpace (show a) ++ ")" <+> parensIfSpace (show b)
-  show (sort s)             = showSort s
-  show (lit l)              = Literal.show l
-  show (meta x args)        = Meta.show x <+> showTerms args
-  show unknown              = "unknown"
-
-  showSort : Sort → String
-  showSort (set t) = "Set" <+> parensIfSpace (show t)
-  showSort (lit n) = "Set" ++ NatShow.show n -- no space to disambiguate from set t
-  showSort unknown = "unknown"
-
-  showClause : Clause → String
-  showClause (clause ps t)      = Pattern.showPatterns ps <+> "→" <+> show t
-  showClause (absurd-clause ps) = Pattern.showPatterns ps
-
-  showClauses : List Clause → String
-  showClauses []       = ""
-  showClauses (c ∷ cs) = showClause c <+> ";" <+> showClauses cs
 
 ------------------------------------------------------------------------
 -- Decidable equality

--- a/src/Tactic/MonoidSolver.agda
+++ b/src/Tactic/MonoidSolver.agda
@@ -82,6 +82,9 @@ open import Data.Nat     as ℕ       using (ℕ; suc; zero)
 open import Data.Product as Product using (_×_; _,_)
 
 open import Agda.Builtin.Reflection
+open import Reflection.TCMonadSyntax
+open import Reflection.Term using (getName; _⋯⟅∷⟆_)
+open import Reflection.Argument
 
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 
@@ -95,8 +98,10 @@ data Expr {a} (A : Set a) : Set a where
   ε′    : Expr A
   [_↑]  : A → Expr A
 
-module _ {m₁ m₂} (mon : Monoid m₁ m₂) where
-  open Monoid mon
+module _ {m₁ m₂} (monoid : Monoid m₁ m₂) where
+
+  open Monoid monoid
+  open SetoidReasoning setoid
 
   -- Convert the AST to an expression (i.e. evaluate it) without
   -- normalising.
@@ -119,8 +124,6 @@ module _ {m₁ m₂} (mon : Monoid m₁ m₂) where
 
   [_⇓] : Expr Carrier → Carrier
   [ x ⇓] = [ x ⇓]′ ε
-
-  open SetoidReasoning setoid
 
   homo′ : ∀ x y → [ x ⇓] ∙ y ≈ [ x ⇓]′ y
   homo′ ε′ y       = identityˡ y
@@ -149,35 +152,13 @@ module _ {m₁ m₂} (mon : Monoid m₁ m₂) where
 _==_ = primQNameEquality
 {-# INLINE _==_ #-}
 
-_>>=_ = bindTC
-{-# INLINE _>>=_ #-}
-
-_>>_ : ∀ {a b} {A : Set a} {B : Set b} → TC A → TC B → TC B
-xs >> ys = xs >>= λ _ → ys
-{-# INLINE _>>_ #-}
-
-infixr 5 _⟨∷⟩_ _⟅∷⟆_
-pattern _⟨∷⟩_ x xs = arg (arg-info visible relevant) x ∷ xs
-pattern _⟅∷⟆_ x xs = arg (arg-info hidden relevant) x ∷ xs
-
-infixr 5 _⋯⟅∷⟆_
-_⋯⟅∷⟆_ : ℕ → List (Arg Term) → List (Arg Term)
-zero  ⋯⟅∷⟆ xs = xs
-suc i ⋯⟅∷⟆ xs = unknown ⟅∷⟆ i ⋯⟅∷⟆ xs
-{-# INLINE _⋯⟅∷⟆_ #-}
-
-getName : Term → Maybe Name
-getName (con c args) = just c
-getName (def f args) = just f
-getName _ = nothing
-
 getArgs : Term → Maybe (Term × Term)
 getArgs (def _ xs) = go xs
   where
   go : List (Arg Term) → Maybe (Term × Term)
-  go (x ⟨∷⟩ y ⟨∷⟩ []) = just (x , y)
-  go (x ∷ xs) = go xs
-  go _ = nothing
+  go (vArg x ∷ vArg y ∷ []) = just (x , y)
+  go (x ∷ xs)               = go xs
+  go _                      = nothing
 getArgs _ = nothing
 
 ----------------------------------------------------------------------
@@ -188,7 +169,9 @@ getArgs _ = nothing
 -- The first is the field accessor for the monoid record itself.
 -- However, users will likely want to use the solver with
 -- expressions like:
+--
 --   xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+--
 -- So we also evaluate the field accessor to find functions like ++.
 
 record MonoidNames : Set where
@@ -196,71 +179,86 @@ record MonoidNames : Set where
     is-∙ : Name → Bool
     is-ε : Name → Bool
 
+buildMatcher : Name → Maybe Name → Name → Bool
+buildMatcher n nothing  x = n == x
+buildMatcher n (just m) x = n == x ∨ m == x
+
 findMonoidNames : Term → TC MonoidNames
 findMonoidNames mon = do
-  ∙-name ← normalise (quote Monoid._∙_ ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ [])
-  ε-name ← normalise (quote Monoid.ε   ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ [])
+  ∙-altName ← normalise (def (quote Monoid._∙_) (2 ⋯⟅∷⟆ mon ⟨∷⟩ []))
+  ε-altName ← normalise (def (quote Monoid.ε)   (2 ⋯⟅∷⟆ mon ⟨∷⟩ []))
   returnTC record
-    { is-∙ = buildMatcher (quote Monoid._∙_) (getName ∙-name)
-    ; is-ε = buildMatcher (quote Monoid.ε)   (getName ε-name)
+    { is-∙ = buildMatcher (quote Monoid._∙_) (getName ∙-altName)
+    ; is-ε = buildMatcher (quote Monoid.ε)   (getName ε-altName)
     }
-  where
-
-  buildMatcher : Name → Maybe Name → Name → Bool
-  buildMatcher n = maybe (λ m x → n == x ∨ m == x) (n ==_)
 
 ----------------------------------------------------------------------
 -- Building Expr
 ----------------------------------------------------------------------
 
-ε″ : Term
-ε″ = quote ε′ ⟨ con ⟩ []
+-- We now define a function that takes an AST representing the LHS
+-- or RHS of the equation to solve and converts it into an AST
+-- respresenting the corresponding Expr.
+
+″ε″ : Term
+″ε″ = quote ε′ ⟨ con ⟩ []
 
 [_↑]′ : Term → Term
 [ t ↑]′ = quote [_↑] ⟨ con ⟩ (t ⟨∷⟩ [])
 
 module _ (names : MonoidNames) where
+
  open MonoidNames names
 
  mutual
-  ∙″ : List (Arg Term) → Term
-  ∙″ (x ⟨∷⟩ y ⟨∷⟩ []) = quote _∙′_ ⟨ con ⟩ E′ x ⟨∷⟩ E′ y ⟨∷⟩ []
-  ∙″ (x ∷ xs) = ∙″ xs
-  ∙″ _ = unknown
+  ″∙″ : List (Arg Term) → Term
+  ″∙″ (x ⟨∷⟩ y ⟨∷⟩ []) = quote _∙′_ ⟨ con ⟩ buildExpr x ⟨∷⟩ buildExpr y ⟨∷⟩ []
+  ″∙″ (x ∷ xs)         = ″∙″ xs
+  ″∙″ _                = unknown
 
-  E′ : Term → Term
-  E′ t@(def n xs) = if is-∙ n
-                      then ∙″ xs
-                    else if is-ε n
-                      then ε″
-                      else [ t ↑]′
-  E′ t@(con n xs) = if is-∙ n
-                      then ∙″ xs
-                    else if is-ε n
-                      then ε″
-                      else [ t ↑]′
-  E′ t = quote [_↑] ⟨ con ⟩ (t ⟨∷⟩ [])
+  buildExpr : Term → Term
+  buildExpr t@(def n xs) =
+    if is-∙ n
+      then ″∙″ xs
+    else if is-ε n
+      then ″ε″
+    else
+      [ t ↑]′
+  buildExpr t@(con n xs) =
+    if is-∙ n
+      then ″∙″ xs
+    else if is-ε n
+      then ″ε″
+    else [ t ↑]′
+  buildExpr t = quote [_↑] ⟨ con ⟩ (t ⟨∷⟩ [])
 
 ----------------------------------------------------------------------
 -- Constructing the solution
 ----------------------------------------------------------------------
 
 -- This function joins up the two homomorphism proofs. It constructs
--- an expression something like the following:
+-- a proof of the following form:
+--
 --   trans (sym (homo x)) (homo y)
+--
 -- where x and y are the Expr representations of each side of the
 -- goal equation.
+
 constructSoln : Term → MonoidNames → Term → Term → Term
 constructSoln mon names lhs rhs =
   quote Monoid.trans ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩
     (quote Monoid.sym ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩
-       (quote homo ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ E′ names lhs ⟨∷⟩ []) ⟨∷⟩ [])
+       (quote homo ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ buildExpr names lhs ⟨∷⟩ []) ⟨∷⟩ [])
     ⟨∷⟩
-    (quote homo ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ E′ names rhs ⟨∷⟩ []) ⟨∷⟩
+    (quote homo ⟨ def ⟩ 2 ⋯⟅∷⟆ mon ⟨∷⟩ buildExpr names rhs ⟨∷⟩ []) ⟨∷⟩
     []
 
+----------------------------------------------------------------------
+-- Macro
+----------------------------------------------------------------------
+
 solve-macro : Term → Term → TC _
-solve-macro mon = λ hole → do
+solve-macro mon hole = do
   hole′ ← inferType hole >>= normalise
   names ← findMonoidNames mon
   just (lhs , rhs) ← returnTC (getArgs hole′)

--- a/src/Tactic/RingSolver.agda
+++ b/src/Tactic/RingSolver.agda
@@ -17,12 +17,15 @@ open import Data.Vec   as Vec   using (Vec; _∷_; [])
 open import Data.List  as List  using (List; _∷_; [])
 open import Data.Maybe.Base as Maybe using (Maybe; just; nothing; fromMaybe)
 open import Data.Nat            using (ℕ; suc; zero; _<ᵇ_)
+open import Data.Nat.Reflection using (toTerm; toFinTerm)
 open import Data.Bool           using (Bool; if_then_else_; true; false)
 open import Data.Unit           using (⊤)
 open import Data.String         using (String)
 open import Data.Product        using (_,_)
 open import Function
 open import Reflection.TCMonadSyntax
+open import Reflection.Argument
+open import Reflection.Term
 
 open import Tactic.RingSolver.NonReflective renaming (solve to solve-fn)
 open import Tactic.RingSolver.Core.AlmostCommutativeRing
@@ -36,138 +39,144 @@ open AlmostCommutativeRing
 ------------------------------------------------------------------------
 
 private
-  record Ring⇓ : Set where
+  record RingNames : Set where
     constructor +⇒_*⇒_^⇒_-⇒_
     field
       +′ *′ ^′ -′ : Maybe Name
 
-  _∈Ring : Term → TC Term
-  ring ∈Ring = checkType ring (def (quote AlmostCommutativeRing) (unknown ⟨∷⟩ unknown ⟨∷⟩ []))
+  checkIsRing : Term → TC Term
+  checkIsRing ring = checkType ring (def (quote AlmostCommutativeRing) (2 ⋯⟨∷⟩ []))
 
-  vars : Term → Maybe NatSet
-  vars = go []
+  getVariableIDs : Term → Maybe NatSet
+  getVariableIDs = go []
     where
     go : NatSet → Term → Maybe NatSet
     go t (con (quote List._∷_) (_ ∷ _ ∷ var i [] ⟨∷⟩ xs ⟨∷⟩ _)) = go (insert i t) xs
-    go t (con (quote List.List.[]) _) = just t
-    go _ _ = nothing
+    go t (con (quote List.List.[]) _)                           = just t
+    go _ _                                                      = nothing
 
   module OverRing (ring : Term) where
-    _∈List⟨Carrier⟩ : Term → TC Term
-    t ∈List⟨Carrier⟩ =
-      checkType t
-        (quote List ⟨ def ⟩ 1 ⋯⟅∷⟆ def (quote Carrier) (2 ⋯⟅∷⟆ ring ⟨∷⟩ []) ⟨∷⟩ []) >>= normalise
 
-    ⟦_⇓⟧ₙ : Name → TC (Maybe Name)
-    ⟦ nm ⇓⟧ₙ = normalise (nm ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ []) <&> λ where
+    -- Takes the name of a function that takes the ring as it's first
+    -- explicit argument and the terms of it's arguments and inserts
+    -- the required ring arguments
+    --   e.g. "_+_" $ʳ xs = "_+_ {_} {_} ring xs"
+    _$ʳ_ : Name → Args Term → Term
+    nm $ʳ args = def nm (2 ⋯⟅∷⟆ ring ⟨∷⟩ args)
+
+    checkIsListOfVariables : Term → TC Term
+    checkIsListOfVariables xs =
+      checkType xs (def (quote List) (1 ⋯⟅∷⟆ (quote Carrier $ʳ []) ⟨∷⟩ [])) >>= normalise
+
+    getFieldName : Name → TC (Maybe Name)
+    getFieldName nm = normalise (nm $ʳ []) <&> λ where
       (def f args) → just f
       _            → nothing
 
-    ring⇓ : TC Ring⇓
-    ring⇓ = ⦇ +⇒ ⟦ quote _+_ ⇓⟧ₙ *⇒ ⟦ quote _*_ ⇓⟧ₙ ^⇒ ⟦ quote _^_ ⇓⟧ₙ -⇒ ⟦ quote -_ ⇓⟧ₙ ⦈
+    getRingOperatorNames : TC RingNames
+    getRingOperatorNames = ⦇
+      +⇒ getFieldName (quote _+_)
+      *⇒ getFieldName (quote _*_)
+      ^⇒ getFieldName (quote _^_)
+      -⇒ getFieldName (quote -_)
+      ⦈
 
-    module _ (nms : Ring⇓) where
-      open Ring⇓ nms
+    module _ (nms : RingNames) (numVars : ℕ) where
+      open RingNames nms
 
-      module _ (numVars : ℕ) where
+      -- This function applies the hidden arguments that the constructors
+      -- that Expr needs. The first is the universe level, the second is the
+      -- type it contains, and the third is the number of variables it's
+      -- indexed by. All three of these could likely be inferred, but to
+      -- make things easier we supply the third because we know it.
+      _$ᵉ_ : Name → List (Arg Term) → Term
+      e $ᵉ xs = con e (1 ⋯⟅∷⟆ quote Carrier $ʳ [] ⟅∷⟆ toTerm numVars ⟅∷⟆ xs)
 
-        -- This function applies the hidden arguments that the constructors
-        -- that Expr needs. The first is the universe level, the second is the
-        -- type it contains, and the third is the number of variables it's
-        -- indexed by. All three of these could likely be inferred, but to
-        -- make things easier we supply the third because we know it.
-        infixr 5 E⟅∷⟆_
-        E⟅∷⟆_ : List (Arg Term) → List (Arg Term)
-        E⟅∷⟆ xs = 1 ⋯⟅∷⟆
-                  (quote Carrier ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ []) ⟅∷⟆
-                  ℕ′ numVars ⟅∷⟆
-                  xs
+      -- A constant expression.
+      Κ′ : Term → Term
+      Κ′ x = quote Κ $ᵉ (x ⟨∷⟩ [])
 
-        -- A constant expression.
-        Κ′ : Term → Term
-        Κ′ x = quote Κ ⟨ con ⟩ E⟅∷⟆ x ⟨∷⟩ []
+      _⇓≟_ : Maybe Name → Name → Bool
+      nothing ⇓≟ _ = false
+      just x  ⇓≟ y = primQNameEquality x y
+      {-# INLINE _⇓≟_ #-}
 
-        _⇓≟_ : Maybe Name → Name → Bool
-        nothing ⇓≟ _ = false
-        just x  ⇓≟ y = primQNameEquality x y
-        {-# INLINE _⇓≟_ #-}
+      module ToExpr (Ι′ : ℕ → Maybe Term) where
+        mutual
+          -- Application of a ring operator often doesn't have a type as
+          -- simple as "Carrier → Carrier → Carrier": there may be hidden
+          -- arguments, etc. Here, we do our best to handle those cases,
+          -- by just taking the last two explicit arguments.
+          E⟨_⟩₂ : Name → List (Arg Term) → Term
+          E⟨ nm ⟩₂ (x ⟨∷⟩ y ⟨∷⟩ []) = nm $ᵉ (E x ⟨∷⟩ E y ⟨∷⟩ [])
+          E⟨ nm ⟩₂ (x ∷ xs)         = E⟨ nm ⟩₂ xs
+          E⟨ nm ⟩₂ _                = unknown
 
-        module ToExpr (Ι′ : ℕ → Maybe Term) where
-          mutual
-            -- Application of a ring operator often doesn't have a type as
-            -- simple as "Carrier → Carrier → Carrier": there may be hidden
-            -- arguments, etc. Here, we do our best to handle those cases,
-            -- by just taking the last two explicit arguments.
-            E⟨_⟩₂ : Name → List (Arg Term) → Term
-            E⟨ nm ⟩₂ (x ⟨∷⟩ y ⟨∷⟩ []) = nm ⟨ con ⟩ E⟅∷⟆ E x ⟨∷⟩ E y ⟨∷⟩ []
-            E⟨ nm ⟩₂ (x ∷ xs)         = E⟨ nm ⟩₂ xs
-            E⟨ nm ⟩₂ _                = unknown
+          E⟨_⟩₁ : Name → List (Arg Term) → Term
+          E⟨ nm ⟩₁ (x ⟨∷⟩ []) = nm $ᵉ (E x ⟨∷⟩ [])
+          E⟨ nm ⟩₁ (x ∷ xs)   = E⟨ nm ⟩₁ xs
+          E⟨ _  ⟩₁ _          = unknown
 
-            E⟨_⟩₁ : Name → List (Arg Term) → Term
-            E⟨ nm ⟩₁ (x ⟨∷⟩ []) = nm ⟨ con ⟩ E⟅∷⟆ E x ⟨∷⟩ []
-            E⟨ nm ⟩₁ (x ∷ xs)   = E⟨ nm ⟩₁ xs
-            E⟨ _  ⟩₁ _          = unknown
+          E⟨^⟩ : List (Arg Term) → Term
+          E⟨^⟩ (x ⟨∷⟩ y ⟨∷⟩ []) = quote _⊛_ $ᵉ (E x ⟨∷⟩ y ⟨∷⟩ [])
+          E⟨^⟩ (x ∷ xs)         = E⟨^⟩ xs
+          E⟨^⟩ _                = unknown
 
-            E⟨^⟩ : List (Arg Term) → Term
-            E⟨^⟩ (x ⟨∷⟩ y ⟨∷⟩ []) = quote _⊛_ ⟨ con ⟩ E⟅∷⟆ E x ⟨∷⟩ y ⟨∷⟩ []
-            E⟨^⟩ (x ∷ xs)         = E⟨^⟩ xs
-            E⟨^⟩ _                = unknown
+          -- When trying to figure out the shape of an expression, one of
+          -- the difficult tasks is recognizing where constants in the
+          -- underlying ring are used. If we were only dealing with ℕ, we
+          -- might look for its constructors: however, we want to deal with
+          -- arbitrary types which implement AlmostCommutativeRing. If the
+          -- Term type contained type information we might be able to
+          -- recognize it there, but it doesn't.
+          --
+          -- We're in luck, though, because all other cases in the following
+          -- function *are* recognizable. As a result, the "catch-all" case
+          -- will just assume that it has a constant expression.
+          E : Term → Term
+          -- Recognise the ring's fields
+          E (def (quote _+_) xs) = E⟨ quote _⊕_ ⟩₂ xs
+          E (def (quote _*_) xs) = E⟨ quote _⊗_ ⟩₂ xs
+          E (def (quote _^_) xs) = E⟨^⟩ xs
+          E (def (quote -_)  xs) = E⟨ quote ⊝_ ⟩₁ xs
+          -- Recognise the underlying implementation of the ring's fields
+          E (def nm          xs) = if +′ ⇓≟ nm then E⟨ quote _⊕_ ⟩₂ xs else
+                                   if *′ ⇓≟ nm then E⟨ quote _⊗_ ⟩₂ xs else
+                                   if ^′ ⇓≟ nm then E⟨^⟩ xs else
+                                   if -′ ⇓≟ nm then E⟨ quote ⊝_ ⟩₁ xs else
+                                   Κ′ (def nm xs)
+          -- Variables
+          E v@(var x _)          = fromMaybe (Κ′ v) (Ι′ x)
+          -- Special case to recognise "suc" for naturals
+          E (con (quote ℕ.suc) (x ⟨∷⟩ [])) = quote _⊕_ $ᵉ (Κ′ (toTerm 1) ⟨∷⟩ E x ⟨∷⟩ [])
+          E t                    = Κ′ t
 
-            ETop : List (Arg Term) → Term
-            ETop (x ⟨∷⟩ []) = E x
-            ETop _          = unknown
+      callSolver : Vec String numVars → Term → Term → Args Type
+      callSolver nms lhs rhs =
+          2 ⋯⟅∷⟆ ring ⟨∷⟩ toTerm numVars ⟨∷⟩
+          vlams nms (quote _⊜_  $ʳ (toTerm numVars ⟨∷⟩ E lhs ⟨∷⟩ E rhs ⟨∷⟩ [])) ⟨∷⟩
+          hlams nms (quote refl $ʳ (1 ⋯⟅∷⟆ [])) ⟨∷⟩
+          []
+        where
+        Ι′ : ℕ → Maybe Term
+        Ι′ i = if i <ᵇ numVars then just (var i []) else nothing
+        open ToExpr Ι′
 
-            -- When trying to figure out the shape of an expression, one of
-            -- the difficult tasks is recognizing where constants in the
-            -- underlying ring are used. If we were only dealing with ℕ, we
-            -- might look for its constructors: however, we want to deal with
-            -- arbitrary types which implement AlmostCommutativeRing. If the
-            -- Term type contained type information we might be able to
-            -- recognize it there, but it doesn't.
-            --
-            -- We're in luck, though, because all other cases in the following
-            -- function *are* recognizable. As a result, the "catch-all" case
-            -- will just assume that it has a constant expression.
-            E : Term → Term
-            E (def (quote _+_) xs) = E⟨ quote _⊕_ ⟩₂ xs
-            E (def (quote _*_) xs) = E⟨ quote _⊗_ ⟩₂ xs
-            E (def (quote _^_) xs) = E⟨^⟩ xs
-            E (def (quote -_)  xs) = E⟨ quote ⊝_ ⟩₁ xs
-            E (def nm          xs) = if +′ ⇓≟ nm then E⟨ quote _⊕_ ⟩₂ xs else
-                                     if *′ ⇓≟ nm then E⟨ quote _⊗_ ⟩₂ xs else
-                                     if ^′ ⇓≟ nm then E⟨^⟩ xs else
-                                     if -′ ⇓≟ nm then E⟨ quote ⊝_ ⟩₁ xs else
-                                     Κ′ (def nm xs)
-            E (con (quote ℕ.suc) (x ⟨∷⟩ [])) = quote _⊕_ ⟨ con ⟩ E⟅∷⟆ Κ′ (ℕ′ (ℕ.suc ℕ.zero)) ⟨∷⟩ E x ⟨∷⟩ []
-            E v@(var x _)          = fromMaybe (Κ′ v) (Ι′ x)
-            E t                    = Κ′ t
+      constructSoln : NatSet → Term → Term → Term
+      constructSoln t lhs rhs =
+          quote trans $ʳ (3 ⋯⟅∷⟆
+            quote sym $ʳ (2 ⋯⟅∷⟆
+              quote Ops.correct $ʳ (1 ⋯⟅∷⟆ E lhs ⟨∷⟩ ρ ⟨∷⟩ []) ⟨∷⟩ [])
+            ⟨∷⟩
+            (quote Ops.correct $ʳ (1 ⋯⟅∷⟆ E rhs ⟨∷⟩ ρ ⟨∷⟩ [])) ⟨∷⟩
+            [])
+        where
+        Ι′ : ℕ → Maybe Term
+        Ι′ i = Maybe.map (λ x → quote Ι $ᵉ (toFinTerm x ⟨∷⟩ [])) (lookup i t)
 
-        callSolver : Vec String numVars → Term → Term → List (Arg Type)
-        callSolver nms lhs rhs =
-            2 ⋯⟅∷⟆ ring ⟨∷⟩ ℕ′ numVars ⟨∷⟩
-            vlams nms (quote _⊜_  ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ ℕ′ numVars ⟨∷⟩ E lhs ⟨∷⟩ E rhs ⟨∷⟩ []) ⟨∷⟩
-            hlams nms (quote refl ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ 1 ⋯⟅∷⟆ []) ⟨∷⟩
-            []
-          where
-          Ι′ : ℕ → Maybe Term
-          Ι′ i = if i <ᵇ numVars then just (var i []) else nothing
-          open ToExpr Ι′
-
-        constructSoln : NatSet → Term → Term → Term
-        constructSoln t lhs rhs =
-            quote trans ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ 3 ⋯⟅∷⟆
-              (quote sym ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ 2 ⋯⟅∷⟆
-                  (quote Ops.correct ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ 1 ⋯⟅∷⟆ E lhs ⟨∷⟩ ρ ⟨∷⟩ []) ⟨∷⟩ [])
-              ⟨∷⟩
-              (quote Ops.correct ⟨ def ⟩ 2 ⋯⟅∷⟆ ring ⟨∷⟩ 1 ⋯⟅∷⟆ E rhs ⟨∷⟩ ρ ⟨∷⟩ []) ⟨∷⟩
-              []
-          where
-          Ι′ : ℕ → Maybe Term
-          Ι′ i = Maybe.map (λ x → quote Ι ⟨ con ⟩ E⟅∷⟆ Fin′ x ⟨∷⟩ []) (lookup i t)
-
-          open ToExpr Ι′
-          ρ : Term
-          ρ = curriedTerm t
+        open ToExpr Ι′
+        ρ : Term
+        ρ = curriedTerm t
 
 ------------------------------------------------------------------------
 -- Macros
@@ -184,19 +193,19 @@ private
 
 solve-∀-macro : Name → Term → TC ⊤
 solve-∀-macro ring hole = do
-  ring′ ← def ring [] ∈Ring
+  ring′ ← checkIsRing (def ring [])
   commitTC
   let open OverRing ring′
-  nms   ← ring⇓
+  operatorNames ← getRingOperatorNames
   hole′ ← inferType hole >>= reduce
-  let i , k , xs = underPi hole′
-  just (lhs ∷ rhs ∷ []) ← pure (getArgs 2 xs)
+  let variables , k , equation = underPi hole′
+  just (lhs ∷ rhs ∷ []) ← pure (getArgs 2 equation)
     where nothing → typeError (strErr "Malformed call to solve." ∷
                                strErr "Expected target type to be like: ∀ x y → x + y ≈ y + x." ∷
                                strErr "Instead: " ∷
                                termErr hole′ ∷
                                [])
-  unify hole (quote solve-fn ⟨ def ⟩ callSolver nms i k lhs rhs)
+  unify hole (def (quote solve-fn) (callSolver operatorNames variables k lhs rhs))
 
 macro
   solve-∀ : Name → Term → TC ⊤
@@ -223,18 +232,18 @@ macro
 
 solve-macro : Term → Name → Term → TC ⊤
 solve-macro i ring hole = do
-  ring′ ← def ring [] ∈Ring
+  ring′ ← checkIsRing (def ring [])
   commitTC
   let open OverRing ring′
-  nms ← ring⇓
-  i′ ← i ∈List⟨Carrier⟩
+  operatorNames ← getRingOperatorNames
+  listOfVariables′ ← checkIsListOfVariables i
   commitTC
   hole′ ← inferType hole >>= reduce
-  just vars′ ← pure (vars i′)
+  just vars′ ← pure (getVariableIDs listOfVariables′)
     where nothing → typeError (strErr "Malformed call to solve." ∷
                                strErr "First argument should be a list of free variables." ∷
                                strErr "Instead: " ∷
-                               termErr i′ ∷
+                               termErr listOfVariables′ ∷
                                [])
   just (lhs ∷ rhs ∷ []) ← pure (getArgs 2 hole′)
     where nothing → typeError (strErr "Malformed call to solve." ∷
@@ -242,7 +251,7 @@ solve-macro i ring hole = do
                                strErr "Instead: " ∷
                                termErr hole′ ∷
                                [])
-  unify hole (constructSoln nms (List.length vars′) vars′ lhs rhs)
+  unify hole (constructSoln operatorNames (List.length vars′) vars′ lhs rhs)
 
 macro
   solve : Term → Name → Term → TC ⊤

--- a/src/Tactic/RingSolver/Core/ReflectionHelp.agda
+++ b/src/Tactic/RingSolver/Core/ReflectionHelp.agda
@@ -20,33 +20,16 @@ open import Data.Maybe.Base as Maybe using (Maybe; just; nothing)
 open import Data.Product
 open import Function
 open import Level using (Level)
+open import Reflection.Term
+open import Reflection.Argument
 
 open import Tactic.RingSolver.Core.NatSet as NatSet
-
 private
   variable
     a : Level
     A : Set a
 
 -- TO-DO - once `Reflection` is --safe after v1.3 a lot of this can be simplified
-
-infixr 5 _⟨∷⟩_ _⟅∷⟆_
-pattern _⟨∷⟩_ x xs = arg (arg-info visible relevant) x ∷ xs
-pattern _⟅∷⟆_ x xs = arg (arg-info hidden  relevant) x ∷ xs
-
-infixr 5 _⋯⟅∷⟆_
-_⋯⟅∷⟆_ : ℕ → List (Arg Term) → List (Arg Term)
-zero  ⋯⟅∷⟆ xs = xs
-suc i ⋯⟅∷⟆ xs = unknown ⟅∷⟆ i ⋯⟅∷⟆ xs
-{-# INLINE _⋯⟅∷⟆_ #-}
-
-ℕ′ : ℕ → Term
-ℕ′ zero    = con (quote zero) []
-ℕ′ (suc i) = con (quote suc)  (ℕ′ i ⟨∷⟩ [])
-
-Fin′ : ℕ → Term
-Fin′ zero    = con (quote Fin.zero) (1 ⋯⟅∷⟆ [])
-Fin′ (suc i) = con (quote Fin.suc)  (1 ⋯⟅∷⟆ Fin′ i ⟨∷⟩ [])
 
 hlams : ∀ {n} → Vec String n → Term → Term
 hlams vs xs = Vec.foldr (const Term) (λ v vs → lam hidden (abs v vs)) xs vs


### PR DESCRIPTION
This is mostly renaming, shuffling of things about and adding additional comments as I go through and try and get my head around reflection.

The one thing I'm not sure about is whether reflection utilities for specific data types should go in `Data.Nat.Reflection` or `Reflection.Data.Nat`? The former is much more standard, i.e. we have `Data.List.Relation` / `Data.Nat.Induction` / `Data.Nat.Tactic`, but maybe reflection is suitably "meta" that it deserves to be all grouped together...
