### PR TITLE
Suppress warnings from `Algebra.Properties.CommutativeMonoid`

### DIFF
--- a/src/Algebra/Operations/CommutativeMonoid.agda
+++ b/src/Algebra/Operations/CommutativeMonoid.agda
@@ -7,6 +7,9 @@
 
 {-# OPTIONS --without-K --safe #-}
 
+-- Disabled to prevent warnings from deprecated Table
+{-# OPTIONS --warn=noUserWarning #-}
+
 open import Algebra
 
 module Algebra.Operations.CommutativeMonoid

--- a/src/Algebra/Properties/CommutativeMonoid.agda
+++ b/src/Algebra/Properties/CommutativeMonoid.agda
@@ -6,6 +6,9 @@
 
 {-# OPTIONS --without-K --safe #-}
 
+-- Disabled to prevent warnings from deprecated Table
+{-# OPTIONS --warn=noUserWarning #-}
+
 open import Algebra.Bundles
 
 module Algebra.Properties.CommutativeMonoid


### PR DESCRIPTION
Whilst trying to improve #1078 I've run into several other outstanding issues:
 - (#759) it uses the old function hierarchy via `Data.Fin.Permutation` which we also want to deprecate.
 - (#1099) we want to prove most of these lemmas over some `Foldable` type rather than once each for list/vector/vec

Therefore to me, it feels that if we fix these problems by naively transferring the proofs over to `Vector` we're simply generating more code we're going to need to deprecate in the future. This is therefore an alternative PR to #1078 which simply suppresses the warnings for the mean time, and we can tackle the problem more completely in `v1.4`.

 @gallais thoughts?