### PR TITLE
Expose `*-zero`, `*-zeroˡ`, `*-zeroʳ` from `Data.Rational.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -330,10 +330,14 @@ Other minor additions
   nonNegative : p ≥ 0ℚ → NonNegative p
   ```
 
-* Added proofs to `Data.Rational.Properties`:
+* Exposed some proofs in `Data.Rational.Properties`:
  ```agda
-  +-*-isCommutativeRing : IsCommutativeRing _+_ _*_ -_ 0ℚ 1ℚ
-  +-*-commutativeRing   : CommutativeRing 0ℓ 0ℓ
+ +-*-isCommutativeRing : IsCommutativeRing _+_ _*_ -_ 0ℚ 1ℚ
+ +-*-commutativeRing   : CommutativeRing 0ℓ 0ℓ
+
+ *-zeroˡ : LeftZero 0ℚ _*_
+ *-zeroʳ : RightZero 0ℚ _*_
+ *-zero  : Zero 0ℚ _*_
  ```
 
 * Added new types and constructors to `Data.Rational.Unnormalised`

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -791,6 +791,15 @@ private
 *-identity : Identity 1ℚ _*_
 *-identity = *-identityˡ , *-identityʳ
 
+*-zeroˡ : LeftZero 0ℚ _*_
+*-zeroˡ = *-Monomorphism.zeroˡ ℚᵘ.+-0-isGroup ℚᵘ.*-isMagma ℚᵘ.*-zeroˡ
+
+*-zeroʳ : RightZero 0ℚ _*_
+*-zeroʳ = *-Monomorphism.zeroʳ ℚᵘ.+-0-isGroup ℚᵘ.*-isMagma ℚᵘ.*-zeroʳ
+
+*-zero : Zero 0ℚ _*_
+*-zero = *-zeroˡ , *-zeroʳ
+
 *-distribˡ-+ : _*_ DistributesOverˡ _+_
 *-distribˡ-+ = *-Monomorphism.distribˡ ℚᵘ.+-0-isGroup ℚᵘ.*-isMagma ℚᵘ.*-distribˡ-+
 


### PR DESCRIPTION
Super minor additional export for consistency. `CHANGELOG.md` updated.

These were technically already available by importing and then opening the exposed `+-*-isRing` bundle (transported from `ℚᵘ`). However this was inconsistent with the other properties (`*-identity`, `*-distrib-+`, etc.) which could be imported directly from `Data.Rational.Properties` as usual.

The definition of these properties is identical to the one created in the `+-*-isRing` structure and consistent with the other declarations.