### PR TITLE
Sort `.gitignore` and ignore `GenerateEverything`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,22 @@
 # Keep this file in alphabetic order please!
-
-*~
-.*.swp
-*.agdai
+# Sort with the command `sort -uf`
 *.agda.el
-./_build/*
-.DS_Store
-*.lagda.el
+*.agdai
 *.hi
+*.lagda.el
 *.o
 *.tix
 *.vim
+*~
+.*.swp
+./_build/*
+.DS_Store
 dist
 dist-newstyle
 Everything.agda
 EverythingSafe.agda
 EverythingSafeGuardedness.agda
 EverythingSafeSizedTypes.agda
-html
 Haskell
+html
 MAlonzo

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ Everything.agda
 EverythingSafe.agda
 EverythingSafeGuardedness.agda
 EverythingSafeSizedTypes.agda
+GenerateEverything
 Haskell
 html
 MAlonzo


### PR DESCRIPTION
Very minor annoyance fix.

I frequently notice untracked files in the `std-lib` submodule in `agda`. It's caused by the `GenerateEverything` binary being built, which isn't (and oughtn't be) checked in.
This adds it to the `.gitignore` file.

Additionall, this sorts the `.gitignore` file consistently as reqeusted in the comment, and adds an additional comment specifying the command to do so (using `sort -uf`, which means "unique and ignore case", and works the same for GNU/BSD/macOS).
