### PR TITLE
Add constructions over binary morphisms and deprecated old morphism code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,14 @@ Highlights
 Bug-fixes
 ---------
 
-* The example module `Maybe` in `Relation.Binary.Construct.Closure.Reflexive` was accidentally exposed publicly. It has been made private.
+* The example module `Maybe` in `Relation.Binary.Construct.Closure.Reflexive` was
+  accidentally exposed publicly. It has been made private.
 
-* Fixed the type of the proof `map-id` in `List.Relation.Unary.All.Properties`, which was incorrectly abstracted over
-  unused module parameters.
+* Fixed the type of the proof `map-id` in `List.Relation.Unary.All.Properties`,
+  which was incorrectly abstracted over unused module parameters.
+
+* Fixed bug where `IsRelIsomorphism` in `Relation.Binary.Morphism.Structures` did not
+  publicly re-export the contents of `IsRelMonomorphism`.
 
 Non-backwards compatible changes
 --------------------------------
@@ -24,10 +28,30 @@ Non-backwards compatible changes
 Deprecated modules
 ------------------
 
-* The module `TransitiveClosure` in `Induction.WellFounded` has been deprecated. You should instead use the standard definition of transitive closure and the accompanying proof of well-foundness defined in `Relation.Binary.Construct.Closure.Transitive`.
+* The module `TransitiveClosure` in `Induction.WellFounded` has been deprecated.
+  You should instead use the standard definition of transitive closure and the
+  accompanying proof of well-foundness defined in `Relation.Binary.Construct.Closure.Transitive`.
+
+* The module `Relation.Binary.OrderMorphism` has been deprecated, as the new
+  `(Homo/Mono/Iso)morphism` infrastructure in `Algebra.Morphism.Structures` is now
+  complete. The new definitions are parameterised by raw bundles instead of bundles
+  meaning they are much more flexible to work with.
 
 Deprecated names
 ----------------
+
+* The immediate contents of `Algebra.Morphism` have been deprecated, as the new
+  `(Homo/Mono/Iso)morphism` infrastructure in `Algebra.Morphism.Structures` is now
+  complete. The new definitions are parameterised by raw bundles instead of bundles
+  meaning they are much more flexible to work with. The replacements are as following:
+  ```agda
+  IsSemigroupMorphism                   ↦ IsSemigroupHomomorphism
+  IsMonoidMorphism                      ↦ IsMonoidHomomorphism
+  IsCommutativeMonoidMorphism           ↦ IsMonoidHomomorphism
+  IsIdempotentCommutativeMonoidMorphism ↦ IsMonoidHomomorphism
+  IsGroupMorphism                       ↦ IsGroupHomomorphism
+  IsAbelianGroupMorphism                ↦ IsGroupHomomorphism
+  ```
 
 * In `Relation.Binary.Construct.Closure.Reflexive`:
   ```agda
@@ -41,6 +65,13 @@ Deprecated names
 
 New modules
 -----------
+
+* Added various generic morphism constructions for binary relations:
+  ```agda
+  Relation.Binary.Morphism.Construct.Composition
+  Relation.Binary.Morphism.Construct.Constant
+  Relation.Binary.Morphism.Construct.Identity
+  ```
 
 * Added `Reflection.Traversal` for generic de Bruijn-aware traversals of reflected terms.
 * Added `Reflection.DeBruijn` with weakening, strengthening and free variable operations

--- a/src/Algebra/Morphism.agda
+++ b/src/Algebra/Morphism.agda
@@ -9,11 +9,11 @@
 module Algebra.Morphism where
 
 import Algebra.Morphism.Definitions as MorphismDefinitions
-open import Relation.Binary
 open import Algebra
 import Algebra.Properties.Group as GroupP
 open import Function hiding (Morphism)
 open import Level
+open import Relation.Binary
 import Relation.Binary.Reasoning.Setoid as EqR
 
 private
@@ -23,15 +23,22 @@ private
     B : Set b
 
 ------------------------------------------------------------------------
---
+-- Re-export
 
 module Definitions {a b ℓ₁} (A : Set a) (B : Set b) (_≈_ : Rel B ℓ₁) where
   open MorphismDefinitions A B _≈_ public
 
 open import Algebra.Morphism.Structures public
 
+
 ------------------------------------------------------------------------
--- Bundle homomorphisms
+-- DEPRECATED
+------------------------------------------------------------------------
+-- Please use the new definitions re-exported from
+-- `Algebra.Morphism.Structures` as continuing support for the below is
+-- no guaranteed.
+
+-- Version 1.5
 
 module _ {c₁ ℓ₁ c₂ ℓ₂}
          (From : Semigroup c₁ ℓ₁)
@@ -175,3 +182,28 @@ module _ {c₁ ℓ₁ c₂ ℓ₂}
 
   IsRingMorphism-syntax = IsRingMorphism
   syntax IsRingMorphism-syntax From To F = F Is From -Ring⟶ To
+
+{-# WARNING_ON_USAGE IsSemigroupMorphism
+"Warning: IsSemigroupMorphism was deprecated in v1.5.
+Please use IsSemigroupHomomorphism instead."
+#-}
+{-# WARNING_ON_USAGE IsMonoidMorphism
+"Warning: IsMonoidMorphism was deprecated in v1.5.
+Please use IsMonoidHomomorphism instead."
+#-}
+{-# WARNING_ON_USAGE IsCommutativeMonoidMorphism
+"Warning: IsCommutativeMonoidMorphism was deprecated in v1.5.
+Please use IsMonoidHomomorphism instead."
+#-}
+{-# WARNING_ON_USAGE IsIdempotentCommutativeMonoidMorphism
+"Warning: IsIdempotentCommutativeMonoidMorphism was deprecated in v1.5.
+Please use IsMonoidHomomorphism instead."
+#-}
+{-# WARNING_ON_USAGE IsGroupMorphism
+"Warning: IsGroupMorphism was deprecated in v1.5.
+Please use IsGroupHomomorphism instead."
+#-}
+{-# WARNING_ON_USAGE IsAbelianGroupMorphism
+"Warning: IsAbelianGroupMorphism was deprecated in v1.5.
+Please use IsGroupHomomorphism instead."
+#-}

--- a/src/Function/Endomorphism/Propositional.agda
+++ b/src/Function/Endomorphism/Propositional.agda
@@ -6,6 +6,9 @@
 
 {-# OPTIONS --without-K --safe #-}
 
+-- Disabled to prevent warnings from deprecated names
+{-# OPTIONS --warn=noUserWarning #-}
+
 module Function.Endomorphism.Propositional {a} (A : Set a) where
 
 open import Algebra

--- a/src/Function/Endomorphism/Setoid.agda
+++ b/src/Function/Endomorphism/Setoid.agda
@@ -6,6 +6,9 @@
 
 {-# OPTIONS --without-K --safe #-}
 
+-- Disabled to prevent warnings from deprecated names
+{-# OPTIONS --warn=noUserWarning #-}
+
 open import Relation.Binary
 
 module Function.Endomorphism.Setoid {c e} (S : Setoid c e) where

--- a/src/Relation/Binary/Morphism/Construct/Composition.agda
+++ b/src/Relation/Binary/Morphism/Construct/Composition.agda
@@ -1,0 +1,78 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The composition of morphisms between binary relations
+------------------------------------------------------------------------
+
+open import Relation.Binary
+
+module Relation.Binary.Morphism.Construct.Composition
+  {a b c ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b} {C : Set c}
+  {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
+  {f : A → B} {g : B → C} where
+
+open import Data.Product using (_,_)
+open import Function.Base using (id; _∘_)
+open import Function.Definitions using (Congruent)
+open import Function.Construct.Composition using (surjective)
+open import Relation.Binary.Morphism.Structures
+
+------------------------------------------------------------------------
+-- Relations
+------------------------------------------------------------------------
+
+isRelHomomorphism : IsRelHomomorphism ≈₁ ≈₂ f →
+                    IsRelHomomorphism ≈₂ ≈₃ g →
+                    IsRelHomomorphism ≈₁ ≈₃ (g ∘ f)
+isRelHomomorphism m₁ m₂ = record
+  { cong = G.cong ∘ F.cong
+  } where module F = IsRelHomomorphism m₁; module G = IsRelHomomorphism m₂
+
+isRelMonomorphism : IsRelMonomorphism ≈₁ ≈₂ f →
+                    IsRelMonomorphism ≈₂ ≈₃ g →
+                    IsRelMonomorphism ≈₁ ≈₃ (g ∘ f)
+isRelMonomorphism m₁ m₂ = record
+  { isHomomorphism = isRelHomomorphism F.isHomomorphism G.isHomomorphism
+  ; injective      = F.injective ∘ G.injective
+  } where module F = IsRelMonomorphism m₁; module G = IsRelMonomorphism m₂
+
+isRelIsomorphism : Transitive ≈₃ →
+                   IsRelIsomorphism ≈₁ ≈₂ f →
+                   IsRelIsomorphism ≈₂ ≈₃ g →
+                   IsRelIsomorphism ≈₁ ≈₃ (g ∘ f)
+isRelIsomorphism ≈₃-trans m₁ m₂ = record
+  { isMonomorphism = isRelMonomorphism F.isMonomorphism G.isMonomorphism
+  ; surjective     = surjective ≈₁ ≈₂ ≈₃ ≈₃-trans G.cong F.surjective G.surjective
+  } where module F = IsRelIsomorphism m₁; module G = IsRelIsomorphism m₂
+
+------------------------------------------------------------------------
+-- Orders
+------------------------------------------------------------------------
+
+module _ {ℓ₄ ℓ₅ ℓ₆} {∼₁ : Rel A ℓ₄} {∼₂ : Rel B ℓ₅} {∼₃ : Rel C ℓ₆} where
+
+  isOrderHomomorphism : IsOrderHomomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                        IsOrderHomomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                        IsOrderHomomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+  isOrderHomomorphism m₁ m₂ = record
+    { cong = G.cong ∘ F.cong
+    ; mono = G.mono ∘ F.mono
+    } where module F = IsOrderHomomorphism m₁; module G = IsOrderHomomorphism m₂
+
+  isOrderMonomorphism : IsOrderMonomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                        IsOrderMonomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                        IsOrderMonomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+  isOrderMonomorphism m₁ m₂ = record
+    { isOrderHomomorphism = isOrderHomomorphism F.isOrderHomomorphism G.isOrderHomomorphism
+    ; injective           = F.injective ∘ G.injective
+    ; cancel              = F.cancel ∘ G.cancel
+    } where module F = IsOrderMonomorphism m₁; module G = IsOrderMonomorphism m₂
+
+  isOrderIsomorphism : Transitive ≈₃ →
+                       IsOrderIsomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                       IsOrderIsomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                       IsOrderIsomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+  isOrderIsomorphism ≈₃-trans m₁ m₂ = record
+    { isOrderMonomorphism = isOrderMonomorphism F.isOrderMonomorphism G.isOrderMonomorphism
+    ; surjective          = surjective ≈₁ ≈₂ ≈₃ ≈₃-trans G.cong F.surjective G.surjective
+    } where module F = IsOrderIsomorphism m₁; module G = IsOrderIsomorphism m₂

--- a/src/Relation/Binary/Morphism/Construct/Composition.agda
+++ b/src/Relation/Binary/Morphism/Construct/Composition.agda
@@ -4,18 +4,19 @@
 -- The composition of morphisms between binary relations
 ------------------------------------------------------------------------
 
-open import Relation.Binary
-
-module Relation.Binary.Morphism.Construct.Composition
-  {a b c ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b} {C : Set c}
-  {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
-  {f : A → B} {g : B → C} where
+{-# OPTIONS --without-K --safe #-}
 
 open import Data.Product using (_,_)
 open import Function.Base using (id; _∘_)
 open import Function.Definitions using (Congruent)
 open import Function.Construct.Composition using (surjective)
+open import Relation.Binary
 open import Relation.Binary.Morphism.Structures
+
+module Relation.Binary.Morphism.Construct.Composition
+  {a b c ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b} {C : Set c}
+  {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
+  {f : A → B} {g : B → C} where
 
 ------------------------------------------------------------------------
 -- Relations

--- a/src/Relation/Binary/Morphism/Construct/Constant.agda
+++ b/src/Relation/Binary/Morphism/Construct/Constant.agda
@@ -4,18 +4,19 @@
 -- Constant morphisms between binary relations
 ------------------------------------------------------------------------
 
-open import Relation.Binary
-
-module Relation.Binary.Morphism.Construct.Constant
-  {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b}
-  (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈-refl : Reflexive ≈₂)
-  where
+{-# OPTIONS --without-K --safe #-}
 
 open import Data.Product using (_,_)
 open import Function.Base using (const; _∘_)
 open import Function.Definitions using (Congruent)
 open import Function.Construct.Composition using (surjective)
+open import Relation.Binary
 open import Relation.Binary.Morphism.Structures
+
+module Relation.Binary.Morphism.Construct.Constant
+  {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b}
+  (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈-refl : Reflexive ≈₂)
+  where
 
 ------------------------------------------------------------------------
 -- Relations

--- a/src/Relation/Binary/Morphism/Construct/Constant.agda
+++ b/src/Relation/Binary/Morphism/Construct/Constant.agda
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Constant morphisms between binary relations
+------------------------------------------------------------------------
+
+open import Relation.Binary
+
+module Relation.Binary.Morphism.Construct.Constant
+  {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b}
+  (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈-refl : Reflexive ≈₂)
+  where
+
+open import Data.Product using (_,_)
+open import Function.Base using (const; _∘_)
+open import Function.Definitions using (Congruent)
+open import Function.Construct.Composition using (surjective)
+open import Relation.Binary.Morphism.Structures
+
+------------------------------------------------------------------------
+-- Relations
+------------------------------------------------------------------------
+
+isRelHomomorphism : ∀ x → IsRelHomomorphism ≈₁ ≈₂ (const x)
+isRelHomomorphism x = record
+  { cong = const ≈-refl
+  }
+
+------------------------------------------------------------------------
+-- Orders
+------------------------------------------------------------------------
+
+module _ {ℓ₃ ℓ₄} (∼₁ : Rel A ℓ₃) (∼₂ : Rel B ℓ₄) where
+
+  isOrderHomomorphism : Reflexive ∼₂ →
+                        ∀ x → IsOrderHomomorphism ≈₁ ≈₂ ∼₁ ∼₂ (const x)
+  isOrderHomomorphism ∼-refl x = record
+    { cong = const ≈-refl
+    ; mono = const ∼-refl
+    }

--- a/src/Relation/Binary/Morphism/Construct/Identity.agda
+++ b/src/Relation/Binary/Morphism/Construct/Identity.agda
@@ -4,14 +4,15 @@
 -- The identity morphism for binary relations
 ------------------------------------------------------------------------
 
-open import Relation.Binary
-
-module Relation.Binary.Morphism.Construct.Identity
-  {a ℓ} {A : Set a} (≈ : Rel A ℓ) where
+{-# OPTIONS --without-K --safe #-}
 
 open import Data.Product using (_,_)
 open import Function.Base using (id)
+open import Relation.Binary
 open import Relation.Binary.Morphism.Structures
+
+module Relation.Binary.Morphism.Construct.Identity
+  {a ℓ} {A : Set a} (≈ : Rel A ℓ) where
 
 ------------------------------------------------------------------------
 -- Relations

--- a/src/Relation/Binary/Morphism/Construct/Identity.agda
+++ b/src/Relation/Binary/Morphism/Construct/Identity.agda
@@ -1,0 +1,60 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The identity morphism for binary relations
+------------------------------------------------------------------------
+
+open import Relation.Binary
+
+module Relation.Binary.Morphism.Construct.Identity
+  {a ℓ} {A : Set a} (≈ : Rel A ℓ) where
+
+open import Data.Product using (_,_)
+open import Function.Base using (id)
+open import Relation.Binary.Morphism.Structures
+
+------------------------------------------------------------------------
+-- Relations
+------------------------------------------------------------------------
+
+isRelHomomorphism : IsRelHomomorphism ≈ ≈ id
+isRelHomomorphism = record
+  { cong = id
+  }
+
+isRelMonomorphism : IsRelMonomorphism ≈ ≈ id
+isRelMonomorphism = record
+  { isHomomorphism = isRelHomomorphism
+  ; injective      = id
+  }
+
+isRelIsomorphism : Reflexive ≈ → IsRelIsomorphism ≈ ≈ id
+isRelIsomorphism refl = record
+  { isMonomorphism = isRelMonomorphism
+  ; surjective     = λ y → y , refl
+  }
+
+------------------------------------------------------------------------
+-- Orders
+------------------------------------------------------------------------
+
+module _ {ℓ₂} (∼ : Rel A ℓ₂) where
+
+  isOrderHomomorphism : IsOrderHomomorphism ≈ ≈ ∼ ∼ id
+  isOrderHomomorphism = record
+    { cong = id
+    ; mono = id
+    }
+
+  isOrderMonomorphism : IsOrderMonomorphism ≈ ≈ ∼ ∼ id
+  isOrderMonomorphism = record
+    { isOrderHomomorphism = isOrderHomomorphism
+    ; injective           = id
+    ; cancel              = id
+    }
+
+  isOrderIsomorphism : Reflexive ≈ → IsOrderIsomorphism ≈ ≈ ∼ ∼ id
+  isOrderIsomorphism refl = record
+    { isOrderMonomorphism = isOrderMonomorphism
+    ; surjective          = λ y → y , refl
+    }

--- a/src/Relation/Binary/Morphism/Structures.agda
+++ b/src/Relation/Binary/Morphism/Structures.agda
@@ -22,7 +22,7 @@ private
     ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
 
 ------------------------------------------------------------------------
--- Raw relations
+-- Relations
 ------------------------------------------------------------------------
 
 record IsRelHomomorphism (_∼₁_ : Rel A ℓ₁) (_∼₂_ : Rel B ℓ₂)
@@ -46,14 +46,14 @@ record IsRelIsomorphism (_∼₁_ : Rel A ℓ₁) (_∼₂_ : Rel B ℓ₂)
     isMonomorphism : IsRelMonomorphism _∼₁_ _∼₂_ ⟦_⟧
     surjective     : Surjective _∼₁_ _∼₂_ ⟦_⟧
 
-  open IsRelMonomorphism isMonomorphism
+  open IsRelMonomorphism isMonomorphism public
 
   bijective : Bijective _∼₁_ _∼₂_ ⟦_⟧
   bijective = injective , surjective
 
 
 ------------------------------------------------------------------------
--- Raw orders
+-- Orders
 ------------------------------------------------------------------------
 
 record IsOrderHomomorphism (_≈₁_ : Rel A ℓ₁) (_≈₂_ : Rel B ℓ₂)

--- a/src/Relation/Binary/OrderMorphism.agda
+++ b/src/Relation/Binary/OrderMorphism.agda
@@ -1,12 +1,18 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Order morphisms
+-- This module is DEPRECATED. Please use `Relation.Binary.Morphism`
+-- instead.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
 module Relation.Binary.OrderMorphism where
+
+{-# WARNING_ON_IMPORT
+"Relation.Binary.OrderMorphism was deprecated in v1.5.
+Use Relation.Binary.Reasoning.Morphism instead."
+#-}
 
 open import Relation.Binary
 open Poset
@@ -19,6 +25,7 @@ record _⇒-Poset_ {p₁ p₂ p₃ p₄ p₅ p₆}
   field
     fun      : Carrier P₁ → Carrier P₂
     monotone : _≤_ P₁ =[ fun ]⇒ _≤_ P₂
+
 
 _⇒-DTO_ : ∀ {p₁ p₂ p₃ p₄ p₅ p₆} →
           DecTotalOrder p₁ p₂ p₃ →
@@ -52,3 +59,24 @@ const {P₂ = P₂} x = record
   { fun      = F.const x
   ; monotone = F.const (refl P₂)
   }
+
+{-# WARNING_ON_USAGE _⇒-Poset_
+"Warning: _⇒-Poset_ was deprecated in v1.5.
+Please use `IsOrderHomomorphism` from `Relation.Binary.Morphism.Structures` instead."
+#-}
+{-# WARNING_ON_USAGE _⇒-DTO_
+"Warning: _⇒-DTO_ was deprecated in v1.5.
+Please use `IsOrderHomomorphism` from `Relation.Binary.Morphism.Structures` instead."
+#-}
+{-# WARNING_ON_USAGE id
+"Warning: id was deprecated in v1.5.
+Please use `issOrderHomomorphism` from `Relation.Binary.Morphism.Construct.Constant` instead."
+#-}
+{-# WARNING_ON_USAGE _∘_
+"Warning: _∘_ was deprecated in v1.5.
+Please use `isOrderHomomorphism` from `Relation.Binary.Morphism.Construct.Composition` instead."
+#-}
+{-# WARNING_ON_USAGE const
+"Warning: const was deprecated in v1.5.
+Please use `isOrderHomomorphism` from `Relation.Binary.Morphism.Construct.Constant` instead."
+#-}


### PR DESCRIPTION
Fixes #1301 by adding some missing constructions and then deprecating the last of the old morphism-related code.