### PR TITLE
Make \prime apostrophe usage consistent (change to prime) (part 2, local identifiers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ Deprecated names
 * The proofs `replace-equality` from `Algebra.Properties.(Lattice/DistributiveLattice/BooleanAlgebra)`
   have been deprecated in favour of the proofs in the new `Algebra.Construct.Subst.Equality` module.
 
+* In order to be consistent in usage of \prime character and apostrophe in identifiers, the following three names were deprecated in favor of their replacement that ends with a \prime character.
+
+  * `Data.List.Base.InitLast._∷ʳ'_` ↦ `Data.List.Base.InitLast._∷ʳ′_`
+  * `Data.List.NonEmpty.SnocView._∷ʳ'_` ↦ `Data.List.NonEmpty.SnocView._∷ʳ′_`
+  * `Relation.Binary.Construct.StrictToNonStrict.decidable'` ↦ `Relation.Binary.Construct.StrictToNonStrict.decidable′`
+
+
 Other major additions
 ---------------------
 

--- a/README/Case.agda
+++ b/README/Case.agda
@@ -57,7 +57,7 @@ div2 : ℕ → ℕ
 div2 zero    = zero
 div2 (suc m) = case m of λ where
   zero     → zero
-  (suc m') → suc (div2 m')
+  (suc m′) → suc (div2 m′)
 
 
 -- Note that some natural uses of case are rejected by the termination

--- a/README/Data/List/Relation/Ternary/Interleaving.agda
+++ b/README/Data/List/Relation/Ternary/Interleaving.agda
@@ -73,12 +73,12 @@ module _ {a p} {A : Set a} {P : Pred A p} (P? : Decidable P) where
   filter []       = [] ≡ [] ⊎ []
   filter (x ∷ xs) =
     -- otherwise we start by running filter on the tail
-    let xs' ≡ ps ⊎ ¬ps = filter xs in
+    let xs′ ≡ ps ⊎ ¬ps = filter xs in
     -- And depending on whether `P` holds of the head,
     -- we cons it to the `kept` or `thrown` list.
     case P? x of λ where -- [1]
-      (yes p) → consˡ xs' ≡ p ∷ ps ⊎      ¬ps
-      (no ¬p) → consʳ xs' ≡     ps ⊎ ¬p ∷ ¬ps
+      (yes p) → consˡ xs′ ≡ p ∷ ps ⊎      ¬ps
+      (no ¬p) → consʳ xs′ ≡     ps ⊎ ¬p ∷ ¬ps
 
 
 

--- a/README/Data/Tree/AVL.agda
+++ b/README/Data/Tree/AVL.agda
@@ -24,8 +24,8 @@ open import Data.String using (String)
 open import Data.Vec using (Vec; _∷_; [])
 open import Relation.Binary.PropositionalEquality
 
-open Data.Tree.AVL <-strictTotalOrder renaming (Tree to Tree')
-Tree = Tree' (MkValue (Vec String) (subst (Vec String)))
+open Data.Tree.AVL <-strictTotalOrder renaming (Tree to Tree′)
+Tree = Tree′ (MkValue (Vec String) (subst (Vec String)))
 
 ------------------------------------------------------------------------
 -- Construction of trees

--- a/README/Debug/Trace.agda
+++ b/README/Debug/Trace.agda
@@ -46,8 +46,8 @@ div m n    = just (go m m) where
   go : (fuel : ℕ) (m : ℕ) → ℕ
   go zero       m = trace ("Invariant: " ++ show m ++ " should be zero.") zero
   go (suc fuel) m =
-    let m' = trace ("Thunk for step " ++ show fuel ++ " forced") (m ∸ n) in
-    trace ("Recursive call for step " ++ show fuel) (suc (go fuel m'))
+    let m′ = trace ("Thunk for step " ++ show fuel ++ " forced") (m ∸ n) in
+    trace ("Recursive call for step " ++ show fuel) (suc (go fuel m′))
 
 -- To observe the behaviour of this code, we need to compile it and run it.
 -- To run it, we need a main function. We define a very basic one: run div,

--- a/README/Nary.agda
+++ b/README/Nary.agda
@@ -147,8 +147,8 @@ curry₁ = curryₙ 4
 -- to be right nested. Which means that if you have a deeply-nested product
 -- then it won't be affected by the procedure.
 
-curry₁' : (A × (B × C) × D → E) → A → (B × C) → D → E
-curry₁' = curryₙ 3
+curry₁′ : (A × (B × C) × D → E) → A → (B × C) → D → E
+curry₁′ = curryₙ 3
 
 -- When we are currying a function, we have no obligation to pass its exact
 -- arity as the parameter: we can decide to only curry part of it like so:
@@ -174,8 +174,8 @@ proj₃ = projₙ 5 (# 2)
 -- passing `projₙ` a natural number which is smaller than the size of the
 -- n-ary product, seeing (A₁ × ⋯ × Aₙ) as (A₁ × ⋯ × (Aₖ × ⋯ × Aₙ)).
 
-proj₃' : (A × B × C × D × E) → C × D × E
-proj₃' = projₙ 3 (# 2)
+proj₃′ : (A × B × C × D × E) → C × D × E
+proj₃′ = projₙ 3 (# 2)
 
 -----------------------------------------------------------------------
 -- insertₙ : ∀ n (k : Fin (suc n)) →
@@ -184,8 +184,8 @@ proj₃' = projₙ 3 (# 2)
 insert₁ : C → (A × B × D × E) → (A × B × C × D × E)
 insert₁ = insertₙ 4 (# 2)
 
-insert₁' : C → (A × B × D × E) → (A × B × C × D × E)
-insert₁' = insertₙ 3 (# 2)
+insert₁′ : C → (A × B × D × E) → (A × B × C × D × E)
+insert₁′ = insertₙ 3 (# 2)
 
 -- Note that `insertₙ` takes a `Fin (suc n)`. Indeed in an n-ary product
 -- there are (suc n) positions at which one may insert a value. We may
@@ -248,10 +248,10 @@ compose₁ f = 1 %= f ⊢ replicate
 -- Here we spell out the equivalent explicit variable-manipulation and
 -- prove the two functions equal.
 
-compose₁' : (A → B) → ℕ → A → List B
-compose₁' f n a = replicate n (f a)
+compose₁′ : (A → B) → ℕ → A → List B
+compose₁′ f n a = replicate n (f a)
 
-compose₁-eq : compose₁ {a} {A} {b} {B} ≡ compose₁'
+compose₁-eq : compose₁ {a} {A} {b} {B} ≡ compose₁′
 compose₁-eq = refl
 
 -----------------------------------------------------------------------

--- a/src/Algebra/Properties/BooleanAlgebra.agda
+++ b/src/Algebra/Properties/BooleanAlgebra.agda
@@ -437,7 +437,7 @@ module XorRing
       ((x ∨ y) ∧ (¬ x ∨ ¬ y)) ∨ z        ≈˘⟨ ∨-congʳ $ ∧-congˡ (deMorgan₁ _ _) ⟩
       ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ z          ∎
 
-    lem₂' = begin
+    lem₂′ = begin
       (x ∨ ¬ y) ∧ (¬ x ∨ y)              ≈˘⟨ ∧-identityˡ _ ⟨ ∧-cong ⟩ ∧-identityʳ _ ⟩
       (⊤ ∧ (x ∨ ¬ y)) ∧ ((¬ x ∨ y) ∧ ⊤)  ≈˘⟨  (∨-complementˡ _ ⟨ ∧-cong ⟩ ∨-comm _ _)
                                                 ⟨ ∧-cong ⟩
@@ -450,7 +450,7 @@ module XorRing
 
     lem₂ = begin
       ((x ∨ ¬ y) ∨ ¬ z) ∧ ((¬ x ∨ y) ∨ ¬ z)  ≈˘⟨ ∨-∧-distribʳ _ _ _ ⟩
-      ((x ∨ ¬ y) ∧ (¬ x ∨ y)) ∨ ¬ z          ≈⟨ ∨-congʳ lem₂' ⟩
+      ((x ∨ ¬ y) ∧ (¬ x ∨ y)) ∨ ¬ z          ≈⟨ ∨-congʳ lem₂′ ⟩
       ¬ ((x ∨ y) ∧ ¬ (x ∧ y)) ∨ ¬ z          ≈˘⟨ deMorgan₁ _ _ ⟩
       ¬ (((x ∨ y) ∧ ¬ (x ∧ y)) ∧ z)          ∎
 
@@ -460,7 +460,7 @@ module XorRing
       (x ∨ (y ∨ z)) ∧ (x ∨ (¬ y ∨ ¬ z))  ≈˘⟨ ∨-assoc _ _ _ ⟨ ∧-cong ⟩ ∨-assoc _ _ _ ⟩
       ((x ∨ y) ∨ z) ∧ ((x ∨ ¬ y) ∨ ¬ z)  ∎
 
-    lem₄' = begin
+    lem₄′ = begin
       ¬ ((y ∨ z) ∧ ¬ (y ∧ z))    ≈⟨ deMorgan₁ _ _ ⟩
       ¬ (y ∨ z) ∨ ¬ ¬ (y ∧ z)    ≈⟨ deMorgan₂ _ _ ⟨ ∨-cong ⟩ ¬-involutive _ ⟩
       (¬ y ∧ ¬ z) ∨ (y ∧ z)      ≈⟨ lemma₂ _ _ _ _ ⟩
@@ -474,7 +474,7 @@ module XorRing
 
     lem₄ = begin
       ¬ (x ∧ ((y ∨ z) ∧ ¬ (y ∧ z)))  ≈⟨ deMorgan₁ _ _ ⟩
-      ¬ x ∨ ¬ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈⟨ ∨-congˡ lem₄' ⟩
+      ¬ x ∨ ¬ ((y ∨ z) ∧ ¬ (y ∧ z))  ≈⟨ ∨-congˡ lem₄′ ⟩
       ¬ x ∨ ((y ∨ ¬ z) ∧ (¬ y ∨ z))  ≈⟨ ∨-∧-distribˡ _ _ _ ⟩
       (¬ x ∨ (y     ∨ ¬ z)) ∧
       (¬ x ∨ (¬ y ∨ z))              ≈˘⟨ ∨-assoc _ _ _ ⟨ ∧-cong ⟩ ∨-assoc _ _ _ ⟩

--- a/src/Category/Monad/Continuation.agda
+++ b/src/Category/Monad/Continuation.agda
@@ -58,7 +58,7 @@ DContTIMonadDCont : ∀ (K : I → Set f) {M} →
 DContTIMonadDCont K Mon = record
   { monad = DContTIMonad K Mon
   ; reset = λ e k → e return >>= k
-  ; shift = λ e k → e (λ a k' → (k a) >>= k') return
+  ; shift = λ e k → e (λ a k′ → (k a) >>= k′) return
   }
   where
   open RawIMonad Mon

--- a/src/Category/Monad/Indexed.agda
+++ b/src/Category/Monad/Indexed.agda
@@ -48,7 +48,7 @@ record RawIMonad {I : Set i} (M : IFun I f) : Set (i ⊔ suc f) where
   rawIApplicative : RawIApplicative M
   rawIApplicative = record
     { pure = return
-    ; _⊛_  = λ f x → f >>= λ f' → x >>= λ x' → return (f' x')
+    ; _⊛_  = λ f x → f >>= λ f′ → x >>= λ x′ → return (f′ x′)
     }
 
   open RawIApplicative rawIApplicative public

--- a/src/Codata/Cowriter.agda
+++ b/src/Codata/Cowriter.agda
@@ -113,7 +113,7 @@ _>>=_ : ∀ {i} → Cowriter W A i → (A → Cowriter W X i) → Cowriter W X i
 
 unfold : ∀ {i} → (X → (W × X) ⊎ A) → X → Cowriter W A i
 unfold next seed with next seed
-... | inj₁ (w , seed') = w ∷ λ where .force → unfold next seed'
+... | inj₁ (w , seed′) = w ∷ λ where .force → unfold next seed′
 ... | inj₂ a           = [ a ]
 
 

--- a/src/Data/DifferenceList.agda
+++ b/src/Data/DifferenceList.agda
@@ -72,10 +72,10 @@ map f xs = λ k → List.map f (toList xs) ⟨ List._++_ ⟩ k
 -- concat is linear in the length of the outer list.
 
 concat : DiffList (DiffList A) → DiffList A
-concat xs = concat' (toList xs)
+concat xs = concat′ (toList xs)
   where
-  concat' : List (DiffList A) → DiffList A
-  concat' = List.foldr _++_ []
+  concat′ : List (DiffList A) → DiffList A
+  concat′ = List.foldr _++_ []
 
 take : ℕ → DiffList A → DiffList A
 take n = lift (List.take n)

--- a/src/Data/Graph/Acyclic.agda
+++ b/src/Data/Graph/Acyclic.agda
@@ -279,11 +279,11 @@ reverse : ∀ {ℓ e} {N : Set ℓ} {E : Set e} →
           ∀ {n} → Graph N E n → Graph N E n
 reverse {N = N} {E} g =
   foldl (Graph N E)
-        (λ i g' c →
+        (λ i g′ c →
            context (label c)
                    (List.map (Prod.swap ∘ Prod.map PC.reverse id) $
                              preds g i)
-           & g')
+           & g′)
         ∅ g
 
 private

--- a/src/Data/Integer/Divisibility/Signed.agda
+++ b/src/Data/Integer/Divisibility/Signed.agda
@@ -43,25 +43,25 @@ open _∣_ using (quotient) public
 
 ∣ᵤ⇒∣ : ∀ {k i} → k ∣ᵤ i → k ∣ i
 ∣ᵤ⇒∣ {k} {i} (divides 0 eq) = divides (+ 0) (∣n∣≡0⇒n≡0 eq)
-∣ᵤ⇒∣ {k} {i} (divides q@(ℕ.suc q') eq) with k ≟ + 0
+∣ᵤ⇒∣ {k} {i} (divides q@(ℕ.suc q′) eq) with k ≟ + 0
 ... | yes refl = divides (+ 0) (∣n∣≡0⇒n≡0 (trans eq (ℕ.*-zeroʳ q)))
 ... | no ¬k≠0  = divides ((S._*_ on sign) i k ◃ q) (◃-≡ sign-eq abs-eq) where
 
-  k'   = ℕ.suc (ℕ.pred ∣ k ∣)
-  ikq' = sign i S.* sign k ◃ ℕ.suc q'
+  k′   = ℕ.suc (ℕ.pred ∣ k ∣)
+  ikq′ = sign i S.* sign k ◃ ℕ.suc q′
 
   sign-eq : sign i ≡ sign (((S._*_ on sign) i k ◃ q) * k)
   sign-eq = sym $ begin
-    sign (((S._*_ on sign) i k ◃ ℕ.suc q') * k)
-      ≡⟨ cong (λ m → sign (sign ikq' S.* sign k ◃ ∣ ikq' ∣ ℕ.* m))
+    sign (((S._*_ on sign) i k ◃ ℕ.suc q′) * k)
+      ≡⟨ cong (λ m → sign (sign ikq′ S.* sign k ◃ ∣ ikq′ ∣ ℕ.* m))
               (sym (ℕ.suc[pred[n]]≡n (¬k≠0 ∘ ∣n∣≡0⇒n≡0))) ⟩
-    sign (sign ikq' S.* sign k ◃ ∣ ikq' ∣ ℕ.* k')
-      ≡⟨ cong (λ m → sign (sign ikq' S.* sign k ◃ m ℕ.* k'))
-              (abs-◃ (sign i S.* sign k) (ℕ.suc q')) ⟩
-    sign (sign ikq' S.* sign k ◃ _)
-      ≡⟨ sign-◃ (sign ikq' S.* sign k) (ℕ.pred ∣ k ∣ ℕ.+ q' ℕ.* k') ⟩
-    sign ikq' S.* sign k
-      ≡⟨ cong (S._* sign k) (sign-◃ (sign i S.* sign k) q') ⟩
+    sign (sign ikq′ S.* sign k ◃ ∣ ikq′ ∣ ℕ.* k′)
+      ≡⟨ cong (λ m → sign (sign ikq′ S.* sign k ◃ m ℕ.* k′))
+              (abs-◃ (sign i S.* sign k) (ℕ.suc q′)) ⟩
+    sign (sign ikq′ S.* sign k ◃ _)
+      ≡⟨ sign-◃ (sign ikq′ S.* sign k) (ℕ.pred ∣ k ∣ ℕ.+ q′ ℕ.* k′) ⟩
+    sign ikq′ S.* sign k
+      ≡⟨ cong (S._* sign k) (sign-◃ (sign i S.* sign k) q′) ⟩
     sign i S.* sign k S.* sign k
         ≡⟨ SProp.*-assoc (sign i) (sign k) (sign k) ⟩
     sign i S.* (sign k S.* sign k)
@@ -73,11 +73,11 @@ open _∣_ using (quotient) public
 
   abs-eq : ∣ i ∣ ≡ ∣ ((S._*_ on sign) i k ◃ q) * k ∣
   abs-eq = sym $ begin
-    ∣ ((S._*_ on sign) i k ◃ ℕ.suc q') * k ∣
-      ≡⟨ abs-◃ (sign ikq' S.* sign k) (∣ ikq' ∣ ℕ.* ∣ k ∣) ⟩
-    ∣ ikq' ∣ ℕ.* ∣ k ∣
-      ≡⟨ cong (ℕ._* ∣ k ∣) (abs-◃ (sign i S.* sign k) (ℕ.suc q')) ⟩
-    ℕ.suc q' ℕ.* ∣ k ∣
+    ∣ ((S._*_ on sign) i k ◃ ℕ.suc q′) * k ∣
+      ≡⟨ abs-◃ (sign ikq′ S.* sign k) (∣ ikq′ ∣ ℕ.* ∣ k ∣) ⟩
+    ∣ ikq′ ∣ ℕ.* ∣ k ∣
+      ≡⟨ cong (ℕ._* ∣ k ∣) (abs-◃ (sign i S.* sign k) (ℕ.suc q′)) ⟩
+    ℕ.suc q′ ℕ.* ∣ k ∣
       ≡⟨ sym eq ⟩
     ∣ i ∣
       ∎ where open ≡-Reasoning

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -1823,7 +1823,7 @@ Please use _<_ instead."
 ≰⇒>′ { -[1+ suc _ ]} { -[1+ 0 ]}     m≰n =  contradiction (-≤- z≤n) m≰n
 ≰⇒>′ { -[1+ m ]}     { -[1+ suc n ]} m≰n with m ℕ.≤? n
 ... | yes m≤n  = -≤- m≤n
-... | no  m≰n' = contradiction (-≤- (ℕₚ.≰⇒> m≰n')) m≰n
+... | no  m≰n′ = contradiction (-≤- (ℕₚ.≰⇒> m≰n′)) m≰n
 {-# WARNING_ON_USAGE ≰⇒>′
 "Warning: _<′_ was deprecated in v1.1.
 Please use _<_ instead."

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -364,17 +364,19 @@ xs ∷ʳ? x = maybe′ (xs ∷ʳ_) xs x
 
 -- Backwards initialisation
 
-infixl 5 _∷ʳ'_
+infixl 5 _∷ʳ′_
 
 data InitLast {A : Set a} : List A → Set a where
   []    : InitLast []
-  _∷ʳ'_ : (xs : List A) (x : A) → InitLast (xs ∷ʳ x)
+  _∷ʳ′_ : (xs : List A) (x : A) → InitLast (xs ∷ʳ x)
+
+
 
 initLast : (xs : List A) → InitLast xs
 initLast []               = []
 initLast (x ∷ xs)         with initLast xs
-... | []       = [] ∷ʳ' x
-... | ys ∷ʳ' y = (x ∷ ys) ∷ʳ' y
+... | []       = [] ∷ʳ′ x
+... | ys ∷ʳ′ y = (x ∷ ys) ∷ʳ′ y
 
 ------------------------------------------------------------------------
 -- Splitting a list
@@ -440,3 +442,13 @@ boolSpan p (x ∷ xs) with p x
 
 boolBreak : (A → Bool) → List A → (List A × List A)
 boolBreak p = boolSpan (not ∘ p)
+
+-- Version 1.4
+
+infixl 5 _∷ʳ'_
+_∷ʳ'_ : (xs : List A) (x : A) → InitLast (xs ∷ʳ x)
+_∷ʳ'_ = InitLast._∷ʳ′_
+{-# WARNING_ON_USAGE _∷ʳ'_
+"Warning: _∷ʳ'_ (ending in an apostrophe) was deprecated in v1.4.
+Please use _∷ʳ′_ (ending in a prime) instead."
+#-}

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -230,7 +230,7 @@ unfold : ∀ (P : ℕ → Set b)
 unfold P f {n = zero}  s = []
 unfold P f {n = suc n} s with f s
 ... | nothing       = []
-... | just (x , s') = x ∷ unfold P f s'
+... | just (x , s′) = x ∷ unfold P f s′
 
 ------------------------------------------------------------------------
 -- Operations for deconstructing lists

--- a/src/Data/List/NonEmpty.agda
+++ b/src/Data/List/NonEmpty.agda
@@ -193,7 +193,7 @@ data SnocView {A : Set a} : List⁺ A → Set a where
 snocView : (xs : List⁺ A) → SnocView xs
 snocView (x ∷ xs)              with List.initLast xs
 snocView (x ∷ .[])             | []            = []       ∷ʳ′ x
-snocView (x ∷ .(xs List.∷ʳ y)) | xs List.∷ʳ' y = (x ∷ xs) ∷ʳ′ y
+snocView (x ∷ .(xs List.∷ʳ y)) | xs List.∷ʳ′ y = (x ∷ xs) ∷ʳ′ y
 
 -- The last element in the list.
 
@@ -326,3 +326,20 @@ private
     wordsBy (ℕ._≡ᵇ 1) (1 ∷ 2 ∷ 3 ∷ 1 ∷ 1 ∷ 2 ∷ 1 ∷ []) ≡
     (2 ∷⁺ [ 3 ]) ∷ [ 2 ] ∷ []
   wordsBy-≡1 = refl
+
+  ------------------------------------------------------------------------
+  -- DEPRECATED
+  ------------------------------------------------------------------------
+  -- Please use the new names as continuing support for the old names is
+  -- not guaranteed.
+
+  -- Version 1.4
+
+  infixl 5 _∷ʳ'_
+
+  _∷ʳ'_ : (xs : List A) (x : A) → SnocView (xs ∷ʳ x)
+  _∷ʳ'_ = SnocView._∷ʳ′_
+  {-# WARNING_ON_USAGE _∷ʳ'_
+  "Warning: _∷ʳ'_ (ending in an apostrophe) was deprecated in v1.4.
+  Please use _∷ʳ′_ (ending in a prime) instead."
+  #-}

--- a/src/Data/List/Relation/Binary/Permutation/Homogeneous.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Homogeneous.agda
@@ -22,7 +22,7 @@ private
 data Permutation {A : Set a} (R : Rel A r) : Rel (List A) (a ⊔ r) where
   refl  : ∀ {xs ys} → Pointwise R xs ys → Permutation R xs ys
   prep  : ∀ {xs ys x y} (eq : R x y) → Permutation R xs ys → Permutation R (x ∷ xs) (y ∷ ys)
-  swap  : ∀ {xs ys x y x' y'} (eq₁ : R x x') (eq₂ : R y y') → Permutation R xs ys → Permutation R (x ∷ y ∷ xs) (y' ∷ x' ∷ ys)
+  swap  : ∀ {xs ys x y x′ y′} (eq₁ : R x x′) (eq₂ : R y y′) → Permutation R xs ys → Permutation R (x ∷ y ∷ xs) (y′ ∷ x′ ∷ ys)
   trans : ∀ {xs ys zs} → Permutation R xs ys → Permutation R ys zs → Permutation R xs zs
 
 ------------------------------------------------------------------------
@@ -32,8 +32,8 @@ module _ {R : Rel A r}  where
 
   sym : Symmetric R → Symmetric (Permutation R)
   sym R-sym (refl xs∼ys)           = refl (Pointwise.symmetric R-sym xs∼ys)
-  sym R-sym (prep x∼x' xs↭ys)      = prep (R-sym x∼x') (sym R-sym xs↭ys)
-  sym R-sym (swap x∼x' y∼y' xs↭ys) = swap (R-sym y∼y') (R-sym x∼x') (sym R-sym xs↭ys)
+  sym R-sym (prep x∼x′ xs↭ys)      = prep (R-sym x∼x′) (sym R-sym xs↭ys)
+  sym R-sym (swap x∼x′ y∼y′ xs↭ys) = swap (R-sym y∼y′) (R-sym x∼x′) (sym R-sym xs↭ys)
   sym R-sym (trans xs↭ys ys↭zs)    = trans (sym R-sym ys↭zs) (sym R-sym xs↭ys)
 
   isEquivalence : Reflexive R → Symmetric R → IsEquivalence (Permutation R)

--- a/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
@@ -104,8 +104,8 @@ module _ {a b} {A : Set a} {B : Set b} (f : A → B) where
   ↭-map-inv {[]}     ρ                                                  = -, ↭-empty-inv (↭-sym ρ) , ↭-refl
   ↭-map-inv {x ∷ []} ρ                                                  = -, ↭-singleton-inv (↭-sym ρ) , ↭-refl
   ↭-map-inv {_ ∷ _ ∷ _} refl                                            = -, refl , ↭-refl
-  ↭-map-inv {_ ∷ _ ∷ _} (prep _ ρ)    with _ , refl , ρ' ← ↭-map-inv ρ  = -, refl , prep _ ρ'
-  ↭-map-inv {_ ∷ _ ∷ _} (swap _ _ ρ)  with _ , refl , ρ' ← ↭-map-inv ρ  = -, refl , swap _ _ ρ'
+  ↭-map-inv {_ ∷ _ ∷ _} (prep _ ρ)    with _ , refl , ρ′ ← ↭-map-inv ρ  = -, refl , prep _ ρ′
+  ↭-map-inv {_ ∷ _ ∷ _} (swap _ _ ρ)  with _ , refl , ρ′ ← ↭-map-inv ρ  = -, refl , swap _ _ ρ′
   ↭-map-inv {_ ∷ _ ∷ _} (trans ρ₁ ρ₂) with _ , refl , ρ₃ ← ↭-map-inv ρ₁
                                       with _ , refl , ρ₄ ← ↭-map-inv ρ₂ = -, refl , trans ρ₃ ρ₄
 

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -746,18 +746,18 @@ module Bin+CSemigroup = CommSemigProp +-commutativeSemigroup
 -- Properties of _+_ and _≤_
 
 +-mono-≤ : _+_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
-+-mono-≤ {x} {x'} {y} {y'} x≤x' y≤y' =  begin
++-mono-≤ {x} {x′} {y} {y′} x≤x′ y≤y′ =  begin
   x + y                 ≡⟨ sym $ cong₂ _+_ (fromℕ-toℕ x) (fromℕ-toℕ y) ⟩
   fromℕ m + fromℕ n     ≡⟨ sym (fromℕ-homo-+ m n) ⟩
-  fromℕ (m ℕ.+ n)       ≤⟨ fromℕ-mono-≤ (ℕₚ.+-mono-≤ m≤m' n≤n') ⟩
-  fromℕ (m' ℕ.+ n')     ≡⟨ fromℕ-homo-+ m' n' ⟩
-  fromℕ m' + fromℕ n'   ≡⟨ cong₂ _+_ (fromℕ-toℕ x') (fromℕ-toℕ y') ⟩
-  x' + y'               ∎
+  fromℕ (m ℕ.+ n)       ≤⟨ fromℕ-mono-≤ (ℕₚ.+-mono-≤ m≤m′ n≤n′) ⟩
+  fromℕ (m′ ℕ.+ n′)     ≡⟨ fromℕ-homo-+ m′ n′ ⟩
+  fromℕ m′ + fromℕ n′   ≡⟨ cong₂ _+_ (fromℕ-toℕ x′) (fromℕ-toℕ y′) ⟩
+  x′ + y′               ∎
   where
   open ≤-Reasoning
-  m    = toℕ x;             m'   = toℕ x'
-  n    = toℕ y;             n'   = toℕ y'
-  m≤m' = toℕ-mono-≤ x≤x';   n≤n' = toℕ-mono-≤ y≤y'
+  m    = toℕ x;             m′   = toℕ x′
+  n    = toℕ y;             n′   = toℕ y′
+  m≤m′ = toℕ-mono-≤ x≤x′;   n≤n′ = toℕ-mono-≤ y≤y′
 
 +-monoˡ-≤ : ∀ x → (_+ x) Preserves _≤_ ⟶ _≤_
 +-monoˡ-≤ x y≤z =  +-mono-≤ y≤z (≤-refl {x})
@@ -766,23 +766,23 @@ module Bin+CSemigroup = CommSemigProp +-commutativeSemigroup
 +-monoʳ-≤ x y≤z =  +-mono-≤ (≤-refl {x}) y≤z
 
 +-mono-<-≤ : _+_ Preserves₂ _<_ ⟶ _≤_ ⟶ _<_
-+-mono-<-≤ {x} {x'} {y} {y'} x<x' y≤y' =  begin-strict
++-mono-<-≤ {x} {x′} {y} {y′} x<x′ y≤y′ =  begin-strict
   x + y                  ≡⟨ sym $ cong₂ _+_ (fromℕ-toℕ x) (fromℕ-toℕ y) ⟩
   fromℕ m + fromℕ n      ≡⟨ sym (fromℕ-homo-+ m n) ⟩
-  fromℕ (m ℕ.+ n)        <⟨ fromℕ-mono-< (ℕₚ.+-mono-<-≤ m<m' n≤n') ⟩
-  fromℕ (m' ℕ.+ n')      ≡⟨ fromℕ-homo-+ m' n' ⟩
-  fromℕ m' + fromℕ n'    ≡⟨ cong₂ _+_ (fromℕ-toℕ x') (fromℕ-toℕ y') ⟩
-  x' + y'                ∎
+  fromℕ (m ℕ.+ n)        <⟨ fromℕ-mono-< (ℕₚ.+-mono-<-≤ m<m′ n≤n′) ⟩
+  fromℕ (m′ ℕ.+ n′)      ≡⟨ fromℕ-homo-+ m′ n′ ⟩
+  fromℕ m′ + fromℕ n′    ≡⟨ cong₂ _+_ (fromℕ-toℕ x′) (fromℕ-toℕ y′) ⟩
+  x′ + y′                ∎
   where
   open ≤-Reasoning
   m    = toℕ x;             n    = toℕ y
-  m'   = toℕ x';            n'   = toℕ y'
-  m<m' = toℕ-mono-< x<x';   n≤n' = toℕ-mono-≤ y≤y'
+  m′   = toℕ x′;            n′   = toℕ y′
+  m<m′ = toℕ-mono-< x<x′;   n≤n′ = toℕ-mono-≤ y≤y′
 
 +-mono-≤-< : _+_ Preserves₂ _≤_ ⟶ _<_ ⟶ _<_
-+-mono-≤-< {x} {x'} {y} {y'} x≤x' y<y' =  subst₂ _<_ (+-comm y x) (+-comm y' x') y+x<y'+x'
++-mono-≤-< {x} {x′} {y} {y′} x≤x′ y<y′ =  subst₂ _<_ (+-comm y x) (+-comm y′ x′) y+x<y′+x′
   where
-  y+x<y'+x' =  +-mono-<-≤ y<y' x≤x'
+  y+x<y′+x′ =  +-mono-<-≤ y<y′ x≤x′
 
 +-monoˡ-< : ∀ x → (_+ x) Preserves _<_ ⟶ _<_
 +-monoˡ-< x y<z =  +-mono-<-≤ y<z (≤-refl {x})
@@ -925,18 +925,18 @@ toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
     ℕ.suc (2 ℕ.* (toℕ (x + y * 1+2x)))      ≡⟨ cong (ℕ.suc ∘ (2 ℕ.*_)) (toℕ-homo-+ x (y * 1+2x)) ⟩
     ℕ.suc (2 ℕ.* (m ℕ.+ (toℕ (y * 1+2x))))  ≡⟨ cong (ℕ.suc ∘ (2 ℕ.*_) ∘ (m ℕ.+_))
                                                  (aux y 1+2x cnt |y|+1+|x|≤cnt) ⟩
-    ℕ.suc (2 ℕ.* (m ℕ.+ (n ℕ.* [1+2x]')))   ≡⟨ cong ℕ.suc $ ℕₚ.*-distribˡ-+ 2 m (n ℕ.* [1+2x]') ⟩
-    ℕ.suc (2m ℕ.+ (2 ℕ.* (n ℕ.* [1+2x]')))  ≡⟨ cong (ℕ.suc ∘ (2m ℕ.+_)) (sym (ℕₚ.*-assoc 2 n _)) ⟩
-    (ℕ.suc 2m) ℕ.+ 2n ℕ.* [1+2x]'           ≡⟨⟩
-    [1+2x]' ℕ.+ 2n ℕ.* [1+2x]'              ≡⟨ cong (ℕ._+ (2n ℕ.* [1+2x]')) $
-                                                    sym (ℕₚ.*-identityˡ [1+2x]') ⟩
-    1 ℕ.* [1+2x]' ℕ.+ 2n ℕ.* [1+2x]'        ≡⟨ sym (ℕₚ.*-distribʳ-+ [1+2x]' 1 2n) ⟩
-    (ℕ.suc 2n) ℕ.* [1+2x]'                  ≡⟨ ℕₚ.*-comm (ℕ.suc 2n) [1+2x]' ⟩
+    ℕ.suc (2 ℕ.* (m ℕ.+ (n ℕ.* [1+2x]′)))   ≡⟨ cong ℕ.suc $ ℕₚ.*-distribˡ-+ 2 m (n ℕ.* [1+2x]′) ⟩
+    ℕ.suc (2m ℕ.+ (2 ℕ.* (n ℕ.* [1+2x]′)))  ≡⟨ cong (ℕ.suc ∘ (2m ℕ.+_)) (sym (ℕₚ.*-assoc 2 n _)) ⟩
+    (ℕ.suc 2m) ℕ.+ 2n ℕ.* [1+2x]′           ≡⟨⟩
+    [1+2x]′ ℕ.+ 2n ℕ.* [1+2x]′              ≡⟨ cong (ℕ._+ (2n ℕ.* [1+2x]′)) $
+                                                    sym (ℕₚ.*-identityˡ [1+2x]′) ⟩
+    1 ℕ.* [1+2x]′ ℕ.+ 2n ℕ.* [1+2x]′        ≡⟨ sym (ℕₚ.*-distribʳ-+ [1+2x]′ 1 2n) ⟩
+    (ℕ.suc 2n) ℕ.* [1+2x]′                  ≡⟨ ℕₚ.*-comm (ℕ.suc 2n) [1+2x]′ ⟩
     toℕ 1+[2 x ] ℕ.* toℕ 1+[2 y ]           ∎
     where
     open ≡-Reasoning
     m    = toℕ x;      n       = toℕ y;     2m = 2 ℕ.* m;    2n = 2 ℕ.* n
-    1+2x = 1+[2 x ];   [1+2x]' = toℕ 1+2x
+    1+2x = 1+[2 x ];   [1+2x]′ = toℕ 1+2x
 
     eq : size x ℕ.+ (ℕ.suc (size y)) ≡ size y ℕ.+ (ℕ.suc (size x))
     eq = ℕ-+-semigroupProperties.x∙yz≈z∙yx (size x) 1 _
@@ -1106,10 +1106,10 @@ private
   where open ℕₚ.≤-Reasoning
 
 *-monoʳ-≤ : ∀ x → (x *_) Preserves _≤_ ⟶ _≤_
-*-monoʳ-≤ x y≤y' = *-mono-≤ (≤-refl {x}) y≤y'
+*-monoʳ-≤ x y≤y′ = *-mono-≤ (≤-refl {x}) y≤y′
 
 *-monoˡ-≤ : ∀ x → (_* x) Preserves _≤_ ⟶ _≤_
-*-monoˡ-≤ x y≤y' = *-mono-≤ y≤y' (≤-refl {x})
+*-monoˡ-≤ x y≤y′ = *-mono-≤ y≤y′ (≤-refl {x})
 
 *-mono-< : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
 *-mono-< {x} {u} {y} {v} x<u y<v = toℕ-cancel-< (begin-strict

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -326,11 +326,11 @@ nonZeroDivisor-lemma m zero r r≢zero (divides (suc q) eq) =
     m                   ∎
     where open ≤-Reasoning
 nonZeroDivisor-lemma m (suc q) r r≢zero d =
-  nonZeroDivisor-lemma m q r r≢zero (∣m+n∣m⇒∣n d' ∣-refl)
+  nonZeroDivisor-lemma m q r r≢zero (∣m+n∣m⇒∣n d′ ∣-refl)
   where
   lem = solve 3 (λ m r q → r :+ (m :+ q)  :=  m :+ (r :+ q))
                 refl (suc m) (toℕ r) (q * suc m)
-  d' = subst (1 + m ∣_) lem d
+  d′ = subst (1 + m ∣_) lem d
 {-# WARNING_ON_USAGE nonZeroDivisor-lemma
 "Warning: nonZeroDivisor-lemma was deprecated in v0.17."
 #-}

--- a/src/Data/Product/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Product/Relation/Binary/Lex/Strict.agda
@@ -144,16 +144,16 @@ module _ {_≈₁_ : Rel A ℓ₁} {_<₁_ : Rel A ℓ₂}
     open IsEquivalence eq₁
 
     respʳ : _<ₗₑₓ_ Respectsʳ _≋_
-    respʳ y≈y' (inj₁ x₁<y₁) = inj₁ (proj₁ resp₁ (proj₁ y≈y') x₁<y₁)
-    respʳ y≈y' (inj₂ x≈<y)  =
-      inj₂ ( trans (proj₁ x≈<y) (proj₁ y≈y')
-           , proj₁ resp₂ (proj₂ y≈y') (proj₂ x≈<y) )
+    respʳ y≈y′ (inj₁ x₁<y₁) = inj₁ (proj₁ resp₁ (proj₁ y≈y′) x₁<y₁)
+    respʳ y≈y′ (inj₂ x≈<y)  =
+      inj₂ ( trans (proj₁ x≈<y) (proj₁ y≈y′)
+           , proj₁ resp₂ (proj₂ y≈y′) (proj₂ x≈<y) )
 
     respˡ : _<ₗₑₓ_ Respectsˡ _≋_
-    respˡ x≈x' (inj₁ x₁<y₁) = inj₁ (proj₂ resp₁ (proj₁ x≈x') x₁<y₁)
-    respˡ x≈x' (inj₂ x≈<y)  =
-      inj₂ ( trans (sym $ proj₁ x≈x') (proj₁ x≈<y)
-           , proj₂ resp₂ (proj₂ x≈x') (proj₂ x≈<y) )
+    respˡ x≈x′ (inj₁ x₁<y₁) = inj₁ (proj₂ resp₁ (proj₁ x≈x′) x₁<y₁)
+    respˡ x≈x′ (inj₂ x≈<y)  =
+      inj₂ ( trans (sym $ proj₁ x≈x′) (proj₁ x≈<y)
+           , proj₂ resp₂ (proj₂ x≈x′) (proj₂ x≈<y) )
 
   ×-compare : Symmetric _≈₁_ →
               Trichotomous _≈₁_ _<₁_ → Trichotomous _≈₂_ _<₂_ →

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -94,12 +94,12 @@ module _ {a₁ a₂ ℓ₁ ℓ₂} {A₁ : Set a₁} {A₂ : Set a₂} where
     _≈_ = Pointwise _≈₁_ _≈₂_
 
     resp¹ : ∀ {x} → (x ∼_) Respects _≈_
-    resp¹ y≈y' x∼y = proj₁ resp₁ (proj₁ y≈y') (proj₁ x∼y) ,
-                     proj₁ resp₂ (proj₂ y≈y') (proj₂ x∼y)
+    resp¹ y≈y′ x∼y = proj₁ resp₁ (proj₁ y≈y′) (proj₁ x∼y) ,
+                     proj₁ resp₂ (proj₂ y≈y′) (proj₂ x∼y)
 
     resp² : ∀ {y} → (_∼ y) Respects _≈_
-    resp² x≈x' x∼y = proj₂ resp₁ (proj₁ x≈x') (proj₁ x∼y) ,
-                     proj₂ resp₂ (proj₂ x≈x') (proj₂ x∼y)
+    resp² x≈x′ x∼y = proj₂ resp₁ (proj₁ x≈x′) (proj₁ x∼y) ,
+                     proj₂ resp₂ (proj₂ x≈x′) (proj₂ x∼y)
 
   ×-total : ∀ {_∼₁_ _∼₂_} → Symmetric _∼₁_ →
     Total _∼₁_ → Total _∼₂_ →

--- a/src/Data/Tree/AVL/IndexedMap.agda
+++ b/src/Data/Tree/AVL/IndexedMap.agda
@@ -45,8 +45,8 @@ private
 private
   open module AVL =
     Data.Tree.AVL (record { isStrictTotalOrder = isStrictTotalOrder })
-    using () renaming (Tree to Map')
-  Map = Map' (AVL.MkValue (Value ∘ proj₁) (subst Value ∘′ cong proj₁))
+    using () renaming (Tree to Map′)
+  Map = Map′ (AVL.MkValue (Value ∘ proj₁) (subst Value ∘′ cong proj₁))
 
 -- Repackaged functions.
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -297,26 +297,26 @@ map-[]≔ f xs i = map-updateAt xs i refl
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {m} {ys ys' : Vec A m} where
+module _ {m} {ys ys′ : Vec A m} where
 
   -- See also Data.Vec.Properties.WithK.++-assoc.
 
-  ++-injectiveˡ : ∀ {n} (xs xs' : Vec A n) →
-                  xs ++ ys ≡ xs' ++ ys' → xs ≡ xs'
+  ++-injectiveˡ : ∀ {n} (xs xs′ : Vec A n) →
+                  xs ++ ys ≡ xs′ ++ ys′ → xs ≡ xs′
   ++-injectiveˡ []       []         _  = refl
-  ++-injectiveˡ (x ∷ xs) (x' ∷ xs') eq =
+  ++-injectiveˡ (x ∷ xs) (x′ ∷ xs′) eq =
     P.cong₂ _∷_ (∷-injectiveˡ eq) (++-injectiveˡ _ _ (∷-injectiveʳ eq))
 
-  ++-injectiveʳ : ∀ {n} (xs xs' : Vec A n) →
-                  xs ++ ys ≡ xs' ++ ys' → ys ≡ ys'
+  ++-injectiveʳ : ∀ {n} (xs xs′ : Vec A n) →
+                  xs ++ ys ≡ xs′ ++ ys′ → ys ≡ ys′
   ++-injectiveʳ []       []         eq = eq
-  ++-injectiveʳ (x ∷ xs) (x' ∷ xs') eq =
-    ++-injectiveʳ xs xs' (∷-injectiveʳ eq)
+  ++-injectiveʳ (x ∷ xs) (x′ ∷ xs′) eq =
+    ++-injectiveʳ xs xs′ (∷-injectiveʳ eq)
 
-  ++-injective  : ∀ {n} (xs xs' : Vec A n) →
-                  xs ++ ys ≡ xs' ++ ys' → xs ≡ xs' × ys ≡ ys'
-  ++-injective xs xs' eq =
-    (++-injectiveˡ xs xs' eq , ++-injectiveʳ xs xs' eq)
+  ++-injective  : ∀ {n} (xs xs′ : Vec A n) →
+                  xs ++ ys ≡ xs′ ++ ys′ → xs ≡ xs′ × ys ≡ ys′
+  ++-injective xs xs′ eq =
+    (++-injectiveˡ xs xs′ eq , ++-injectiveʳ xs xs′ eq)
 
 lookup-++-< : ∀ {m n} (xs : Vec A m) (ys : Vec A n) →
               ∀ i (i<m : toℕ i < m) →

--- a/src/Data/Vec/Properties/WithK.agda
+++ b/src/Data/Vec/Properties/WithK.agda
@@ -23,8 +23,8 @@ module _ {a} {A : Set a} where
   []=-irrelevant : ∀ {n} {xs : Vec A n} {i x} →
                     (p q : xs [ i ]= x) → p ≡ q
   []=-irrelevant here            here             = refl
-  []=-irrelevant (there xs[i]=x) (there xs[i]=x') =
-    P.cong there ([]=-irrelevant xs[i]=x xs[i]=x')
+  []=-irrelevant (there xs[i]=x) (there xs[i]=x′) =
+    P.cong there ([]=-irrelevant xs[i]=x xs[i]=x′)
 
 ------------------------------------------------------------------------
 -- _++_

--- a/src/Function/Nary/NonDependent.agda
+++ b/src/Function/Nary/NonDependent.agda
@@ -68,7 +68,7 @@ module _ n {ls} {as : Sets n ls} {R : Set r} (f : as ⇉ R) where
 
 -- Congruence at a specific location
 
-module _ m n {ls ls'} {as : Sets m ls} {bs : Sets n ls'}
+module _ m n {ls ls′} {as : Sets m ls} {bs : Sets n ls′}
          (f : as ⇉ (A → bs ⇉ B)) where
 
   private

--- a/src/Induction/Lexicographic.agda
+++ b/src/Induction/Lexicographic.agda
@@ -19,10 +19,10 @@ open import Level
         RecStruct (Σ A B) _ _
 Σ-Rec RecA RecB P (x , y) =
   -- Either x is constant and y is "smaller", ...
-  RecB x (λ y' → P (x , y')) y
+  RecB x (λ y′ → P (x , y′)) y
     ×
   -- ...or x is "smaller" and y is arbitrary.
-  RecA (λ x' → ∀ y' → P (x' , y')) x
+  RecA (λ x′ → ∀ y′ → P (x′ , y′)) x
 
 _⊗_ : ∀ {a b ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b} →
       RecStruct A (ℓ₁ ⊔ b) ℓ₂ → RecStruct B ℓ₁ ℓ₃ →
@@ -41,14 +41,14 @@ RecA ⊗ RecB = Σ-Rec RecA (λ _ → RecB)
   (p₁ x y p₂x , p₂x)
   where
   p₁ : ∀ x y →
-       RecA (λ x' → ∀ y' → P (x' , y')) x →
-       RecB x (λ y' → P (x , y')) y
+       RecA (λ x′ → ∀ y′ → P (x′ , y′)) x →
+       RecB x (λ y′ → P (x , y′)) y
   p₁ x y x-rec = recB x
-                      (λ y' → P (x , y'))
+                      (λ y′ → P (x , y′))
                       (λ y y-rec → f (x , y) (y-rec , x-rec))
                       y
 
-  p₂ : ∀ x → RecA (λ x' → ∀ y' → P (x' , y')) x
+  p₂ : ∀ x → RecA (λ x′ → ∀ y′ → P (x′ , y′)) x
   p₂ = recA (λ x → ∀ y → P (x , y))
             (λ x x-rec y → f (x , y) (p₁ x y x-rec , x-rec))
 

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -108,13 +108,13 @@ module All {_<_ : Rel A r} (wf : WellFounded _<_) ℓ where
 module FixPoint
   {_<_ : Rel A ℓ} (wf : WellFounded _<_)
   (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P)
-  (f-ext : (x : A) {IH IH' : WfRec _<_ P x} → (∀ {y} y<x → IH y y<x ≡ IH' y y<x) → f x IH ≡ f x IH')
+  (f-ext : (x : A) {IH IH′ : WfRec _<_ P x} → (∀ {y} y<x → IH y y<x ≡ IH′ y y<x) → f x IH ≡ f x IH′)
   where
 
-  some-wfRec-irrelevant : ∀ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q'
+  some-wfRec-irrelevant : ∀ x → (q q′ : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q′
   some-wfRec-irrelevant = All.wfRec wf _
-                                   (λ x → (q q' : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q')
-                                   (λ { x IH (acc rs) (acc rs') → f-ext x (λ y<x → IH _ y<x (rs _ y<x) (rs' _ y<x)) })
+                                   (λ x → (q q′ : Acc _<_ x) → Some.wfRec P f x q ≡ Some.wfRec P f x q′)
+                                   (λ { x IH (acc rs) (acc rs′) → f-ext x (λ y<x → IH _ y<x (rs _ y<x) (rs′ _ y<x)) })
 
   open All wf ℓ
   wfRecBuilder-wfRec : ∀ {x y} y<x → wfRecBuilder P f x y y<x ≡ wfRec P f y

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -32,10 +32,10 @@ private
 module _ {_∼_ : Rel A ℓ} (P : Rel A p) where
 
   subst⟶respˡ : Substitutive _∼_ p → P Respectsˡ _∼_
-  subst⟶respˡ subst {y} x'∼x Px'y = subst (flip P y) x'∼x Px'y
+  subst⟶respˡ subst {y} x′∼x Px′y = subst (flip P y) x′∼x Px′y
 
   subst⟶respʳ : Substitutive _∼_ p → P Respectsʳ _∼_
-  subst⟶respʳ subst {x} y'∼y Pxy' = subst (P x) y'∼y Pxy'
+  subst⟶respʳ subst {x} y′∼y Pxy′ = subst (P x) y′∼y Pxy′
 
   subst⟶resp₂ : Substitutive _∼_ p → P Respects₂ _∼_
   subst⟶resp₂ subst = subst⟶respʳ subst , subst⟶respˡ subst

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -49,7 +49,7 @@ module _ {_~_ : Rel A ℓ} where
   trans ~-trans refl    [ x∼y ]  = [ x∼y ]
   trans ~-trans refl    refl     = refl
 
-  antisym : ∀ {ℓ'} (_≈_ : Rel A ℓ') → Reflexive _≈_ →
+  antisym : ∀ {ℓ′} (_≈_ : Rel A ℓ′) → Reflexive _≈_ →
             Asymmetric _~_ → Antisymmetric _≈_ (Refl _~_)
   antisym _≈_ ref asym [ x∼y ] [ y∼x ] = contradiction x∼y (asym y∼x)
   antisym _≈_ ref asym [ x∼y ] refl    = ref

--- a/src/Relation/Binary/Construct/StrictToNonStrict.agda
+++ b/src/Relation/Binary/Construct/StrictToNonStrict.agda
@@ -76,12 +76,12 @@ trans eq (respʳ , respˡ) <-trans = tr
 ≤-<-trans sym trans respˡ (inj₂ x≈y) y<z = respˡ (sym x≈y) y<z
 
 ≤-respʳ-≈ : Transitive _≈_ → _<_ Respectsʳ _≈_ → _≤_ Respectsʳ _≈_
-≤-respʳ-≈ trans respʳ y'≈y (inj₁ x<y') = inj₁ (respʳ y'≈y x<y')
-≤-respʳ-≈ trans respʳ y'≈y (inj₂ x≈y') = inj₂ (trans x≈y' y'≈y)
+≤-respʳ-≈ trans respʳ y′≈y (inj₁ x<y′) = inj₁ (respʳ y′≈y x<y′)
+≤-respʳ-≈ trans respʳ y′≈y (inj₂ x≈y′) = inj₂ (trans x≈y′ y′≈y)
 
 ≤-respˡ-≈ : Symmetric _≈_ → Transitive _≈_ → _<_ Respectsˡ _≈_ → _≤_ Respectsˡ _≈_
-≤-respˡ-≈ sym trans respˡ x'≈x (inj₁ x'<y) = inj₁ (respˡ x'≈x x'<y)
-≤-respˡ-≈ sym trans respˡ x'≈x (inj₂ x'≈y) = inj₂ (trans (sym x'≈x) x'≈y)
+≤-respˡ-≈ sym trans respˡ x′≈x (inj₁ x′<y) = inj₁ (respˡ x′≈x x′<y)
+≤-respˡ-≈ sym trans respˡ x′≈x (inj₂ x′≈y) = inj₂ (trans (sym x′≈x) x′≈y)
 
 ≤-resp-≈ : IsEquivalence _≈_ → _<_ Respects₂ _≈_ → _≤_ Respects₂ _≈_
 ≤-resp-≈ eq (respʳ , respˡ) = ≤-respʳ-≈ Eq.trans respʳ , ≤-respˡ-≈ Eq.sym Eq.trans respˡ

--- a/src/Relation/Binary/Construct/StrictToNonStrict.agda
+++ b/src/Relation/Binary/Construct/StrictToNonStrict.agda
@@ -96,8 +96,8 @@ total <-tri x y with <-tri x y
 decidable : Decidable _≈_ → Decidable _<_ → Decidable _≤_
 decidable ≈-dec <-dec x y = <-dec x y ⊎-dec ≈-dec x y
 
-decidable' : Trichotomous _≈_ _<_ → Decidable _≤_
-decidable' compare x y with compare x y
+decidable′ : Trichotomous _≈_ _<_ → Decidable _≤_
+decidable′ compare x y with compare x y
 ... | tri< x<y _   _ = yes (inj₁ x<y)
 ... | tri≈ _   x≈y _ = yes (inj₂ x≈y)
 ... | tri> x≮y x≉y _ = no [ x≮y , x≉y ]′
@@ -139,6 +139,22 @@ isDecTotalOrder : IsStrictTotalOrder _≈_ _<_ → IsDecTotalOrder _≈_ _≤_
 isDecTotalOrder STO = record
   { isTotalOrder = isTotalOrder STO
   ; _≟_          = S._≟_
-  ; _≤?_         = decidable' S.compare
+  ; _≤?_         = decidable′ S.compare
   }
   where module S = IsStrictTotalOrder STO
+
+
+------------------------------------------------------------------------
+-- DEPRECATED
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.4
+
+decidable' : Trichotomous _≈_ _<_ → Decidable _≤_
+decidable' = decidable′
+{-# WARNING_ON_USAGE decidable'
+"Warning: decidable' (ending in an apostrophe) was deprecated in v1.4.
+Please use decidable′ (ending in a prime) instead."
+#-}

--- a/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
+++ b/src/Relation/Binary/HeterogeneousEquality/Quotients/Examples.agda
@@ -22,7 +22,7 @@ open ≅-Reasoning
 ℕ² = ℕ × ℕ
 
 _∼_ : ℕ² → ℕ² → Set
-(x , y) ∼ (x' , y') = x + y' ≅ x' + y
+(x , y) ∼ (x′ , y′) = x + y′ ≅ x′ + y
 
 infix 10 _∼_
 
@@ -60,7 +60,7 @@ module Integers (quot : Quotients 0ℓ 0ℓ) where
   _+²_ : ℕ² → ℕ² → ℕ²
   (x₁ , y₁) +² (x₂ , y₂) = x₁ + x₂ , y₁ + y₂
 
-  +²-cong : ∀{a b a' b'} → a ∼ a' → b ∼ b' → a +² b ∼ a' +² b'
+  +²-cong : ∀{a b a′ b′} → a ∼ a′ → b ∼ b′ → a +² b ∼ a′ +² b′
   +²-cong {a₁ , b₁} {c₁ , d₁} {a₂ , b₂} {c₂ , d₂} ab∼cd₁ ab∼cd₂ = begin
     (a₁ + c₁) + (b₂ + d₂) ≡⟨ ≡.cong (_+ (b₂ + d₂)) (+-comm a₁ c₁) ⟩
     (c₁ + a₁) + (b₂ + d₂) ≡⟨ +-assoc c₁ a₁ (b₂ + d₂) ⟩
@@ -83,7 +83,7 @@ module Integers (quot : Quotients 0ℓ 0ℓ) where
 
     _+ℤ_ : ℤ → ℤ → ℤ
     _+ℤ_ = Properties₂.lift₂ ext Int Int (λ i j → abs (i +² j))
-         $ λ {a} {b} {c} p p' → compat-abs (+²-cong {a} {b} {c} p p')
+         $ λ {a} {b} {c} p p′ → compat-abs (+²-cong {a} {b} {c} p p′)
 
     zero² : ℕ²
     zero² = 0 , 0

--- a/src/Relation/Binary/Properties/Setoid.agda
+++ b/src/Relation/Binary/Properties/Setoid.agda
@@ -39,10 +39,10 @@ preorder = record
 ≉-sym x≉y =  x≉y ∘ sym
 
 ≉-respˡ : _≉_ Respectsˡ _≈_
-≉-respˡ x≈x' x≉y = x≉y ∘ trans x≈x'
+≉-respˡ x≈x′ x≉y = x≉y ∘ trans x≈x′
 
 ≉-respʳ : _≉_ Respectsʳ _≈_
-≉-respʳ y≈y' x≉y x≈y' = x≉y $ trans x≈y' (sym y≈y')
+≉-respʳ y≈y′ x≉y x≈y′ = x≉y $ trans x≈y′ (sym y≈y′)
 
 ≉-resp₂ : _≉_ Respects₂ _≈_
 ≉-resp₂ = ≉-respʳ , ≉-respˡ

--- a/src/Relation/Binary/PropositionalEquality/TrustMe.agda
+++ b/src/Relation/Binary/PropositionalEquality/TrustMe.agda
@@ -26,7 +26,7 @@ erase : ∀ {a} {A : Set a} {x y : A} → x ≡ y → x ≡ y
 erase _ = trustMe
 
 -- A "postulate with a reduction": postulate[ a ↦ b ] a evaluates to b,
--- while postulate[ a ↦ b ] a' gets stuck if a' is not definitionally
+-- while postulate[ a ↦ b ] a′ gets stuck if a′ is not definitionally
 -- equal to a. This can be used to define a postulate of type (x : A) → B x
 -- by only specifying the behaviour at B t for some t : A. Introduced in
 --
@@ -36,7 +36,7 @@ erase _ = trustMe
 
 postulate[_↦_] : ∀ {a b} {A : Set a}{B : A → Set b} →
                   (t : A) → B t → (x : A) → B x
-postulate[ a ↦ b ] a' with trustMe {x = a} {a'}
+postulate[ a ↦ b ] a′ with trustMe {x = a} {a′}
 postulate[ a ↦ b ] .a | refl = b
 
 

--- a/src/Text/Printf.agda
+++ b/src/Text/Printf.agda
@@ -48,9 +48,9 @@ private
   Printf (inj₁ err) = Error err
   Printf (inj₂ fmt) = Arrows _ ⟦ fmt ⟧ String
 
-  printf' : ∀ pr → Printf pr
-  printf' (inj₁ err) = _
-  printf' (inj₂ fmt) = curry⊤ₙ _ (concat ∘′ assemble fmt)
+  printf′ : ∀ pr → Printf pr
+  printf′ (inj₁ err) = _
+  printf′ (inj₂ fmt) = curry⊤ₙ _ (concat ∘′ assemble fmt)
 
 printf : (input : String) → Printf (lexer input)
-printf input = printf' (lexer input)
+printf input = printf′ (lexer input)


### PR DESCRIPTION
Re: issue #995:
So this changes the use of apostrophe's in identifiers to use prime symbols where possible. 
No CHANGELOGs were modified.

