### PR TITLE
Tidying up in `Relation.Binary.Construct.Closure`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Highlights
 Bug-fixes
 ---------
 
+* The example module `Maybe` in `Relation.Binary.Construct.Closure.Reflexive` was accidentally exposed publicly. It has been made private.
+
 Non-backwards compatible changes
 --------------------------------
 
@@ -19,8 +21,20 @@ Non-backwards compatible changes
 Deprecated modules
 ------------------
 
+* The module `TransitiveClosure` in `Induction.WellFounded` has been deprecated. You should instead use the standard definition of transitive closure and the accompanying proof of well-foundness defined in `Relation.Binary.Construct.Closure.Transitive`.
+
 Deprecated names
 ----------------
+
+* In `Relation.Binary.Construct.Closure.Reflexive`:
+  ```agda
+  Refl ↦ ReflClosure
+  ```
+
+* In `Relation.Binary.Construct.Closure.Transitive`:
+  ```agda
+  Plus′ ↦ TransClosure
+  ```
 
 New modules
 -----------
@@ -54,6 +68,14 @@ Other minor additions
   IsLatticeHomomorphism  (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂)
   IsLatticeMonomorphism  (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂)
   IsLatticeIsomorphism   (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂)
+  ```
+
+* Added new proofs to `Relation.Binary.Construct.Closure.Transitive`:
+  ```agda
+  reflexive   : Reflexive _∼_ → Reflexive _∼⁺_
+  symmetric   : Symmetric _∼_ → Symmetric _∼⁺_
+  transitive  : Transitive _∼⁺_
+  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
   ```
 
 * Add version to library name

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -201,7 +201,7 @@ private
   ix∙⁺jz : IPointwise (Plus _R_) ix jz
   ix∙⁺jz = [ iRj ] ∷ xR⁺z ∷ []
 
-  ¬ix⁺∙jz : ¬ Plus′ (IPointwise _R_) ix jz
+  ¬ix⁺∙jz : ¬ TransClosure (IPointwise _R_) ix jz
   ¬ix⁺∙jz [ iRj ∷ () ∷ [] ]
   ¬ix⁺∙jz ((iRj ∷ xRy ∷ []) ∷ [ () ∷ yRz ∷ [] ])
   ¬ix⁺∙jz ((iRj ∷ xRy ∷ []) ∷ (() ∷ yRz ∷ []) ∷ _)

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -39,10 +39,6 @@ WfRec _<_ P x = ∀ y → y < x → P y
 data Acc {A : Set a} (_<_ : Rel A ℓ) (x : A) : Set (a ⊔ ℓ) where
   acc : (rs : WfRec _<_ (Acc _<_) x) → Acc _<_ x
 
-acc-inverse : ∀ {_<_ : Rel A ℓ} {x : A} (q : Acc _<_ x) →
-              (y : A) → y < x → Acc _<_ y
-acc-inverse (acc rs) y y<x = rs y y<x
-
 -- The accessibility predicate encodes what it means to be
 -- well-founded; if all elements are accessible, then _<_ is
 -- well-founded.
@@ -58,6 +54,10 @@ Please use WellFounded instead."
 
 ------------------------------------------------------------------------
 -- Basic properties
+
+acc-inverse : ∀ {_<_ : Rel A ℓ} {x : A} (q : Acc _<_ x) →
+              (y : A) → y < x → Acc _<_ y
+acc-inverse (acc rs) y y<x = rs y y<x
 
 Acc-resp-≈ : {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} → Symmetric _≈_ →
              _<_ Respectsʳ _≈_ → (Acc _<_) Respects _≈_
@@ -146,6 +146,9 @@ module Subrelation {_<₁_ : Rel A ℓ₁} {_<₂_ : Rel A ℓ₂}
 \ \Please use wellFounded instead."
   #-}
 
+
+-- DEPRECATED in v1.4.
+-- Please use proofs in `Relation.Binary.Construct.On` instead.
 module InverseImage {_<_ : Rel B ℓ} (f : A → B) where
 
   accessible : ∀ {x} → Acc _<_ (f x) → Acc (_<_ on f) x
@@ -168,6 +171,9 @@ module InverseImage {_<_ : Rel B ℓ} (f : A → B) where
 \ \Please use wellFounded from `Relation.Binary.Construct.On` instead."
   #-}
 
+
+-- DEPRECATED in v1.5.
+-- Please use `TransClosure` from `Relation.Binary.Construct.Closure.Transitive` instead.
 module TransitiveClosure {A : Set a} (_<_ : Rel A ℓ) where
 
   infix 4 _<⁺_
@@ -192,15 +198,17 @@ module TransitiveClosure {A : Set a} (_<_ : Rel A ℓ) where
   wellFounded : WellFounded _<_ → WellFounded _<⁺_
   wellFounded wf = λ x → accessible (wf x)
 
+  {-# WARNING_ON_USAGE _<⁺_
+  "Warning: _<⁺_ was deprecated in v1.5.
+\ \Please use TransClosure from Relation.Binary.Construct.Closure.Transitive instead."
+  #-}
   downwards-closed = downwardsClosed
   {-# WARNING_ON_USAGE downwards-closed
-  "Warning: downwards-closed was deprecated in v0.15.
-\ \Please use downwardsClosed instead."
+  "Warning: downwards-closed was deprecated in v0.15."
   #-}
   well-founded     = wellFounded
   {-# WARNING_ON_USAGE well-founded
-  "Warning: well-founded was deprecated in v0.15.
-\ \Please use wellFounded instead."
+  "Warning: well-founded was deprecated in v0.15."
   #-}
 
 

--- a/src/Relation/Binary/Construct/Closure/Equivalence.agda
+++ b/src/Relation/Binary/Construct/Closure/Equivalence.agda
@@ -10,22 +10,40 @@
 module Relation.Binary.Construct.Closure.Equivalence where
 
 open import Function using (flip; id; _∘_)
-open import Level using (_⊔_)
+open import Level using (Level; _⊔_)
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.ReflexiveTransitive as Star
   using (Star; ε; _◅◅_; reverse)
-open import Relation.Binary.Construct.Closure.Symmetric as SC using (SymClosure)
+open import Relation.Binary.Construct.Closure.Symmetric as SC
+  using (SymClosure)
+
+private
+  variable
+    a ℓ ℓ₁ ℓ₂ : Level
+    A B : Set a
 
 ------------------------------------------------------------------------
 -- Definition
 
-EqClosure : ∀ {a ℓ} {A : Set a} → Rel A ℓ → Rel A (a ⊔ ℓ)
+EqClosure : {A : Set a} → Rel A ℓ → Rel A (a ⊔ ℓ)
 EqClosure _∼_ = Star (SymClosure _∼_)
 
 ------------------------------------------------------------------------
--- Equivalence closures are equivalences.
+-- Operations
 
-module _ {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) where
+-- A generalised variant of map which allows the index type to change.
+gmap : {P : Rel A ℓ₁} {Q : Rel B ℓ₂} →
+       (f : A → B) → P =[ f ]⇒ Q → EqClosure P =[ f ]⇒ EqClosure Q
+gmap {Q = Q} f = Star.gmap f ∘ SC.gmap {Q = Q} f
+
+map : ∀ {P : Rel A ℓ₁} {Q : Rel A ℓ₂} →
+      P ⇒ Q → EqClosure P ⇒ EqClosure Q
+map = gmap id
+
+------------------------------------------------------------------------
+-- Properties
+
+module _ (_∼_ : Rel A ℓ) where
 
   reflexive : Reflexive (EqClosure _∼_)
   reflexive = ε
@@ -43,23 +61,8 @@ module _ {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) where
     ; trans = transitive
     }
 
-  setoid : Setoid a (a ⊔ ℓ)
-  setoid = record
-    { _≈_           = EqClosure _∼_
-    ; isEquivalence = isEquivalence
-    }
-
-------------------------------------------------------------------------
--- Operations
-
-module _ {a ℓ₁ ℓ₂} {A : Set a} where
-
-  -- A generalised variant of map which allows the index type to change.
-
-  gmap : ∀ {b} {B : Set b} {P : Rel A ℓ₁} {Q : Rel B ℓ₂} →
-         (f : A → B) → P =[ f ]⇒ Q → EqClosure P =[ f ]⇒ EqClosure Q
-  gmap {Q = Q} f = Star.gmap f ∘ SC.gmap {Q = Q} f
-
-  map : ∀ {P : Rel A ℓ₁} {Q : Rel A ℓ₂} →
-        P ⇒ Q → EqClosure P ⇒ EqClosure Q
-  map = gmap id
+setoid : {A : Set a} (_∼_ : Rel A ℓ) → Setoid a (a ⊔ ℓ)
+setoid _∼_ = record
+  { _≈_           = EqClosure _∼_
+  ; isEquivalence = isEquivalence _∼_
+  }

--- a/src/Relation/Binary/Construct/Closure/Reflexive.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive.agda
@@ -23,40 +23,57 @@ private
 ------------------------------------------------------------------------
 -- Definition
 
-data Refl {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
-  refl : Reflexive (Refl _∼_)
-  [_]  : ∀ {x y} (x∼y : x ∼ y) → Refl _∼_ x y
+data ReflClosure {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
+  refl : Reflexive (ReflClosure _∼_)
+  [_]  : ∀ {x y} (x∼y : x ∼ y) → ReflClosure _∼_ x y
 
 ------------------------------------------------------------------------
 -- Operations
 
-map : ∀ {_R₁_ : Rel A ℓ₁} {_R₂_ : Rel B ℓ₂} {f : A → B} →
-      _R₁_ =[ f ]⇒ _R₂_ → Refl _R₁_ =[ f ]⇒ Refl _R₂_
-map R₁⇒R₂ [ xRy ] = [ R₁⇒R₂ xRy ]
-map R₁⇒R₂ refl    = refl
+map : ∀ {R : Rel A ℓ₁} {S : Rel B ℓ₂} {f : A → B} →
+      R =[ f ]⇒ S → ReflClosure R =[ f ]⇒ ReflClosure S
+map R⇒S [ xRy ] = [ R⇒S xRy ]
+map R⇒S refl    = refl
 
 ------------------------------------------------------------------------
 -- Properties
 
 -- The reflexive closure has no effect on reflexive relations.
-drop-refl : {_R_ : Rel A ℓ} → Reflexive _R_ → Refl _R_ ⇒ _R_
-drop-refl rfl [ x∼y ] = x∼y
+drop-refl : {R : Rel A ℓ} → Reflexive R → ReflClosure R ⇒ R
+drop-refl rfl [ xRy ] = xRy
 drop-refl rfl refl    = rfl
 
-[]-injective : {_∼_ : Rel A ℓ} → ∀ {x y p q} →
-               (Refl _∼_ x y ∋ [ p ]) ≡ [ q ] → p ≡ q
+[]-injective : {R : Rel A ℓ} → ∀ {x y p q} →
+               (ReflClosure R x y ∋ [ p ]) ≡ [ q ] → p ≡ q
 []-injective refl = refl
 
 ------------------------------------------------------------------------
--- Example: Maybe
+-- Example usage
 
-module Maybe where
+private
+  module Maybe where
+    Maybe : Set a → Set a
+    Maybe A = ReflClosure (Const A) tt tt
 
-  Maybe : ∀ {ℓ} → Set ℓ → Set ℓ
-  Maybe A = Refl (Const A) tt tt
+    nothing : Maybe A
+    nothing = refl
 
-  nothing : ∀ {a} {A : Set a} → Maybe A
-  nothing = refl
+    just : A → Maybe A
+    just = [_]
 
-  just : ∀ {a} {A : Set a} → A → Maybe A
-  just = [_]
+
+
+------------------------------------------------------------------------
+-- Deprecations
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- v1.5
+
+Refl = ReflClosure
+{-# WARNING_ON_USAGE Refl
+"Warning: Refl was deprecated in v1.5.
+Please use ReflClosure instead."
+#-}
+

--- a/src/Relation/Binary/Construct/Closure/Reflexive.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive.agda
@@ -15,31 +15,37 @@ open import Relation.Binary
 open import Relation.Binary.Construct.Constant using (Const)
 open import Relation.Binary.PropositionalEquality using (_≡_ ; refl)
 
+private
+  variable
+    a ℓ ℓ₁ ℓ₂ : Level
+    A B : Set a
+
 ------------------------------------------------------------------------
--- Reflexive closure
+-- Definition
 
-data Refl {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
-  [_]  : ∀ {x y} (x∼y : x ∼ y) → Refl _∼_ x y
+data Refl {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
   refl : Reflexive (Refl _∼_)
+  [_]  : ∀ {x y} (x∼y : x ∼ y) → Refl _∼_ x y
 
-[]-injective : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} {x y p q} →
-               (Refl _∼_ x y ∋ [ p ]) ≡ [ q ] → p ≡ q
-[]-injective refl = refl
+------------------------------------------------------------------------
+-- Operations
 
--- Map.
+map : ∀ {_R₁_ : Rel A ℓ₁} {_R₂_ : Rel B ℓ₂} {f : A → B} →
+      _R₁_ =[ f ]⇒ _R₂_ → Refl _R₁_ =[ f ]⇒ Refl _R₂_
+map R₁⇒R₂ [ xRy ] = [ R₁⇒R₂ xRy ]
+map R₁⇒R₂ refl    = refl
 
-map : ∀ {a a′ ℓ ℓ′} {A : Set a} {A′ : Set a′}
-        {_R_ : Rel A ℓ} {_R′_ : Rel A′ ℓ′} {f : A → A′} →
-      _R_ =[ f ]⇒ _R′_ → Refl _R_ =[ f ]⇒ Refl _R′_
-map R⇒R′ [ xRy ] = [ R⇒R′ xRy ]
-map R⇒R′ refl    = refl
+------------------------------------------------------------------------
+-- Properties
 
 -- The reflexive closure has no effect on reflexive relations.
-
-drop-refl : ∀ {a ℓ} {A : Set a} {_R_ : Rel A ℓ} →
-            Reflexive _R_ → Refl _R_ ⇒ _R_
+drop-refl : {_R_ : Rel A ℓ} → Reflexive _R_ → Refl _R_ ⇒ _R_
 drop-refl rfl [ x∼y ] = x∼y
 drop-refl rfl refl    = rfl
+
+[]-injective : {_∼_ : Rel A ℓ} → ∀ {x y p q} →
+               (Refl _∼_ x y ∋ [ p ]) ≡ [ q ] → p ≡ q
+[]-injective refl = refl
 
 ------------------------------------------------------------------------
 -- Example: Maybe

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -33,70 +33,73 @@ private
 
 module _ {P : Rel A p} {Q : Rel B q} where
 
-  =[]⇒ : ∀ {f : A → B} → P =[ f ]⇒ Q → Refl P =[ f ]⇒ Refl Q
+  =[]⇒ : ∀ {f : A → B} → P =[ f ]⇒ Q → ReflClosure P =[ f ]⇒ ReflClosure Q
   =[]⇒ x [ x∼y ] = [ x x∼y ]
   =[]⇒ x refl    = refl
 
 module _ {_~_ : Rel A ℓ} where
 
-  sym : Symmetric _~_ → Symmetric (Refl _~_)
+  private
+    _~ᵒ_ = ReflClosure _~_
+
+  fromSum : ∀ {x y} → x ≡ y ⊎ x ~ y → x ~ᵒ y
+  fromSum (inj₁ refl) = refl
+  fromSum (inj₂ y) = [ y ]
+
+  toSum : ∀ {x y} → x ~ᵒ y → x ≡ y ⊎ x ~ y
+  toSum [ x∼y ] = inj₂ x∼y
+  toSum refl = inj₁ refl
+
+  ⊎⇔Refl : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ a ~ᵒ b
+  ⊎⇔Refl = equivalence fromSum toSum
+
+  sym : Symmetric _~_ → Symmetric _~ᵒ_
   sym ~-sym [ x∼y ] = [ ~-sym x∼y ]
   sym ~-sym refl    = refl
 
-  trans : Transitive _~_ → Transitive (Refl _~_)
+  trans : Transitive _~_ → Transitive _~ᵒ_
   trans ~-trans [ x∼y ] [ x∼y₁ ] = [ ~-trans x∼y x∼y₁ ]
   trans ~-trans [ x∼y ] refl     = [ x∼y ]
   trans ~-trans refl    [ x∼y ]  = [ x∼y ]
   trans ~-trans refl    refl     = refl
 
-  antisym : ∀ {ℓ′} (_≈_ : Rel A ℓ′) → Reflexive _≈_ →
-            Asymmetric _~_ → Antisymmetric _≈_ (Refl _~_)
+  antisym : (_≈_ : Rel A p) → Reflexive _≈_ →
+            Asymmetric _~_ → Antisymmetric _≈_ _~ᵒ_
   antisym _≈_ ref asym [ x∼y ] [ y∼x ] = contradiction x∼y (asym y∼x)
   antisym _≈_ ref asym [ x∼y ] refl    = ref
   antisym _≈_ ref asym refl    _       = ref
 
-  total : Trichotomous _≡_ _~_ → Total (Refl _~_)
+  total : Trichotomous _≡_ _~_ → Total _~ᵒ_
   total compare x y with compare x y
   ... | tri< a _    _ = inj₁ [ a ]
   ... | tri≈ _ refl _ = inj₁ refl
   ... | tri> _ _    c = inj₂ [ c ]
 
-  fromSum : ∀ {a b} → a ≡ b ⊎ a ~ b → Refl _~_ a b
-  fromSum (inj₁ refl) = refl
-  fromSum (inj₂ y) = [ y ]
-
-  toSum : ∀ {a b} → Refl _~_ a b → a ≡ b ⊎ a ~ b
-  toSum [ x∼y ] = inj₂ x∼y
-  toSum refl = inj₁ refl
-
-  ⊎⇔Refl : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ Refl _~_ a b
-  ⊎⇔Refl = equivalence fromSum toSum
-
-  dec : Decidable {A = A} _≡_ → Decidable _~_ → Decidable (Refl _~_)
+  dec : Decidable {A = A} _≡_ → Decidable _~_ → Decidable _~ᵒ_
   dec ≡-dec ~-dec a b = Dec.map ⊎⇔Refl (≡-dec a b ⊎-dec ~-dec a b)
 
-  decidable : Trichotomous _≡_ _~_ → Decidable (Refl _~_)
+  decidable : Trichotomous _≡_ _~_ → Decidable _~ᵒ_
   decidable ~-tri a b with ~-tri a b
   ... | tri< a~b  _  _ = yes [ a~b ]
   ... | tri≈ _  refl _ = yes refl
   ... | tri> ¬a ¬b   _ = no λ { refl → ¬b refl ; [ p ] → ¬a p }
 
-  respˡ : ∀ {P : REL A B p} → P Respectsˡ _~_ → P Respectsˡ (Refl _~_)
+  respˡ : ∀ {P : REL A B p} → P Respectsˡ _~_ → P Respectsˡ _~ᵒ_
   respˡ p-respˡ-~ [ x∼y ] = p-respˡ-~ x∼y
   respˡ _         refl    = id
 
-  respʳ : ∀ {P : REL B A p} → P Respectsʳ _~_ → P Respectsʳ (Refl _~_)
+  respʳ : ∀ {P : REL B A p} → P Respectsʳ _~_ → P Respectsʳ _~ᵒ_
   respʳ = respˡ
 
 module _ {_~_ : Rel A ℓ} {P : Pred A p} where
 
-  resp : P Respects _~_ → P Respects (Refl _~_)
+  resp : P Respects _~_ → P Respects (ReflClosure _~_)
   resp p-resp-~ [ x∼y ] = p-resp-~ x∼y
   resp _        refl    = id
 
 module _ {_~_ : Rel A ℓ} {P : Rel A p} where
 
-  resp₂ : P Respects₂ _~_ → P Respects₂ (Refl _~_)
+  resp₂ : P Respects₂ _~_ → P Respects₂ (ReflClosure _~_)
   resp₂ = Prod.map respˡ respʳ
 
 ------------------------------------------------------------------------
@@ -104,33 +107,36 @@ module _ {_~_ : Rel A ℓ} {P : Rel A p} where
 
 module _ {_~_ : Rel A ℓ} where
 
-  isPreorder : Transitive _~_ → IsPreorder _≡_ (Refl _~_)
+  private
+    _~ᵒ_ = ReflClosure _~_
+
+  isPreorder : Transitive _~_ → IsPreorder _≡_ _~ᵒ_
   isPreorder ~-trans = record
     { isEquivalence = PropEq.isEquivalence
     ; reflexive     = λ { refl → refl }
     ; trans         = trans ~-trans
     }
 
-  isPartialOrder : IsStrictPartialOrder _≡_ _~_ → IsPartialOrder _≡_ (Refl _~_)
+  isPartialOrder : IsStrictPartialOrder _≡_ _~_ → IsPartialOrder _≡_ _~ᵒ_
   isPartialOrder O = record
     { isPreorder = isPreorder O.trans
     ; antisym    = antisym _≡_ refl O.asym
     } where module O = IsStrictPartialOrder O
 
-  isDecPartialOrder : IsDecStrictPartialOrder _≡_ _~_ → IsDecPartialOrder _≡_ (Refl _~_)
+  isDecPartialOrder : IsDecStrictPartialOrder _≡_ _~_ → IsDecPartialOrder _≡_ _~ᵒ_
   isDecPartialOrder O = record
     { isPartialOrder = isPartialOrder O.isStrictPartialOrder
     ; _≟_            = O._≟_
     ; _≤?_           = dec O._≟_ O._<?_
     } where module O = IsDecStrictPartialOrder O
 
-  isTotalOrder : IsStrictTotalOrder _≡_ _~_ → IsTotalOrder _≡_ (Refl _~_)
+  isTotalOrder : IsStrictTotalOrder _≡_ _~_ → IsTotalOrder _≡_ _~ᵒ_
   isTotalOrder O = record
     { isPartialOrder = isPartialOrder isStrictPartialOrder
     ; total          = total compare
     } where open IsStrictTotalOrder O
 
-  isDecTotalOrder : IsStrictTotalOrder _≡_ _~_ → IsDecTotalOrder _≡_ (Refl _~_)
+  isDecTotalOrder : IsStrictTotalOrder _≡_ _~_ → IsDecTotalOrder _≡_ _~ᵒ_
   isDecTotalOrder O = record
     { isTotalOrder = isTotalOrder O
     ; _≟_          = _≟_

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties/WithK.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties/WithK.agda
@@ -8,18 +8,16 @@
 
 module Relation.Binary.Construct.Closure.Reflexive.Properties.WithK where
 
-open import Data.Empty.Irrelevant using (⊥-elim)
-open import Data.Product as Prod
-open import Data.Sum.Base as Sum
 open import Relation.Binary
 open import Relation.Binary.Construct.Closure.Reflexive
-open import Relation.Binary.Construct.Closure.Reflexive.Properties public
 open import Relation.Binary.PropositionalEquality as PropEq using (_≡_; refl; cong)
 open import Relation.Nullary.Negation using (contradiction)
 
+open import Relation.Binary.Construct.Closure.Reflexive.Properties public
+
 module _ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} where
 
-  irrel : Irrelevant _∼_ → Irreflexive _≡_ _∼_ → Irrelevant (Refl _∼_)
+  irrel : Irrelevant _∼_ → Irreflexive _≡_ _∼_ → Irrelevant (ReflClosure _∼_)
   irrel irrel irrefl [ x∼y₁ ] [ x∼y₂ ] = cong [_] (irrel x∼y₁ x∼y₂)
   irrel irrel irrefl [ x∼y ]  refl     = contradiction x∼y (irrefl refl)
   irrel irrel irrefl refl     [ x∼y ]  = contradiction x∼y (irrefl refl)

--- a/src/Relation/Binary/Construct/Closure/Symmetric.agda
+++ b/src/Relation/Binary/Construct/Closure/Symmetric.agda
@@ -10,29 +10,40 @@ module Relation.Binary.Construct.Closure.Symmetric where
 
 open import Data.Sum.Base as Sum using (_⊎_)
 open import Function using (id)
+open import Level using (Level)
 open import Relation.Binary
 
-open Sum public using () renaming (inj₁ to fwd; inj₂ to bwd)
+private
+  variable
+    a ℓ ℓ₁ ℓ₂ : Level
+    A B : Set a
 
--- The symmetric closure of a relation.
+------------------------------------------------------------------------
+-- Definition
 
-SymClosure : ∀ {a ℓ} {A : Set a} → Rel A ℓ → Rel A ℓ
+SymClosure : Rel A ℓ → Rel A ℓ
 SymClosure _∼_ a b = a ∼ b ⊎ b ∼ a
 
-module _ {a ℓ} {A : Set a} where
+open Sum public using ()
+  renaming (inj₁ to fwd; inj₂ to bwd)
 
-  -- Symmetric closures are symmetric.
+------------------------------------------------------------------------
+-- Operations
 
-  symmetric : (_∼_ : Rel A ℓ) → Symmetric (SymClosure _∼_)
-  symmetric _ (fwd a∼b) = bwd a∼b
-  symmetric _ (bwd b∼a) = fwd b∼a
+-- A generalised variant of map which allows the index type to change.
+gmap : {P : Rel A ℓ₁} {Q : Rel B ℓ₂} (f : A → B) →
+       P =[ f ]⇒ Q → SymClosure P =[ f ]⇒ SymClosure Q
+gmap _ g = Sum.map g g
 
-  -- A generalised variant of map which allows the index type to change.
+map : {P : Rel A ℓ₁} {Q : Rel A ℓ₂} →
+      P ⇒ Q → SymClosure P ⇒ SymClosure Q
+map = gmap id
 
-  gmap : ∀ {b ℓ₂} {B : Set b} {P : Rel A ℓ} {Q : Rel B ℓ₂} →
-         (f : A → B) → P =[ f ]⇒ Q → SymClosure P =[ f ]⇒ SymClosure Q
-  gmap _ g = Sum.map g g
+------------------------------------------------------------------------
+-- Properties
 
-  map : ∀ {ℓ₂} {P : Rel A ℓ} {Q : Rel A ℓ₂} →
-        P ⇒ Q → SymClosure P ⇒ SymClosure Q
-  map = gmap id
+-- Symmetric closures are symmetric.
+symmetric : (_∼_ : Rel A ℓ) → Symmetric (SymClosure _∼_)
+symmetric _ (fwd a∼b) = bwd a∼b
+symmetric _ (bwd b∼a) = fwd b∼a
+

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -14,6 +14,11 @@ open import Level
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality using (_≡_ ; refl)
 
+private
+  variable
+    a ℓ ℓ₁ ℓ₂ : Level
+    A B : Set a
+
 ------------------------------------------------------------------------
 -- Transitive closure
 
@@ -21,12 +26,12 @@ infix 4 Plus
 
 syntax Plus R x y = x [ R ]⁺ y
 
-data Plus {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
+data Plus {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
   [_]     : ∀ {x y} (x∼y : x ∼ y) → x [ _∼_ ]⁺ y
   _∼⁺⟨_⟩_ : ∀ x {y z} (x∼⁺y : x [ _∼_ ]⁺ y) (y∼⁺z : y [ _∼_ ]⁺ z) →
             x [ _∼_ ]⁺ z
 
-module _ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} where
+module _ {_∼_ : Rel A ℓ} where
 
  []-injective : ∀ {x y p q} → (x [ _∼_ ]⁺ y ∋ [ p ]) ≡ [ q ] → p ≡ q
  []-injective refl = refl
@@ -41,8 +46,7 @@ module _ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} where
 --     y  ∼⁺⟨ lemma₂ ⟩∎
 --     z  ∎
 
-finally : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} x y →
-          x [ _∼_ ]⁺ y → x [ _∼_ ]⁺ y
+finally : ∀ {_∼_ : Rel A ℓ} x y → x [ _∼_ ]⁺ y → x [ _∼_ ]⁺ y
 finally _ _ = id
 
 syntax finally x y x∼⁺y = x ∼⁺⟨ x∼⁺y ⟩∎ y ∎
@@ -52,12 +56,11 @@ infix  3 finally
 
 -- Map.
 
-map : ∀ {a a′ ℓ ℓ′} {A : Set a} {A′ : Set a′}
-        {_R_ : Rel A ℓ} {_R′_ : Rel A′ ℓ′} {f : A → A′} →
-      _R_ =[ f ]⇒ _R′_ → Plus _R_ =[ f ]⇒ Plus _R′_
-map R⇒R′ [ xRy ]             = [ R⇒R′ xRy ]
-map R⇒R′ (x ∼⁺⟨ xR⁺z ⟩ zR⁺y) =
-  _ ∼⁺⟨ map R⇒R′ xR⁺z ⟩ map R⇒R′ zR⁺y
+map : {_R₁_ : Rel A ℓ} {_R₂_ : Rel B ℓ₂} {f : A → B} →
+      _R₁_ =[ f ]⇒ _R₂_ → Plus _R₁_ =[ f ]⇒ Plus _R₂_
+map R₁⇒R₂ [ xRy ]             = [ R₁⇒R₂ xRy ]
+map R₁⇒R₂ (x ∼⁺⟨ xR⁺z ⟩ zR⁺y) =
+  _ ∼⁺⟨ map R₁⇒R₂ xR⁺z ⟩ map R₁⇒R₂ zR⁺y
 
 ------------------------------------------------------------------------
 -- Alternative definition of transitive closure
@@ -69,13 +72,13 @@ infix  4 Plus′
 
 syntax Plus′ R x y = x ⟨ R ⟩⁺ y
 
-data Plus′ {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
+data Plus′ {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
   [_] : ∀ {x y} (x∼y : x ∼ y) → x ⟨ _∼_ ⟩⁺ y
   _∷_ : ∀ {x y z} (x∼y : x ∼ y) (y∼⁺z : y ⟨ _∼_ ⟩⁺ z) → x ⟨ _∼_ ⟩⁺ z
 
 -- Transitivity.
 
-_++_ : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} {x y z} →
+_++_ : ∀ {_∼_ : Rel A ℓ} {x y z} →
        x ⟨ _∼_ ⟩⁺ y → y ⟨ _∼_ ⟩⁺ z → x ⟨ _∼_ ⟩⁺ z
 [ x∼y ]      ++ y∼⁺z = x∼y ∷ y∼⁺z
 (x∼y ∷ y∼⁺z) ++ z∼⁺u = x∼y ∷ (y∼⁺z ++ z∼⁺u)

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -10,9 +10,10 @@ module Relation.Binary.Construct.Closure.Transitive where
 
 open import Function.Base
 open import Function.Equivalence as Equiv using (_⇔_)
+open import Induction.WellFounded
 open import Level
 open import Relation.Binary hiding (_⇔_)
-open import Relation.Binary.PropositionalEquality using (_≡_ ; refl)
+open import Relation.Binary.PropositionalEquality as P using (_≡_)
 
 private
   variable
@@ -20,7 +21,65 @@ private
     A B : Set a
 
 ------------------------------------------------------------------------
--- Transitive closure
+-- Definition
+
+infixr 5 _∷_
+infix  4 TransClosure
+
+data TransClosure {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
+  [_] : ∀ {x y} (x∼y : x ∼ y) → TransClosure _∼_ x y
+  _∷_ : ∀ {x y z} (x∼y : x ∼ y) (y∼⁺z : TransClosure _∼_ y z) → TransClosure _∼_ x z
+
+syntax TransClosure R x y = x ⟨ R ⟩⁺ y
+
+------------------------------------------------------------------------
+-- Operations
+
+module _ {_∼_ : Rel A ℓ} where
+  private
+    _∼⁺_ = TransClosure _∼_
+
+  _∷ʳ_ : ∀ {x y z} → (x∼⁺y : x ∼⁺ y) (y∼z : y ∼ z) → x ∼⁺ z
+  [ x∼y ]      ∷ʳ y∼z = x∼y ∷ [ y∼z ]
+  (x∼y ∷ x∼⁺y) ∷ʳ y∼z = x∼y ∷ (x∼⁺y ∷ʳ y∼z)
+
+  infixr 5 _++_
+  _++_ : ∀ {x y z} → x ∼⁺ y → y ∼⁺ z → x ∼⁺ z
+  [ x∼y ]      ++ y∼⁺z = x∼y ∷ y∼⁺z
+  (x∼y ∷ y∼⁺z) ++ z∼⁺u = x∼y ∷ (y∼⁺z ++ z∼⁺u)
+
+------------------------------------------------------------------------
+-- Properties
+
+module _ (_∼_ : Rel A ℓ) where
+  private
+    _∼⁺_ = TransClosure _∼_
+
+  reflexive : Reflexive _∼_ → Reflexive _∼⁺_
+  reflexive refl = [ refl ]
+
+  symmetric : Symmetric _∼_ → Symmetric _∼⁺_
+  symmetric sym [ x∼y ]      = [ sym x∼y ]
+  symmetric sym (x∼y ∷ y∼⁺z) = symmetric sym y∼⁺z ∷ʳ sym x∼y
+
+  transitive : Transitive _∼⁺_
+  transitive = _++_
+
+  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
+  wellFounded wf = λ x → acc (accessible′ (wf x))
+    where
+    downwardsClosed : ∀ {x y} → Acc _∼⁺_ y → x ∼ y → Acc _∼⁺_ x
+    downwardsClosed (acc rec) x∼y = acc (λ z z∼x → rec z (z∼x ∷ʳ x∼y))
+
+    accessible′ : ∀ {x} → Acc _∼_ x → WfRec _∼⁺_ (Acc _∼⁺_) x
+    accessible′ (acc rec) y [ y∼x ]      = acc (accessible′ (rec y y∼x))
+    accessible′ acc[x]    y (y∼z ∷ z∼⁺x) =
+      downwardsClosed (accessible′ acc[x] _ z∼⁺x) y∼z
+
+
+
+------------------------------------------------------------------------
+-- Alternative definition of transitive closure
 
 infix 4 Plus
 
@@ -34,7 +93,7 @@ data Plus {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
 module _ {_∼_ : Rel A ℓ} where
 
  []-injective : ∀ {x y p q} → (x [ _∼_ ]⁺ y ∋ [ p ]) ≡ [ q ] → p ≡ q
- []-injective refl = refl
+ []-injective P.refl = P.refl
 
  -- See also ∼⁺⟨⟩-injectiveˡ and ∼⁺⟨⟩-injectiveʳ in
  -- Relation.Binary.Construct.Closure.Transitive.WithK.
@@ -62,37 +121,29 @@ map R₁⇒R₂ [ xRy ]             = [ R₁⇒R₂ xRy ]
 map R₁⇒R₂ (x ∼⁺⟨ xR⁺z ⟩ zR⁺y) =
   _ ∼⁺⟨ map R₁⇒R₂ xR⁺z ⟩ map R₁⇒R₂ zR⁺y
 
-------------------------------------------------------------------------
--- Alternative definition of transitive closure
-
--- A generalisation of Data.List.Nonempty.List⁺.
-
-infixr 5 _∷_ _++_
-infix  4 Plus′
-
-syntax Plus′ R x y = x ⟨ R ⟩⁺ y
-
-data Plus′ {A : Set a} (_∼_ : Rel A ℓ) : Rel A (a ⊔ ℓ) where
-  [_] : ∀ {x y} (x∼y : x ∼ y) → x ⟨ _∼_ ⟩⁺ y
-  _∷_ : ∀ {x y z} (x∼y : x ∼ y) (y∼⁺z : y ⟨ _∼_ ⟩⁺ z) → x ⟨ _∼_ ⟩⁺ z
-
--- Transitivity.
-
-_++_ : ∀ {_∼_ : Rel A ℓ} {x y z} →
-       x ⟨ _∼_ ⟩⁺ y → y ⟨ _∼_ ⟩⁺ z → x ⟨ _∼_ ⟩⁺ z
-[ x∼y ]      ++ y∼⁺z = x∼y ∷ y∼⁺z
-(x∼y ∷ y∼⁺z) ++ z∼⁺u = x∼y ∷ (y∼⁺z ++ z∼⁺u)
-
--- Plus and Plus′ are equivalent.
-
-equivalent : ∀ {a ℓ} {A : Set a} {_∼_ : Rel A ℓ} {x y} →
-             Plus _∼_ x y ⇔ Plus′ _∼_ x y
+-- Plus and TransClosure are equivalent.
+equivalent : ∀ {_∼_ : Rel A ℓ} {x y} →
+             Plus _∼_ x y ⇔ TransClosure _∼_ x y
 equivalent {_∼_ = _∼_} = Equiv.equivalence complete sound
   where
-  complete : Plus _∼_ ⇒ Plus′ _∼_
+  complete : Plus _∼_ ⇒ TransClosure _∼_
   complete [ x∼y ]             = [ x∼y ]
   complete (x ∼⁺⟨ x∼⁺y ⟩ y∼⁺z) = complete x∼⁺y ++ complete y∼⁺z
 
-  sound : Plus′ _∼_ ⇒ Plus _∼_
+  sound : TransClosure _∼_ ⇒ Plus _∼_
   sound [ x∼y ]      = [ x∼y ]
   sound (x∼y ∷ y∼⁺z) = _ ∼⁺⟨ [ x∼y ] ⟩ sound y∼⁺z
+
+------------------------------------------------------------------------
+-- Deprecations
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- v1.5
+
+Plus′ = TransClosure
+{-# WARNING_ON_USAGE Plus′
+"Warning: Plus′ was deprecated in v1.5.
+Please use TransClosure instead."
+#-}


### PR DESCRIPTION
Some tidying:
 - use variables
 - standardise closure names to `XClosure`
 - add additional proofs for `TransClosure` including well-foundedness
 - deprecate `Induction.WellFounded.TransitiveClosure` (fixes #819 fixes #1310)