### PR TITLE
Added stack.yaml files to match agda/agda

### DIFF
--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: lts-9.21
+compiler: ghc-8.0.2
 compiler-check: match-exact
 
 packages:

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -2,5 +2,9 @@ resolver: ghc-8.10.1
 compiler: ghc-8.10.1
 compiler-check: match-exact
 
+extra-deps:
+- filemanip-0.3.6.3@sha256:7b5f8aa0626724fbd77721f4d01241b1e7f390dd6a4086bddba77c0cea25fcd7,1223
+- unix-compat-0.5.2@sha256:5508ebcfaf1a862886cd217178e283d613d47803785d8ab4a3bd2bb9b542a3fb,2041
+
 packages:
 - '.'

--- a/stack-8.10.1.yaml
+++ b/stack-8.10.1.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: ghc-8.10.1
+compiler: ghc-8.10.1
 compiler-check: match-exact
 
 packages:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: lts-11.22
+compiler: ghc-8.2.2
 compiler-check: match-exact
 
 packages:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: lts-14.27
+compiler: ghc-8.6.5
 compiler-check: match-exact
 
 packages:

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: lts-15.3
+compiler: ghc-8.8.2
 compiler-check: match-exact
 
 packages:

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -1,5 +1,5 @@
-resolver: lts-12.26
-compiler: ghc-8.4.4
+resolver: lts-16.5
+compiler: ghc-8.8.3
 compiler-check: match-exact
 
 packages:


### PR DESCRIPTION
Added stack.yaml files for the same GHC versions Agda supports:

- stack-8.0.2.yaml
- stack-8.2.2.yaml
- stack-8.4.4.yaml
- stack-8.6.5.yaml
- stack-8.8.2.yaml
- stack-8.8.3.yaml
- stack-8.10.1.yaml