### PR TITLE
[ refactor ] IO module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Non-backwards compatible changes
   were causing cyclic import dependencies.
 
 * Clean up of `IO` to make it more friendly:
-  + Renamed `_>>=_` and `_>>_` to `_‵bind‵_` and `_‵seq‵_` respectively to free up the names
+  + Renamed `_>>=_` and `_>>_` to `bind` and `seq` respectively to free up the names
     for `do`-notation friendly combinators.
   + Introduced `Colist` and `List` modules for the various `sequence` and `mapM` functions.
     This breaks code that relied on the `Colist`-specific function being exported as part of `IO`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,13 @@ Non-backwards compatible changes
   to `Data.List.Relation.Binary.BagAndSetEquality` as their current location
   were causing cyclic import dependencies.
 
+* Clean up of `IO` to make it more friendly:
+  + Renamed `_>>=_` and `_>>_` to `_‵bind‵_` and `_‵seq‵_` respectively to free up the names
+    for `do`-notation friendly combinators.
+  + Introduced `Colist` and `List` modules for the various `sequence` and `mapM` functions.
+    This breaks code that relied on the `Colist`-specific function being exported as part of `IO`.
+
+
 Deprecated modules
 ------------------
 
@@ -388,4 +395,9 @@ Other minor additions
   ```agda
   function : Func S S
   id-⟶     : A ⟶ A
+  ```
+
+* Added new function to `Data.String.Base`:
+  ```agda
+  lines : String → List String
   ```

--- a/README/Foreign/Haskell.agda
+++ b/README/Foreign/Haskell.agda
@@ -88,11 +88,11 @@ open import Relation.Nullary.Negation
 
 -- example program using uncons, catMaybes, and testChar
 
-main = run $
-  ♯ readFiniteFile "README/Foreign/Haskell.agda" {- read this file -} >>= λ f →
-  ♯ let chars   = toList f in
-    let cleanup = catMaybes ∘ List.map (λ c → if testChar c then just c else nothing) in
-    let cleaned = dropWhile ('\n' ≟_) $ cleanup chars in
+main = run $ do
+  content ← readFiniteFile "README/Foreign/Haskell.agda"
+  let chars = toList content
+  let cleanup = catMaybes ∘ List.map (λ c → if testChar c then just c else nothing)
+  let cleaned = dropWhile ('\n' ≟_) $ cleanup chars
   case uncons cleaned of λ where
     nothing         → putStrLn "I cannot believe this file is filed with dashes only!"
     (just (c , cs)) → putStrLn $ unlines

--- a/README/IO.agda
+++ b/README/IO.agda
@@ -57,4 +57,4 @@ open import Data.Unit.Polymorphic.Base
 -- you reach the end!
 isFinite : ∀ {a} {A : Set a} → Colist A → IO Bool
 isFinite []       = return true
-isFinite (x ∷ xs) = ♯ return tt ‵seq‵ ♯ isFinite (♭ xs)
+isFinite (x ∷ xs) = seq (♯ return tt) (♯ isFinite (♭ xs))

--- a/README/IO.agda
+++ b/README/IO.agda
@@ -1,0 +1,60 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Simple examples of programs using IO
+------------------------------------------------------------------------
+
+{-# OPTIONS --guardedness #-}
+
+module README.IO where
+
+open import Data.Nat.Base
+open import Data.Nat.Show using (show)
+open import Data.String.Base using (String; lines)
+open import Function.Base using (_$_)
+open import IO
+open import System.Environment
+
+------------------------------------------------------------------------
+-- NO GUARDEDNESS
+
+-- If you do not need to rely on guardedness for the function to be seen as
+-- terminating (for instance because it is structural in an inductive argument)
+-- then you can use `do` notations to write fairly readable programs.
+
+-- Countdown to explosion
+countdown : ℕ → IO _
+countdown zero      = putStrLn "BOOM!"
+countdown m@(suc n) = do
+  let str = show m
+  putStrLn str
+  countdown n
+
+-- cat the content of a finite file
+cat : String → IO _
+cat fp = do
+  content ← readFiniteFile fp
+  let ls = lines content
+  List.mapM′ putStrLn ls
+
+open import Codata.Musical.Notation
+open import Codata.Musical.Colist
+open import Data.Bool
+open import Data.Unit.Polymorphic.Base
+
+------------------------------------------------------------------------
+-- GUARDEDNESS
+
+-- If you are performing coinduction on a potentially infinite piece of codata
+-- then you need to rely on guardedness. That is to say that the coinductive
+-- call needs to be obviously under a coinductive constructor and guarded by a
+-- sharp (♯_).
+-- In this case you cannot use the convenient combinators that make `do`-notations
+-- and have to revert back to the underlying coinductive constructors.
+
+
+-- Whether a colist is finite is semi decidable: just let the user wait until
+-- you reach the end!
+isFinite : ∀ {a} {A : Set a} → Colist A → IO Bool
+isFinite []       = return true
+isFinite (x ∷ xs) = ♯ return tt ‵seq‵ ♯ isFinite (♭ xs)

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -89,9 +89,6 @@ intersperse sep = concat ∘′ (List.intersperse sep)
 
 -- String-specific functions
 
-unlines : List String → String
-unlines = intersperse "\n"
-
 wordsBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
 wordsBy P? = List.map fromList ∘ List.wordsBy P? ∘ toList
 
@@ -100,6 +97,12 @@ words = wordsBy (T? ∘ Char.isSpace)
 
 unwords : List String → String
 unwords = intersperse " "
+
+lines : String → List String
+lines = wordsBy ('\n' Char.≟_)
+
+unlines : List String → String
+unlines = intersperse "\n"
 
 parens : String → String
 parens s = "(" ++ s ++ ")"

--- a/src/IO.agda
+++ b/src/IO.agda
@@ -41,10 +41,13 @@ pure = return
 
 module _ {A B : Set a} where
 
-  infixl 1 _<*>_ _>>=_ _>>_
+  infixl 1 _<$>_ _<*>_ _>>=_ _>>_
 
   _<*>_ : IO (A → B) → IO A → IO B
   mf <*> mx = bind (♯ mf) λ f → ♯ (bind (♯ mx) λ x → ♯ pure (f x))
+
+  _<$>_ : (A → B) → IO A → IO B
+  f <$> m = pure f <*> m
 
   _>>=_ : IO A → (A → IO B) → IO B
   m >>= f = bind (♯ m) λ x → ♯ f x


### PR DESCRIPTION
Once again: given that sized IO is not around the corner, we may as
well make the best of what we have. This means making it easier to
use `do`-notations when we don't actually need to rely on guardedness.