### PR TITLE
WIP: Introduce AllPairs for vectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,20 @@ New modules
   Text.Printf.Generic
   ```
 
+* A predicate for vectors in which every pair of elements is related.
+  ```
+  Data.Vec.Relation.Unary.AllPairs
+  Data.Vec.Relation.Unary.AllPairs.Properties
+  ```
+
+* A predicate for vectors in which every element is unique.
+  ```
+  Data.Vec.Relation.Unary.Unique.Propositional
+  Data.Vec.Relation.Unary.Unique.Propositional.Properties
+  Data.Vec.Relation.Unary.Unique.Setoid
+  Data.Vec.Relation.Unary.Unique.Setoid.Properties
+  ```
+
 Other major changes
 -------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -469,6 +469,7 @@ Other minor additions
 * Added new proofs to `Data.Vec.Properties`:
   ```agda
   unfold-take : ∀ n {m} x (xs : Vec A (n + m)) → take (suc n) (x ∷ xs) ≡ x ∷ take n xs
+  unfold-drop : ∀ n {m} x (xs : Vec A (n + m)) → drop (suc n) (x ∷ xs) ≡ drop n xs
   lookup-inject≤-take : ∀ m {n} (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                         lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
   ```
@@ -489,6 +490,15 @@ Other minor additions
   init : ∀ {n} → Vector A (suc n) → Vector A n
   last : ∀ {n} → Vector A (suc n) → A
   transpose : ∀ {m n} → Vector (Vector A n) m → Vector (Vector A m) n
+  ```
+
+* Added new proofs to `Data.Vec.Relation.Unary.All.Properties`:
+  ```agda
+  All-swap : ∀ {xs ys} → All (λ x → All (x ~_) ys) xs → All (λ y → All (_~ y) xs) ys
+  tabulate⁺ : ∀ {f : Fin n → A} → (∀ i → P (f i)) → All P (tabulate f)
+  tabulate⁻ : ∀ {f : Fin n → A} → All P (tabulate f) → (∀ i → P (f i))
+  drop⁺ : ∀ {n} m {xs} → All P {m + n} xs → All P {n} (drop m xs)
+  take⁺ : ∀ {n} m {xs} → All P {m + n} xs → All P {m} (take m xs)
   ```
 
 Refactorings

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -77,6 +77,13 @@ unfold-take n x xs with splitAt n xs
 unfold-take n x .(xs ++ ys) | xs , ys , refl = refl
 
 ------------------------------------------------------------------------
+-- drop
+
+unfold-drop : ∀ n {m} x (xs : Vec A (n + m)) → drop (suc n) (x ∷ xs) ≡ drop n xs
+unfold-drop n x xs with splitAt n xs
+unfold-drop n x .(xs ++ ys) | xs , ys , refl = refl
+
+------------------------------------------------------------------------
 -- lookup
 
 []=⇒lookup : ∀ {n} {x : A} {xs} {i : Fin n} →

--- a/src/Data/Vec/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/All/Properties.agda
@@ -8,15 +8,19 @@
 
 module Data.Vec.Relation.Unary.All.Properties where
 
+open import Data.Nat.Base using (zero; suc; _+_)
+open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base using ([]; _∷_)
 open import Data.List.Relation.Unary.All as List using ([]; _∷_)
 open import Data.Product as Prod using (_×_; _,_; uncurry; uncurry′)
 open import Data.Vec.Base as Vec
+import Data.Vec.Properties as Vecₚ
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
 open import Level using (Level)
 open import Function.Base using (_∘_; id)
 open import Function.Inverse using (_↔_; inverse)
 open import Relation.Unary using (Pred) renaming (_⊆_ to _⋐_)
+open import Relation.Binary as B using (REL)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; refl; cong; cong₂; →-to-⟶)
 
@@ -101,6 +105,51 @@ module _ {m} {P : Pred A p} where
             All P (concat xss) → All (All P) xss
   concat⁻ []         []   = []
   concat⁻ (xs ∷ xss) pxss = ++ˡ⁻ xs pxss ∷ concat⁻ xss (++ʳ⁻ xs pxss)
+
+------------------------------------------------------------------------
+-- swap
+
+module _ {_~_ : REL A B p} where
+
+  All-swap : ∀ {n m xs ys} →
+             All (λ x → All (x ~_) ys) {n} xs →
+             All (λ y → All (_~ y) xs) {m} ys
+  All-swap {ys = []}     _   = []
+  All-swap {ys = y ∷ ys} []  = All.universal (λ _ → []) (y ∷ ys)
+  All-swap {ys = y ∷ ys} ((x~y ∷ x~ys) ∷ pxs) =
+    (x~y ∷ (All.map All.head pxs)) ∷
+    All-swap (x~ys ∷ (All.map All.tail pxs))
+
+
+------------------------------------------------------------------------
+-- tabulate
+
+module _ {P : A → Set p} where
+
+  tabulate⁺ : ∀ {n} {f : Fin n → A} →
+              (∀ i → P (f i)) → All P (tabulate f)
+  tabulate⁺ {zero}  Pf = []
+  tabulate⁺ {suc n} Pf = Pf zero ∷ tabulate⁺ (Pf ∘ suc)
+
+  tabulate⁻ : ∀ {n} {f : Fin n → A} →
+              All P (tabulate f) → (∀ i → P (f i))
+  tabulate⁻ {suc n} (px ∷ _) zero    = px
+  tabulate⁻ {suc n} (_ ∷ pf) (suc i) = tabulate⁻ pf i
+
+------------------------------------------------------------------------
+-- take and drop
+
+module _ {P : A → Set p} where
+
+  drop⁺ : ∀ {n} m {xs} → All P {m + n} xs → All P {n} (drop m xs)
+  drop⁺ zero pxs = pxs
+  drop⁺ (suc m) {x ∷ xs} (px ∷ pxs)
+    rewrite Vecₚ.unfold-drop m x xs = drop⁺ m pxs
+
+  take⁺ : ∀ {n} m {xs} → All P {m + n} xs → All P {m} (take m xs)
+  take⁺ zero pxs = []
+  take⁺ (suc m) {x ∷ xs} (px ∷ pxs)
+    rewrite Vecₚ.unfold-take m x xs = px ∷ take⁺ m pxs
 
 ------------------------------------------------------------------------
 -- toList

--- a/src/Data/Vec/Relation/Unary/AllPairs.agda
+++ b/src/Data/Vec/Relation/Unary/AllPairs.agda
@@ -1,0 +1,82 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors where every pair of elements are related (symmetrically)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Relation.Binary using (Rel)
+
+module Data.Vec.Relation.Unary.AllPairs
+       {a ℓ} {A : Set a} {R : Rel A ℓ} where
+
+open import Data.Vec.Base using (Vec; []; _∷_)
+open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
+open import Data.Product as Prod using (_,_; _×_; uncurry; <_,_>)
+open import Function using (id; _∘_)
+open import Level using (_⊔_)
+open import Relation.Binary as B using (Rel; _⇒_)
+open import Relation.Binary.Construct.Intersection renaming (_∩_ to _∩ᵇ_)
+open import Relation.Binary.PropositionalEquality
+open import Relation.Unary as U renaming (_∩_ to _∩ᵘ_) hiding (_⇒_)
+open import Relation.Nullary using (yes; no)
+import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
+
+------------------------------------------------------------------------
+-- Definition
+
+open import Data.Vec.Relation.Unary.AllPairs.Core public
+
+------------------------------------------------------------------------
+-- Operations
+
+head : ∀ {x n} {xs : Vec A n} → AllPairs R (x ∷ xs) → All (R x) xs
+head (px ∷ pxs) = px
+
+tail : ∀ {x n} {xs : Vec A n} → AllPairs R (x ∷ xs) → AllPairs R xs
+tail (px ∷ pxs) = pxs
+
+uncons : ∀ {x n} {xs : Vec A n} → AllPairs R (x ∷ xs) → All (R x) xs × AllPairs R xs
+uncons = < head , tail >
+
+module _ {s} {S : Rel A s} where
+
+  map : ∀ {n} → R ⇒ S → AllPairs R {n} ⊆ AllPairs S {n}
+  map ~₁⇒~₂ [] = []
+  map ~₁⇒~₂ (x~xs ∷ pxs) = All.map ~₁⇒~₂ x~xs ∷ (map ~₁⇒~₂ pxs)
+
+module _ {s t} {S : Rel A s} {T : Rel A t} where
+
+  zipWith : ∀ {n} → R ∩ᵇ S ⇒ T → AllPairs R {n} ∩ᵘ AllPairs S {n} ⊆ AllPairs T {n}
+  zipWith f ([] , [])             = []
+  zipWith f (px ∷ pxs , qx ∷ qxs) = All.map f (All.zip (px , qx)) ∷ zipWith f (pxs , qxs)
+
+  unzipWith : ∀ {n} → T ⇒ R ∩ᵇ S → AllPairs T {n} ⊆ AllPairs R {n} ∩ᵘ AllPairs S {n}
+  unzipWith f []         = [] , []
+  unzipWith f (rx ∷ rxs) = Prod.zip _∷_ _∷_ (All.unzip (All.map f rx)) (unzipWith f rxs)
+
+module _ {s} {S : Rel A s} where
+
+  zip : ∀ {n} → AllPairs R {n} ∩ᵘ AllPairs S {n} ⊆ AllPairs (R ∩ᵇ S) {n}
+  zip = zipWith id
+
+  unzip : ∀ {n} → AllPairs (R ∩ᵇ S) {n} ⊆ AllPairs R {n} ∩ᵘ AllPairs S {n}
+  unzip = unzipWith id
+
+------------------------------------------------------------------------
+-- Properties of predicates preserved by AllPairs
+
+allPairs? : ∀ {n} → B.Decidable R → U.Decidable (AllPairs R {n})
+allPairs? R? []       = yes []
+allPairs? R? (x ∷ xs) =
+  Dec.map′ (uncurry _∷_) uncons (All.all (R? x) xs ×-dec allPairs? R? xs)
+
+irrelevant : ∀ {n} → B.Irrelevant R → U.Irrelevant (AllPairs R {n})
+irrelevant irr []           []           = refl
+irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
+  cong₂ _∷_ (All.irrelevant irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)
+
+satisfiable : U.Satisfiable (AllPairs R)
+satisfiable = [] , []

--- a/src/Data/Vec/Relation/Unary/AllPairs/Core.agda
+++ b/src/Data/Vec/Relation/Unary/AllPairs/Core.agda
@@ -1,0 +1,34 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors where every pair of elements are related (symmetrically)
+------------------------------------------------------------------------
+
+-- Core modules are not meant to be used directly outside of the
+-- standard library.
+
+-- This module should be removable if and when Agda issue
+-- https://github.com/agda/agda/issues/3210 is fixed
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Relation.Binary using (Rel)
+
+module Data.Vec.Relation.Unary.AllPairs.Core
+  {a ℓ} {A : Set a} (R : Rel A ℓ) where
+
+open import Level
+open import Data.Vec.Base
+open import Data.Vec.Relation.Unary.All
+
+------------------------------------------------------------------------
+-- Definition
+
+-- AllPairs R xs means that every pair of elements (x , y) in xs is a
+-- member of relation R (as long as x comes before y in the vector).
+
+infixr 5 _∷_
+
+data AllPairs : ∀ {n} → Vec A n → Set (a ⊔ ℓ) where
+  []  : AllPairs []
+  _∷_ : ∀ {n x} {xs : Vec A n} → All (R x) xs → AllPairs xs → AllPairs (x ∷ xs)

--- a/src/Data/Vec/Relation/Unary/AllPairs/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/AllPairs/Properties.agda
@@ -1,0 +1,91 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties related to AllPairs
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Relation.Unary.AllPairs.Properties where
+
+open import Data.Vec
+import Data.Vec.Properties as Vecₚ
+open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
+import Data.Vec.Relation.Unary.All.Properties as Allₚ
+open import Data.Vec.Relation.Unary.AllPairs as AllPairs using (AllPairs; []; _∷_)
+open import Data.Bool.Base using (true; false)
+open import Data.Fin.Base using (Fin)
+open import Data.Fin.Properties using (suc-injective)
+open import Data.Nat.Base using (zero; suc; _+_)
+open import Function using (_∘_)
+open import Level using (Level)
+open import Relation.Binary using (Rel)
+open import Relation.Binary.PropositionalEquality using (_≢_)
+
+private
+  variable
+    a b c p ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Introduction (⁺) and elimination (⁻) rules for vector operations
+------------------------------------------------------------------------
+-- map
+
+module _ {R : Rel A ℓ} {f : B → A} where
+
+  map⁺ : ∀ {n xs} → AllPairs (λ x y → R (f x) (f y)) {n} xs →
+         AllPairs R {n} (map f xs)
+  map⁺ []           = []
+  map⁺ (x∉xs ∷ xs!) = Allₚ.map⁺ x∉xs ∷ map⁺ xs!
+
+------------------------------------------------------------------------
+-- ++
+
+module _ {R : Rel A ℓ} where
+
+  ++⁺ : ∀ {n m xs ys} → AllPairs R {n} xs → AllPairs R {m} ys →
+        All (λ x → All (R x) ys) xs → AllPairs R (xs ++ ys)
+  ++⁺ []         Rys _              = Rys
+  ++⁺ (px ∷ Rxs) Rys (Rxys ∷ Rxsys) = Allₚ.++⁺ px Rxys ∷ ++⁺ Rxs Rys Rxsys
+
+------------------------------------------------------------------------
+-- concat
+
+module _ {R : Rel A ℓ} where
+
+  concat⁺ : ∀ {n m xss} → All (AllPairs R {n}) {m} xss →
+            AllPairs (λ xs ys → All (λ x → All (R x) ys) xs) xss →
+            AllPairs R (concat xss)
+  concat⁺ []           []              = []
+  concat⁺ (pxs ∷ pxss) (Rxsxss ∷ Rxss) = ++⁺ pxs (concat⁺ pxss Rxss)
+    (All.map Allₚ.concat⁺ (Allₚ.All-swap Rxsxss))
+
+------------------------------------------------------------------------
+-- take and drop
+
+module _ {R : Rel A ℓ} where
+
+  take⁺ : ∀ {n} m {xs} → AllPairs R {m + n} xs → AllPairs R {m} (take m xs)
+  take⁺ zero pxs = []
+  take⁺ (suc m) {x ∷ xs} (px ∷ pxs)
+    rewrite Vecₚ.unfold-take m x xs = Allₚ.take⁺ m px ∷ take⁺ m pxs
+
+  drop⁺ : ∀ {n} m {xs} → AllPairs R {m + n} xs → AllPairs R {n} (drop m xs)
+  drop⁺ zero pxs = pxs
+  drop⁺ (suc m) {x ∷ xs} (_ ∷ pxs)
+    rewrite Vecₚ.unfold-drop m x xs = drop⁺ m pxs
+
+------------------------------------------------------------------------
+-- tabulate
+
+module _ {R : Rel A ℓ} where
+
+  tabulate⁺ : ∀ {n} {f : Fin n → A} → (∀ {i j} → i ≢ j → R (f i) (f j)) →
+              AllPairs R (tabulate f)
+  tabulate⁺ {zero}  fᵢ~fⱼ = []
+  tabulate⁺ {suc n} fᵢ~fⱼ =
+    Allₚ.tabulate⁺ (λ j → fᵢ~fⱼ λ()) ∷
+    tabulate⁺ (fᵢ~fⱼ ∘ (_∘ suc-injective))

--- a/src/Data/Vec/Relation/Unary/Unique/Propositional.agda
+++ b/src/Data/Vec/Relation/Unary/Unique/Propositional.agda
@@ -1,0 +1,18 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors made up entirely of unique elements (propositional equality)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Relation.Unary.Unique.Propositional {a} {A : Set a} where
+
+open import Relation.Binary.PropositionalEquality using (setoid)
+open import Data.Vec.Relation.Unary.Unique.Setoid as SetoidUnique
+
+------------------------------------------------------------------------
+-- Re-export the contents of setoid uniqueness
+
+open SetoidUnique (setoid A) public
+

--- a/src/Data/Vec/Relation/Unary/Unique/Propositional/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Unique/Propositional/Properties.agda
@@ -1,0 +1,69 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of unique vectors (setoid equality)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Relation.Unary.Unique.Propositional.Properties where
+
+open import Data.Fin.Base using (Fin)
+open import Data.Vec.Base
+open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
+open import Data.Vec.Relation.Unary.AllPairs as AllPairs using (AllPairs)
+open import Data.Vec.Relation.Unary.Unique.Propositional
+import Data.Vec.Relation.Unary.Unique.Setoid.Properties as Setoid
+open import Data.Nat.Base
+open import Data.Nat.Properties using (<⇒≢)
+open import Data.Product using (_×_; _,_)
+open import Data.Product.Relation.Binary.Pointwise.NonDependent using (≡⇒≡×≡)
+open import Function.Base using (id; _∘_)
+open import Level using (Level)
+open import Relation.Binary using (Rel; Setoid)
+open import Relation.Binary.PropositionalEquality
+  using (refl; _≡_; _≢_; sym; setoid)
+open import Relation.Unary using (Pred; Decidable)
+open import Relation.Nullary using (¬_)
+
+private
+  variable
+    a b c p : Level
+
+------------------------------------------------------------------------
+-- Introduction (⁺) and elimination (⁻) rules for list operations
+------------------------------------------------------------------------
+-- map
+
+module _ {A : Set a} {B : Set b} where
+
+  map⁺ : ∀ {f} → (∀ {x y} → f x ≡ f y → x ≡ y) →
+         ∀ {n} {xs : Vec A n} → Unique xs → Unique (map f xs)
+  map⁺ = Setoid.map⁺ (setoid A) (setoid B)
+
+------------------------------------------------------------------------
+-- take & drop
+
+module _ {A : Set a} where
+
+  drop⁺ : ∀ {n} m {xs : Vec A (m + n)} → Unique xs → Unique (drop m xs)
+  drop⁺ = Setoid.drop⁺ (setoid A)
+
+  take⁺ : ∀ {n} m {xs : Vec A (m + n)} → Unique xs → Unique (take m xs)
+  take⁺ = Setoid.take⁺ (setoid A)
+
+------------------------------------------------------------------------
+-- tabulate
+
+module _ {A : Set a} where
+
+  tabulate⁺ : ∀ {n} {f : Fin n → A} → (∀ {i j} → f i ≡ f j → i ≡ j) → Unique (tabulate f)
+  tabulate⁺ = Setoid.tabulate⁺ (setoid A)
+
+------------------------------------------------------------------------
+-- lookup
+
+module _ {A : Set a} where
+
+  lookup-injective : ∀ {n} {xs : Vec A n} → Unique xs → ∀ i j → lookup xs i ≡ lookup xs j → i ≡ j
+  lookup-injective = Setoid.lookup-injective (setoid A)

--- a/src/Data/Vec/Relation/Unary/Unique/Setoid.agda
+++ b/src/Data/Vec/Relation/Unary/Unique/Setoid.agda
@@ -1,0 +1,33 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Vectors made up entirely of unique elements (setoid equality)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Relation.Binary using (Rel; Setoid)
+
+module Data.Vec.Relation.Unary.Unique.Setoid {a ℓ} (S : Setoid a ℓ) where
+
+open Setoid S renaming (Carrier to A)
+
+open import Data.Vec.Base
+import Data.Vec.Relation.Unary.AllPairs as AllPairsM
+open import Level using (_⊔_)
+open import Relation.Unary using (Pred)
+open import Relation.Nullary using (¬_)
+
+
+------------------------------------------------------------------------
+-- Definition
+
+private
+  Distinct : Rel A ℓ
+  Distinct x y = ¬ (x ≈ y)
+
+open import Data.Vec.Relation.Unary.AllPairs.Core Distinct public
+     renaming (AllPairs to Unique)
+
+open import Data.Vec.Relation.Unary.AllPairs {R = Distinct} public
+     using (head; tail)

--- a/src/Data/Vec/Relation/Unary/Unique/Setoid/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Unique/Setoid/Properties.agda
@@ -1,0 +1,75 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of unique vectors (setoid equality)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Vec.Relation.Unary.Unique.Setoid.Properties where
+
+open import Data.Fin.Base using (Fin; zero; suc)
+open import Data.Vec.Base as Vec
+open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
+open import Data.Vec.Relation.Unary.AllPairs as AllPairs using (AllPairs)
+open import Data.Vec.Relation.Unary.Unique.Setoid
+import Data.Vec.Relation.Unary.AllPairs.Properties as AllPairsₚ
+open import Data.Nat.Base
+open import Function.Base using (_∘_; id)
+open import Level using (Level)
+open import Relation.Binary using (Rel; Setoid)
+open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Relation.Nullary.Negation using (contradiction; contraposition)
+
+private
+  variable
+    a b c p ℓ ℓ₁ ℓ₂ ℓ₃ : Level
+
+------------------------------------------------------------------------
+-- Introduction (⁺) and elimination (⁻) rules for list operations
+------------------------------------------------------------------------
+-- map
+
+module _ (S : Setoid a ℓ₁) (R : Setoid b ℓ₂) where
+
+  open Setoid S renaming (Carrier to A; _≈_ to _≈₁_)
+  open Setoid R renaming (Carrier to B; _≈_ to _≈₂_)
+
+  map⁺ : ∀ {f} → (∀ {x y} → f x ≈₂ f y → x ≈₁ y) →
+         ∀ {n xs} → Unique S {n} xs → Unique R {n} (map f xs)
+  map⁺ inj xs! = AllPairsₚ.map⁺ (AllPairs.map (contraposition inj) xs!)
+
+------------------------------------------------------------------------
+-- take & drop
+
+module _ (S : Setoid a ℓ) where
+
+  drop⁺ : ∀ {n} m {xs} → Unique S {m + n} xs → Unique S {n} (drop m xs)
+  drop⁺ = AllPairsₚ.drop⁺
+
+  take⁺ : ∀ {n} m {xs} → Unique S {m + n} xs → Unique S {m} (take m xs)
+  take⁺ = AllPairsₚ.take⁺
+
+------------------------------------------------------------------------
+-- tabulate
+
+module _ (S : Setoid a ℓ) where
+
+  open Setoid S renaming (Carrier to A)
+
+  tabulate⁺ : ∀ {n} {f : Fin n → A} → (∀ {i j} → f i ≈ f j → i ≡ j) →
+              Unique S (tabulate f)
+  tabulate⁺ f-inj = AllPairsₚ.tabulate⁺ (_∘ f-inj)
+
+------------------------------------------------------------------------
+-- lookup
+
+module _ (S : Setoid a ℓ) where
+
+  open Setoid S renaming (Carrier to A)
+
+  lookup-injective : ∀ {n xs} → Unique S {n} xs → ∀ i j → lookup xs i ≈ lookup xs j → i ≡ j
+  lookup-injective (px ∷ pxs) zero zero eq = P.refl
+  lookup-injective (px ∷ pxs) zero (suc j) eq = contradiction eq (All.lookup j px)
+  lookup-injective (px ∷ pxs) (suc i) zero eq = contradiction (sym eq) (All.lookup i px)
+  lookup-injective (px ∷ pxs) (suc i) (suc j) eq = P.cong suc (lookup-injective pxs i j eq)


### PR DESCRIPTION
Mostly as taken from `Data.List.Relation.Unary.AllPairs`. I had to add a couple of proofs to `Data.Vec.Properties` and `Data.Vec.Relation.Unary.All.Properties`. The work on `Disjoint` is still missing (not sure how important that is). I believe `lookup-injective` is missing from the list counterpart, might be a useful addition.