### PR TITLE
≗-Reasoning - a simple and elegant way to reason about function equality

### DIFF
--- a/README/Function/Reasoning.agda
+++ b/README/Function/Reasoning.agda
@@ -66,3 +66,51 @@ _ = refl
 
 _ : subpalindromes "elle-meme" ≡ "ll" ∷ "elle" ∷ "mem" ∷ "eme" ∷ []
 _ = refl
+
+
+
+-- Example of using ≗-Reasoning
+module _ where
+
+  open import Data.Sum
+  open import Data.Sum.Properties
+  open import Relation.Binary.PropositionalEquality using (_≡_; _≗_)
+
+  variable
+    A B C D E F : Set
+
+  -- Use scenario:
+  -- a ∘ b ∘ c ∘ d ∘ e ∘ f ∘ g    ≈⟨ a ∘ b ∘ c ∘> d≗d′ ∘ e ⟩∘⟨ f≗f′ ∘ g ⟩
+  -- a ∘ b ∘ c ∘ d′ ∘ e ∘ f′ ∘ g    ≈⟨...
+  --
+  -- The above step performs 2 substitutions simultaneously by using the ⟩∘⟨
+  -- divider (which can be used as many times as one wants to perform any
+  -- number of substitutions).
+  -- Thanks to the properties of function composition, it is very easy to
+  -- specify a substitution in a long string of compositions. All one has to do
+  -- is list the terms in the composition chain as they appear to the left
+  -- of the equal sign but replace the function in question with a proof that
+  -- it is ≗ to some other one and replace the `∘` before it (if any) by `∘>`.
+  -- Note the lack of a need for any bracketing!
+
+  example : ∀ {f g : C → D} {h i : B → C} {j k : A → B} → f ≗ g → h ≗ i → j ≗ k → f ∘ h ∘ j ≗ g ∘ i ∘ k
+  example {f = f} {g} {h} {i} {j} {k} fg hi jk = begin
+    f ∘ h ∘ j ≈⟨ f ∘> hi ∘ j ⟩
+    f ∘ i ∘ j ≈⟨ fg ∘ i ∘ j ⟩
+    g ∘ i ∘ j ≈⟨ g ∘ i ∘> jk ⟩
+    g ∘ i ∘ k ∎
+    where open ≗-Reasoning
+
+  example2 : ∀ {f g : C → D} {h i : B → C} {j k : A → B} → f ≗ g → h ≗ i → j ≗ k → f ∘ h ∘ j ≗ g ∘ i ∘ k
+  example2 {f = f} {g} {h} {i} {j} {k} fg hi jk = begin
+    f ∘ h ∘ j ≈⟨ fg ⟩∘⟨ hi ⟩∘⟨ jk ⟩
+    g ∘ i ∘ k ∎
+    where open ≗-Reasoning
+
+  example3 : ∀ {f g : C → D} {h i : A → C} {j k : B → C} → f ≗ g → h ≗ i → j ≗ k → (ab : A ⊎ B) →
+             (f ∘ [ h , j ]) ab ≡ [ g ∘ i , g ∘ k ] ab
+  example3 {f = f} {g} {h} {i} {j} {k} fg hi jk ab = on ab begin
+    f ∘ [ h , j ]     ≈⟨ fg ⟩∘⟨ [ hi , jk ] ⟩
+    g ∘ [ i , k ]     ≈⟨ g ∘[,] ⟩
+    [ g ∘ i , g ∘ k ] ∎
+    where open SumReasoning

--- a/src/Data/Sum/Properties.agda
+++ b/src/Data/Sum/Properties.agda
@@ -11,6 +11,7 @@ module Data.Sum.Properties where
 open import Level
 open import Data.Sum.Base
 open import Function
+open import Function.Reasoning
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
@@ -61,3 +62,22 @@ map-commute : {f : A → B}  {g : C → D}
               ((map f′ g′) ∘ (map f g)) ≗ map (f′ ∘ f) (g′ ∘ g)
 map-commute (inj₁ _) = refl
 map-commute (inj₂ _) = refl
+
+
+
+module SumReasoning where
+  open ≗-Reasoning public
+
+  infix 6 _∘[_,_] _∘[,] [_,_]∘map [,]∘map
+
+  _∘[_,_] : (f : C → D) (g : A → C) (h : B → C) → f ∘ [ g , h ] ≗ [ f ∘ g , f ∘ h ]
+  f ∘[ g , h ] = [,]-∘-distr {f = f} {g} {h}
+
+  _∘[,] : (f : C → D) {g : A → C} {h : B → C} → f ∘ [ g , h ] ≗ [ f ∘ g , f ∘ h ]
+  f ∘[,] = [,]-∘-distr {f = f}
+
+  [_,_]∘map : (f : C → E) (g : D → E) {h : A → C} {i : B → D} → [ f , g ] ∘ (map h i) ≗ [ f ∘ h , g ∘ i ]
+  [ f , g ]∘map = [,]-map-commute {f′ = f} {g}
+
+  [,]∘map : {f : C → E} {g : D → E} {h : A → C} {i : B → D} → [ f , g ] ∘ (map h i) ≗ [ f ∘ h , g ∘ i ]
+  [,]∘map = [,]-map-commute

--- a/src/Function/Reasoning.agda
+++ b/src/Function/Reasoning.agda
@@ -9,7 +9,7 @@
 
 module Function.Reasoning where
 
-open import Function.Base using (_∋_)
+open import Function.Base using (_∋_; _∘_)
 
 -- Need to give _∋_ a new name as syntax cannot contain underscores
 infixl 0 ∋-syntax
@@ -20,3 +20,26 @@ syntax ∋-syntax A a = a ∶ A
 
 -- Export pipeline functions
 open import Function public using (_|>_; _|>′_)
+
+
+
+module ≗-Reasoning {ℓ₁} {ℓ₂} {A : Set ℓ₁} {B : Set ℓ₂} where
+  open import Relation.Binary using (Setoid)
+  open import Relation.Binary.PropositionalEquality using (_≡_; cong; _→-setoid_; _≗_)
+  open import Relation.Binary.Reasoning.Setoid (A →-setoid B) public
+  open Setoid (A →-setoid B) using (refl; trans)
+
+  infix  1 on_begin_
+  infix  5 _∘>_
+  infixr 4 _⟩∘⟨_
+
+  on_begin_ : {f g : A → B} → (a : A) → f IsRelatedTo g → f a ≡ g a
+  on a begin P = (begin P) a
+
+  _∘>_ : ∀ {ℓ} {C : Set ℓ} {g h : A → C} (f : C → B) (gh : g ≗ h) → f ∘ g ≗ f ∘ h
+  f ∘> gh = (cong f) ∘ gh
+
+  _⟩∘⟨_ : ∀ {ℓ} {C : Set ℓ} {f f′ : C → B} {g g′ : A → C} → f ≗ f′ → g ≗ g′ → f ∘ g ≗ f′ ∘ g′
+  _⟩∘⟨_ {f′ = f′} {g} ff′ gg′ = trans (ff′ ∘ g) (f′ ∘> gg′)
+
+  ≗-refl = refl


### PR DESCRIPTION
Here is a first draft of a little thing that I put together after being frustrated with having to work with long chains of functions composition'd together. Because of how function composition works in Agda, I believe this has the potential to make some proofs a lot more clear, with a minimal amount of machinery that has to be defined.
As noted before, this is just a Proof of Concept and I would be very happy for people to change this or provide me with any feedback.
Having tried to use this "in the wild" I found that this Reasoning system fails to infer implicit terms a lot more often than if I just used ≡-Reasoning but that may be fixable.
I also made an extension for Sum functions that should come in handy for certain situations where pattern matching is not so easy. (See the examples in `README/Function/Reasoning.agda`).
Thanks for taking the time to look at this!