### PR TITLE
Tiny build utils enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ matrix:
 
         # generating Everything.agda
         - cd agda-stdlib
-        - cabal install lib.cabal
+        - cabal install agda-stdlib-utils.cabal
         - runghc GenerateEverything.hs
 
         # setting up travis-specific scripts and files

--- a/AllNonAsciiChars.hs
+++ b/AllNonAsciiChars.hs
@@ -24,8 +24,7 @@ main = do
                     "src"
   nonAsciiChars <-
     filter (not . isAscii) . concat <$> mapM readUTF8File agdaFiles
-  let table = reverse $
-              L.sortBy (compare `on` snd) $
+  let table = L.sortBy (flip compare `on` snd) $
               map (\cs -> (head cs, length cs)) $
               L.group $ L.sort $ nonAsciiChars
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Bug-fixes
 Non-backwards compatible changes
 --------------------------------
 
+* The internal build utilities package `lib.cabal` has been renamed
+  `agda-stdlib-utils.cabal` to avoid potential conflict or confusion.
+  Please note that the package is not intended for external use.
+
 Deprecated modules
 ------------------
 

--- a/GenerateEverything.hs
+++ b/GenerateEverything.hs
@@ -43,7 +43,7 @@ unsafeModules = map modToFile
   , "Relation.Binary.PropositionalEquality.TrustMe"
   , "Text.Pretty.Core"
   , "Text.Pretty"
-  ] where
+  ]
 
 isUnsafeModule :: FilePath -> Bool
 isUnsafeModule fp =
@@ -158,13 +158,13 @@ classify fp hd ls
 
     -- based on detected comment in header
     deprecated  = let detect = List.isSubsequenceOf "This module is DEPRECATED."
-                  in not $ null $ filter detect hd
+                  in any detect hd
 
     -- GA 2019-02-24: note that we do not reprocess the whole module for every
     -- option check: the shared @options@ definition ensures we only inspect a
     -- handful of lines (at most one, ideally)
     option str = let detect = List.isSubsequenceOf ["{-#", "OPTIONS", str, "#-}"]
-                  in not $ null $ filter detect options
+                  in any detect options
     options    = words <$> filter (List.isInfixOf "OPTIONS") ls
 
     -- formatting error messages
@@ -275,7 +275,7 @@ usage = unlines
 -- | Formats the extracted module information.
 
 format :: [LibraryFile] -> String
-format = unlines . concat . map fmt
+format = unlines . concatMap fmt
   where
   fmt lf = "" : header lf ++ ["import " ++ fileToMod (filepath lf)]
 

--- a/agda-stdlib-utils.cabal
+++ b/agda-stdlib-utils.cabal
@@ -1,4 +1,4 @@
-name:            lib
+name:            agda-stdlib-utils
 version:         1.5-dev
 cabal-version:   >= 1.10
 build-type:      Simple

--- a/lib.cabal
+++ b/lib.cabal
@@ -26,3 +26,4 @@ executable AllNonAsciiChars
   default-language: Haskell2010
   build-depends:      base >= 4.9.0.0 && < 4.15
                     , filemanip >= 0.3.6.2 && < 0.4
+                    , text >= 1.2.3.0 && < 1.3


### PR DESCRIPTION
Happy to split this into multiple PRs, let me know. This contains three small changes:
  * Renames the package `lib.cabal` to `agda-stdlib-utils.cabal`, since that is `cabal install`ed and not a good global package name.
  * Fixed some tiny hlint suggestions in `GenerateEverything.hs` and `AllNonAsciiChars.hs`
  * Fixed `AllNonAsciiChars`, which was failing with "too many open files" on macOS. Some light research indicated this was caused by the lazy IO and that the easiest fix was to use the strict IO from `Data.Text`. I've verified that now works.