### PR TITLE
Fixed function names in comments

### DIFF
--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -62,13 +62,13 @@ fromℕ : (n : ℕ) → Fin (suc n)
 fromℕ zero    = zero
 fromℕ (suc n) = suc (fromℕ n)
 
--- fromℕ≤ {m} _ = "m".
+-- fromℕ< {m} _ = "m".
 
 fromℕ< : ∀ {m n} → m ℕ.< n → Fin n
 fromℕ< {zero}  {suc n} m≤n = zero
 fromℕ< {suc m} {suc n} m≤n = suc (fromℕ< (ℕₚ.≤-pred m≤n))
 
--- fromℕ≤″ m _ = "m".
+-- fromℕ<″ m _ = "m".
 
 fromℕ<″ : ∀ m {n} → m ℕ.<″ n → Fin n
 fromℕ<″ zero    (ℕ.less-than-or-equal refl) = zero


### PR DESCRIPTION
The comments for fromℕ< and fromℕ<″ still had ≤ in their names remaining from an older version.