### PR TITLE
Add some properties relating to List.concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Other minor additions
 
 * Added new properties to `Data.List.Properties`:
   ```agda
-<<<<<<< HEAD
+  concat-++ : concat xss ++ concat yss ≡ concat (xss ++ yss)
   concat-concat : concat ∘ map concat ≗ concat ∘ concat
   concat-[-] : concat ∘ map [_] ≗ id
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,9 @@ Other minor additions
 
 * Added new properties to `Data.List.Properties`:
   ```agda
+<<<<<<< HEAD
   concat-concat : concat ∘ map concat ≗ concat ∘ concat
+  concat-[-] : concat ∘ map [_] ≗ id
   ```
 
 * Add version to library name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,9 @@ Other minor additions
   IsLatticeIsomorphism   (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂)
   ```
 
+* Added new properties to `Data.List.Properties`:
+  ```agda
+  concat-concat : concat ∘ map concat ≗ concat ∘ concat
+  ```
+
 * Add version to library name

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -496,11 +496,17 @@ concat-map {f = f} xss = begin
   foldr (λ ys → map f ys ++_) [] xss         ≡⟨ sym (foldr-fusion (map f) [] (map-++-commute f) xss) ⟩
   map f (concat xss)                         ∎
 
+concat-++ : (xss yss : List (List A)) → concat xss ++ concat yss ≡ concat (xss ++ yss)
+concat-++ [] yss = refl
+concat-++ ([] ∷ xss) yss = concat-++ xss yss
+concat-++ ((x ∷ xs) ∷ xss) yss = cong (x ∷_) (concat-++ (xs ∷ xss) yss)
+
 concat-concat : concat {a} {A} ∘ map concat ≗ concat ∘ concat
 concat-concat [] = refl
-concat-concat ([] ∷ xsss) = concat-concat xsss
-concat-concat (([] ∷ xss) ∷ xsss) = concat-concat (xss ∷ xsss)
-concat-concat (((x ∷ xs) ∷ xss) ∷ xsss) = cong (x ∷_) (concat-concat ((xs ∷ xss) ∷ xsss))
+concat-concat (xss ∷ xsss) = begin
+  concat (map concat (xss ∷ xsss))   ≡⟨ cong (concat xss ++_) (concat-concat xsss) ⟩
+  concat xss ++ concat (concat xsss) ≡⟨ concat-++ xss (concat xsss) ⟩
+  concat (concat (xss ∷ xsss))       ∎
 
 concat-[-] : concat {a} {A} ∘ map [_] ≗ id
 concat-[-] [] = refl

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -501,7 +501,7 @@ concat-++ [] yss = refl
 concat-++ ([] ∷ xss) yss = concat-++ xss yss
 concat-++ ((x ∷ xs) ∷ xss) yss = cong (x ∷_) (concat-++ (xs ∷ xss) yss)
 
-concat-concat : concat {a} {A} ∘ map concat ≗ concat ∘ concat
+concat-concat : concat {A = A} ∘ map concat ≗ concat ∘ concat
 concat-concat [] = refl
 concat-concat (xss ∷ xsss) = begin
   concat (map concat (xss ∷ xsss))   ≡⟨ cong (concat xss ++_) (concat-concat xsss) ⟩

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -496,6 +496,12 @@ concat-map {f = f} xss = begin
   foldr (λ ys → map f ys ++_) [] xss         ≡⟨ sym (foldr-fusion (map f) [] (map-++-commute f) xss) ⟩
   map f (concat xss)                         ∎
 
+concat-concat : concat {a} {A} ∘ map concat ≗ concat ∘ concat
+concat-concat [] = refl
+concat-concat ([] ∷ xsss) = concat-concat xsss
+concat-concat (([] ∷ xss) ∷ xsss) = concat-concat (xss ∷ xsss)
+concat-concat (((x ∷ xs) ∷ xss) ∷ xsss) = cong (x ∷_) (concat-concat ((xs ∷ xss) ∷ xsss))
+
 ------------------------------------------------------------------------
 -- sum
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -508,7 +508,7 @@ concat-concat (xss ∷ xsss) = begin
   concat xss ++ concat (concat xsss) ≡⟨ concat-++ xss (concat xsss) ⟩
   concat (concat (xss ∷ xsss))       ∎
 
-concat-[-] : concat {a} {A} ∘ map [_] ≗ id
+concat-[-] : concat {A = A} ∘ map [_] ≗ id
 concat-[-] [] = refl
 concat-[-] (x ∷ xs) = cong (x ∷_) (concat-[-] xs)
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -502,6 +502,10 @@ concat-concat ([] ∷ xsss) = concat-concat xsss
 concat-concat (([] ∷ xss) ∷ xsss) = concat-concat (xss ∷ xsss)
 concat-concat (((x ∷ xs) ∷ xss) ∷ xsss) = cong (x ∷_) (concat-concat ((xs ∷ xss) ∷ xsss))
 
+concat-[-] : concat {a} {A} ∘ map [_] ≗ id
+concat-[-] [] = refl
+concat-[-] (x ∷ xs) = cong (x ∷_) (concat-[-] xs)
+
 ------------------------------------------------------------------------
 -- sum
 


### PR DESCRIPTION
I was looking for these when trying to prove that `List` is a `Monad` for `categories-examples`.

We might desire a property similar to `concat-[-]` with type `concat ∘ [_] ≗ id` but that turns out to be `++-identityʳ`.