### PR TITLE
Update .gitignore (2 entries added)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ EverythingSafe.agda
 EverythingSafeGuardedness.agda
 EverythingSafeSizedTypes.agda
 html
+Haskell
+MAlonzo


### PR DESCRIPTION
This resolves issue: #1199 

The folder MAlonzo, and the file Haskell were generated by the build process (specificallly when running `make test` ). Therefore they do not need to be saved in source control management. So it makes sense to include them in the .gitignore file so that future contributors do not accidentally include them in a commit.