### PR TITLE
finish deprecating MonadSyntax

### DIFF
--- a/src/Reflection/TypeChecking/MonadSyntax.agda
+++ b/src/Reflection/TypeChecking/MonadSyntax.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- This module is DEPRECATED
+-- This module is DEPRECATED.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}

--- a/src/Tactic/MonoidSolver.agda
+++ b/src/Tactic/MonoidSolver.agda
@@ -84,7 +84,7 @@ open import Data.Product as Product using (_×_; _,_)
 open import Agda.Builtin.Reflection
 open import Reflection.Argument
 open import Reflection.Term using (getName; _⋯⟅∷⟆_)
-open import Reflection.TypeChecking.MonadSyntax
+open import Reflection.TypeChecking.Monad.Syntax
 
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
 


### PR DESCRIPTION
`Everything.agda` will not build at the moment.
The full stop is necessary for `generateEverything.hs` to realise the module is deprecated