### PR TITLE
Update `fix-whitespace` config file to match new version

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -3,8 +3,8 @@ included-dirs:
   - README
 
 included-files:
-  - "**.agda"
-  - "**.md"
+  - "*.agda"
+  - "*.md"
   - ".travis.yml"
 
 excluded-files:


### PR DESCRIPTION
This PR updates the `fix-whitespace` config file to match the very slightly different path format required by the recently merged changes to the program. 

See https://github.com/agda/fix-whitespace/pull/5 for more information.