### PR TITLE
Add version to library name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,5 @@ Other minor additions
   IsLatticeMonomorphism  (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂)
   IsLatticeIsomorphism   (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂)
   ```
+
+* Add version to library name

--- a/notes/release-guide.txt
+++ b/notes/release-guide.txt
@@ -9,6 +9,8 @@ procedure should be followed:
 
 * Update `lib.cabal` version to `X.Y`.
 
+* Update the version in standard-library.agda-lib to `X.Y`
+
 * Update `notes/installation-guide.txt`
 
 * Update `CHANGELOG.md`.

--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -1,2 +1,2 @@
-name: standard-library
+name: standard-library-1.5
 include: src


### PR DESCRIPTION
Since Agda supports [library versioning](https://agda.readthedocs.io/en/v2.6.1.1/tools/package-system.html#version-numbers), I suggest the standard-library should make use of it.