### PR TITLE
Use generalized variables in Category subdirectory

### DIFF
--- a/src/Category/Applicative.agda
+++ b/src/Category/Applicative.agda
@@ -11,27 +11,31 @@
 
 module Category.Applicative where
 
-open import Level using (suc; _⊔_)
+open import Level using (Level; suc; _⊔_)
 open import Data.Unit
 open import Category.Applicative.Indexed
 
-RawApplicative : ∀ {f} → (Set f → Set f) → Set (suc f)
+private
+  variable
+    f : Level
+
+RawApplicative : (Set f → Set f) → Set (suc f)
 RawApplicative F = RawIApplicative {I = ⊤} λ _ _ → F
 
-module RawApplicative {f} {F : Set f → Set f}
+module RawApplicative {F : Set f → Set f}
                       (app : RawApplicative F) where
   open RawIApplicative app public
 
-RawApplicativeZero : ∀ {f} → (Set f → Set f) → Set _
+RawApplicativeZero : (Set f → Set f) → Set _
 RawApplicativeZero F = RawIApplicativeZero {I = ⊤} (λ _ _ → F)
 
-module RawApplicativeZero {f} {F : Set f → Set f}
+module RawApplicativeZero {F : Set f → Set f}
                           (app : RawApplicativeZero F) where
   open RawIApplicativeZero app public
 
-RawAlternative : ∀ {f} → (Set f → Set f) → Set _
+RawAlternative : (Set f → Set f) → Set _
 RawAlternative F = RawIAlternative {I = ⊤} (λ _ _ → F)
 
-module RawAlternative {f} {F : Set f → Set f}
-                          (app : RawAlternative F) where
+module RawAlternative {F : Set f → Set f}
+                      (app : RawAlternative F) where
   open RawIAlternative app public

--- a/src/Category/Applicative/Predicate.agda
+++ b/src/Category/Applicative/Predicate.agda
@@ -18,9 +18,13 @@ open import Level
 open import Relation.Unary
 open import Relation.Unary.PredicateTransformer using (Pt)
 
+private
+  variable
+    i ℓ : Level
+
 ------------------------------------------------------------------------
 
-record RawPApplicative {i ℓ} {I : Set i} (F : Pt I ℓ) :
+record RawPApplicative {I : Set i} (F : Pt I ℓ) :
                        Set (i ⊔ suc ℓ) where
   infixl 4 _⊛_ _<⊛_ _⊛>_
   infix  4 _⊗_

--- a/src/Category/Comonad.agda
+++ b/src/Category/Comonad.agda
@@ -13,29 +13,36 @@ module Category.Comonad where
 open import Level
 open import Function
 
-record RawComonad {f} (W : Set f → Set f) : Set (suc f) where
+private
+  variable
+    a b c f : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+record RawComonad (W : Set f → Set f) : Set (suc f) where
 
   infixl 1 _=>>_ _=>=_
   infixr 1 _<<=_ _=<=_
 
   field
-    extract : ∀ {A} → W A → A
-    extend  : ∀ {A B} → (W A → B) → (W A → W B)
+    extract : W A → A
+    extend  : (W A → B) → (W A → W B)
 
-  duplicate : ∀ {A} → W A → W (W A)
+  duplicate : W A → W (W A)
   duplicate = extend id
 
-  liftW : ∀ {A B} → (A → B) → W A → W B
+  liftW : (A → B) → W A → W B
   liftW f = extend (f ∘′ extract)
 
-  _=>>_ : ∀ {A B} → W A → (W A → B) → W B
+  _=>>_ : W A → (W A → B) → W B
   _=>>_ = flip extend
 
-  _=>=_ : ∀ {c A B} {C : Set c} → (W A → B) → (W B → C) → W A → C
+  _=>=_ : (W A → B) → (W B → C) → W A → C
   f =>= g = g ∘′ extend f
 
-  _<<=_ : ∀ {A B} → (W A → B) → W A → W B
+  _<<=_ : (W A → B) → W A → W B
   _<<=_ = extend
 
-  _=<=_ : ∀ {A B c} {C : Set c} → (W B → C) → (W A → B) → W A → C
+  _=<=_ : (W B → C) → (W A → B) → W A → C
   _=<=_ = flip _=>=_

--- a/src/Category/Functor.agda
+++ b/src/Category/Functor.agda
@@ -15,27 +15,32 @@ open import Level
 
 open import Relation.Binary.PropositionalEquality
 
-record RawFunctor {ℓ ℓ′} (F : Set ℓ → Set ℓ′) : Set (suc ℓ ⊔ ℓ′) where
+private
+  variable
+    ℓ ℓ′ ℓ″ : Level
+    A B X Y : Set ℓ
+
+record RawFunctor (F : Set ℓ → Set ℓ′) : Set (suc ℓ ⊔ ℓ′) where
   infixl 4 _<$>_ _<$_
   infixl 1 _<&>_
 
   field
-    _<$>_ : ∀ {A B} → (A → B) → F A → F B
+    _<$>_ : (A → B) → F A → F B
 
-  _<$_ : ∀ {A B} → A → F B → F A
+  _<$_ : A → F B → F A
   x <$ y = const x <$> y
 
-  _<&>_ : ∀ {A B} → F A → (A → B) → F B
+  _<&>_ : F A → (A → B) → F B
   _<&>_ = flip _<$>_
 
 -- A functor morphism from F₁ to F₂ is an operation op such that
 -- op (F₁ f x) ≡ F₂ f (op x)
 
-record Morphism {ℓ ℓ′ ℓ″} {F₁ : Set ℓ → Set ℓ′} {F₂ : Set ℓ → Set ℓ″}
+record Morphism {F₁ : Set ℓ → Set ℓ′} {F₂ : Set ℓ → Set ℓ″}
                 (fun₁ : RawFunctor F₁)
                 (fun₂ : RawFunctor F₂) : Set (suc ℓ ⊔ ℓ′ ⊔ ℓ″) where
   open RawFunctor
   field
-    op     : ∀{X} → F₁ X → F₂ X
-    op-<$> : ∀{X Y} (f : X → Y) (x : F₁ X) →
+    op     : F₁ X → F₂ X
+    op-<$> : (f : X → Y) (x : F₁ X) →
              op (fun₁ ._<$>_ f x) ≡ fun₂ ._<$>_ f (op x)

--- a/src/Category/Functor/Predicate.agda
+++ b/src/Category/Functor/Predicate.agda
@@ -15,7 +15,11 @@ open import Level
 open import Relation.Unary
 open import Relation.Unary.PredicateTransformer using (PT)
 
-record RawPFunctor {i j ℓ₁ ℓ₂} {I : Set i} {J : Set j}
+private
+  variable
+    i j ℓ₁ ℓ₂ : Level
+
+record RawPFunctor {I : Set i} {J : Set j}
                    (F : PT I J ℓ₁ ℓ₂) : Set (i ⊔ j ⊔ suc ℓ₁ ⊔ suc ℓ₂)
                    where
   infixl 4 _<$>_ _<$_

--- a/src/Category/Monad.agda
+++ b/src/Category/Monad.agda
@@ -13,27 +13,29 @@ module Category.Monad where
 open import Function
 open import Category.Monad.Indexed
 open import Data.Unit
+open import Level
 
-RawMonad : ∀ {f} → (Set f → Set f) → Set _
+private
+  variable
+    f : Level
+
+RawMonad : (Set f → Set f) → Set _
 RawMonad M = RawIMonad {I = ⊤} (λ _ _ → M)
 
-RawMonadT : ∀ {f} (T : (Set f → Set f) → (Set f → Set f)) → Set _
+RawMonadT : (T : (Set f → Set f) → (Set f → Set f)) → Set _
 RawMonadT T = RawIMonadT {I = ⊤} (λ M _ _ → T (M _ _))
 
-RawMonadZero : ∀ {f} → (Set f → Set f) → Set _
+RawMonadZero : (Set f → Set f) → Set _
 RawMonadZero M = RawIMonadZero {I = ⊤} (λ _ _ → M)
 
-RawMonadPlus : ∀ {f} → (Set f → Set f) → Set _
+RawMonadPlus : (Set f → Set f) → Set _
 RawMonadPlus M = RawIMonadPlus {I = ⊤} (λ _ _ → M)
 
-module RawMonad {f} {M : Set f → Set f}
-                (Mon : RawMonad M) where
+module RawMonad {M : Set f → Set f} (Mon : RawMonad M) where
   open RawIMonad Mon public
 
-module RawMonadZero {f} {M : Set f → Set f}
-                    (Mon : RawMonadZero M) where
+module RawMonadZero {M : Set f → Set f}(Mon : RawMonadZero M) where
   open RawIMonadZero Mon public
 
-module RawMonadPlus {f} {M : Set f → Set f}
-                    (Mon : RawMonadPlus M) where
+module RawMonadPlus {M : Set f → Set f} (Mon : RawMonadPlus M) where
   open RawIMonadPlus Mon public

--- a/src/Category/Monad/Continuation.agda
+++ b/src/Category/Monad/Continuation.agda
@@ -16,30 +16,34 @@ open import Category.Monad.Indexed
 open import Function
 open import Level
 
+private
+  variable
+    i f : Level
+    I : Set i
+
 ------------------------------------------------------------------------
 -- Delimited continuation monads
 
-DContT : ∀ {i f} {I : Set i} → (I → Set f) → (Set f → Set f) → IFun I f
+DContT : (I → Set f) → (Set f → Set f) → IFun I f
 DContT K M r₂ r₁ a = (a → M (K r₁)) → M (K r₂)
 
-DCont : ∀ {i f} {I : Set i} → (I → Set f) → IFun I f
+DCont : (I → Set f) → IFun I f
 DCont K = DContT K Identity
 
-DContTIMonad : ∀ {i f} {I : Set i} (K : I → Set f) {M} →
-               RawMonad M → RawIMonad (DContT K M)
+DContTIMonad : ∀ (K : I → Set f) {M} → RawMonad M → RawIMonad (DContT K M)
 DContTIMonad K Mon = record
   { return = λ a k → k a
   ; _>>=_  = λ c f k → c (flip f k)
   }
   where open RawMonad Mon
 
-DContIMonad : ∀ {i f} {I : Set i} (K : I → Set f) → RawIMonad (DCont K)
+DContIMonad : (K : I → Set f) → RawIMonad (DCont K)
 DContIMonad K = DContTIMonad K Id.monad
 
 ------------------------------------------------------------------------
 -- Delimited continuation operations
 
-record RawIMonadDCont {i f} {I : Set i} (K : I → Set f)
+record RawIMonadDCont {I : Set i} (K : I → Set f)
                       (M : IFun I f) : Set (i ⊔ suc f) where
   field
     monad : RawIMonad M
@@ -49,7 +53,7 @@ record RawIMonadDCont {i f} {I : Set i} (K : I → Set f)
 
   open RawIMonad monad public
 
-DContTIMonadDCont : ∀ {i f} {I : Set i} (K : I → Set f) {M} →
+DContTIMonadDCont : ∀ (K : I → Set f) {M} →
                     RawMonad M → RawIMonadDCont K (DContT K M)
 DContTIMonadDCont K Mon = record
   { monad = DContTIMonad K Mon
@@ -59,6 +63,5 @@ DContTIMonadDCont K Mon = record
   where
   open RawIMonad Mon
 
-DContIMonadDCont : ∀ {i f} {I : Set i}
-                   (K : I → Set f) → RawIMonadDCont K (DCont K)
+DContIMonadDCont : (K : I → Set f) → RawIMonadDCont K (DCont K)
 DContIMonadDCont K = DContTIMonadDCont K Id.monad

--- a/src/Category/Monad/Indexed.agda
+++ b/src/Category/Monad/Indexed.agda
@@ -14,30 +14,35 @@ open import Category.Applicative.Indexed
 open import Function
 open import Level
 
-record RawIMonad {i f} {I : Set i} (M : IFun I f) :
-                 Set (i ⊔ suc f) where
+private
+  variable
+    a b c i f : Level
+    A : Set a
+    B : Set b
+    C : Set c
+    I : Set i
+
+record RawIMonad {I : Set i} (M : IFun I f) : Set (i ⊔ suc f) where
   infixl 1 _>>=_ _>>_ _>=>_
   infixr 1 _=<<_ _<=<_
 
   field
-    return : ∀ {i A} → A → M i i A
-    _>>=_  : ∀ {i j k A B} → M i j A → (A → M j k B) → M i k B
+    return : ∀ {i} → A → M i i A
+    _>>=_  : ∀ {i j k} → M i j A → (A → M j k B) → M i k B
 
-  _>>_ : ∀ {i j k A B} → M i j A → M j k B → M i k B
+  _>>_ : ∀ {i j k} → M i j A → M j k B → M i k B
   m₁ >> m₂ = m₁ >>= λ _ → m₂
 
-  _=<<_ : ∀ {i j k A B} → (A → M j k B) → M i j A → M i k B
+  _=<<_ : ∀ {i j k} → (A → M j k B) → M i j A → M i k B
   f =<< c = c >>= f
 
-  _>=>_ : ∀ {i j k a} {A : Set a} {B C} →
-          (A → M i j B) → (B → M j k C) → (A → M i k C)
+  _>=>_ : ∀ {i j k} → (A → M i j B) → (B → M j k C) → (A → M i k C)
   f >=> g = _=<<_ g ∘ f
 
-  _<=<_ : ∀ {i j k B C a} {A : Set a} →
-          (B → M j k C) → (A → M i j B) → (A → M i k C)
+  _<=<_ : ∀ {i j k} → (B → M j k C) → (A → M i j B) → (A → M i k C)
   g <=< f = f >=> g
 
-  join : ∀ {i j k A} → M i j (M j k A) → M i k A
+  join : ∀ {i j k} → M i j (M j k A) → M i k A
   join m = m >>= id
 
   rawIApplicative : RawIApplicative M
@@ -48,11 +53,10 @@ record RawIMonad {i f} {I : Set i} (M : IFun I f) :
 
   open RawIApplicative rawIApplicative public
 
-RawIMonadT : ∀ {i f} {I : Set i} (T : IFun I f → IFun I f) → Set (i ⊔ suc f)
+RawIMonadT : {I : Set i} (T : IFun I f → IFun I f) → Set (i ⊔ suc f)
 RawIMonadT T = ∀ {M} → RawIMonad M → RawIMonad (T M)
 
-record RawIMonadZero {i f} {I : Set i} (M : IFun I f) :
-                     Set (i ⊔ suc f) where
+record RawIMonadZero {I : Set i} (M : IFun I f) : Set (i ⊔ suc f) where
   field
     monad           : RawIMonad M
     applicativeZero : RawIApplicativeZero M
@@ -60,8 +64,7 @@ record RawIMonadZero {i f} {I : Set i} (M : IFun I f) :
   open RawIMonad monad public
   open RawIApplicativeZero applicativeZero using (∅) public
 
-record RawIMonadPlus {i f} {I : Set i} (M : IFun I f) :
-                     Set (i ⊔ suc f) where
+record RawIMonadPlus {I : Set i} (M : IFun I f) : Set (i ⊔ suc f) where
   field
     monad       : RawIMonad M
     alternative : RawIAlternative M

--- a/src/Category/Monad/Partiality.agda
+++ b/src/Category/Monad/Partiality.agda
@@ -16,7 +16,7 @@ open import Data.Product as Prod hiding (map)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base
 open import Function.Equivalence using (_⇔_; equivalence)
-open import Level using (_⊔_)
+open import Level using (Level; _⊔_)
 open import Relation.Binary as B hiding (Rel)
 import Relation.Binary.Properties.Setoid as SetoidProperties
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
@@ -24,20 +24,27 @@ open import Relation.Nullary
 open import Relation.Nullary.Decidable hiding (map)
 open import Relation.Nullary.Negation
 
+private
+  variable
+    a b c f s ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
 ------------------------------------------------------------------------
 -- The partiality monad
 
-data _⊥ {a} (A : Set a) : Set a where
+data _⊥ (A : Set a) : Set a where
   now   : (x : A) → A ⊥
   later : (x : ∞ (A ⊥)) → A ⊥
 
-monad : ∀ {f} → RawMonad {f = f} _⊥
+monad : RawMonad {f = f} _⊥
 monad = record
   { return = now
   ; _>>=_  = _>>=_
   }
   where
-  _>>=_ : ∀ {A B} → A ⊥ → (A → B ⊥) → B ⊥
+  _>>=_ : A ⊥ → (A → B ⊥) → B ⊥
   now x   >>= f = f x
   later x >>= f = later (♯ (♭ x >>= f))
 
@@ -45,19 +52,19 @@ private module M {f} = RawMonad (monad {f})
 
 -- Non-termination.
 
-never : ∀ {a} {A : Set a} → A ⊥
+never : A ⊥
 never = later (♯ never)
 
 -- run x for n steps peels off at most n "later" constructors from x.
 
-run_for_steps : ∀ {a} {A : Set a} → A ⊥ → ℕ → A ⊥
+run_for_steps : A ⊥ → ℕ → A ⊥
 run now   x for n     steps = now x
 run later x for zero  steps = later x
 run later x for suc n steps = run ♭ x for n steps
 
 -- Is the computation done?
 
-isNow : ∀ {a} {A : Set a} → A ⊥ → Bool
+isNow : A ⊥ → Bool
 isNow (now x)   = true
 isNow (later x) = false
 
@@ -100,7 +107,7 @@ Equality k = False (k ≟-Kind other geq)
 ------------------------------------------------------------------------
 -- Equality/ordering
 
-module Equality {a ℓ} {A : Set a} -- The "return type".
+module Equality {A : Set a} -- The "return type".
                 (_∼_ : A → A → Set ℓ) where
 
   -- The three relations.
@@ -155,7 +162,7 @@ module Equality {a ℓ} {A : Set a} -- The "return type".
 ------------------------------------------------------------------------
 -- Lemmas relating the three relations
 
-module _ {a ℓ} {A : Set a} {_∼_ : A → A → Set ℓ} where
+module _ {A : Set a} {_∼_ : A → A → Set ℓ} where
 
   open Equality _∼_ using (Rel; _≅_; _≳_; _≲_; _≈_; _⇓[_]_; _⇑[_])
   open Equality.Rel
@@ -437,11 +444,11 @@ module _ {a ℓ} {A : Set a} {_∼_ : A → A → Set ℓ} where
 
   -- Never is a left and right "zero" of bind.
 
-  left-zero : {B : Set a} (f : B → A ⊥) → let open M in
+  left-zero : (f : B → A ⊥) → let open M in
               (never >>= f) ≅ never
   left-zero f = later (♯ left-zero f)
 
-  right-zero : ∀ {B} (x : B ⊥) → let open M in
+  right-zero : (x : B ⊥) → let open M in
                (x >>= λ _ → never) ≅ never
   right-zero (later x) = later (♯ right-zero (♭ x))
   right-zero (now   x) = never≅never
@@ -452,7 +459,7 @@ module _ {a ℓ} {A : Set a} {_∼_ : A → A → Set ℓ} where
   -- underlying relation).
 
   left-identity : Reflexive _∼_ →
-                  ∀ {B} (x : B) (f : B → A ⊥) → let open M in
+                  (x : B) (f : B → A ⊥) → let open M in
                   (now x >>= f) ≅ f x
   left-identity refl-∼ x f = Equivalence.refl refl-∼
 
@@ -465,14 +472,14 @@ module _ {a ℓ} {A : Set a} {_∼_ : A → A → Set ℓ} where
   -- Bind is associative (for a reflexive underlying relation).
 
   associative : Reflexive _∼_ →
-                ∀ {B C} (x : C ⊥) (f : C → B ⊥) (g : B → A ⊥) →
+                (x : C ⊥) (f : C → B ⊥) (g : B → A ⊥) →
                 let open M in
                 (x >>= f >>= g) ≅ (x >>= λ y → f y >>= g)
   associative refl-∼ (now x)   f g = Equivalence.refl refl-∼
   associative refl-∼ (later x) f g =
     later (♯ associative refl-∼ (♭ x) f g)
 
-module _ {s ℓ} {A B : Set s}
+module _ {A B : Set s}
          {_∼A_ : A → A → Set ℓ}
          {_∼B_ : B → B → Set ℓ} where
 
@@ -538,7 +545,7 @@ module _ {s ℓ} {A B : Set s}
                                           now z ∎)
                                     , ≳⇒ fz⇑)
 
-module _ {ℓ} {A B : Set ℓ} {_∼_ : B → B → Set ℓ} where
+module _ {A B : Set ℓ} {_∼_ : B → B → Set ℓ} where
 
   open Equality
 
@@ -564,23 +571,23 @@ module Workaround {a} where
   infixl 1 _>>=_
 
   data _⊥P : Set a → Set (Level.suc a) where
-    now   : ∀ {A} (x : A) → A ⊥P
-    later : ∀ {A} (x : ∞ (A ⊥P)) → A ⊥P
-    _>>=_ : ∀ {A B} (x : A ⊥P) (f : A → B ⊥P) → B ⊥P
+    now   : (x : A) → A ⊥P
+    later : (x : ∞ (A ⊥P)) → A ⊥P
+    _>>=_ : (x : A ⊥P) (f : A → B ⊥P) → B ⊥P
 
   private
 
     data _⊥W : Set a → Set (Level.suc a) where
-      now   : ∀ {A} (x : A) → A ⊥W
-      later : ∀ {A} (x : A ⊥P) → A ⊥W
+      now   : (x : A) → A ⊥W
+      later : (x : A ⊥P) → A ⊥W
 
     mutual
 
-      _>>=W_ : ∀ {A B} → A ⊥W → (A → B ⊥P) → B ⊥W
+      _>>=W_ : A ⊥W → (A → B ⊥P) → B ⊥W
       now   x >>=W f = whnf (f x)
       later x >>=W f = later (x >>= f)
 
-      whnf : ∀ {A} → A ⊥P → A ⊥W
+      whnf : A ⊥P → A ⊥W
       whnf (now   x) = now x
       whnf (later x) = later (♭ x)
       whnf (x >>= f) = whnf x >>=W f
@@ -589,11 +596,11 @@ module Workaround {a} where
 
     private
 
-      ⟦_⟧W : ∀ {A} → A ⊥W → A ⊥
+      ⟦_⟧W : A ⊥W → A ⊥
       ⟦ now   x ⟧W = now x
       ⟦ later x ⟧W = later (♯ ⟦ x ⟧P)
 
-    ⟦_⟧P : ∀ {A} → A ⊥P → A ⊥
+    ⟦_⟧P : A ⊥P → A ⊥
     ⟦ x ⟧P = ⟦ whnf x ⟧W
 
   -- The definitions above make sense. ⟦_⟧P is homomorphic with
@@ -605,23 +612,22 @@ module Workaround {a} where
       open module Eq {A : Set a} = Equality  {A = A} _≡_
       open module R  {A : Set a} = Reasoning (P.isEquivalence {A = A})
 
-    now-hom : ∀ {A} (x : A) → ⟦ now x ⟧P ≅ now x
+    now-hom : (x : A) → ⟦ now x ⟧P ≅ now x
     now-hom x = now x ∎
 
-    later-hom : ∀ {A} (x : ∞ (A ⊥P)) →
-                ⟦ later x ⟧P ≅ later (♯ ⟦ ♭ x ⟧P)
+    later-hom : (x : ∞ (A ⊥P)) → ⟦ later x ⟧P ≅ later (♯ ⟦ ♭ x ⟧P)
     later-hom x = later (♯ (⟦ ♭ x ⟧P ∎))
 
     mutual
 
       private
 
-        >>=-homW : ∀ {A B} (x : B ⊥W) (f : B → A ⊥P) →
+        >>=-homW : (x : B ⊥W) (f : B → A ⊥P) →
                    ⟦ x >>=W f ⟧W ≅ M._>>=_ ⟦ x ⟧W (λ y → ⟦ f y ⟧P)
         >>=-homW (now   x) f = ⟦ f x ⟧P ∎
         >>=-homW (later x) f = later (♯ >>=-hom x f)
 
-      >>=-hom : ∀ {A B} (x : B ⊥P) (f : B → A ⊥P) →
+      >>=-hom : (x : B ⊥P) (f : B → A ⊥P) →
                 ⟦ x >>= f ⟧P ≅ M._>>=_ ⟦ x ⟧P (λ y → ⟦ f y ⟧P)
       >>=-hom x f = >>=-homW (whnf x) f
 
@@ -877,7 +883,7 @@ module AlternativeEquality {a ℓ} where
 -- Bind is "idempotent".
 
 idempotent :
-  ∀ {ℓ} {A : Set ℓ} (B : Setoid ℓ ℓ) →
+  (B : Setoid ℓ ℓ) →
   let open M; open Setoid B using (_≈_; Carrier); open Equality _≈_ in
   (x : A ⊥) (f : A → A → Carrier ⊥) →
   (x >>= λ y′ → x >>= λ y″ → f y′ y″) ≳ (x >>= λ y′ → f y′ y′)

--- a/src/Category/Monad/Predicate.agda
+++ b/src/Category/Monad/Predicate.agda
@@ -21,10 +21,13 @@ open import Relation.Binary.PropositionalEquality
 open import Relation.Unary
 open import Relation.Unary.PredicateTransformer using (Pt)
 
+private
+  variable
+    i ℓ : Level
+
 ------------------------------------------------------------------------
 
-record RawPMonad {i ℓ} {I : Set i} (M : Pt I (i ⊔ ℓ)) :
-                 Set (suc i ⊔ suc ℓ) where
+record RawPMonad {I : Set i} (M : Pt I (i ⊔ ℓ)) : Set (suc i ⊔ suc ℓ) where
 
   infixl 1 _?>=_ _?>_ _>?>_
   infixr 1 _=<?_ _<?<_

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -17,13 +17,18 @@ open import Category.Monad.Indexed
 open import Category.Monad
 open import Data.Unit
 
+private
+  variable
+    ℓ : Level
+    A B I : Set ℓ
+
 ------------------------------------------------------------------------
 -- Indexed reader
 
-IReaderT : ∀ {ℓ} {I : Set ℓ} → IFun I (r ⊔ a) → IFun I (r ⊔ a)
+IReaderT : IFun I (r ⊔ a) → IFun I (r ⊔ a)
 IReaderT M i j A = R → M i j A
 
-module _ {ℓ} {I : Set ℓ} {M : IFun I (r ⊔ a)} where
+module _ {M : IFun I (r ⊔ a)} where
 
   ------------------------------------------------------------------------
   -- Indexed reader applicative
@@ -71,22 +76,22 @@ module _ {ℓ} {I : Set ℓ} {M : IFun I (r ⊔ a)} where
 ------------------------------------------------------------------------
 -- Reader monad operations
 
-record RawIMonadReader {ℓ} {I : Set ℓ} (M : IFun I (r ⊔ a))
+record RawIMonadReader {I : Set ℓ} (M : IFun I (r ⊔ a))
                        : Set (ℓ ⊔ suc (r ⊔ a)) where
   field
     monad  : RawIMonad M
-    reader : ∀ {i A} → (R → A) → M i i A
-    local  : ∀ {i j A} → (R → R) → M i j A → M i j A
+    reader : ∀ {i} → (R → A) → M i i A
+    local  : ∀ {i j} → (R → R) → M i j A → M i j A
 
   open RawIMonad monad public
 
   ask : ∀ {i} → M i i (Lift (r ⊔ a) R)
   ask = reader lift
 
-  asks : ∀ {i A} → (R → A) → M i i A
+  asks : ∀ {i} → (R → A) → M i i A
   asks = reader
 
-ReaderTIMonadReader : ∀ {ℓ} {I : Set ℓ} {M : IFun I (r ⊔ a)} →
+ReaderTIMonadReader : {I : Set ℓ} {M : IFun I (r ⊔ a)} →
                       RawIMonad M → RawIMonadReader (IReaderT M)
 ReaderTIMonadReader Mon = record
   { monad = ReaderTIMonad Mon

--- a/src/Category/Monad/State.agda
+++ b/src/Category/Monad/State.agda
@@ -17,16 +17,21 @@ open import Data.Unit
 open import Function
 open import Level
 
+private
+  variable
+    i f : Level
+    I : Set i
+
 ------------------------------------------------------------------------
 -- Indexed state
 
-IStateT : ∀ {i f} {I : Set i} → (I → Set f) → (Set f → Set f) → IFun I f
+IStateT : (I → Set f) → (Set f → Set f) → IFun I f
 IStateT S M i j A = S i → M (A × S j)
 
 ------------------------------------------------------------------------
 -- Indexed state applicative
 
-StateTIApplicative : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
+StateTIApplicative : ∀ (S : I → Set f) {M} →
                      RawMonad M → RawIApplicative (IStateT S M)
 StateTIApplicative S Mon = record
   { pure = λ a s → return (a , s)
@@ -36,14 +41,14 @@ StateTIApplicative S Mon = record
      return (f′ t′ , s′′)
   } where open RawMonad Mon
 
-StateTIApplicativeZero : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
+StateTIApplicativeZero : ∀ (S : I → Set f) {M} →
                          RawMonadZero M → RawIApplicativeZero (IStateT S M)
 StateTIApplicativeZero S Mon = record
   { applicative = StateTIApplicative S monad
   ; ∅           = const ∅
   } where open RawMonadZero Mon
 
-StateTIAlternative : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
+StateTIAlternative : ∀ (S : I → Set f) {M} →
                      RawMonadPlus M → RawIAlternative (IStateT S M)
 StateTIAlternative S Mon = record
   { applicativeZero = StateTIApplicativeZero S monadZero
@@ -53,21 +58,20 @@ StateTIAlternative S Mon = record
 ------------------------------------------------------------------------
 -- Indexed state monad
 
-StateTIMonad : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
-               RawMonad M → RawIMonad (IStateT S M)
+StateTIMonad : ∀ (S : I → Set f) {M} → RawMonad M → RawIMonad (IStateT S M)
 StateTIMonad S Mon = record
   { return = λ x s → return (x , s)
   ; _>>=_  = λ m f s → m s >>= uncurry f
   } where open RawMonad Mon
 
-StateTIMonadZero : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
+StateTIMonadZero : ∀ (S : I → Set f) {M} →
                    RawMonadZero M → RawIMonadZero (IStateT S M)
 StateTIMonadZero S Mon = record
   { monad           = StateTIMonad S (RawMonadZero.monad Mon)
   ; applicativeZero = StateTIApplicativeZero S Mon
   } where open RawMonadZero Mon
 
-StateTIMonadPlus : ∀ {i f} {I : Set i} (S : I → Set f) {M} →
+StateTIMonadPlus : ∀ (S : I → Set f) {M} →
                    RawMonadPlus M → RawIMonadPlus (IStateT S M)
 StateTIMonadPlus S Mon = record
   { monad       = StateTIMonad S monad
@@ -77,7 +81,7 @@ StateTIMonadPlus S Mon = record
 ------------------------------------------------------------------------
 -- State monad operations
 
-record RawIMonadState {i f} {I : Set i} (S : I → Set f)
+record RawIMonadState {I : Set i} (S : I → Set f)
                       (M : IFun I f) : Set (i ⊔ suc f) where
   field
     monad : RawIMonad M
@@ -101,41 +105,41 @@ StateTIMonadState S Mon = record
 ------------------------------------------------------------------------
 -- Ordinary state monads
 
-RawMonadState : ∀ {f} → Set f → (Set f → Set f) → Set _
+RawMonadState : Set f → (Set f → Set f) → Set _
 RawMonadState S M = RawIMonadState {I = ⊤} (λ _ → S) (λ _ _ → M)
 
-module RawMonadState {f} {S : Set f} {M : Set f → Set f}
+module RawMonadState {S : Set f} {M : Set f → Set f}
                      (Mon : RawMonadState S M) where
   open RawIMonadState Mon public
 
-StateT : ∀ {f} → Set f → (Set f → Set f) → Set f → Set f
+StateT : Set f → (Set f → Set f) → Set f → Set f
 StateT S M = IStateT {I = ⊤} (λ _ → S) M _ _
 
-StateTMonad : ∀ {f} (S : Set f) {M} → RawMonad M → RawMonad (StateT S M)
+StateTMonad : ∀ (S : Set f) {M} → RawMonad M → RawMonad (StateT S M)
 StateTMonad S = StateTIMonad (λ _ → S)
 
-StateTMonadZero : ∀ {f} (S : Set f) {M} →
+StateTMonadZero : ∀ (S : Set f) {M} →
                   RawMonadZero M → RawMonadZero (StateT S M)
 StateTMonadZero S = StateTIMonadZero (λ _ → S)
 
-StateTMonadPlus : ∀ {f} (S : Set f) {M} →
+StateTMonadPlus : ∀ (S : Set f) {M} →
                   RawMonadPlus M → RawMonadPlus (StateT S M)
 StateTMonadPlus S = StateTIMonadPlus (λ _ → S)
 
-StateTMonadState : ∀ {f} (S : Set f) {M} →
+StateTMonadState : ∀ (S : Set f) {M} →
                    RawMonad M → RawMonadState S (StateT S M)
 StateTMonadState S = StateTIMonadState (λ _ → S)
 
-State : ∀ {f} → Set f → Set f → Set f
+State : Set f → Set f → Set f
 State S = StateT S Identity
 
-StateMonad : ∀ {f} (S : Set f) → RawMonad (State S)
+StateMonad : (S : Set f) → RawMonad (State S)
 StateMonad S = StateTMonad S Id.monad
 
-StateMonadState : ∀ {f} (S : Set f) → RawMonadState S (State S)
+StateMonadState : (S : Set f) → RawMonadState S (State S)
 StateMonadState S = StateTMonadState S Id.monad
 
-LiftMonadState : ∀ {f S₁} (S₂ : Set f) {M} →
+LiftMonadState : ∀ {S₁} (S₂ : Set f) {M} →
                  RawMonadState S₁ M →
                  RawMonadState S₁ (StateT S₂ M)
 LiftMonadState S₂ Mon = record


### PR DESCRIPTION
This PR simply updates all modules in the Category subdirectory to use generalized variables for universe levels and types, hopefully making the type signatures a bit easier to read.