### PR TITLE
Fix whitespace in README.Text.Tabular.

### DIFF
--- a/README/Text/Tabular.agda
+++ b/README/Text/Tabular.agda
@@ -100,9 +100,10 @@ _ = refl
 _ : unlines (Tabularᵛ.display whitespace
             (Right ∷ Left ∷ [])
             foobar)
-  ≡ "foo bar
-\   \  1 2
-\   \  4 3  "
+  ≡ unlines ( "foo bar"
+            ∷ "  1 2  "
+            ∷ "  4 3  "
+            ∷ [])
 _ = refl
 
 ------------------------------------------------------------------------
@@ -129,11 +130,12 @@ _ = refl
 _ : unlines (Tabularᵛ.display (noBorder unicode)
             (Right ∷ Left ∷ [])
             foobar)
-  ≡ "foo│bar
-\   \───┼───
-\   \  1│2
-\   \───┼───
-\   \  4│3  "
+  ≡ unlines ( "foo│bar"
+            ∷ "───┼───"
+            ∷ "  1│2  "
+            ∷ "───┼───"
+            ∷ "  4│3  "
+            ∷ [])
 _ = refl
 
 -- addSpace : add whitespace space inside cells

--- a/README/Text/Tabular.agda
+++ b/README/Text/Tabular.agda
@@ -101,7 +101,7 @@ _ : unlines (Tabularᵛ.display whitespace
             (Right ∷ Left ∷ [])
             foobar)
   ≡ "foo bar
-\   \  1 2  
+\   \  1 2
 \   \  4 3  "
 _ = refl
 
@@ -131,7 +131,7 @@ _ : unlines (Tabularᵛ.display (noBorder unicode)
             foobar)
   ≡ "foo│bar
 \   \───┼───
-\   \  1│2  
+\   \  1│2
 \   \───┼───
 \   \  4│3  "
 _ = refl


### PR DESCRIPTION
Remove trailing whitespace in `README.Text.Tabular`.