### PR TITLE
Revamp of `Data.List.Relation.Binary.Subset`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Bug-fixes
 * The binary relation `_≉_` exposed by records in `Relation.Binary.Bundles` now has
   the correct infix precedence.
 
+* Fixed the fixity of the reasoning combinators in
+  `Data.List.Relation.Binary.Subset.(Propositional/Setoid).Properties`so that they
+  compose properly.
+
 * Added version to library name
 
 Non-backwards compatible changes
@@ -40,7 +44,7 @@ Non-backwards compatible changes
   ℕ.zero  ⊖ ℕ.suc n = -[1+ n ]
   ℕ.suc m ⊖ ℕ.suc n = m ⊖ n
   ```
-  which meant that it had to recursively evaluate its the unary arguments.
+  which meant that it had to recursively evaluate its unary arguments.
   The definition has been changed as follows to use operations on `ℕ` that are backed
   by builtin operations, greatly improving its performance:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,23 +33,27 @@ Non-backwards compatible changes
 * The module `Algebra.Construct.Zero` and `Algebra.Module.Construct.Zero`
   are now level-polymorphic, each taking two implicit level parameters.
 
-* Previously the definition of `_⊖_` in `Data.Integer.Base` was defined
-  inductively as:
+* Previously `_⊖_` in `Data.Integer.Base` was defined inductively as:
   ```agda
   _⊖_ : ℕ → ℕ → ℤ
   m       ⊖ ℕ.zero  = + m
   ℕ.zero  ⊖ ℕ.suc n = -[1+ n ]
   ℕ.suc m ⊖ ℕ.suc n = m ⊖ n
   ```
-  which meant that the unary arguments had to be evaluated. To make it
-  much faster it's definition has been changed to use operations on `ℕ`
-  that are backed by builtin operations:
+  which meant that it had to recursively evaluate its the unary arguments.
+  The definition has been changed as follows to use operations on `ℕ` that are backed
+  by builtin operations, greatly improving its performance:
   ```agda
   _⊖_ : ℕ → ℕ → ℤ
   m ⊖ n with m ℕ.<ᵇ n
   ... | true  = - + (n ℕ.∸ m)
   ... | false = + (m ℕ.∸ n)
   ```
+
+* The proofs `↭⇒∼bag` and `∼bag⇒↭` have been moved from
+  `Data.List.Relation.Binary.Permutation.Setoid.Properties`
+  to `Data.List.Relation.Binary.BagAndSetEquality` as their current location
+  were causing cyclic import dependencies.
 
 Deprecated modules
 ------------------
@@ -208,6 +212,60 @@ Other minor additions
   ⊖-≤             : m ≤ n → m ⊖ n ≡ - + (n ∸ m)
   -m+n≡n⊖m        : - (+ m) + + n ≡ n ⊖ m
   m-n≡m⊖n         : + m + (- + n) ≡ m ⊖ n
+  ```
+
+* Added new relations in `Data.List.Relation.Binary.Subset.(Propositional/Setoid)`:
+  ```agda
+  xs ⊇ ys = ys ⊆ xs
+  xs ⊉ ys = ¬ xs ⊇ ys
+  ```
+
+* Added new proofs in `Data.List.Relation.Binary.Subset.Propositional.Properties`:
+  ```agda
+  ⊆-respʳ-≋      : _⊆_ Respectsʳ _≋_
+  ⊆-respˡ-≋      : _⊆_ Respectsˡ _≋_
+
+  ↭⇒⊆            : _↭_ ⇒ _⊆_
+  ⊆-respʳ-↭      : _⊆_ Respectsʳ _↭_
+  ⊆-respˡ-↭      : _⊆_ Respectsˡ _↭_
+  ⊆-↭-isPreorder : IsPreorder _↭_ _⊆_
+  ⊆-↭-preorder   : Preorder _ _ _
+
+  Any-resp-⊆     : P Respects _≈_ → (Any P) Respects _⊆_
+  All-resp-⊇     : P Respects _≈_ → (All P) Respects _⊇_
+
+  xs⊆xs++ys      : xs ⊆ xs ++ ys
+  xs⊆ys++xs      : xs ⊆ ys ++ xs
+  ++⁺ʳ           : xs ⊆ ys → zs ++ xs ⊆ zs ++ ys
+  ++⁺ˡ           : xs ⊆ ys → xs ++ zs ⊆ ys ++ zs
+  ++⁺            : ws ⊆ xs → ys ⊆ zs → ws ++ ys ⊆ xs ++ zs
+  ```
+
+* Added new proofs in `Data.List.Relation.Binary.Subset.Propositional.Properties`:
+  ```agda
+  ↭⇒⊆            : _↭_ ⇒ _⊆_
+  ⊆-respʳ-↭      : _⊆_ Respectsʳ _↭_
+  ⊆-respˡ-↭      : _⊆_ Respectsˡ _↭_
+  ⊆-↭-isPreorder : IsPreorder _↭_ _⊆_
+  ⊆-↭-preorder   : Preorder _ _ _
+
+  Any-resp-⊆     : (Any P) Respects _⊆_
+  All-resp-⊇     : (All P) Respects _⊇_
+
+  xs⊆xs++ys      : xs ⊆ xs ++ ys
+  xs⊆ys++xs      : xs ⊆ ys ++ xs
+  ++⁺ʳ           : xs ⊆ ys → zs ++ xs ⊆ zs ++ ys
+  ++⁺ˡ           : xs ⊆ ys → xs ++ zs ⊆ ys ++ zs
+  ```
+
+* Added new proof in `Data.List.Relation.Binary.Permutation.Propositional.Properties`:
+  ```agda
+  ++↭ʳ++ : xs ++ ys ↭ xs ʳ++ ys
+  ```
+
+* Added new proof in `Data.List.Relation.Binary.Permutation.Setoi.Properties`:
+  ```agda
+  ++↭ʳ++ : xs ++ ys ↭ xs ʳ++ ys
   ```
 
 * Added new definition in `Data.Nat.Base`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,19 @@ Deprecated names
   Plus′ ↦ TransClosure
   ```
 
+* In `Data.List.Relation.Binary.Subset.Propositional.Properties`:
+  ```agda
+  mono            ↦ Any-resp-⊆
+  map-mono        ↦ map⁺
+  concat-mono     ↦ concat⁺
+  >>=-mono        ↦ >>=⁺
+  _⊛-mono_        ↦ ⊛⁺
+  _⊗-mono_        ↦ ⊗⁺
+  any-mono        ↦ any⁺
+  map-with-∈-mono ↦ map-with-∈⁺
+  filter⁺         ↦ filter-⊆
+  ```
+
 New modules
 -----------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ Deprecated names
   filter⁺         ↦ filter-⊆
   ```
 
+* In `Data.List.Relation.Binary.Subset.Setoid.Properties`:
+    ```agda
+  filter⁺         ↦ filter-⊆
+  ```
+
 New modules
 -----------
 

--- a/src/Data/List/Relation/Binary/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/Binary/BagAndSetEquality.agda
@@ -17,10 +17,12 @@ open import Data.List.Base
 open import Data.List.Categorical using (monad; module MonadProperties)
 import Data.List.Properties as LP
 open import Data.List.Relation.Unary.Any using (Any; here; there)
-open import Data.List.Relation.Unary.Any.Properties
+open import Data.List.Relation.Unary.Any.Properties hiding (++-comm)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Binary.Subset.Propositional.Properties
   using (⊆-preorder)
+open import Data.List.Relation.Binary.Permutation.Propositional
+open import Data.List.Relation.Binary.Permutation.Propositional.Properties
 open import Data.Product as Prod hiding (map)
 import Data.Product.Function.Dependent.Propositional as Σ
 open import Data.Sum.Base as Sum hiding (map)
@@ -558,3 +560,48 @@ drop-cons {A = A} {x} {xs} {ys} x∷xs≈x∷ys =
     open Inverse
     open P.≡-Reasoning
   ... | ()
+
+
+
+------------------------------------------------------------------------
+-- Relationships to other relations
+
+module _ {a} {A : Set a} where
+
+  ↭⇒∼bag : _↭_ ⇒ _∼[ bag ]_
+  ↭⇒∼bag xs↭ys {v} = inverse (to xs↭ys) (from xs↭ys) (from∘to xs↭ys) (to∘from xs↭ys)
+    where
+    to : ∀ {xs ys} → xs ↭ ys → v ∈ xs → v ∈ ys
+    to xs↭ys = Any-resp-↭ {A = A} xs↭ys
+
+    from : ∀ {xs ys} → xs ↭ ys → v ∈ ys → v ∈ xs
+    from xs↭ys = Any-resp-↭ (↭-sym xs↭ys)
+
+    from∘to : ∀ {xs ys} (p : xs ↭ ys) (q : v ∈ xs) → from p (to p q) ≡ q
+    from∘to refl          v∈xs                 = refl
+    from∘to (prep _ _)    (here refl)          = refl
+    from∘to (prep _ p)    (there v∈xs)         = P.cong there (from∘to p v∈xs)
+    from∘to (swap x y p)  (here refl)          = refl
+    from∘to (swap x y p)  (there (here refl))  = refl
+    from∘to (swap x y p)  (there (there v∈xs)) = P.cong (there ∘ there) (from∘to p v∈xs)
+    from∘to (trans p₁ p₂) v∈xs
+      rewrite from∘to p₂ (Any-resp-↭ p₁ v∈xs)
+            | from∘to p₁ v∈xs                  = refl
+
+    to∘from : ∀ {xs ys} (p : xs ↭ ys) (q : v ∈ ys) → to p (from p q) ≡ q
+    to∘from p with from∘to (↭-sym p)
+    ... | res rewrite ↭-sym-involutive p = res
+
+  ∼bag⇒↭ : _∼[ bag ]_ ⇒ _↭_
+  ∼bag⇒↭ {[]} eq with empty-unique {A = A} (Inv.sym eq)
+  ... | refl = refl
+  ∼bag⇒↭ {x ∷ xs} eq with ∈-∃++ (to ⟨$⟩ (here P.refl))
+    where open Inv.Inverse (eq {x})
+  ... | zs₁ , zs₂ , p rewrite p = begin
+    x ∷ xs           <⟨ ∼bag⇒↭ (drop-cons (Inv._∘_ (comm zs₁ (x ∷ zs₂)) eq)) ⟩
+    x ∷ (zs₂ ++ zs₁) <⟨ ++-comm zs₂ zs₁ ⟩
+    x ∷ (zs₁ ++ zs₂) ↭˘⟨ shift x zs₁ zs₂ ⟩
+    zs₁ ++ x ∷ zs₂   ∎
+    where
+    open CommutativeMonoid (commutativeMonoid bag A)
+    open PermutationReasoning

--- a/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
@@ -19,8 +19,6 @@ open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
 open import Data.List.Membership.Propositional
 open import Data.List.Membership.Propositional.Properties
-open import Data.List.Relation.Binary.BagAndSetEquality
-  using (bag; _∼[_]_; empty-unique; drop-cons; commutativeMonoid)
 import Data.List.Properties as Lₚ
 open import Data.Product using (_,_; _×_; ∃; ∃₂)
 open import Function using (_∘_; _⟨_⟩_)
@@ -304,63 +302,10 @@ module _ {a} {A : Set a} where
     x ∷ xs        ∎)
 
 ------------------------------------------------------------------------
--- Relationships to other relations
+-- ʳ++
 
 module _ {a} {A : Set a} where
 
-  ↭⇒∼bag : _↭_ ⇒ _∼[ bag ]_
-  ↭⇒∼bag xs↭ys {v} = inverse (to xs↭ys) (from xs↭ys) (from∘to xs↭ys) (to∘from xs↭ys)
-    where
-    to : ∀ {xs ys} → xs ↭ ys → v ∈ xs → v ∈ ys
-    to xs↭ys = Any-resp-↭ {A = A} xs↭ys
-
-    from : ∀ {xs ys} → xs ↭ ys → v ∈ ys → v ∈ xs
-    from xs↭ys = Any-resp-↭ (↭-sym xs↭ys)
-
-    from∘to : ∀ {xs ys} (p : xs ↭ ys) (q : v ∈ xs) → from p (to p q) ≡ q
-    from∘to refl          v∈xs                 = refl
-    from∘to (prep _ _)    (here refl)          = refl
-    from∘to (prep _ p)    (there v∈xs)         = cong there (from∘to p v∈xs)
-    from∘to (swap x y p)  (here refl)          = refl
-    from∘to (swap x y p)  (there (here refl))  = refl
-    from∘to (swap x y p)  (there (there v∈xs)) = cong (there ∘ there) (from∘to p v∈xs)
-    from∘to (trans p₁ p₂) v∈xs
-      rewrite from∘to p₂ (Any-resp-↭ p₁ v∈xs)
-            | from∘to p₁ v∈xs                  = refl
-
-    to∘from : ∀ {xs ys} (p : xs ↭ ys) (q : v ∈ ys) → to p (from p q) ≡ q
-    to∘from p with from∘to (↭-sym p)
-    ... | res rewrite ↭-sym-involutive p = res
-
-  ∼bag⇒↭ : _∼[ bag ]_ ⇒ _↭_
-  ∼bag⇒↭ {[]} eq with empty-unique {A = A} (Inv.sym eq)
-  ... | refl = refl
-  ∼bag⇒↭ {x ∷ xs} eq with ∈-∃++ (to ⟨$⟩ (here ≡.refl))
-    where open Inv.Inverse (eq {x})
-  ... | zs₁ , zs₂ , p rewrite p = begin
-    x ∷ xs           <⟨ ∼bag⇒↭ (drop-cons (Inv._∘_ (comm zs₁ (x ∷ zs₂)) eq)) ⟩
-    x ∷ (zs₂ ++ zs₁) <⟨ ++-comm zs₂ zs₁ ⟩
-    x ∷ (zs₁ ++ zs₂) ↭˘⟨ shift x zs₁ zs₂ ⟩
-    zs₁ ++ x ∷ zs₂   ∎
-    where open CommutativeMonoid (commutativeMonoid bag A)
-
-
-------------------------------------------------------------------------
--- DEPRECATED NAMES
-------------------------------------------------------------------------
--- Please use the new names as continuing support for the old names is
--- not guaranteed.
-
--- Version 1.0
-
-↭⇒~bag = ↭⇒∼bag
-{-# WARNING_ON_USAGE ↭⇒~bag
-"Warning: ↭⇒~bag was deprecated in v1.0.
-Please use ? instead (now typed with '\\sim' rather than '~')."
-#-}
-
-~bag⇒↭ = ∼bag⇒↭
-{-# WARNING_ON_USAGE ~bag⇒↭
-"Warning: ~bag⇒↭ was deprecated in v1.0.
-Please use ? instead (now typed with '\\sim' rather than '~')."
-#-}
+  ++↭ʳ++ : ∀ (xs ys : List A) → xs ++ ys ↭ xs ʳ++ ys
+  ++↭ʳ++ []       ys = ↭-refl
+  ++↭ʳ++ (x ∷ xs) ys = ↭-trans (↭-sym (shift x xs ys)) (++↭ʳ++ xs (x ∷ ys))

--- a/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
@@ -24,6 +24,7 @@ open import Data.Product using (_,_; _×_; ∃; ∃₂)
 open import Function using (_∘_; _⟨_⟩_)
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Inverse as Inv using (inverse)
+open import Level using (Level)
 open import Relation.Unary using (Pred)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as ≡
@@ -32,64 +33,63 @@ open import Relation.Nullary
 
 open PermutationReasoning
 
+private
+  variable
+    a b p : Level
+    A : Set a
+    B : Set b
 
 ------------------------------------------------------------------------
 -- Permutations of empty and singleton lists
 
-module _ {a} {A : Set a} where
+↭-empty-inv : ∀ {xs : List A} → xs ↭ [] → xs ≡ []
+↭-empty-inv refl = refl
+↭-empty-inv (trans p q) with refl ← ↭-empty-inv q = ↭-empty-inv p
 
-  ↭-empty-inv : ∀ {xs : List A} → xs ↭ [] → xs ≡ []
-  ↭-empty-inv refl = refl
-  ↭-empty-inv (trans p q) with refl ← ↭-empty-inv q = ↭-empty-inv p
+¬x∷xs↭[] : ∀ {x} {xs : List A} → ¬ ((x ∷ xs) ↭ [])
+¬x∷xs↭[] (trans s₁ s₂) with ↭-empty-inv s₂
+... | refl = ¬x∷xs↭[] s₁
 
-  ¬x∷xs↭[] : ∀ {x} {xs : List A} → ¬ ((x ∷ xs) ↭ [])
-  ¬x∷xs↭[] (trans s₁ s₂) with ↭-empty-inv s₂
-  ... | refl = ¬x∷xs↭[] s₁
-
-  ↭-singleton-inv : ∀ {x} {xs : List A} → xs ↭ [ x ] → xs ≡ [ x ]
-  ↭-singleton-inv refl                                             = refl
-  ↭-singleton-inv (prep _ ρ) with refl ← ↭-empty-inv ρ             = refl
-  ↭-singleton-inv (_↭_.trans ρ₁ ρ₂) with refl ← ↭-singleton-inv ρ₂ = ↭-singleton-inv ρ₁
+↭-singleton-inv : ∀ {x} {xs : List A} → xs ↭ [ x ] → xs ≡ [ x ]
+↭-singleton-inv refl                                             = refl
+↭-singleton-inv (prep _ ρ) with refl ← ↭-empty-inv ρ             = refl
+↭-singleton-inv (trans ρ₁ ρ₂) with refl ← ↭-singleton-inv ρ₂ = ↭-singleton-inv ρ₁
 
 ------------------------------------------------------------------------
 -- sym
 
-module _ {a} {A : Set a} where
-
-  ↭-sym-involutive : ∀ {xs ys : List A} (p : xs ↭ ys) → ↭-sym (↭-sym p) ≡ p
-  ↭-sym-involutive refl          = refl
-  ↭-sym-involutive (prep x ↭)    = cong (prep x) (↭-sym-involutive ↭)
-  ↭-sym-involutive (swap x y ↭)  = cong (swap x y) (↭-sym-involutive ↭)
-  ↭-sym-involutive (trans ↭₁ ↭₂) =
-    cong₂ trans (↭-sym-involutive ↭₁) (↭-sym-involutive ↭₂)
+↭-sym-involutive : ∀ {xs ys : List A} (p : xs ↭ ys) → ↭-sym (↭-sym p) ≡ p
+↭-sym-involutive refl          = refl
+↭-sym-involutive (prep x ↭)    = cong (prep x) (↭-sym-involutive ↭)
+↭-sym-involutive (swap x y ↭)  = cong (swap x y) (↭-sym-involutive ↭)
+↭-sym-involutive (trans ↭₁ ↭₂) =
+  cong₂ trans (↭-sym-involutive ↭₁) (↭-sym-involutive ↭₂)
 
 ------------------------------------------------------------------------
 -- Relationships to other predicates
 
-module _ {a} {A : Set a} where
+All-resp-↭ : ∀ {P : Pred A p} → (All P) Respects _↭_
+All-resp-↭ refl wit                     = wit
+All-resp-↭ (prep x p) (px ∷ wit)        = px ∷ All-resp-↭ p wit
+All-resp-↭ (swap x y p) (px ∷ py ∷ wit) = py ∷ px ∷ All-resp-↭ p wit
+All-resp-↭ (trans p₁ p₂) wit            = All-resp-↭ p₂ (All-resp-↭ p₁ wit)
 
-  All-resp-↭ : ∀ {ℓ} {P : Pred A ℓ} → (All P) Respects _↭_
-  All-resp-↭ refl wit                     = wit
-  All-resp-↭ (prep x p) (px ∷ wit)        = px ∷ All-resp-↭ p wit
-  All-resp-↭ (swap x y p) (px ∷ py ∷ wit) = py ∷ px ∷ All-resp-↭ p wit
-  All-resp-↭ (trans p₁ p₂) wit            = All-resp-↭ p₂ (All-resp-↭ p₁ wit)
+Any-resp-↭ : ∀ {P : Pred A p} → (Any P) Respects _↭_
+Any-resp-↭ refl         wit                 = wit
+Any-resp-↭ (prep x p)   (here px)           = here px
+Any-resp-↭ (prep x p)   (there wit)         = there (Any-resp-↭ p wit)
+Any-resp-↭ (swap x y p) (here px)           = there (here px)
+Any-resp-↭ (swap x y p) (there (here px))   = here px
+Any-resp-↭ (swap x y p) (there (there wit)) = there (there (Any-resp-↭ p wit))
+Any-resp-↭ (trans p p₁) wit                 = Any-resp-↭ p₁ (Any-resp-↭ p wit)
 
-  Any-resp-↭ : ∀ {ℓ} {P : Pred A ℓ} → (Any P) Respects _↭_
-  Any-resp-↭ refl         wit                 = wit
-  Any-resp-↭ (prep x p)   (here px)           = here px
-  Any-resp-↭ (prep x p)   (there wit)         = there (Any-resp-↭ p wit)
-  Any-resp-↭ (swap x y p) (here px)           = there (here px)
-  Any-resp-↭ (swap x y p) (there (here px))   = here px
-  Any-resp-↭ (swap x y p) (there (there wit)) = there (there (Any-resp-↭ p wit))
-  Any-resp-↭ (trans p p₁) wit                 = Any-resp-↭ p₁ (Any-resp-↭ p wit)
-
-  ∈-resp-↭ : ∀ {x : A} → (x ∈_) Respects _↭_
-  ∈-resp-↭ = Any-resp-↭
+∈-resp-↭ : ∀ {x : A} → (x ∈_) Respects _↭_
+∈-resp-↭ = Any-resp-↭
 
 ------------------------------------------------------------------------
 -- map
 
-module _ {a b} {A : Set a} {B : Set b} (f : A → B) where
+module _ (f : A → B) where
 
   map⁺ : ∀ {xs ys} → xs ↭ ys → map f xs ↭ map f ys
   map⁺ refl          = refl
@@ -110,202 +110,193 @@ module _ {a b} {A : Set a} {B : Set b} (f : A → B) where
 ------------------------------------------------------------------------
 -- length
 
-module _ {a} {A : Set a} where
-
-  ↭-length : ∀ {xs ys : List A} → xs ↭ ys → length xs ≡ length ys
-  ↭-length refl            = refl
-  ↭-length (prep x lr)     = cong suc (↭-length lr)
-  ↭-length (swap x y lr)   = cong (λ n → suc (suc n)) (↭-length lr)
-  ↭-length (trans lr₁ lr₂) = ≡.trans (↭-length lr₁) (↭-length lr₂)
+↭-length : ∀ {xs ys : List A} → xs ↭ ys → length xs ≡ length ys
+↭-length refl            = refl
+↭-length (prep x lr)     = cong suc (↭-length lr)
+↭-length (swap x y lr)   = cong (suc ∘ suc) (↭-length lr)
+↭-length (trans lr₁ lr₂) = ≡.trans (↭-length lr₁) (↭-length lr₂)
 
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {a} {A : Set a} where
+++⁺ˡ : ∀ xs {ys zs : List A} → ys ↭ zs → xs ++ ys ↭ xs ++ zs
+++⁺ˡ []       ys↭zs = ys↭zs
+++⁺ˡ (x ∷ xs) ys↭zs = prep x (++⁺ˡ xs ys↭zs)
 
+++⁺ʳ : ∀ {xs ys : List A} zs → xs ↭ ys → xs ++ zs ↭ ys ++ zs
+++⁺ʳ zs refl          = refl
+++⁺ʳ zs (prep x ↭)    = prep x (++⁺ʳ zs ↭)
+++⁺ʳ zs (swap x y ↭)  = swap x y (++⁺ʳ zs ↭)
+++⁺ʳ zs (trans ↭₁ ↭₂) = trans (++⁺ʳ zs ↭₁) (++⁺ʳ zs ↭₂)
 
-  ++⁺ˡ : ∀ xs {ys zs : List A} → ys ↭ zs → xs ++ ys ↭ xs ++ zs
-  ++⁺ˡ []       ys↭zs = ys↭zs
-  ++⁺ˡ (x ∷ xs) ys↭zs = prep x (++⁺ˡ xs ys↭zs)
+++⁺ : _++_ {A = A} Preserves₂ _↭_ ⟶ _↭_ ⟶ _↭_
+++⁺ ws↭xs ys↭zs = trans (++⁺ʳ _ ws↭xs) (++⁺ˡ _ ys↭zs)
 
-  ++⁺ʳ : ∀ {xs ys : List A} zs → xs ↭ ys → xs ++ zs ↭ ys ++ zs
-  ++⁺ʳ zs refl          = refl
-  ++⁺ʳ zs (prep x ↭)    = prep x (++⁺ʳ zs ↭)
-  ++⁺ʳ zs (swap x y ↭)  = swap x y (++⁺ʳ zs ↭)
-  ++⁺ʳ zs (trans ↭₁ ↭₂) = trans (++⁺ʳ zs ↭₁) (++⁺ʳ zs ↭₂)
+-- Some useful lemmas
 
-  ++⁺ : _++_ Preserves₂ _↭_ ⟶ _↭_ ⟶ _↭_
-  ++⁺ ws↭xs ys↭zs = trans (++⁺ʳ _ ws↭xs) (++⁺ˡ _ ys↭zs)
+zoom : ∀ h {t xs ys : List A} → xs ↭ ys → h ++ xs ++ t ↭ h ++ ys ++ t
+zoom h {t} = ++⁺ˡ h ∘ ++⁺ʳ t
 
-  -- Some useful lemmas
+inject : ∀  (v : A) {ws xs ys zs} → ws ↭ ys → xs ↭ zs →
+        ws ++ [ v ] ++ xs ↭ ys ++ [ v ] ++ zs
+inject v ws↭ys xs↭zs = trans (++⁺ˡ _ (prep v xs↭zs)) (++⁺ʳ _ ws↭ys)
 
-  zoom : ∀ h {t xs ys : List A} → xs ↭ ys → h ++ xs ++ t ↭ h ++ ys ++ t
-  zoom h {t} = ++⁺ˡ h ∘ ++⁺ʳ t
+shift : ∀ v (xs ys : List A) → xs ++ [ v ] ++ ys ↭ v ∷ xs ++ ys
+shift v []       ys = refl
+shift v (x ∷ xs) ys = begin
+  x ∷ (xs ++ [ v ] ++ ys) <⟨ shift v xs ys ⟩
+  x ∷ v ∷ xs ++ ys        <<⟨ refl ⟩
+  v ∷ x ∷ xs ++ ys        ∎
 
-  inject : ∀  (v : A) {ws xs ys zs} → ws ↭ ys → xs ↭ zs →
-           ws ++ [ v ] ++ xs ↭ ys ++ [ v ] ++ zs
-  inject v ws↭ys xs↭zs = trans (++⁺ˡ _ (prep v xs↭zs)) (++⁺ʳ _ ws↭ys)
-
-  shift : ∀ v (xs ys : List A) → xs ++ [ v ] ++ ys ↭ v ∷ xs ++ ys
-  shift v []       ys = refl
-  shift v (x ∷ xs) ys = begin
-    x ∷ (xs ++ [ v ] ++ ys) <⟨ shift v xs ys ⟩
-    x ∷ v ∷ xs ++ ys        <<⟨ refl ⟩
-    v ∷ x ∷ xs ++ ys        ∎
-
-  drop-mid-≡ : ∀ {x : A} ws xs {ys} {zs} →
-               ws ++ [ x ] ++ ys ≡ xs ++ [ x ] ++ zs →
-               ws ++ ys ↭ xs ++ zs
-  drop-mid-≡ []       []       eq   with cong tail eq
-  drop-mid-≡ []       []       eq   | refl = refl
-  drop-mid-≡ []       (x ∷ xs) refl = shift _ xs _
-  drop-mid-≡ (w ∷ ws) []       refl = ↭-sym (shift _ ws _)
-  drop-mid-≡ (w ∷ ws) (x ∷ xs) eq with Lₚ.∷-injective eq
-  ... | refl , eq′ = prep w (drop-mid-≡ ws xs eq′)
-
-  drop-mid : ∀ {x} ws xs {ys zs} →
-             ws ++ [ x ] ++ ys ↭ xs ++ [ x ] ++ zs →
+drop-mid-≡ : ∀ {x : A} ws xs {ys} {zs} →
+             ws ++ [ x ] ++ ys ≡ xs ++ [ x ] ++ zs →
              ws ++ ys ↭ xs ++ zs
-  drop-mid {x} ws xs p = drop-mid′ p ws xs refl refl
-    where
-    drop-mid′ : ∀ {l′ l″ : List A} → l′ ↭ l″ →
-                ∀ ws xs {ys zs : List A} →
-                ws ++ [ x ] ++ ys ≡ l′ →
-                xs ++ [ x ] ++ zs ≡ l″ →
-                ws ++ ys ↭ xs ++ zs
-    drop-mid′ refl         ws           xs           refl eq   = drop-mid-≡ ws xs (≡.sym eq)
-    drop-mid′ (prep x p)   []           []           refl eq   with cong tail eq
-    drop-mid′ (prep x p)   []           []           refl eq   | refl = p
-    drop-mid′ (prep x p)   []           (x ∷ xs)     refl refl = trans p (shift _ _ _)
-    drop-mid′ (prep x p)   (w ∷ ws)     []           refl refl = trans (↭-sym (shift _ _ _)) p
-    drop-mid′ (prep x p)   (w ∷ ws)     (x ∷ xs)     refl refl = prep _ (drop-mid′ p ws xs refl refl)
-    drop-mid′ (swap y z p) []           []           refl refl = prep _ p
-    drop-mid′ (swap y z p) []           (x ∷ [])     refl eq   with cong {B = List _}
-                                                                         (λ { (x ∷ _ ∷ xs) → x ∷ xs
-                                                                            ; _            → []
-                                                                            })
-                                                                         eq
-    drop-mid′ (swap y z p) []           (x ∷ [])     refl eq   | refl = prep _ p
-    drop-mid′ (swap y z p) []           (x ∷ _ ∷ xs) refl refl = prep _ (trans p (shift _ _ _))
-    drop-mid′ (swap y z p) (w ∷ [])     []           refl eq   with cong tail eq
-    drop-mid′ (swap y z p) (w ∷ [])     []           refl eq   | refl = prep _ p
-    drop-mid′ (swap y z p) (w ∷ x ∷ ws) []           refl refl = prep _ (trans (↭-sym (shift _ _ _)) p)
-    drop-mid′ (swap y y p) (y ∷ [])     (y ∷ [])     refl refl = prep _ p
-    drop-mid′ (swap y z p) (y ∷ [])     (z ∷ y ∷ xs) refl refl = begin
-        _ ∷ _             <⟨ p ⟩
-        _ ∷ (xs ++ _ ∷ _) <⟨ shift _ _ _ ⟩
-        _ ∷ _ ∷ xs ++ _   <<⟨ refl ⟩
-        _ ∷ _ ∷ xs ++ _   ∎
-    drop-mid′ (swap y z p) (y ∷ z ∷ ws) (z ∷ [])     refl refl = begin
-        _ ∷ _ ∷ ws ++ _   <<⟨ refl ⟩
-        _ ∷ (_ ∷ ws ++ _) <⟨ ↭-sym (shift _ _ _) ⟩
-        _ ∷ (ws ++ _ ∷ _) <⟨ p ⟩
-        _ ∷ _             ∎
-    drop-mid′ (swap y z p) (y ∷ z ∷ ws) (z ∷ y ∷ xs) refl refl = swap y z (drop-mid′ p _ _ refl refl)
-    drop-mid′ (trans p₁ p₂) ws  xs refl refl with ∈-∃++ (∈-resp-↭ p₁ (∈-insert ws))
-    ... | (h , t , refl) = trans (drop-mid′ p₁ ws h refl refl) (drop-mid′ p₂ h xs refl refl)
+drop-mid-≡ []       []       eq   with cong tail eq
+drop-mid-≡ []       []       eq   | refl = refl
+drop-mid-≡ []       (x ∷ xs) refl = shift _ xs _
+drop-mid-≡ (w ∷ ws) []       refl = ↭-sym (shift _ ws _)
+drop-mid-≡ (w ∷ ws) (x ∷ xs) eq with Lₚ.∷-injective eq
+... | refl , eq′ = prep w (drop-mid-≡ ws xs eq′)
+  
+drop-mid : ∀ {x : A} ws xs {ys zs} →
+           ws ++ [ x ] ++ ys ↭ xs ++ [ x ] ++ zs →
+           ws ++ ys ↭ xs ++ zs
+drop-mid {A = A} {x} ws xs p = drop-mid′ p ws xs refl refl
+  where
+  drop-mid′ : ∀ {l′ l″ : List A} → l′ ↭ l″ →
+              ∀ ws xs {ys zs} →
+              ws ++ [ x ] ++ ys ≡ l′ →
+              xs ++ [ x ] ++ zs ≡ l″ →
+              ws ++ ys ↭ xs ++ zs
+  drop-mid′ refl         ws           xs           refl eq   = drop-mid-≡ ws xs (≡.sym eq)
+  drop-mid′ (prep x p)   []           []           refl eq   with cong tail eq
+  drop-mid′ (prep x p)   []           []           refl eq   | refl = p
+  drop-mid′ (prep x p)   []           (x ∷ xs)     refl refl = trans p (shift _ _ _)
+  drop-mid′ (prep x p)   (w ∷ ws)     []           refl refl = trans (↭-sym (shift _ _ _)) p
+  drop-mid′ (prep x p)   (w ∷ ws)     (x ∷ xs)     refl refl = prep _ (drop-mid′ p ws xs refl refl)
+  drop-mid′ (swap y z p) []           []           refl refl = prep _ p
+  drop-mid′ (swap y z p) []           (x ∷ [])     refl eq   with cong {B = List _}
+                                                                       (λ { (x ∷ _ ∷ xs) → x ∷ xs
+                                                                          ; _            → []
+                                                                          })
+                                                                       eq
+  drop-mid′ (swap y z p) []           (x ∷ [])     refl eq   | refl = prep _ p
+  drop-mid′ (swap y z p) []           (x ∷ _ ∷ xs) refl refl = prep _ (trans p (shift _ _ _))
+  drop-mid′ (swap y z p) (w ∷ [])     []           refl eq   with cong tail eq
+  drop-mid′ (swap y z p) (w ∷ [])     []           refl eq   | refl = prep _ p
+  drop-mid′ (swap y z p) (w ∷ x ∷ ws) []           refl refl = prep _ (trans (↭-sym (shift _ _ _)) p)
+  drop-mid′ (swap y y p) (y ∷ [])     (y ∷ [])     refl refl = prep _ p
+  drop-mid′ (swap y z p) (y ∷ [])     (z ∷ y ∷ xs) refl refl = begin
+      _ ∷ _             <⟨ p ⟩
+      _ ∷ (xs ++ _ ∷ _) <⟨ shift _ _ _ ⟩
+      _ ∷ _ ∷ xs ++ _   <<⟨ refl ⟩
+      _ ∷ _ ∷ xs ++ _   ∎
+  drop-mid′ (swap y z p) (y ∷ z ∷ ws) (z ∷ [])     refl refl = begin
+      _ ∷ _ ∷ ws ++ _   <<⟨ refl ⟩
+      _ ∷ (_ ∷ ws ++ _) <⟨ ↭-sym (shift _ _ _) ⟩
+      _ ∷ (ws ++ _ ∷ _) <⟨ p ⟩
+      _ ∷ _             ∎
+  drop-mid′ (swap y z p) (y ∷ z ∷ ws) (z ∷ y ∷ xs) refl refl = swap y z (drop-mid′ p _ _ refl refl)
+  drop-mid′ (trans p₁ p₂) ws  xs refl refl with ∈-∃++ (∈-resp-↭ p₁ (∈-insert ws))
+  ... | (h , t , refl) = trans (drop-mid′ p₁ ws h refl refl) (drop-mid′ p₂ h xs refl refl)
 
-  -- Algebraic properties
+-- Algebraic properties
 
-  ++-identityˡ : LeftIdentity {A = List A} _↭_ [] _++_
-  ++-identityˡ xs = refl
+++-identityˡ : LeftIdentity {A = List A} _↭_ [] _++_
+++-identityˡ xs = refl
 
-  ++-identityʳ : RightIdentity {A = List A} _↭_ [] _++_
-  ++-identityʳ xs = ↭-reflexive (Lₚ.++-identityʳ xs)
+++-identityʳ : RightIdentity {A = List A} _↭_ [] _++_
+++-identityʳ xs = ↭-reflexive (Lₚ.++-identityʳ xs)
 
-  ++-identity : Identity {A = List A} _↭_ [] _++_
-  ++-identity = ++-identityˡ , ++-identityʳ
+++-identity : Identity {A = List A} _↭_ [] _++_
+++-identity = ++-identityˡ , ++-identityʳ
 
-  ++-assoc : Associative {A = List A} _↭_ _++_
-  ++-assoc xs ys zs = ↭-reflexive (Lₚ.++-assoc xs ys zs)
+++-assoc : Associative {A = List A} _↭_ _++_
+++-assoc xs ys zs = ↭-reflexive (Lₚ.++-assoc xs ys zs)
 
-  ++-comm : Commutative _↭_ _++_
-  ++-comm []       ys = ↭-sym (++-identityʳ ys)
-  ++-comm (x ∷ xs) ys = begin
-    x ∷ xs ++ ys         ↭⟨ prep x (++-comm xs ys) ⟩
-    x ∷ ys ++ xs         ≡⟨ cong (λ v → x ∷ v ++ xs) (≡.sym (Lₚ.++-identityʳ _)) ⟩
-    (x ∷ ys ++ []) ++ xs ↭⟨ ++⁺ʳ xs (↭-sym (shift x ys [])) ⟩
-    (ys ++ [ x ]) ++ xs  ↭⟨ ++-assoc ys [ x ] xs ⟩
-    ys ++ ([ x ] ++ xs)  ≡⟨⟩
-    ys ++ (x ∷ xs)       ∎
+++-comm : Commutative {A = List A} _↭_ _++_
+++-comm []       ys = ↭-sym (++-identityʳ ys)
+++-comm (x ∷ xs) ys = begin
+  x ∷ xs ++ ys         ↭⟨ prep x (++-comm xs ys) ⟩
+  x ∷ ys ++ xs         ≡⟨ cong (λ v → x ∷ v ++ xs) (≡.sym (Lₚ.++-identityʳ _)) ⟩
+  (x ∷ ys ++ []) ++ xs ↭⟨ ++⁺ʳ xs (↭-sym (shift x ys [])) ⟩
+  (ys ++ [ x ]) ++ xs  ↭⟨ ++-assoc ys [ x ] xs ⟩
+  ys ++ ([ x ] ++ xs)  ≡⟨⟩
+  ys ++ (x ∷ xs)       ∎
 
-  ++-isMagma : IsMagma _↭_ _++_
-  ++-isMagma = record
-    { isEquivalence = ↭-isEquivalence
-    ; ∙-cong        = ++⁺
-    }
+++-isMagma : IsMagma {A = List A} _↭_ _++_
+++-isMagma = record
+  { isEquivalence = ↭-isEquivalence
+  ; ∙-cong        = ++⁺
+  }
+
+++-isSemigroup : IsSemigroup {A = List A} _↭_ _++_
+++-isSemigroup = record
+  { isMagma = ++-isMagma
+  ; assoc   = ++-assoc
+  }
+
+++-isMonoid : IsMonoid {A = List A} _↭_ _++_ []
+++-isMonoid = record
+  { isSemigroup = ++-isSemigroup
+  ; identity    = ++-identity
+  }
+
+++-isCommutativeMonoid : IsCommutativeMonoid {A = List A} _↭_ _++_ []
+++-isCommutativeMonoid = record
+  { isMonoid = ++-isMonoid
+  ; comm     = ++-comm
+  }
+
+module _ {a} {A : Set a} where
 
   ++-magma : Magma _ _
   ++-magma = record
-    { isMagma = ++-isMagma
-    }
-
-  ++-isSemigroup : IsSemigroup _↭_ _++_
-  ++-isSemigroup = record
-    { isMagma = ++-isMagma
-    ; assoc   = ++-assoc
+    { isMagma = ++-isMagma {A = A}
     }
 
   ++-semigroup : Semigroup a _
   ++-semigroup = record
-    { isSemigroup = ++-isSemigroup
-    }
-
-  ++-isMonoid : IsMonoid _↭_ _++_ []
-  ++-isMonoid = record
-    { isSemigroup = ++-isSemigroup
-    ; identity    = ++-identity
+    { isSemigroup = ++-isSemigroup {A = A}
     }
 
   ++-monoid : Monoid a _
   ++-monoid = record
-    { isMonoid = ++-isMonoid
+    { isMonoid = ++-isMonoid {A = A}
     }
-
-  ++-isCommutativeMonoid : IsCommutativeMonoid _↭_ _++_ []
-  ++-isCommutativeMonoid = record
-    { isMonoid = ++-isMonoid
-    ; comm     = ++-comm
-    }
-
+  
   ++-commutativeMonoid : CommutativeMonoid _ _
   ++-commutativeMonoid = record
-    { isCommutativeMonoid = ++-isCommutativeMonoid
+    { isCommutativeMonoid = ++-isCommutativeMonoid {A = A}
     }
 
-  -- Another useful lemma
+-- Another useful lemma
 
-  shifts : ∀ xs ys {zs : List A} → xs ++ ys ++ zs ↭ ys ++ xs ++ zs
-  shifts xs ys {zs} = begin
-     xs ++ ys  ++ zs ↭˘⟨ ++-assoc xs ys zs ⟩
-    (xs ++ ys) ++ zs ↭⟨ ++⁺ʳ zs (++-comm xs ys) ⟩
-    (ys ++ xs) ++ zs ↭⟨ ++-assoc ys xs zs ⟩
-     ys ++ xs  ++ zs ∎
+shifts : ∀ xs ys {zs : List A} → xs ++ ys ++ zs ↭ ys ++ xs ++ zs
+shifts xs ys {zs} = begin
+   xs ++ ys  ++ zs ↭˘⟨ ++-assoc xs ys zs ⟩
+  (xs ++ ys) ++ zs ↭⟨ ++⁺ʳ zs (++-comm xs ys) ⟩
+  (ys ++ xs) ++ zs ↭⟨ ++-assoc ys xs zs ⟩
+   ys ++ xs  ++ zs ∎
 
 ------------------------------------------------------------------------
 -- _∷_
 
-module _ {a} {A : Set a} where
-
-  drop-∷ : ∀ {x : A} {xs ys} → x ∷ xs ↭ x ∷ ys → xs ↭ ys
-  drop-∷ = drop-mid [] []
+drop-∷ : ∀ {x : A} {xs ys} → x ∷ xs ↭ x ∷ ys → xs ↭ ys
+drop-∷ = drop-mid [] []
 
 ------------------------------------------------------------------------
 -- _∷ʳ_
 
-module _ {a} {A : Set a} where
-
-  ∷↭∷ʳ : ∀ (x : A) xs → x ∷ xs ↭ xs ∷ʳ x
-  ∷↭∷ʳ x xs = ↭-sym (begin
-    xs ++ [ x ]   ↭⟨ shift x xs [] ⟩
-    x ∷ xs ++ []  ≡⟨ Lₚ.++-identityʳ _ ⟩
-    x ∷ xs        ∎)
+∷↭∷ʳ : ∀ (x : A) xs → x ∷ xs ↭ xs ∷ʳ x
+∷↭∷ʳ x xs = ↭-sym (begin
+  xs ++ [ x ]   ↭⟨ shift x xs [] ⟩
+  x ∷ xs ++ []  ≡⟨ Lₚ.++-identityʳ _ ⟩
+  x ∷ xs        ∎)
 
 ------------------------------------------------------------------------
 -- ʳ++
 
-module _ {a} {A : Set a} where
-
-  ++↭ʳ++ : ∀ (xs ys : List A) → xs ++ ys ↭ xs ʳ++ ys
-  ++↭ʳ++ []       ys = ↭-refl
-  ++↭ʳ++ (x ∷ xs) ys = ↭-trans (↭-sym (shift x xs ys)) (++↭ʳ++ xs (x ∷ ys))
+++↭ʳ++ : ∀ (xs ys : List A) → xs ++ ys ↭ xs ʳ++ ys
+++↭ʳ++ []       ys = ↭-refl
+++↭ʳ++ (x ∷ xs) ys = ↭-trans (↭-sym (shift x xs ys)) (++↭ʳ++ xs (x ∷ ys))

--- a/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
@@ -157,7 +157,7 @@ drop-mid-≡ []       (x ∷ xs) refl = shift _ xs _
 drop-mid-≡ (w ∷ ws) []       refl = ↭-sym (shift _ ws _)
 drop-mid-≡ (w ∷ ws) (x ∷ xs) eq with Lₚ.∷-injective eq
 ... | refl , eq′ = prep w (drop-mid-≡ ws xs eq′)
-  
+
 drop-mid : ∀ {x : A} ws xs {ys zs} →
            ws ++ [ x ] ++ ys ↭ xs ++ [ x ] ++ zs →
            ws ++ ys ↭ xs ++ zs
@@ -264,7 +264,7 @@ module _ {a} {A : Set a} where
   ++-monoid = record
     { isMonoid = ++-isMonoid {A = A}
     }
-  
+
   ++-commutativeMonoid : CommutativeMonoid _ _
   ++-commutativeMonoid = record
     { isCommutativeMonoid = ++-isCommutativeMonoid {A = A}

--- a/src/Data/List/Relation/Binary/Permutation/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Setoid/Properties.agda
@@ -25,8 +25,6 @@ open import Data.List.Relation.Unary.AllPairs using (AllPairs; []; _∷_)
 import Data.List.Relation.Unary.Unique.Setoid as Unique
 import Data.List.Membership.Setoid as Membership
 open import Data.List.Membership.Setoid.Properties using (∈-∃++; ∈-insert)
-open import Data.List.Relation.Binary.BagAndSetEquality
-  using (bag; _∼[_]_; empty-unique; drop-cons; commutativeMonoid)
 import Data.List.Properties as Lₚ
 open import Data.Nat hiding (_⊔_)
 open import Data.Nat.Induction
@@ -437,3 +435,10 @@ module _ {p} {P : Pred A p} (P? : Decidable P) (P≈ : P Respects _≈_) where
   x ∷ xs ++ []  ≡⟨ Lₚ.++-identityʳ _ ⟩
   x ∷ xs        ∎)
   where open PermutationReasoning
+
+------------------------------------------------------------------------
+-- ʳ++
+
+++↭ʳ++ : ∀ (xs ys : List A) → xs ++ ys ↭ xs ʳ++ ys
+++↭ʳ++ []       ys = ↭-refl
+++↭ʳ++ (x ∷ xs) ys = ↭-trans (↭-sym (shift ≈-refl xs ys)) (++↭ʳ++ xs (x ∷ ys))

--- a/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
@@ -56,7 +56,7 @@ private
 ⊆-refl x∈xs = x∈xs
 
 ⊆-trans : Transitive {A = List A} _⊆_
-⊆-trans xs⊆ys ys⊆zs x∈xs = ys⊆zs (xs⊆ys x∈xs)
+⊆-trans xs⊆ys ys⊆zs = ys⊆zs ∘ xs⊆ys
 
 module _ (A : Set a) where
 
@@ -188,7 +188,9 @@ module _ {xs : List A} {f : ∀ {x} → x ∈ xs → B}
 module _ {P : Pred A p} (P? : Decidable P) where
 
   filter-⊆ : ∀ xs → filter P? xs ⊆ xs
-  filter-⊆ = Setoidₚ.filter⁺ (setoid A) P?
+  filter-⊆ = Setoidₚ.filter-⊆ (setoid A) P?
+
+
 
 ------------------------------------------------------------------------
 -- DEPRECATED

--- a/src/Data/List/Relation/Binary/Subset/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid.agda
@@ -13,6 +13,7 @@ module Data.List.Relation.Binary.Subset.Setoid
 
 open import Data.List.Base using (List)
 open import Data.List.Membership.Setoid S using (_∈_)
+open import Function.Base using (flip)
 open import Level using (_⊔_)
 open import Relation.Nullary using (¬_)
 
@@ -21,10 +22,16 @@ open Setoid S renaming (Carrier to A)
 ------------------------------------------------------------------------
 -- Definitions
 
-infix 4 _⊆_ _⊈_
+infix 4 _⊆_ _⊇_ _⊈_ _⊉_
 
 _⊆_ : Rel (List A) (c ⊔ ℓ)
 xs ⊆ ys = ∀ {x} → x ∈ xs → x ∈ ys
 
+_⊇_ : Rel (List A) (c ⊔ ℓ)
+_⊇_ = flip _⊆_
+
 _⊈_ : Rel (List A) (c ⊔ ℓ)
 xs ⊈ ys = ¬ xs ⊆ ys
+
+_⊉_ : Rel (List A) (c ⊔ ℓ)
+xs ⊉ ys = ¬ xs ⊇ ys

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -25,6 +25,7 @@ open Setoid using (Carrier)
 
 ------------------------------------------------------------------------
 -- Relational properties
+------------------------------------------------------------------------
 
 module _ {a ℓ} (S : Setoid a ℓ) where
 
@@ -78,6 +79,8 @@ module _ {a ℓ} (S : Setoid a ℓ) where
     syntax step-≋˘ xs ys⊆zs xs≋ys = xs ≋˘⟨ xs≋ys ⟩ ys⊆zs
 
 ------------------------------------------------------------------------
+-- Properties of list functions
+------------------------------------------------------------------------
 -- filter
 
 module _ {a p ℓ} (S : Setoid a ℓ)
@@ -86,9 +89,23 @@ module _ {a p ℓ} (S : Setoid a ℓ)
   open Setoid S renaming (Carrier to A)
   open Sublist S
 
-  filter⁺ : ∀ xs → filter P? xs ⊆ xs
-  filter⁺ (x ∷ xs) y∈f[x∷xs] with does (P? x)
-  ... | false = there (filter⁺ xs y∈f[x∷xs])
+  filter-⊆ : ∀ xs → filter P? xs ⊆ xs
+  filter-⊆ (x ∷ xs) y∈f[x∷xs] with does (P? x)
+  ... | false = there (filter-⊆ xs y∈f[x∷xs])
   ... | true  with y∈f[x∷xs]
   ...   | here  y≈x     = here y≈x
-  ...   | there y∈f[xs] = there (filter⁺ xs y∈f[xs])
+  ...   | there y∈f[xs] = there (filter-⊆ xs y∈f[xs])
+
+
+
+------------------------------------------------------------------------
+-- DEPRECATED
+------------------------------------------------------------------------
+
+-- Version 1.5
+
+filter⁺ = filter-⊆
+{-# WARNING_ON_USAGE filter⁺
+"Warning: filter⁺ was deprecated in v1.5.
+Please use filter-⊆ instead."
+#-}

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -12,25 +12,35 @@ module Data.List.Relation.Binary.Subset.Setoid.Properties where
 
 open import Data.Bool.Base using (Bool; true; false)
 open import Data.List.Base
-open import Data.List.Relation.Unary.Any using (here; there)
+open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
+open import Data.List.Relation.Unary.All as All using (All)
 import Data.List.Membership.Setoid as Membership
 open import Data.List.Membership.Setoid.Properties
 import Data.List.Relation.Binary.Subset.Setoid as Sublist
 import Data.List.Relation.Binary.Equality.Setoid as Equality
+import Data.List.Relation.Binary.Permutation.Setoid as Permutation
+import Data.List.Relation.Binary.Permutation.Setoid.Properties as Permutationₚ
+open import Data.Product using (_,_)
+open import Function.Base using (_∘_; _∘₂_)
+open import Level using (Level)
 open import Relation.Nullary using (¬_; does)
 open import Relation.Unary using (Pred; Decidable)
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 
 open Setoid using (Carrier)
 
+private
+  variable
+    a p ℓ : Level
+
 ------------------------------------------------------------------------
--- Relational properties
+-- Relational properties with _≋_ (pointwise equality)
 ------------------------------------------------------------------------
 
-module _ {a ℓ} (S : Setoid a ℓ) where
+module _ (S : Setoid a ℓ) where
 
-  open Equality S
   open Sublist S
+  open Equality S
   open Membership S
 
   ⊆-reflexive : _≋_ ⇒ _⊆_
@@ -41,6 +51,12 @@ module _ {a ℓ} (S : Setoid a ℓ) where
 
   ⊆-trans : Transitive _⊆_
   ⊆-trans xs⊆ys ys⊆zs x∈xs = ys⊆zs (xs⊆ys x∈xs)
+
+  ⊆-respʳ-≋ : _⊆_ Respectsʳ _≋_
+  ⊆-respʳ-≋ xs≋ys = ∈-resp-≋ S xs≋ys ∘_
+
+  ⊆-respˡ-≋ : _⊆_ Respectsˡ _≋_
+  ⊆-respˡ-≋ xs≋ys = _∘ ∈-resp-≋ S (≋-sym xs≋ys)
 
   ⊆-isPreorder : IsPreorder _≋_ _⊆_
   ⊆-isPreorder = record
@@ -54,39 +70,120 @@ module _ {a ℓ} (S : Setoid a ℓ) where
     { isPreorder = ⊆-isPreorder
     }
 
-  -- Reasoning over subsets
-  module ⊆-Reasoning where
-    private
-      module Base = PreorderReasoning ⊆-preorder
+------------------------------------------------------------------------
+-- Relational properties with _↭_ (permutations)
+------------------------------------------------------------------------
 
-    open Base public
-      hiding (step-∼; step-≈; step-≈˘)
-      renaming (_≈⟨⟩_ to _≋⟨⟩_)
+module _ (S : Setoid a ℓ) where
 
-    infix 2 step-⊆ step-≋ step-≋˘
-    infix 1 step-∈
+  open Sublist S
+  open Permutation S
+  open Membership S
 
-    step-∈ : ∀ x {xs ys} → xs IsRelatedTo ys → x ∈ xs → x ∈ ys
-    step-∈ x xs⊆ys x∈xs = (begin xs⊆ys) x∈xs
+  ↭⇒⊆ : _↭_ ⇒ _⊆_
+  ↭⇒⊆ xs↭ys = Permutationₚ.∈-resp-↭ S xs↭ys
 
-    step-⊆  = Base.step-∼
-    step-≋  = Base.step-≈
-    step-≋˘ = Base.step-≈˘
+  ⊆-respʳ-↭ : _⊆_ Respectsʳ _↭_
+  ⊆-respʳ-↭ xs↭ys = Permutationₚ.∈-resp-↭ S xs↭ys ∘_
 
-    syntax step-∈  x  xs⊆ys x∈xs  = x  ∈⟨  x∈xs  ⟩ xs⊆ys
-    syntax step-⊆  xs ys⊆zs xs⊆ys = xs ⊆⟨  xs⊆ys ⟩ ys⊆zs
-    syntax step-≋  xs ys⊆zs xs≋ys = xs ≋⟨  xs≋ys ⟩ ys⊆zs
-    syntax step-≋˘ xs ys⊆zs xs≋ys = xs ≋˘⟨ xs≋ys ⟩ ys⊆zs
+  ⊆-respˡ-↭ : _⊆_ Respectsˡ _↭_
+  ⊆-respˡ-↭ xs↭ys = _∘ Permutationₚ.∈-resp-↭ S (↭-sym xs↭ys)
+
+  ⊆-↭-isPreorder : IsPreorder _↭_ _⊆_
+  ⊆-↭-isPreorder = record
+    { isEquivalence = ↭-isEquivalence
+    ; reflexive     = ↭⇒⊆
+    ; trans         = ⊆-trans S
+    }
+
+  ⊆-↭-preorder : Preorder _ _ _
+  ⊆-↭-preorder = record
+    { isPreorder = ⊆-↭-isPreorder
+    }
+
+------------------------------------------------------------------------
+-- Reasoning over subsets
+------------------------------------------------------------------------
+
+module ⊆-Reasoning (S : Setoid a ℓ) where
+
+  open Setoid S renaming (Carrier to A)
+  open Sublist S
+  open Membership S
+
+  private
+    module Base = PreorderReasoning (⊆-preorder S)
+
+  open Base public
+    hiding (step-∼; step-≈; step-≈˘)
+    renaming (_≈⟨⟩_ to _≋⟨⟩_)
+
+  infix 2 step-⊆ step-≋ step-≋˘
+  infix 1 step-∈
+
+  step-∈ : ∀ x {xs ys} → xs IsRelatedTo ys → x ∈ xs → x ∈ ys
+  step-∈ x xs⊆ys x∈xs = (begin xs⊆ys) x∈xs
+
+  step-⊆  = Base.step-∼
+  step-≋  = Base.step-≈
+  step-≋˘ = Base.step-≈˘
+
+  syntax step-∈  x  xs⊆ys x∈xs  = x  ∈⟨  x∈xs  ⟩ xs⊆ys
+  syntax step-⊆  xs ys⊆zs xs⊆ys = xs ⊆⟨  xs⊆ys ⟩ ys⊆zs
+  syntax step-≋  xs ys⊆zs xs≋ys = xs ≋⟨  xs≋ys ⟩ ys⊆zs
+  syntax step-≋˘ xs ys⊆zs xs≋ys = xs ≋˘⟨ xs≋ys ⟩ ys⊆zs
+
+------------------------------------------------------------------------
+-- Relationship with predicates
+------------------------------------------------------------------------
+
+module _ (S : Setoid a ℓ) where
+
+  open Setoid S renaming (Carrier to A)
+  open Sublist S
+  open Membership S
+
+  Any-resp-⊆ : ∀ {P : Pred A p} → P Respects _≈_ → (Any P) Respects _⊆_
+  Any-resp-⊆ resp ⊆ pxs with find pxs
+  ... | (x , x∈xs , px) = lose resp (⊆ x∈xs) px
+
+  All-resp-⊇ : ∀ {P : Pred A p} → P Respects _≈_ → (All P) Respects _⊇_
+  All-resp-⊇ resp ⊇ pxs = All.tabulateₛ S (All.lookupₛ S resp pxs ∘ ⊇)
 
 ------------------------------------------------------------------------
 -- Properties of list functions
 ------------------------------------------------------------------------
+-- ++
+
+module _ (S : Setoid a ℓ) where
+
+  open Sublist S
+  open Membership S
+
+  xs⊆xs++ys : ∀ xs ys → xs ⊆ xs ++ ys
+  xs⊆xs++ys xs ys = ∈-++⁺ˡ S
+
+  xs⊆ys++xs : ∀ xs ys → xs ⊆ ys ++ xs
+  xs⊆ys++xs xs ys = ∈-++⁺ʳ S _
+
+  ++⁺ʳ : ∀ {xs ys} zs → xs ⊆ ys → zs ++ xs ⊆ zs ++ ys
+  ++⁺ʳ []       xs⊆ys           = xs⊆ys
+  ++⁺ʳ (x ∷ zs) xs⊆ys (here p)  = here p
+  ++⁺ʳ (x ∷ zs) xs⊆ys (there p) = there (++⁺ʳ zs xs⊆ys p)
+
+  ++⁺ˡ : ∀ {xs ys} zs → xs ⊆ ys → xs ++ zs ⊆ ys ++ zs
+  ++⁺ˡ {[]}     {ys} zs xs⊆ys           = xs⊆ys++xs zs ys
+  ++⁺ˡ {x ∷ xs} {ys} zs xs⊆ys (here  p) = xs⊆xs++ys ys zs (xs⊆ys (here p))
+  ++⁺ˡ {x ∷ xs} {ys} zs xs⊆ys (there p) = ++⁺ˡ zs (xs⊆ys ∘ there) p
+
+  ++⁺ : ∀ {ws xs ys zs} → ws ⊆ xs → ys ⊆ zs → ws ++ ys ⊆ xs ++ zs
+  ++⁺ ws⊆xs ys⊆zs = ⊆-trans S (++⁺ˡ _ ws⊆xs) (++⁺ʳ _ ys⊆zs)
+
+------------------------------------------------------------------------
 -- filter
 
-module _ {a p ℓ} (S : Setoid a ℓ)
-         {P : Pred (Carrier S) p} (P? : Decidable P) where
+module _ (S : Setoid a ℓ) {P : Pred (Carrier S) p} (P? : Decidable P) where
 
-  open Setoid S renaming (Carrier to A)
   open Sublist S
 
   filter-⊆ : ∀ xs → filter P? xs ⊆ xs


### PR DESCRIPTION
- Updated names to match current conventions
- Added a bunch of new properties

Some small problems with `BagAndSetEquality` causing cyclic imports, as it fails to follow the conventions of the other binary relations in this part of the library. That module has needed sorting out for many years, and I _almost_ had the willpower to do it this time.... however, in the end I took the easy route out and contained it's craziness by moving `↭⇒∼bag` and `∼bag⇒↭` from
`Data.List.Relation.Binary.Permutation.Setoid.Properties` to `Data.List.Relation.Binary.BagAndSetEquality`