### PR TITLE
Add `+-*-commutativeRing` structure to `Data.Rational` (ℚ) via ℚᵘ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ New modules
   ```
   Relation.Nullary.Indexed
   ```
- 
+
 Other major changes
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,7 +276,7 @@ Other minor additions
   recompute       : .(Coprime n d) → Coprime n d
   ```
 
-* Added new types and constructors to `Data.Rational.Unnormalised`:
+* Added new types and constructors to `Data.Rational`:
   ```agda
   NonZero     : Pred ℚ 0ℓ
   Positive    : Pred ℚ 0ℓ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -299,6 +299,12 @@ Other minor additions
   nonNegative : p ≥ 0ℚ → NonNegative p
   ```
 
+* Added proofs to `Data.Rational.Properties`:
+ ```agda
+  +-*-isCommutativeRing : IsCommutativeRing _+_ _*_ -_ 0ℚ 1ℚ
+  +-*-commutativeRing   : CommutativeRing 0ℓ 0ℓ
+ ```
+
 * Added new types and constructors to `Data.Rational.Unnormalised`
   ```agda
   _≠_         : Rel ℚᵘ 0ℓ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,6 +276,12 @@ Other minor additions
   recompute       : .(Coprime n d) → Coprime n d
   ```
 
+* Add proof to `Algebra.Morphism.RingMonomorphism`:
+ ```agda
+ isCommutativeRing : IsCommutativeRing _≈₂_ _⊕_ _⊛_ ⊝_ 0#₂ 1#₂ →
+                     IsCommutativeRing _≈₁_ _+_ _*_ -_ 0# 1#
+ ```
+
 * Added new types and constructors to `Data.Rational`:
   ```agda
   NonZero     : Pred ℚ 0ℓ

--- a/src/Algebra/Morphism/RingMonomorphism.agda
+++ b/src/Algebra/Morphism/RingMonomorphism.agda
@@ -127,3 +127,10 @@ isRing isRing = record
   ; distrib          = distrib R.+-isGroup R.*-isMagma R.distrib
   ; zero             = zero R.+-isGroup R.*-isMagma R.zero
   } where module R = IsRing isRing
+
+isCommutativeRing : IsCommutativeRing _≈₂_ _⊕_ _⊛_ ⊝_ 0#₂ 1#₂ →
+                    IsCommutativeRing _≈₁_ _+_ _*_ -_ 0# 1#
+isCommutativeRing isCommRing = record
+  { isRing = isRing C.isRing
+  ; *-comm = *-comm C.*-isMagma C.*-comm
+  } where module C = IsCommutativeRing isCommRing

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -818,6 +818,9 @@ private
 +-*-isRing : IsRing _+_ _*_ -_ 0ℚ 1ℚ
 +-*-isRing = *-Monomorphism.isRing ℚᵘ.+-*-isRing
 
++-*-isCommutativeRing : IsCommutativeRing _+_ _*_ -_ 0ℚ 1ℚ
++-*-isCommutativeRing = *-Monomorphism.isCommutativeRing ℚᵘ.+-*-isCommutativeRing
+
 ------------------------------------------------------------------------
 -- Packages
 
@@ -844,6 +847,11 @@ private
 +-*-ring : Ring 0ℓ 0ℓ
 +-*-ring = record
   { isRing = +-*-isRing
+  }
+
++-*-commutativeRing : CommutativeRing 0ℓ 0ℓ
++-*-commutativeRing = record
+  { isCommutativeRing = +-*-isCommutativeRing
   }
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Tiny missing `+-*-isCommutativeRing` and `+-*-commutativeRing` structures from #1072, which were included for [`ℚᵘ` (`Data.Rational.Unnormalised`)](https://github.com/agda/agda-stdlib/pull/1072/files#diff-9b7cc0a9d4127a4b2f3940952508a60aR586) but [not for `ℚ`](https://github.com/agda/agda-stdlib/pull/1072/files#diff-4d7a7de4d2025327784740eb7436dbe8R847).

The reason it was omitted is probably that it was missing from `Algebra.Morphism.RingMonomorphism`, which I've added in the same manner as `isCommutativeMonoid` is done in `Algebra.Morphism.MonoidMonomorphism`.