### PR TITLE
Moved well-founded proofs for `on` to `Relation.Binary.Construct.On`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,5 +58,7 @@ Other major changes
 Other minor additions
 ---------------------
 
+* `Data.Nat.Bin.Induction` now re-exports `Acc` and `acc`.
+
 * Made first argument of [,]-∘-distr in `Data.Sum.Properties` explicit
 * Added map-id, map₁₂-commute, [,]-cong, [-,]-cong, [,-]-cong, map-cong, map₁-cong and map₂-cong to `Data.Sum.Properties`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Non-backwards compatible changes
 Deprecated modules
 ------------------
 
+* The module `Induction.WellFounded.InverseImage` has been deprecated. The proofs
+  `accessible` and `wellFounded` have been moved to `Relation.Binary.Construct.On`.
+
 Deprecated names
 ----------------
 

--- a/src/Codata/Musical/Colist/Infinite-merge.agda
+++ b/src/Codata/Musical/Colist/Infinite-merge.agda
@@ -24,6 +24,7 @@ import Function.Related as Related
 open import Function.Related.TypeIsomorphisms
 import Induction.WellFounded as WF
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
+import Relation.Binary.Construct.On as On
 
 ------------------------------------------------------------------------
 -- Some code that is used to work around Agda's syntactic guardedness
@@ -177,7 +178,7 @@ module _ {a p} {A : Set a} {P : A → Set p} where
 
     to : ∀ xss p → Pred (xss , p)
     to = λ xss p →
-      WF.All.wfRec (WF.InverseImage.wellFounded size <′-wellFounded) _
+      WF.All.wfRec (On.wellFounded size <′-wellFounded) _
                    Pred step (xss , p)
       where
       size : Input → ℕ

--- a/src/Data/Fin/Subset/Induction.agda
+++ b/src/Data/Fin/Subset/Induction.agda
@@ -14,6 +14,7 @@ open import Data.Fin.Subset using (Subset; _⊂_; ∣_∣)
 open import Data.Fin.Subset.Properties
 open import Induction
 open import Induction.WellFounded as WF
+import Relation.Binary.Construct.On as On
 
 ------------------------------------------------------------------------
 -- Re-export accessability
@@ -26,5 +27,6 @@ open WF public using (Acc; acc)
 ⊂-Rec : ∀ {n ℓ} → RecStruct (Subset n) ℓ ℓ
 ⊂-Rec = WfRec _⊂_
 
-⊂-wellFounded : ∀ {n} → WellFounded (_⊂_ {n})
-⊂-wellFounded {n} = Subrelation.wellFounded p⊂q⇒∣p∣<∣q∣ (InverseImage.wellFounded ∣_∣ <-wellFounded)
+⊂-wellFounded : ∀ {n} → WellFounded {A = Subset n} _⊂_
+⊂-wellFounded {n} = Subrelation.wellFounded p⊂q⇒∣p∣<∣q∣
+  (On.wellFounded ∣_∣ <-wellFounded)

--- a/src/Data/Nat/Binary/Induction.agda
+++ b/src/Data/Nat/Binary/Induction.agda
@@ -12,12 +12,17 @@ open import Data.Nat.Binary.Base
 open import Data.Nat.Binary.Properties
 open import Data.Nat.Base as ℕ using (ℕ)
 import Data.Nat.Induction as ℕ
-open import Induction.WellFounded
+open import Induction.WellFounded as WFI
+import Relation.Binary.Construct.On as On
+
+------------------------------------------------------------------------
+-- Re-export Acc and acc
+
+open WFI public using (Acc; acc)
 
 ------------------------------------------------------------------------
 -- _<_ is wellFounded
 
 <-wellFounded : WellFounded _<_
-<-wellFounded x = Subrelation.accessible <⇒<ℕ toℕ[x]-acc
-  where
-  toℕ[x]-acc = InverseImage.accessible toℕ (ℕ.<-wellFounded (toℕ x))
+<-wellFounded = Subrelation.wellFounded <⇒<ℕ
+  (On.wellFounded toℕ ℕ.<-wellFounded)

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -155,9 +155,17 @@ module InverseImage {_<_ : Rel B ℓ} (f : A → B) where
   wellFounded wf = λ x → accessible (wf (f x))
 
   well-founded = wellFounded
+  {-# WARNING_ON_USAGE accessible
+  "Warning: accessible was deprecated in v1.4.
+\ \Please use accessible from `Relation.Binary.Construct.On` instead."
+  #-}
+  {-# WARNING_ON_USAGE wellFounded
+  "Warning: wellFounded was deprecated in v1.4.
+\ \Please use wellFounded from `Relation.Binary.Construct.On` instead."
+  #-}
   {-# WARNING_ON_USAGE well-founded
   "Warning: well-founded was deprecated in v0.15.
-\ \Please use wellFounded instead."
+\ \Please use wellFounded from `Relation.Binary.Construct.On` instead."
   #-}
 
 module TransitiveClosure {A : Set a} (_<_ : Rel A ℓ) where

--- a/src/Relation/Binary/Construct/On.agda
+++ b/src/Relation/Binary/Construct/On.agda
@@ -1,203 +1,218 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Many properties which hold for _∼_ also hold for _∼_ on f
+-- Many properties which hold for `_∼_` also hold for `_∼_ on f`
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Relation.Binary
-
 module Relation.Binary.Construct.On where
 
-open import Function
 open import Data.Product
+open import Function using (_on_; _∘_)
+open import Induction.WellFounded using (WellFounded; Acc; acc)
+open import Level using (Level)
+open import Relation.Binary
 
-module _ {a b} {A : Set a} {B : Set b} (f : B → A) where
+private
+  variable
+    a b p ℓ ℓ₁ ℓ₂ : Level
+    A : Set a
+    B : Set b
 
-  implies : ∀ {ℓ₁ ℓ₂} (≈ : Rel A ℓ₁) (∼ : Rel A ℓ₂) →
+------------------------------------------------------------------------
+-- Definitions
+
+module _ (f : B → A) where
+
+  implies : (≈ : Rel A ℓ₁) (∼ : Rel A ℓ₂) →
             ≈ ⇒ ∼ → (≈ on f) ⇒ (∼ on f)
   implies _ _ impl = impl
 
-  reflexive : ∀ {ℓ} (∼ : Rel A ℓ) → Reflexive ∼ → Reflexive (∼ on f)
+  reflexive : (∼ : Rel A ℓ) → Reflexive ∼ → Reflexive (∼ on f)
   reflexive _ refl = refl
 
-  irreflexive : ∀ {ℓ₁ ℓ₂} (≈ : Rel A ℓ₁) (∼ : Rel A ℓ₂) →
+  irreflexive : (≈ : Rel A ℓ₁) (∼ : Rel A ℓ₂) →
                 Irreflexive ≈ ∼ → Irreflexive (≈ on f) (∼ on f)
   irreflexive _ _ irrefl = irrefl
 
-  symmetric : ∀ {ℓ} (∼ : Rel A ℓ) → Symmetric ∼ → Symmetric (∼ on f)
+  symmetric : (∼ : Rel A ℓ) → Symmetric ∼ → Symmetric (∼ on f)
   symmetric _ sym = sym
 
-  transitive : ∀ {ℓ} (∼ : Rel A ℓ) → Transitive ∼ → Transitive (∼ on f)
+  transitive : (∼ : Rel A ℓ) → Transitive ∼ → Transitive (∼ on f)
   transitive _ trans = trans
 
-  antisymmetric : ∀ {ℓ₁ ℓ₂} (≈ : Rel A ℓ₁) (≤ : Rel A ℓ₂) →
+  antisymmetric : (≈ : Rel A ℓ₁) (≤ : Rel A ℓ₂) →
                   Antisymmetric ≈ ≤ → Antisymmetric (≈ on f) (≤ on f)
   antisymmetric _ _ antisym = antisym
 
-  asymmetric : ∀ {ℓ} (< : Rel A ℓ) → Asymmetric < → Asymmetric (< on f)
+  asymmetric : (< : Rel A ℓ) → Asymmetric < → Asymmetric (< on f)
   asymmetric _ asym = asym
 
-  respects : ∀ {ℓ p} (∼ : Rel A ℓ) (P : A → Set p) →
+  respects : (∼ : Rel A ℓ) (P : A → Set p) →
              P Respects ∼ → (P ∘ f) Respects (∼ on f)
   respects _ _ resp = resp
 
-  respects₂ : ∀ {ℓ₁ ℓ₂} (∼₁ : Rel A ℓ₁) (∼₂ : Rel A ℓ₂) →
+  respects₂ : (∼₁ : Rel A ℓ₁) (∼₂ : Rel A ℓ₂) →
               ∼₁ Respects₂ ∼₂ → (∼₁ on f) Respects₂ (∼₂ on f)
-  respects₂ _ _ (resp₁ , resp₂) =
-    ((λ {_} {_} {_} → resp₁) , λ {_} {_} {_} → resp₂)
+  respects₂ _ _ (resp₁ , resp₂) = (resp₁ , resp₂)
 
-  decidable : ∀ {ℓ} (∼ : Rel A ℓ) → Decidable ∼ → Decidable (∼ on f)
-  decidable _ dec = λ x y → dec (f x) (f y)
+  decidable : (∼ : Rel A ℓ) → Decidable ∼ → Decidable (∼ on f)
+  decidable _ dec x y = dec (f x) (f y)
 
-  total : ∀ {ℓ} (∼ : Rel A ℓ) → Total ∼ → Total (∼ on f)
-  total _ tot = λ x y → tot (f x) (f y)
+  total : (∼ : Rel A ℓ) → Total ∼ → Total (∼ on f)
+  total _ tot x y = tot (f x) (f y)
 
-  trichotomous : ∀ {ℓ₁ ℓ₂} (≈ : Rel A ℓ₁) (< : Rel A ℓ₂) →
+  trichotomous : (≈ : Rel A ℓ₁) (< : Rel A ℓ₂) →
                  Trichotomous ≈ < → Trichotomous (≈ on f) (< on f)
-  trichotomous _ _ compare = λ x y → compare (f x) (f y)
+  trichotomous _ _ compare x y = compare (f x) (f y)
 
-  isEquivalence : ∀ {ℓ} {≈ : Rel A ℓ} →
-                  IsEquivalence ≈ → IsEquivalence (≈ on f)
-  isEquivalence {≈ = ≈} eq = record
-    { refl  = reflexive  ≈ Eq.refl
-    ; sym   = symmetric  ≈ Eq.sym
-    ; trans = transitive ≈ Eq.trans
-    }
-    where module Eq = IsEquivalence eq
+  accessible : ∀ {∼ : Rel A ℓ} {x} → Acc ∼ (f x) → Acc (∼ on f) x
+  accessible (acc rs) = acc (λ y fy<fx → accessible (rs (f y) fy<fx))
 
-  isPreorder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {∼ : Rel A ℓ₂} →
-               IsPreorder ≈ ∼ → IsPreorder (≈ on f) (∼ on f)
-  isPreorder {≈ = ≈} {∼} pre = record
-    { isEquivalence = isEquivalence Pre.isEquivalence
-    ; reflexive     = implies ≈ ∼ Pre.reflexive
-    ; trans         = transitive ∼ Pre.trans
-    }
-    where module Pre = IsPreorder pre
+  wellFounded : {∼ : Rel A ℓ} → WellFounded ∼ → WellFounded (∼ on f)
+  wellFounded wf x = accessible (wf (f x))
 
-  isDecEquivalence : ∀ {ℓ} {≈ : Rel A ℓ} →
-                     IsDecEquivalence ≈ → IsDecEquivalence (≈ on f)
-  isDecEquivalence {≈ = ≈} dec = record
+------------------------------------------------------------------------
+-- Structures
+
+module _ (f : B → A) {≈ : Rel A ℓ₁} where
+
+  isEquivalence : IsEquivalence ≈ →
+                  IsEquivalence (≈ on f)
+  isEquivalence eq = record
+    { refl  = reflexive  f ≈ Eq.refl
+    ; sym   = symmetric  f ≈ Eq.sym
+    ; trans = transitive f ≈ Eq.trans
+    } where module Eq = IsEquivalence eq
+
+  isDecEquivalence : IsDecEquivalence ≈ →
+                     IsDecEquivalence (≈ on f)
+  isDecEquivalence dec = record
     { isEquivalence = isEquivalence Dec.isEquivalence
-    ; _≟_           = decidable ≈ Dec._≟_
-    }
-    where module Dec = IsDecEquivalence dec
+    ; _≟_           = decidable f ≈ Dec._≟_
+    } where module Dec = IsDecEquivalence dec
 
-  isPartialOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {≤ : Rel A ℓ₂} →
-                   IsPartialOrder ≈ ≤ →
-                   IsPartialOrder (≈ on f) (≤ on f)
-  isPartialOrder {≈ = ≈} {≤} po = record
+module _ (f : B → A) {≈ : Rel A ℓ₁} {∼ : Rel A ℓ₂} where
+
+  isPreorder : IsPreorder ≈ ∼ → IsPreorder (≈ on f) (∼ on f)
+  isPreorder pre = record
+    { isEquivalence = isEquivalence f Pre.isEquivalence
+    ; reflexive     = implies f ≈ ∼ Pre.reflexive
+    ; trans         = transitive f ∼ Pre.trans
+    } where module Pre = IsPreorder pre
+
+  isPartialOrder : IsPartialOrder ≈ ∼ →
+                   IsPartialOrder (≈ on f) (∼ on f)
+  isPartialOrder po = record
     { isPreorder = isPreorder Po.isPreorder
-    ; antisym    = antisymmetric ≈ ≤ Po.antisym
-    }
-    where module Po = IsPartialOrder po
+    ; antisym    = antisymmetric f ≈ ∼ Po.antisym
+    } where module Po = IsPartialOrder po
 
-  isDecPartialOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {≤ : Rel A ℓ₂} →
-                      IsDecPartialOrder ≈ ≤ →
-                      IsDecPartialOrder (≈ on f) (≤ on f)
+  isDecPartialOrder : IsDecPartialOrder ≈ ∼ →
+                      IsDecPartialOrder (≈ on f) (∼ on f)
   isDecPartialOrder dpo = record
     { isPartialOrder = isPartialOrder DPO.isPartialOrder
-    ; _≟_            = decidable _ DPO._≟_
-    ; _≤?_           = decidable _ DPO._≤?_
-    }
-    where module DPO = IsDecPartialOrder dpo
+    ; _≟_            = decidable f _ DPO._≟_
+    ; _≤?_           = decidable f _ DPO._≤?_
+    } where module DPO = IsDecPartialOrder dpo
 
-  isStrictPartialOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {< : Rel A ℓ₂} →
-                         IsStrictPartialOrder ≈ < →
-                         IsStrictPartialOrder (≈ on f) (< on f)
-  isStrictPartialOrder {≈ = ≈} {<} spo = record
-    { isEquivalence = isEquivalence Spo.isEquivalence
-    ; irrefl        = irreflexive ≈ < Spo.irrefl
-    ; trans         = transitive < Spo.trans
-    ; <-resp-≈      = respects₂ < ≈ Spo.<-resp-≈
-    }
-    where module Spo = IsStrictPartialOrder spo
+  isStrictPartialOrder : IsStrictPartialOrder ≈ ∼ →
+                         IsStrictPartialOrder (≈ on f) (∼ on f)
+  isStrictPartialOrder spo = record
+    { isEquivalence = isEquivalence f Spo.isEquivalence
+    ; irrefl        = irreflexive f ≈ ∼ Spo.irrefl
+    ; trans         = transitive f ∼ Spo.trans
+    ; <-resp-≈      = respects₂ f ∼ ≈ Spo.<-resp-≈
+    } where module Spo = IsStrictPartialOrder spo
 
-  isTotalOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {≤ : Rel A ℓ₂} →
-                 IsTotalOrder ≈ ≤ →
-                 IsTotalOrder (≈ on f) (≤ on f)
-  isTotalOrder {≈ = ≈} {≤} to = record
+  isTotalOrder : IsTotalOrder ≈ ∼ →
+                 IsTotalOrder (≈ on f) (∼ on f)
+  isTotalOrder to = record
     { isPartialOrder = isPartialOrder To.isPartialOrder
-    ; total          = total ≤ To.total
-    }
-    where module To = IsTotalOrder to
+    ; total          = total f ∼ To.total
+    } where module To = IsTotalOrder to
 
-  isDecTotalOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {≤ : Rel A ℓ₂} →
-                    IsDecTotalOrder ≈ ≤ →
-                    IsDecTotalOrder (≈ on f) (≤ on f)
-  isDecTotalOrder {≈ = ≈} {≤} dec = record
+  isDecTotalOrder : IsDecTotalOrder ≈ ∼ →
+                    IsDecTotalOrder (≈ on f) (∼ on f)
+  isDecTotalOrder dec = record
     { isTotalOrder = isTotalOrder Dec.isTotalOrder
-    ; _≟_          = decidable ≈ Dec._≟_
-    ; _≤?_         = decidable ≤ Dec._≤?_
-    }
-    where module Dec = IsDecTotalOrder dec
+    ; _≟_          = decidable f ≈ Dec._≟_
+    ; _≤?_         = decidable f ∼ Dec._≤?_
+    } where module Dec = IsDecTotalOrder dec
 
-  isStrictTotalOrder : ∀ {ℓ₁ ℓ₂} {≈ : Rel A ℓ₁} {< : Rel A ℓ₂} →
-                       IsStrictTotalOrder ≈ < →
-                       IsStrictTotalOrder (≈ on f) (< on f)
-  isStrictTotalOrder {≈ = ≈} {<} sto = record
-    { isEquivalence = isEquivalence Sto.isEquivalence
-    ; trans         = transitive < Sto.trans
-    ; compare       = trichotomous ≈ < Sto.compare
-    }
-    where module Sto = IsStrictTotalOrder sto
+  isStrictTotalOrder : IsStrictTotalOrder ≈ ∼ →
+                       IsStrictTotalOrder (≈ on f) (∼ on f)
+  isStrictTotalOrder sto = record
+    { isEquivalence = isEquivalence f Sto.isEquivalence
+    ; trans         = transitive f ∼ Sto.trans
+    ; compare       = trichotomous f ≈ ∼ Sto.compare
+    } where module Sto = IsStrictTotalOrder sto
 
-preorder : ∀ {p₁ p₂ p₃ b} {B : Set b} (P : Preorder p₁ p₂ p₃) →
-           (B → Preorder.Carrier P) → Preorder _ _ _
+------------------------------------------------------------------------
+-- Bundles
+
+preorder : (P : Preorder a ℓ₁ ℓ₂) →
+           (B → Preorder.Carrier P) →
+           Preorder _ _ _
 preorder P f = record
   { isPreorder = isPreorder f (Preorder.isPreorder P)
   }
 
-setoid : ∀ {s₁ s₂ b} {B : Set b} (S : Setoid s₁ s₂) →
-         (B → Setoid.Carrier S) → Setoid _ _
+setoid : (S : Setoid a ℓ) →
+         (B → Setoid.Carrier S) →
+         Setoid _ _
 setoid S f = record
   { isEquivalence = isEquivalence f (Setoid.isEquivalence S)
   }
 
-decSetoid : ∀ {d₁ d₂ b} {B : Set b} (D : DecSetoid d₁ d₂) →
-            (B → DecSetoid.Carrier D) → DecSetoid _ _
+decSetoid : (D : DecSetoid a ℓ) →
+            (B → DecSetoid.Carrier D) →
+            DecSetoid _ _
 decSetoid D f = record
   { isDecEquivalence = isDecEquivalence f (DecSetoid.isDecEquivalence D)
   }
 
-poset : ∀ {p₁ p₂ p₃ b} {B : Set b} (P : Poset p₁ p₂ p₃) →
-        (B → Poset.Carrier P) → Poset _ _ _
+poset : ∀ (P : Poset a ℓ₁ ℓ₂) →
+        (B → Poset.Carrier P) →
+        Poset _ _ _
 poset P f = record
   { isPartialOrder = isPartialOrder f (Poset.isPartialOrder P)
   }
 
-decPoset : ∀ {d₁ d₂ d₃ b} {B : Set b} (D : DecPoset d₁ d₂ d₃) →
-           (B → DecPoset.Carrier D) → DecPoset _ _ _
+decPoset : (D : DecPoset a ℓ₁ ℓ₂) →
+           (B → DecPoset.Carrier D) →
+           DecPoset _ _ _
 decPoset D f = record
   { isDecPartialOrder =
       isDecPartialOrder f (DecPoset.isDecPartialOrder D)
   }
 
-strictPartialOrder :
-  ∀ {s₁ s₂ s₃ b} {B : Set b} (S : StrictPartialOrder s₁ s₂ s₃) →
-  (B → StrictPartialOrder.Carrier S) → StrictPartialOrder _ _ _
+strictPartialOrder : (S : StrictPartialOrder a ℓ₁ ℓ₂) →
+                     (B → StrictPartialOrder.Carrier S) →
+                     StrictPartialOrder _ _ _
 strictPartialOrder S f = record
   { isStrictPartialOrder =
       isStrictPartialOrder f (StrictPartialOrder.isStrictPartialOrder S)
   }
 
-totalOrder : ∀ {t₁ t₂ t₃ b} {B : Set b} (T : TotalOrder t₁ t₂ t₃) →
-             (B → TotalOrder.Carrier T) → TotalOrder _ _ _
+totalOrder : (T : TotalOrder a ℓ₁ ℓ₂) →
+             (B → TotalOrder.Carrier T) →
+             TotalOrder _ _ _
 totalOrder T f = record
   { isTotalOrder = isTotalOrder f (TotalOrder.isTotalOrder T)
   }
 
-decTotalOrder :
-  ∀ {d₁ d₂ d₃ b} {B : Set b} (D : DecTotalOrder d₁ d₂ d₃) →
-  (B → DecTotalOrder.Carrier D) → DecTotalOrder _ _ _
+decTotalOrder : (D : DecTotalOrder a ℓ₁ ℓ₂) →
+                (B → DecTotalOrder.Carrier D) →
+                DecTotalOrder _ _ _
 decTotalOrder D f = record
   { isDecTotalOrder = isDecTotalOrder f (DecTotalOrder.isDecTotalOrder D)
   }
 
-strictTotalOrder :
-  ∀ {s₁ s₂ s₃ b} {B : Set b} (S : StrictTotalOrder s₁ s₂ s₃) →
-  (B → StrictTotalOrder.Carrier S) → StrictTotalOrder _ _ _
+strictTotalOrder : (S : StrictTotalOrder a ℓ₁ ℓ₂) →
+                   (B → StrictTotalOrder.Carrier S) →
+                   StrictTotalOrder _ _ _
 strictTotalOrder S f = record
   { isStrictTotalOrder =
       isStrictTotalOrder f (StrictTotalOrder.isStrictTotalOrder S)


### PR DESCRIPTION
Partially addresses #819 for `on`. Changelog entry left until #1039 is merged in.