### PR TITLE
Data.Vec.Properties: Add take/drop proofs, zipWith-replicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,20 @@ Other minor additions
   ```
 
 * Add version to library name
+
+* Add new properties to `Data.Vec.Properties`:
+  ```agda
+  take-distr-zipWith : ∀ {m n} → (f : A → B → C) →
+                       (u : Vec A (m + n)) → (v : Vec B (m + n)) →
+                       take m (zipWith f u v) ≡ zipWith f (take m u) (take m v)
+  take-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
+                   take m (map f v) ≡ map f (take m v)
+  drop-distr-zipWith : ∀ {m n} → (f : A → B → C) →
+                       (u : Vec A (m + n)) → (v : Vec B (m + n)) →
+                       drop m (zipWith f u v) ≡ zipWith f (drop m u) (drop m v)
+  drop-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
+                   drop m (map f v) ≡ map f (drop m v)
+  take-drop-id : ∀ {n} → (m : ℕ) → (v : Vec A (m + n)) → take m v ++ drop m v ≡ v
+  zipWith-replicate : ∀ {n : ℕ} (_⊕_ : A → B → C) (x : A) (y : B) →
+                      zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
+  ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,17 +60,10 @@ Other minor additions
 
 * Add new properties to `Data.Vec.Properties`:
   ```agda
-  take-distr-zipWith : ∀ {m n} → (f : A → B → C) →
-                       (u : Vec A (m + n)) → (v : Vec B (m + n)) →
-                       take m (zipWith f u v) ≡ zipWith f (take m u) (take m v)
-  take-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
-                   take m (map f v) ≡ map f (take m v)
-  drop-distr-zipWith : ∀ {m n} → (f : A → B → C) →
-                       (u : Vec A (m + n)) → (v : Vec B (m + n)) →
-                       drop m (zipWith f u v) ≡ zipWith f (drop m u) (drop m v)
-  drop-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
-                   drop m (map f v) ≡ map f (drop m v)
-  take-drop-id : ∀ {n} → (m : ℕ) → (v : Vec A (m + n)) → take m v ++ drop m v ≡ v
-  zipWith-replicate : ∀ {n : ℕ} (_⊕_ : A → B → C) (x : A) (y : B) →
-                      zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
+  take-distr-zipWith : take m (zipWith f u v) ≡ zipWith f (take m u) (take m v)
+  take-distr-map : take m (map f v) ≡ map f (take m v)
+  drop-distr-zipWith : drop m (zipWith f u v) ≡ zipWith f (drop m u) (drop m v)
+  drop-distr-map : drop m (map f v) ≡ map f (drop m v)
+  take-drop-id : take m v ++ drop m v ≡ v
+  zipWith-replicate : zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
   ```

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -701,13 +701,13 @@ zipWith-replicate {n = zero} _⊕_ x y = refl
 zipWith-replicate {n = suc n} _⊕_ x y = P.cong (x ⊕ y ∷_) (zipWith-replicate _⊕_ x y)
 
 zipWith-replicate₁ : ∀ {n} (_⊕_ : A → B → C) (x : A) (ys : Vec B n) →
-                   zipWith _⊕_ (replicate x) ys ≡ map (x ⊕_) ys
+                     zipWith _⊕_ (replicate x) ys ≡ map (x ⊕_) ys
 zipWith-replicate₁ _⊕_ x []       = refl
 zipWith-replicate₁ _⊕_ x (y ∷ ys) =
   P.cong (x ⊕ y ∷_) (zipWith-replicate₁ _⊕_ x ys)
 
 zipWith-replicate₂ : ∀ {n} (_⊕_ : A → B → C) (xs : Vec A n) (y : B) →
-                   zipWith _⊕_ xs (replicate y) ≡ map (_⊕ y) xs
+                     zipWith _⊕_ xs (replicate y) ≡ map (_⊕ y) xs
 zipWith-replicate₂ _⊕_ []       y = refl
 zipWith-replicate₂ _⊕_ (x ∷ xs) y =
   P.cong (x ⊕ y ∷_) (zipWith-replicate₂ _⊕_ xs y)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -80,7 +80,7 @@ unfold-take n x .(xs ++ ys) | xs , ys , refl = refl
 take-distr-zipWith : ∀ {m n} → (f : A → B → C) →
                      (u : Vec A (m + n)) → (v : Vec B (m + n)) →
                      take m (zipWith f u v) ≡ zipWith f (take m u) (take m v)
-take-distr-zipWith {m = zero} f u v = refl
+take-distr-zipWith {m = zero}  f  u        v = refl
 take-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) = begin
     take (suc m) (zipWith f (u ∷ us) (v ∷ vs))
   ≡⟨⟩
@@ -91,7 +91,7 @@ take-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) = begin
     f u v ∷ (zipWith f (take m us) (take m vs))
   ≡⟨⟩
     zipWith f (u ∷ (take m us)) (v ∷ (take m vs))
-  ≡⟨ P.cong₂ (zipWith f) (P.sym (unfold-take m u us)) (P.sym (unfold-take m v vs)) ⟩
+  ≡˘⟨ P.cong₂ (zipWith f) (unfold-take m u us) (unfold-take m v vs) ⟩
     zipWith f (take (suc m) (u ∷ us)) (take (suc m) (v ∷ vs))
   ∎
 
@@ -104,7 +104,7 @@ take-distr-map f (suc m) (v ∷ vs) =
     take (suc m) (f v ∷ map f vs) ≡⟨ unfold-take m (f v) (map f vs) ⟩
     f v ∷ (take m (map f vs))     ≡⟨ P.cong (f v ∷_) (take-distr-map f m vs) ⟩
     f v ∷ (map f (take m vs))     ≡⟨⟩
-    map f (v ∷ take m vs)         ≡⟨ P.cong (map f) (P.sym (unfold-take m v vs)) ⟩
+    map f (v ∷ take m vs)         ≡˘⟨ P.cong (map f) (unfold-take m v vs) ⟩
     map f (take (suc m) (v ∷ vs)) ∎
 
 ------------------------------------------------------------------------
@@ -126,7 +126,7 @@ drop-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) = begin
     drop m (zipWith f us vs)
   ≡⟨ drop-distr-zipWith f us vs ⟩
     zipWith f (drop m us) (drop m vs)
-  ≡⟨ P.cong₂ (zipWith f) (P.sym (unfold-drop m u us)) (P.sym (unfold-drop m v vs)) ⟩
+  ≡˘⟨ P.cong₂ (zipWith f) (unfold-drop m u us) (unfold-drop m v vs) ⟩
     zipWith f (drop (suc m) (u ∷ us)) (drop (suc m) (v ∷ vs))
   ∎
 
@@ -152,7 +152,7 @@ take-drop-id (suc m) (v ∷ vs) = begin
   ≡⟨⟩
     v ∷ (take m vs ++ drop m vs)
   ≡⟨ P.cong (v ∷_) (take-drop-id m vs) ⟩
-    (v ∷ vs)
+    v ∷ vs
   ∎
 
 ------------------------------------------------------------------------
@@ -696,7 +696,7 @@ map-replicate f x zero = refl
 map-replicate f x (suc n) = P.cong (f x ∷_) (map-replicate f x n)
 
 zipWith-replicate : ∀ {n : ℕ} (_⊕_ : A → B → C) (x : A) (y : B) →
-                  zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
+                    zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)
 zipWith-replicate {n = zero} _⊕_ x y = refl
 zipWith-replicate {n = suc n} _⊕_ x y = P.cong (x ⊕ y ∷_) (zipWith-replicate _⊕_ x y)
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -78,34 +78,34 @@ unfold-take n x xs with splitAt n xs
 unfold-take n x .(xs ++ ys) | xs , ys , refl = refl
 
 take-distr-zipWith : ∀ {m n} → (f : A → B → C) →
-                     (u : Vec A (m + n)) → (v : Vec B (m + n)) →
-                     take m (zipWith f u v) ≡ zipWith f (take m u) (take m v)
-take-distr-zipWith {m = zero}  f  u        v = refl
-take-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) = begin
-    take (suc m) (zipWith f (u ∷ us) (v ∷ vs))
+                     (xs : Vec A (m + n)) → (ys : Vec B (m + n)) →
+                     take m (zipWith f xs ys) ≡ zipWith f (take m xs) (take m ys)
+take-distr-zipWith {m = zero}  f  xs       ys = refl
+take-distr-zipWith {m = suc m} f (x ∷ xs) (y ∷ ys) = begin
+    take (suc m) (zipWith f (x ∷ xs) (y ∷ ys))
   ≡⟨⟩
-    take (suc m) (f u v ∷ (zipWith f us vs))
-  ≡⟨ unfold-take m (f u v) (zipWith f us vs) ⟩
-    f u v ∷ take m (zipWith f us vs)
-  ≡⟨ P.cong (f u v ∷_) (take-distr-zipWith f us vs) ⟩
-    f u v ∷ (zipWith f (take m us) (take m vs))
+    take (suc m) (f x y ∷ (zipWith f xs ys))
+  ≡⟨ unfold-take m (f x y) (zipWith f xs ys) ⟩
+    f x y ∷ take m (zipWith f xs ys)
+  ≡⟨ P.cong (f x y ∷_) (take-distr-zipWith f xs ys) ⟩
+    f x y ∷ (zipWith f (take m xs) (take m ys))
   ≡⟨⟩
-    zipWith f (u ∷ (take m us)) (v ∷ (take m vs))
-  ≡˘⟨ P.cong₂ (zipWith f) (unfold-take m u us) (unfold-take m v vs) ⟩
-    zipWith f (take (suc m) (u ∷ us)) (take (suc m) (v ∷ vs))
+    zipWith f (x ∷ (take m xs)) (y ∷ (take m ys))
+  ≡˘⟨ P.cong₂ (zipWith f) (unfold-take m x xs) (unfold-take m y ys) ⟩
+    zipWith f (take (suc m) (x ∷ xs)) (take (suc m) (y ∷ ys))
   ∎
 
-take-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
-                 take m (map f v) ≡ map f (take m v)
-take-distr-map f zero v = refl
-take-distr-map f (suc m) (v ∷ vs) =
+take-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (xs : Vec A (m + n)) →
+                 take m (map f xs) ≡ map f (take m xs)
+take-distr-map f zero xs = refl
+take-distr-map f (suc m) (x ∷ xs) =
   begin
-    take (suc m) (map f (v ∷ vs)) ≡⟨⟩
-    take (suc m) (f v ∷ map f vs) ≡⟨ unfold-take m (f v) (map f vs) ⟩
-    f v ∷ (take m (map f vs))     ≡⟨ P.cong (f v ∷_) (take-distr-map f m vs) ⟩
-    f v ∷ (map f (take m vs))     ≡⟨⟩
-    map f (v ∷ take m vs)         ≡˘⟨ P.cong (map f) (unfold-take m v vs) ⟩
-    map f (take (suc m) (v ∷ vs)) ∎
+    take (suc m) (map f (x ∷ xs)) ≡⟨⟩
+    take (suc m) (f x ∷ map f xs) ≡⟨ unfold-take m (f x) (map f xs) ⟩
+    f x ∷ (take m (map f xs))     ≡⟨ P.cong (f x ∷_) (take-distr-map f m xs) ⟩
+    f x ∷ (map f (take m xs))     ≡⟨⟩
+    map f (x ∷ take m xs)         ≡˘⟨ P.cong (map f) (unfold-take m x xs) ⟩
+    map f (take (suc m) (x ∷ xs)) ∎
 
 ------------------------------------------------------------------------
 -- drop
@@ -115,44 +115,44 @@ unfold-drop n x xs with splitAt n xs
 unfold-drop n x .(xs ++ ys) | xs , ys , refl = refl
 
 drop-distr-zipWith : ∀ {m n} → (f : A → B → C) →
-                     (u : Vec A (m + n)) → (v : Vec B (m + n)) →
-                     drop m (zipWith f u v) ≡ zipWith f (drop m u) (drop m v)
-drop-distr-zipWith {m = zero} f u v = refl
-drop-distr-zipWith {m = suc m} f (u ∷ us) (v ∷ vs) = begin
-    drop (suc m) (zipWith f (u ∷ us) (v ∷ vs))
+                     (x : Vec A (m + n)) → (y : Vec B (m + n)) →
+                     drop m (zipWith f x y) ≡ zipWith f (drop m x) (drop m y)
+drop-distr-zipWith {m = zero} f   xs       ys = refl
+drop-distr-zipWith {m = suc m} f (x ∷ xs) (y ∷ ys) = begin
+    drop (suc m) (zipWith f (x ∷ xs) (y ∷ ys))
   ≡⟨⟩
-    drop (suc m) (f u v ∷ (zipWith f us vs))
-  ≡⟨ unfold-drop m (f u v) (zipWith f us vs) ⟩
-    drop m (zipWith f us vs)
-  ≡⟨ drop-distr-zipWith f us vs ⟩
-    zipWith f (drop m us) (drop m vs)
-  ≡˘⟨ P.cong₂ (zipWith f) (unfold-drop m u us) (unfold-drop m v vs) ⟩
-    zipWith f (drop (suc m) (u ∷ us)) (drop (suc m) (v ∷ vs))
+    drop (suc m) (f x y ∷ (zipWith f xs ys))
+  ≡⟨ unfold-drop m (f x y) (zipWith f xs ys) ⟩
+    drop m (zipWith f xs ys)
+  ≡⟨ drop-distr-zipWith f xs ys ⟩
+    zipWith f (drop m xs) (drop m ys)
+  ≡˘⟨ P.cong₂ (zipWith f) (unfold-drop m x xs) (unfold-drop m y ys) ⟩
+    zipWith f (drop (suc m) (x ∷ xs)) (drop (suc m) (y ∷ ys))
   ∎
 
-drop-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (v : Vec A (m + n)) →
-                 drop m (map f v) ≡ map f (drop m v)
-drop-distr-map f zero v = refl
-drop-distr-map f (suc m) (v ∷ vs) = begin
-  drop (suc m) (map f (v ∷ vs)) ≡⟨⟩
-  drop (suc m) (f v ∷ map f vs) ≡⟨ unfold-drop m (f v) (map f vs) ⟩
-  drop m (map f vs)             ≡⟨ drop-distr-map f m vs ⟩
-  map f (drop m vs)             ≡⟨ P.cong (map f) (P.sym (unfold-drop m v vs)) ⟩
-  map f (drop (suc m) (v ∷ vs)) ∎
+drop-distr-map : ∀ {n} → (f : A → B) → (m : ℕ) → (x : Vec A (m + n)) →
+                 drop m (map f x) ≡ map f (drop m x)
+drop-distr-map f zero x = refl
+drop-distr-map f (suc m) (x ∷ xs) = begin
+  drop (suc m) (map f (x ∷ xs)) ≡⟨⟩
+  drop (suc m) (f x ∷ map f xs) ≡⟨ unfold-drop m (f x) (map f xs) ⟩
+  drop m (map f xs)             ≡⟨ drop-distr-map f m xs ⟩
+  map f (drop m xs)             ≡⟨ P.cong (map f) (P.sym (unfold-drop m x xs)) ⟩
+  map f (drop (suc m) (x ∷ xs)) ∎
 
 ------------------------------------------------------------------------
 -- take and drop together
 
-take-drop-id : ∀ {n} → (m : ℕ) → (v : Vec A (m + n)) → take m v ++ drop m v ≡ v
-take-drop-id zero v = refl
-take-drop-id (suc m) (v ∷ vs) = begin
-    take (suc m) (v ∷ vs) ++ drop (suc m) (v ∷ vs)
-  ≡⟨ cong₂ _++_ (unfold-take m v vs) (unfold-drop m v vs) ⟩
-    (v ∷ take m vs) ++ (drop m vs)
+take-drop-id : ∀ {n} → (m : ℕ) → (x : Vec A (m + n)) → take m x ++ drop m x ≡ x
+take-drop-id zero x = refl
+take-drop-id (suc m) (x ∷ xs) = begin
+    take (suc m) (x ∷ xs) ++ drop (suc m) (x ∷ xs)
+  ≡⟨ cong₂ _++_ (unfold-take m x xs) (unfold-drop m x xs) ⟩
+    (x ∷ take m xs) ++ (drop m xs)
   ≡⟨⟩
-    v ∷ (take m vs ++ drop m vs)
-  ≡⟨ P.cong (v ∷_) (take-drop-id m vs) ⟩
-    v ∷ vs
+    x ∷ (take m xs ++ drop m xs)
+  ≡⟨ P.cong (x ∷_) (take-drop-id m xs) ⟩
+    x ∷ xs
   ∎
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Adds a few properties for `take`, `drop`, and `zipWith`:

- `take-distr-zipWith`: proof that `take` can be distributed over `zipWith`. 
- `take-distr-map`:  proof that `take` can be distributed over `map`. 
- `drop-distr-zipWith`: proof that `drop` can be distributed over `zipWith`. 
- `drop-distr-map`:  proof that `drop` can be distributed over `map`. 
- `take-drop-id`: proof of `take m v ++ drop m v ≡ v`
- `zipWith-replicate`: similar to existing zipWith-replicate₁ but where both arguments are `replicate` vectors. `zipWith _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)`