### PR TITLE
Bikeshedding #1326: what to do about _⇒_ and ∀[_] on SizedType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,15 @@ New modules
   on reflected terms.
 * Added `Reflection.Universe` defining a universe for the reflected syntax types.
 
+* Added `Relation.Unary.Sized` for unary relations over sized types now that `Size` lives in it's own universe since Agda 2.6.2.
+
 Other major changes
 -------------------
 
 Other minor additions
 ---------------------
+
+* Added new type in `Size`:
+  ```agda
+  SizedSet ℓ = Size → Set ℓ
+  ```

--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -14,16 +14,16 @@ open import Relation.Unary.Sized
 ------------------------------------------------------------------------
 -- Basic types.
 
-record Thunk {ℓ} (F : SizedType ℓ) (i : Size) : Set ℓ where
+record Thunk {ℓ} (F : SizedSet ℓ) (i : Size) : Set ℓ where
   coinductive
   field force : {j : Size< i} → F j
 open Thunk public
 
-Thunk^P : ∀ {f p} {F : SizedType f} (P : Size → F ∞ → Set p)
+Thunk^P : ∀ {f p} {F : SizedSet f} (P : Size → F ∞ → Set p)
           (i : Size) (tf : Thunk F ∞) → Set p
 Thunk^P P i tf = Thunk (λ i → P i (tf .force)) i
 
-Thunk^R : ∀ {f g r} {F : SizedType f} {G : SizedType g}
+Thunk^R : ∀ {f g r} {F : SizedSet f} {G : SizedSet g}
           (R : Size → F ∞ → G ∞ → Set r)
           (i : Size) (tf : Thunk F ∞) (tg : Thunk G ∞) → Set r
 Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
@@ -31,7 +31,7 @@ Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
 ------------------------------------------------------------------------
 -- Syntax
 
-Thunk-syntax : ∀ {ℓ} → SizedType ℓ → Size → Set ℓ
+Thunk-syntax : ∀ {ℓ} → SizedSet ℓ → Size → Set ℓ
 Thunk-syntax = Thunk
 
 syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
@@ -40,13 +40,13 @@ syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
 -- Basic functions.
 
 -- Thunk is a functor
-module _ {p q} {P : SizedType p} {Q : SizedType q} where
+module _ {p q} {P : SizedSet p} {Q : SizedSet q} where
 
   map : ∀[ P ⇒ Q ] → ∀[ Thunk P ⇒ Thunk Q ]
   map f p .force = f (p .force)
 
 -- Thunk is a comonad
-module _ {p} {P : SizedType p} where
+module _ {p} {P : SizedSet p} where
 
   extract : ∀[ Thunk P ] → P ∞
   extract p = p .force
@@ -54,14 +54,14 @@ module _ {p} {P : SizedType p} where
   duplicate : ∀[ Thunk P ⇒ Thunk (Thunk P) ]
   duplicate p .force .force = p .force
 
-module _ {p q} {P : SizedType p} {Q : SizedType q} where
+module _ {p q} {P : SizedSet p} {Q : SizedSet q} where
 
   infixl 1 _<*>_
   _<*>_ : ∀[ Thunk (P ⇒ Q) ⇒ Thunk P ⇒ Thunk Q ]
   (f <*> p) .force = f .force (p .force)
 
 -- We can take cofixpoints of functions only making Thunk'd recursive calls
-module _ {p} (P : SizedType p) where
+module _ {p} (P : SizedSet p) where
 
   cofix : ∀[ Thunk P ⇒ P ] → ∀[ P ]
   cofix f = f λ where .force → cofix f

--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -8,7 +8,7 @@
 
 module Codata.Thunk where
 
-open import Size
+open import Size; open SizedType
 
 ------------------------------------------------------------------------
 -- Basic types.
@@ -41,26 +41,26 @@ syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
 -- Thunk is a functor
 module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
 
-  map : (∀{i} → P i → Q i) → ∀{i} → Thunk P i → Thunk Q i
+  map : ∀[ P ⇒ Q ] → ∀[ Thunk P ⇒ Thunk Q ]
   map f p .force = f (p .force)
 
 -- Thunk is a comonad
 module _ {p} {P : Size → Set p} where
 
-  extract : (∀{i} → Thunk P i) → P ∞
+  extract : ∀[ Thunk P ] → P ∞
   extract p = p .force
 
-  duplicate : ∀{i} → Thunk P i → Thunk (Thunk P) i
+  duplicate : ∀[ Thunk P ⇒ Thunk (Thunk P) ]
   duplicate p .force .force = p .force
 
 module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
 
   infixl 1 _<*>_
-  _<*>_ : ∀{i} → Thunk (λ i → P i → Q i) i → Thunk P i → Thunk Q i
+  _<*>_ : ∀[ Thunk (P ⇒ Q) ⇒ Thunk P ⇒ Thunk Q ]
   (f <*> p) .force = f .force (p .force)
 
 -- We can take cofixpoints of functions only making Thunk'd recursive calls
 module _ {p} (P : Size → Set p) where
 
-  cofix : (∀{i} → Thunk P i → P i) → ∀{i} → P i
+  cofix : ∀[ Thunk P ⇒ P ] → ∀[ P ]
   cofix f = f λ where .force → cofix f

--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -8,7 +8,7 @@
 
 module Codata.Thunk where
 
-open import Size; open SizedType
+open import Size
 
 ------------------------------------------------------------------------
 -- Basic types.
@@ -41,26 +41,26 @@ syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
 -- Thunk is a functor
 module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
 
-  map : ∀[ P ⇒ Q ] → ∀[ Thunk P ⇒ Thunk Q ]
+  map : (∀{i} → P i → Q i) → ∀{i} → Thunk P i → Thunk Q i
   map f p .force = f (p .force)
 
 -- Thunk is a comonad
 module _ {p} {P : Size → Set p} where
 
-  extract : ∀[ Thunk P ] → P ∞
+  extract : (∀{i} → Thunk P i) → P ∞
   extract p = p .force
 
-  duplicate : ∀[ Thunk P ⇒ Thunk (Thunk P) ]
+  duplicate : ∀{i} → Thunk P i → Thunk (Thunk P) i
   duplicate p .force .force = p .force
 
 module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
 
   infixl 1 _<*>_
-  _<*>_ : ∀[ Thunk (P ⇒ Q) ⇒ Thunk P ⇒ Thunk Q ]
+  _<*>_ : ∀{i} → Thunk (λ i → P i → Q i) i → Thunk P i → Thunk Q i
   (f <*> p) .force = f .force (p .force)
 
 -- We can take cofixpoints of functions only making Thunk'd recursive calls
 module _ {p} (P : Size → Set p) where
 
-  cofix : ∀[ Thunk P ⇒ P ] → ∀[ P ]
+  cofix : (∀{i} → Thunk P i → P i) → ∀{i} → P i
   cofix f = f λ where .force → cofix f

--- a/src/Codata/Thunk.agda
+++ b/src/Codata/Thunk.agda
@@ -8,21 +8,22 @@
 
 module Codata.Thunk where
 
-open import Size; open SizedType
+open import Size
+open import Relation.Unary.Sized
 
 ------------------------------------------------------------------------
 -- Basic types.
 
-record Thunk {ℓ} (F : Size → Set ℓ) (i : Size) : Set ℓ where
+record Thunk {ℓ} (F : SizedType ℓ) (i : Size) : Set ℓ where
   coinductive
   field force : {j : Size< i} → F j
 open Thunk public
 
-Thunk^P : ∀ {f p} {F : Size → Set f} (P : Size → F ∞ → Set p)
+Thunk^P : ∀ {f p} {F : SizedType f} (P : Size → F ∞ → Set p)
           (i : Size) (tf : Thunk F ∞) → Set p
 Thunk^P P i tf = Thunk (λ i → P i (tf .force)) i
 
-Thunk^R : ∀ {f g r} {F : Size → Set f} {G : Size → Set g}
+Thunk^R : ∀ {f g r} {F : SizedType f} {G : SizedType g}
           (R : Size → F ∞ → G ∞ → Set r)
           (i : Size) (tf : Thunk F ∞) (tg : Thunk G ∞) → Set r
 Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
@@ -30,7 +31,7 @@ Thunk^R R i tf tg = Thunk (λ i → R i (tf .force) (tg .force)) i
 ------------------------------------------------------------------------
 -- Syntax
 
-Thunk-syntax : ∀ {ℓ} → (Size → Set ℓ) → Size → Set ℓ
+Thunk-syntax : ∀ {ℓ} → SizedType ℓ → Size → Set ℓ
 Thunk-syntax = Thunk
 
 syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
@@ -39,13 +40,13 @@ syntax Thunk-syntax (λ j → e) i = Thunk[ j < i ] e
 -- Basic functions.
 
 -- Thunk is a functor
-module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
+module _ {p q} {P : SizedType p} {Q : SizedType q} where
 
   map : ∀[ P ⇒ Q ] → ∀[ Thunk P ⇒ Thunk Q ]
   map f p .force = f (p .force)
 
 -- Thunk is a comonad
-module _ {p} {P : Size → Set p} where
+module _ {p} {P : SizedType p} where
 
   extract : ∀[ Thunk P ] → P ∞
   extract p = p .force
@@ -53,14 +54,14 @@ module _ {p} {P : Size → Set p} where
   duplicate : ∀[ Thunk P ⇒ Thunk (Thunk P) ]
   duplicate p .force .force = p .force
 
-module _ {p q} {P : Size → Set p} {Q : Size → Set q} where
+module _ {p q} {P : SizedType p} {Q : SizedType q} where
 
   infixl 1 _<*>_
   _<*>_ : ∀[ Thunk (P ⇒ Q) ⇒ Thunk P ⇒ Thunk Q ]
   (f <*> p) .force = f .force (p .force)
 
 -- We can take cofixpoints of functions only making Thunk'd recursive calls
-module _ {p} (P : Size → Set p) where
+module _ {p} (P : SizedType p) where
 
   cofix : ∀[ Thunk P ⇒ P ] → ∀[ P ]
   cofix f = f λ where .force → cofix f

--- a/src/Relation/Unary/Sized.agda
+++ b/src/Relation/Unary/Sized.agda
@@ -20,8 +20,8 @@ private
     ℓ ℓ₁ ℓ₂ : Level
 
 infixr 8 _⇒_
-_⇒_ : SizedType ℓ₁ → SizedType ℓ₂ → SizedType (ℓ₁ ⊔ ℓ₂)
+_⇒_ : SizedSet ℓ₁ → SizedSet ℓ₂ → SizedSet (ℓ₁ ⊔ ℓ₂)
 F ⇒ G = λ i → F i → G i
 
-∀[_] : SizedType ℓ → Set ℓ
+∀[_] : SizedSet ℓ → Set ℓ
 ∀[ F ] = ∀{i} → F i

--- a/src/Relation/Unary/Sized.agda
+++ b/src/Relation/Unary/Sized.agda
@@ -1,0 +1,27 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Indexed unary relations over sized types
+------------------------------------------------------------------------
+
+-- Sized types live in the special sort `SizeUniv` and therefore are no
+-- longer compatible with the ordinary combinators defined in
+-- `Relation.Unary`.
+
+{-# OPTIONS --without-K --safe --sized-types #-}
+
+module Relation.Unary.Sized  where
+
+open import Level
+open import Size
+
+private
+  variable
+    ℓ ℓ₁ ℓ₂ : Level
+
+infixr 8 _⇒_
+_⇒_ : SizedType ℓ₁ → SizedType ℓ₂ → SizedType (ℓ₁ ⊔ ℓ₂)
+F ⇒ G = λ i → F i → G i
+
+∀[_] : SizedType ℓ → Set ℓ
+∀[ F ] = ∀{i} → F i

--- a/src/Size.agda
+++ b/src/Size.agda
@@ -25,5 +25,5 @@ open import Agda.Builtin.Size public using
 ------------------------------------------------------------------------
 -- Concept of sized type
 
-SizedType : (ℓ : Level) → Set (suc ℓ)
-SizedType ℓ = Size → Set ℓ
+SizedSet : (ℓ : Level) → Set (suc ℓ)
+SizedSet ℓ = Size → Set ℓ

--- a/src/Size.agda
+++ b/src/Size.agda
@@ -27,3 +27,15 @@ private
 
 SizedType : (ℓ : Level) → Set (suc ℓ)
 SizedType ℓ = Size → Set ℓ
+
+-- Type constructors involving SizedType
+
+module SizedType where
+
+  infixr 8 _⇒_
+
+  _⇒_ : SizedType ℓ₁ → SizedType ℓ₂ → SizedType (ℓ₁ ⊔ ℓ₂)
+  F ⇒ G = λ i → F i → G i
+
+  ∀[_] : SizedType ℓ → Set ℓ
+  ∀[ F ] = ∀{i} → F i

--- a/src/Size.agda
+++ b/src/Size.agda
@@ -27,15 +27,3 @@ private
 
 SizedType : (ℓ : Level) → Set (suc ℓ)
 SizedType ℓ = Size → Set ℓ
-
--- Type constructors involving SizedType
-
-module SizedType where
-
-  infixr 8 _⇒_
-
-  _⇒_ : SizedType ℓ₁ → SizedType ℓ₂ → SizedType (ℓ₁ ⊔ ℓ₂)
-  F ⇒ G = λ i → F i → G i
-
-  ∀[_] : SizedType ℓ → Set ℓ
-  ∀[ F ] = ∀{i} → F i

--- a/src/Size.agda
+++ b/src/Size.agda
@@ -8,34 +8,22 @@
 
 module Size where
 
-open import Agda.Builtin.Size public
-  using ( SizeUniv            --  sort SizeUniv
-        ; Size                --  Size   : SizeUniv
-        ; Size<_              --  Size<_ : Size → SizeUniv
-        ; ↑_                  --  ↑_     : Size → Size
-        ; _⊔ˢ_                --  _⊔ˢ_   : Size → Size → Size
-        ; ∞                   --  ∞      : Size
-        )
-
 open import Level
 
-private
-  variable
-    ℓ ℓ₁ ℓ₂ : Level
+------------------------------------------------------------------------
+-- Re-export builtins
 
+open import Agda.Builtin.Size public using
+  ( SizeUniv  --  sort SizeUniv
+  ; Size      --  : SizeUniv
+  ; Size<_    --  : Size → SizeUniv
+  ; ↑_        --  : Size → Size
+  ; _⊔ˢ_      --  : Size → Size → Size
+  ; ∞         --  : Size
+  )
+
+------------------------------------------------------------------------
 -- Concept of sized type
 
 SizedType : (ℓ : Level) → Set (suc ℓ)
 SizedType ℓ = Size → Set ℓ
-
--- Type constructors involving SizedType
-
-module SizedType where
-
-  infixr 8 _⇒_
-
-  _⇒_ : SizedType ℓ₁ → SizedType ℓ₂ → SizedType (ℓ₁ ⊔ ℓ₂)
-  F ⇒ G = λ i → F i → G i
-
-  ∀[_] : SizedType ℓ → Set ℓ
-  ∀[ F ] = ∀{i} → F i


### PR DESCRIPTION
One proposal in continuation of #1326: remove `_⇒_` and `∀[_]` on `SizedType`

See discussion around https://github.com/agda/agda-stdlib/pull/1326#discussion_r511751993.

The nested module is not in style with the `std-lib`, and exporting these short definitions on top-level creates unpleasant clashes with `Relation.Unary`.

Thus, one solution is to remove the offending definitions and wait whether they will grow back naturally.

@MatthewDaggitt suggested instead:
> I think a better solution is to mimic the normal module hierarchy underneath `Size` just as we do elsewhere in the library. For example we would put `∀[_]` in `Size.Relation.Unary` and `_⇒_` in `Size.Function`. That would make it so much easier to expand these later on if we found it necessary.

