### PR TITLE
conflicting universe levels in Induction.WellFounded.FixPoint

### DIFF
--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -106,7 +106,7 @@ module All {_<_ : Rel A r} (wf : WellFounded _<_) ℓ where
   #-}
 
 module FixPoint
-  {_<_ : Rel A ℓ} (wf : WellFounded _<_)
+  {_<_ : Rel A r} (wf : WellFounded _<_)
   (P : Pred A ℓ) (f : WfRec _<_ P ⊆′ P)
   (f-ext : (x : A) {IH IH′ : WfRec _<_ P x} → (∀ {y} y<x → IH y y<x ≡ IH′ y y<x) → f x IH ≡ f x IH′)
   where


### PR DESCRIPTION
In the module `FixPoint`, both `_<_` and `P` have the same level, which does not seem to be intended. Here is a small example where this is a problem:

```agda
open import Data.Nat.Induction
open import Data.Nat
open import Relation.Binary.PropositionalEquality
import Induction.WellFounded as WF
open WF.All <′-wellFounded

module _ {α} {A : Set α} (z : A) where
  mutual
    f : ℕ → A
    f = wfRec _ _ step

    step = λ
      { zero rec → z
      ; (suc n) rec → rec n ≤′-refl
      }

  -- the following fails with:  Set != (Set α)
  open WF.FixPoint <′-wellFounded _ step (λ
    { zero rec → refl
    ; (suc n) rec → rec ≤′-refl
    })
```