### PR TITLE
[ fix agda#1338 ] Made Data.Vec._⊛_ stricter

### DIFF
--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -149,7 +149,7 @@ _⋎_ : ∀ {m n} → Vec A m → Vec A n → Vec A (m +⋎ n)
 infixl 4 _⊛_
 
 _⊛_ : ∀ {n} → Vec (A → B) n → Vec A n → Vec B n
-[]       ⊛ _        = []
+[]       ⊛ []       = []
 (f ∷ fs) ⊛ (x ∷ xs) = f x ∷ (fs ⊛ xs)
 
 -- Multiplication


### PR DESCRIPTION
Fixes #1338. Note that `zipWith` is already defined as

```agda
zipWith : ∀ {n} → (A → B → C) → Vec A n → Vec B n → Vec C n
zipWith f []       []       = []
zipWith f (x ∷ xs) (y ∷ ys) = f x y ∷ zipWith f xs ys
```

so we're only making things consistent here.