### PR TITLE
Add Symmetry relations for Inverse (& friends) and IsEquivalence bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,16 @@ Other major additions
   Data.Nat.Binary.Subtraction
   ```
 
+* Symmetry of various functional properties
+  ```agda
+  Function.Construct.Symmetry
+  ```
+
+* `IsEquivalence` bundles for `Inverse`, `Equivalence`, `↔` and `⇔`
+  ```agda
+  Function.Construct.IsEquivalence
+  ```
+
 Other major changes
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,9 +98,10 @@ Other major additions
   Function.Construct.Symmetry
   ```
 
-* `IsEquivalence` bundles for `Inverse`, `Equivalence`, `↔` and `⇔`
+* `IsEquivalence` bundles for `Inverse`, `Equivalence`, `↔` and `⇔` in
   ```agda
-  Function.Construct.IsEquivalence
+  Function.Properties.Inverse
+  Function.Properties.Equivalence
   ```
 
 Other major changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Other major additions
   Function.Construct.Symmetry
   ```
 
-* `IsEquivalence` bundles for `Inverse`, `Equivalence`, `↔` and `⇔` in
+* `IsEquivalence` structures for `Inverse`, `Equivalence`, `↔` and `⇔` in
   ```agda
   Function.Properties.Inverse
   Function.Properties.Equivalence

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The identity function
+-- Composition of functional properties
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}

--- a/src/Function/Construct/IsEquivalence.agda
+++ b/src/Function/Construct/IsEquivalence.agda
@@ -1,0 +1,63 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Some functional properties are Equivalence Relations
+--   This file is meant to be imported qualified.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Function.Construct.IsEquivalence where
+
+open import Data.Product using (_,_; swap)
+open import Function
+open import Level using (Level; _⊔_; suc)
+open import Relation.Binary hiding (_⇔_)
+open import Relation.Binary.PropositionalEquality using (setoid)
+
+import Function.Construct.Identity as I
+import Function.Construct.Symmetry as Sy
+import Function.Construct.Composition as C
+
+private
+  variable
+    a b ℓ₁ ℓ₂ : Level
+    A : Set a
+    B : Set b
+
+------------------------------------------------------------------------
+-- Setoid bundles
+
+module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
+
+  inverse : IsEquivalence (Inverse {a} {b})
+  inverse = record
+    { refl = λ {x} → I.inverse x
+    ; sym = Sy.inverse
+    ; trans = C.inverse
+    }
+
+  equivalence : IsEquivalence (Equivalence {a} {b})
+  equivalence = record
+    { refl = λ {x} → I.equivalence x
+    ; sym = Sy.equivalence
+    ; trans = C.equivalence
+    }
+
+------------------------------------------------------------------------
+-- Propositional bundles
+
+-- need to η-expand for everything to line up properly
+↔ : IsEquivalence {ℓ = ℓ₁} _↔_
+↔ = record
+  { refl = λ {x} → I.inverse (setoid x)
+  ; sym = Sy.inverse
+  ; trans = C.inverse
+  }
+
+⇔ : IsEquivalence {ℓ = ℓ₁} _⇔_
+⇔ = record
+  { refl = λ {x} → I.equivalence (setoid x)
+  ; sym = Sy.equivalence
+  ; trans = C.equivalence
+  }

--- a/src/Function/Construct/Symmetry.agda
+++ b/src/Function/Construct/Symmetry.agda
@@ -43,6 +43,30 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
          {f : A → B} {f⁻¹ : B → A}
          where
 
+  isLeftInverse : IsRightInverse ≈₁ ≈₂ f f⁻¹ → IsLeftInverse ≈₂ ≈₁ f⁻¹ f
+  isLeftInverse inv = record
+    { isCongruent = record
+      { cong = F.cong₂
+      ; isEquivalence₁ = F.isEquivalence₂
+      ; isEquivalence₂ = F.isEquivalence₁
+      }
+    ; cong₂ = F.cong₁
+    ; inverseˡ = inverseˡ ≈₁ ≈₂ f {f⁻¹} F.inverseʳ
+    }
+    where module F = IsRightInverse inv
+
+  isRightInverse : IsLeftInverse ≈₁ ≈₂ f f⁻¹ → IsRightInverse ≈₂ ≈₁ f⁻¹ f
+  isRightInverse inv = record
+    { isCongruent = record
+      { cong = F.cong₂
+      ; isEquivalence₁ = F.isEquivalence₂
+      ; isEquivalence₂ = F.isEquivalence₁
+      }
+    ; cong₂ = F.cong₁
+    ; inverseʳ = inverseʳ ≈₁ ≈₂ f {f⁻¹} F.inverseˡ
+    }
+    where module F = IsLeftInverse inv
+
   isInverse : IsInverse ≈₁ ≈₂ f f⁻¹ → IsInverse ≈₂ ≈₁ f⁻¹ f
   isInverse f-inv = record
     { isLeftInverse = record
@@ -68,7 +92,8 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} where
     { f = E.g
     ; g = E.f
     ; cong₁ = E.cong₂
-    ; cong₂ = E.cong₁ }
+    ; cong₂ = E.cong₁
+    }
     where module E = Equivalence equiv
 
   rightInverse : LeftInverse R S → RightInverse S R

--- a/src/Function/Construct/Symmetry.agda
+++ b/src/Function/Construct/Symmetry.agda
@@ -1,0 +1,116 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Some functional properties are symmetric
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Function.Construct.Symmetry where
+
+open import Data.Product using (_,_; swap)
+open import Function
+open import Level using (Level)
+open import Relation.Binary hiding (_⇔_)
+
+private
+  variable
+    a b c ℓ₁ ℓ₂ ℓ₃ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Properties
+
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂)
+         (f : A → B) {f⁻¹ : B → A}
+         where
+
+  inverseʳ : Inverseˡ ≈₁ ≈₂ f f⁻¹ → Inverseʳ ≈₂ ≈₁ f⁻¹ f
+  inverseʳ inv = inv
+
+  inverseˡ : Inverseʳ ≈₁ ≈₂ f f⁻¹ → Inverseˡ ≈₂ ≈₁ f⁻¹ f
+  inverseˡ inv = inv
+
+  inverseᵇ : Inverseᵇ ≈₁ ≈₂ f f⁻¹ → Inverseᵇ ≈₂ ≈₁ f⁻¹ f
+  inverseᵇ (invˡ , invʳ) = (invʳ , invˡ)
+
+------------------------------------------------------------------------
+-- Structures
+
+module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
+         {f : A → B} {f⁻¹ : B → A}
+         where
+
+  isInverse : IsInverse ≈₁ ≈₂ f f⁻¹ → IsInverse ≈₂ ≈₁ f⁻¹ f
+  isInverse f-inv = record
+    { isLeftInverse = record
+      { isCongruent = record
+        { cong = F.cong₂
+        ; isEquivalence₁ = F.isEquivalence₂
+        ; isEquivalence₂ = F.isEquivalence₁
+        }
+      ; cong₂ = F.cong₁
+      ; inverseˡ = F.inverseʳ
+      }
+    ; inverseʳ = inverseʳ ≈₁ ≈₂ f F.inverseˡ
+    }
+    where module F = IsInverse f-inv
+
+------------------------------------------------------------------------
+-- Setoid bundles
+
+module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} where
+
+  equivalence : Equivalence R S → Equivalence S R
+  equivalence equiv = record
+    { f = E.g
+    ; g = E.f
+    ; cong₁ = E.cong₂
+    ; cong₂ = E.cong₁ }
+    where module E = Equivalence equiv
+
+  rightInverse : LeftInverse R S → RightInverse S R
+  rightInverse left = record
+    { f = L.g
+    ; g = L.f
+    ; cong₁ = L.cong₂
+    ; cong₂ = L.cong₁
+    ; inverseʳ = L.inverseˡ
+    } where module L = LeftInverse left
+
+  leftInverse : RightInverse R S → LeftInverse S R
+  leftInverse right = record
+    { f = R.g
+    ; g = R.f
+    ; cong₁ = R.cong₂
+    ; cong₂ = R.cong₁
+    ; inverseˡ = R.inverseʳ
+    } where module R = RightInverse right
+
+  inverse : Inverse R S → Inverse S R
+  inverse inv = record
+    { f = I.f⁻¹
+    ; f⁻¹ = I.f
+    ; cong₁ = I.cong₂
+    ; cong₂ = I.cong₁
+    ; inverse = swap I.inverse
+    } where module I = Inverse inv
+
+------------------------------------------------------------------------
+-- Propositional bundles
+
+infix 8 sym-⇔ sym-↩ sym-↪ sym-↔
+
+sym-⇔ : A ⇔ B → B ⇔ A
+sym-⇔ = equivalence
+
+sym-↩ : A ↩ B → B ↪ A
+sym-↩ = rightInverse
+
+sym-↪ : A ↪ B → B ↩ A
+sym-↪ = leftInverse
+
+sym-↔ : A ↔ B → B ↔ A
+sym-↔ = inverse

--- a/src/Function/Construct/Symmetry.agda
+++ b/src/Function/Construct/Symmetry.agda
@@ -101,8 +101,6 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} where
 ------------------------------------------------------------------------
 -- Propositional bundles
 
-infix 8 sym-⇔ sym-↩ sym-↪ sym-↔
-
 sym-⇔ : A ⇔ B → B ⇔ A
 sym-⇔ = equivalence
 

--- a/src/Function/Construct/Symmetry.agda
+++ b/src/Function/Construct/Symmetry.agda
@@ -43,13 +43,17 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
          {f : A → B} {f⁻¹ : B → A}
          where
 
+  isCongruent : IsCongruent ≈₁ ≈₂ f → Congruent ≈₂ ≈₁ f⁻¹ → IsCongruent ≈₂ ≈₁ f⁻¹
+  isCongruent ic cg = record
+    { cong = cg
+    ; isEquivalence₁ = IC.isEquivalence₂
+    ; isEquivalence₂ = IC.isEquivalence₁
+    }
+    where module IC = IsCongruent ic
+
   isLeftInverse : IsRightInverse ≈₁ ≈₂ f f⁻¹ → IsLeftInverse ≈₂ ≈₁ f⁻¹ f
   isLeftInverse inv = record
-    { isCongruent = record
-      { cong = F.cong₂
-      ; isEquivalence₁ = F.isEquivalence₂
-      ; isEquivalence₂ = F.isEquivalence₁
-      }
+    { isCongruent = isCongruent F.isCongruent F.cong₂
     ; cong₂ = F.cong₁
     ; inverseˡ = inverseˡ ≈₁ ≈₂ f {f⁻¹} F.inverseʳ
     }
@@ -57,11 +61,7 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
 
   isRightInverse : IsLeftInverse ≈₁ ≈₂ f f⁻¹ → IsRightInverse ≈₂ ≈₁ f⁻¹ f
   isRightInverse inv = record
-    { isCongruent = record
-      { cong = F.cong₂
-      ; isEquivalence₁ = F.isEquivalence₂
-      ; isEquivalence₂ = F.isEquivalence₁
-      }
+    { isCongruent = isCongruent F.isCongruent F.cong₂
     ; cong₂ = F.cong₁
     ; inverseʳ = inverseʳ ≈₁ ≈₂ f {f⁻¹} F.inverseˡ
     }
@@ -69,15 +69,7 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
 
   isInverse : IsInverse ≈₁ ≈₂ f f⁻¹ → IsInverse ≈₂ ≈₁ f⁻¹ f
   isInverse f-inv = record
-    { isLeftInverse = record
-      { isCongruent = record
-        { cong = F.cong₂
-        ; isEquivalence₁ = F.isEquivalence₂
-        ; isEquivalence₂ = F.isEquivalence₁
-        }
-      ; cong₂ = F.cong₁
-      ; inverseˡ = F.inverseʳ
-      }
+    { isLeftInverse = isLeftInverse F.isRightInverse
     ; inverseʳ = inverseʳ ≈₁ ≈₂ f F.inverseˡ
     }
     where module F = IsInverse f-inv

--- a/src/Function/Properties/Equivalence.agda
+++ b/src/Function/Properties/Equivalence.agda
@@ -1,0 +1,45 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- An Equivalence (on functions) is an Equivalence relation
+--   This file is meant to be imported qualified.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Function.Properties.Equivalence where
+
+open import Function.Bundles using (Equivalence; _⇔_)
+open import Level using (Level)
+open import Relation.Binary using (Setoid; IsEquivalence)
+open import Relation.Binary.PropositionalEquality using (setoid)
+
+import Function.Construct.Identity as Identity
+import Function.Construct.Symmetry as Symmetry
+import Function.Construct.Composition as Composition
+
+private
+  variable
+    a b ℓ₁ ℓ₂ : Level
+
+------------------------------------------------------------------------
+-- Setoid bundles
+
+module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
+
+  equivalence : IsEquivalence (Equivalence {a} {b})
+  equivalence = record
+    { refl = λ {x} → Identity.equivalence x
+    ; sym = Symmetry.equivalence
+    ; trans = Composition.equivalence
+    }
+
+------------------------------------------------------------------------
+-- Propositional bundles
+
+⇔ : IsEquivalence {ℓ = ℓ₁} _⇔_
+⇔ = record
+  { refl = λ {x} → Identity.equivalence (setoid x)
+  ; sym = Symmetry.equivalence
+  ; trans = Composition.equivalence
+  }

--- a/src/Function/Properties/Equivalence.agda
+++ b/src/Function/Properties/Equivalence.agda
@@ -27,8 +27,8 @@ private
 
 module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 
-  equivalence : IsEquivalence (Equivalence {a} {b})
-  equivalence = record
+  isEquivalence : IsEquivalence (Equivalence {a} {b})
+  isEquivalence = record
     { refl = λ {x} → Identity.equivalence x
     ; sym = Symmetry.equivalence
     ; trans = Composition.equivalence
@@ -37,8 +37,8 @@ module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 ------------------------------------------------------------------------
 -- Propositional bundles
 
-⇔ : IsEquivalence {ℓ = ℓ₁} _⇔_
-⇔ = record
+⇔-isEquivalence : IsEquivalence {ℓ = ℓ₁} _⇔_
+⇔-isEquivalence = record
   { refl = λ {x} → Identity.equivalence (setoid x)
   ; sym = Symmetry.equivalence
   ; trans = Composition.equivalence

--- a/src/Function/Properties/Inverse.agda
+++ b/src/Function/Properties/Inverse.agda
@@ -27,8 +27,8 @@ private
 
 module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 
-  inverse : IsEquivalence (Inverse {a} {b})
-  inverse = record
+  isEquivalence : IsEquivalence (Inverse {a} {b})
+  isEquivalence = record
     { refl = λ {x} → Identity.inverse x
     ; sym = Symmetry.inverse
     ; trans = Composition.inverse
@@ -38,8 +38,8 @@ module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 -- Propositional bundles
 
 -- need to η-expand for everything to line up properly
-↔ : IsEquivalence {ℓ = ℓ₁} _↔_
-↔ = record
+↔-isEquivalence : IsEquivalence {ℓ = ℓ₁} _↔_
+↔-isEquivalence = record
   { refl = λ {x} → Identity.inverse (setoid x)
   ; sym = Symmetry.inverse
   ; trans = Composition.inverse

--- a/src/Function/Properties/Inverse.agda
+++ b/src/Function/Properties/Inverse.agda
@@ -7,23 +7,20 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-module Function.Construct.IsEquivalence where
+module Function.Properties.Inverse where
 
-open import Data.Product using (_,_; swap)
-open import Function
-open import Level using (Level; _⊔_; suc)
-open import Relation.Binary hiding (_⇔_)
+open import Function.Bundles using (Inverse; _↔_)
+open import Level using (Level)
+open import Relation.Binary using (Setoid; IsEquivalence)
 open import Relation.Binary.PropositionalEquality using (setoid)
 
-import Function.Construct.Identity as I
-import Function.Construct.Symmetry as Sy
-import Function.Construct.Composition as C
+import Function.Construct.Identity as Identity
+import Function.Construct.Symmetry as Symmetry
+import Function.Construct.Composition as Composition
 
 private
   variable
     a b ℓ₁ ℓ₂ : Level
-    A : Set a
-    B : Set b
 
 ------------------------------------------------------------------------
 -- Setoid bundles
@@ -32,16 +29,9 @@ module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 
   inverse : IsEquivalence (Inverse {a} {b})
   inverse = record
-    { refl = λ {x} → I.inverse x
-    ; sym = Sy.inverse
-    ; trans = C.inverse
-    }
-
-  equivalence : IsEquivalence (Equivalence {a} {b})
-  equivalence = record
-    { refl = λ {x} → I.equivalence x
-    ; sym = Sy.equivalence
-    ; trans = C.equivalence
+    { refl = λ {x} → Identity.inverse x
+    ; sym = Symmetry.inverse
+    ; trans = Composition.inverse
     }
 
 ------------------------------------------------------------------------
@@ -50,14 +40,7 @@ module _ (R : Setoid a ℓ₁) (S : Setoid b ℓ₂) where
 -- need to η-expand for everything to line up properly
 ↔ : IsEquivalence {ℓ = ℓ₁} _↔_
 ↔ = record
-  { refl = λ {x} → I.inverse (setoid x)
-  ; sym = Sy.inverse
-  ; trans = C.inverse
-  }
-
-⇔ : IsEquivalence {ℓ = ℓ₁} _⇔_
-⇔ = record
-  { refl = λ {x} → I.equivalence (setoid x)
-  ; sym = Sy.equivalence
-  ; trans = C.equivalence
+  { refl = λ {x} → Identity.inverse (setoid x)
+  ; sym = Symmetry.inverse
+  ; trans = Composition.inverse
   }


### PR DESCRIPTION
Add `Function.Construct.Symmetry`, to go along with its `Identity` and `Composition` cousins.  Put all 3 together in `Function.Construct.IsEquivalence`.

This PR will be needed to continue the work of porting the  Algebra part of `TypeIsomorphisms` to the new-style `Inverse` (and friends).