### PR TITLE
Add `it` utility function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -900,6 +900,11 @@ Other minor additions
   _<+>_ : String → String → String -- space-introducing append
   ```
   
+* Added utility function to `Function.Base`:
+  ```agda
+  it : {A : Set a} → {{A}} → A
+  ```
+
 Version 2.6.1 changes
 =====================
 

--- a/src/Function/Base.agda
+++ b/src/Function/Base.agda
@@ -175,3 +175,8 @@ A ∋ x = x
 
 typeOf : {A : Set a} → A → Set a
 typeOf {A = A} _ = A
+
+-- Construct an element of the given type by instance search.
+
+it : {A : Set a} → {{A}} → A
+it {{x}} = x


### PR DESCRIPTION
This adds the simple but useful function `it` that uses instance search to fill in an argument of the appropriate type.