### PR TITLE
Update variable policy in style guide

### DIFF
--- a/fix-whitespace.yaml
+++ b/fix-whitespace.yaml
@@ -9,4 +9,4 @@ included-files:
 
 excluded-files:
   - "README/Text/Tabular.agda"
-
+  - CHANGELOG.md

--- a/notes/style-guide.md
+++ b/notes/style-guide.md
@@ -327,7 +327,7 @@ line of code, indented by two spaces.
   predicates are not used in the definition of `List`, even though they are used
   in may list functions such as `filter`.
 
-* Example 2: the main type in `Data.List.Relation.Unary.All` is `Any P xs` where
+* Example 2: the main type in `Data.List.Relation.Unary.All` is `All P xs` where
   `A : Set a`, `P : Pred A p`, `xs : List A`. It therefore may declare variables
   over `Level`, `Set a`, `A`, `List A`, `Pred A p`. It may not declare, for example,
   variables of type `Rel` or `Vec`.

--- a/notes/style-guide.md
+++ b/notes/style-guide.md
@@ -311,10 +311,21 @@ line of code, indented by two spaces.
 * If there are lots of implicit arguments that are common to a collection
   of proofs they should be extracted by using an anonymous module.
 
-* Implicit of type `Level` and `Set` can be generalized using the keyword
-  `variable`. At the moment the policy is *not* to generalize over any other
-  types to minimize the amount of information that users have to keep in
-  their head concurrently.
+#### Variables
+
+* `Level` and `Set`s can always be generalized using the keyword `variable`.
+
+* A file may only declare variables of other types if those types are used
+  in the definition of the main type that the file concerns itself with.
+  At the moment the policy is *not* to generalize over any other types to
+  minimize the amount of information that users have to keep in their head
+  concurrently.
+
+* Example: the main type in `Data.List.Properties` is `List A` where `A : Set a`.
+  Therefore it may declare variables over `Level`, `Set a`, `A`, `List A`. It may
+  not declare variables over predicates (e.g. `P : Pred A l`) as predicates are
+  not used in the definition of `List`, even though they are used in may list
+  functions such as `filter`.
 
 ## Naming conventions
 

--- a/notes/style-guide.md
+++ b/notes/style-guide.md
@@ -321,11 +321,16 @@ line of code, indented by two spaces.
   minimize the amount of information that users have to keep in their head
   concurrently.
 
-* Example: the main type in `Data.List.Properties` is `List A` where `A : Set a`.
+* Example 1: the main type in `Data.List.Properties` is `List A` where `A : Set a`.
   Therefore it may declare variables over `Level`, `Set a`, `A`, `List A`. It may
-  not declare variables over predicates (e.g. `P : Pred A l`) as predicates are
-  not used in the definition of `List`, even though they are used in may list
-  functions such as `filter`.
+  not declare variables, for example, over predicates (e.g. `P : Pred A p`) as
+  predicates are not used in the definition of `List`, even though they are used
+  in may list functions such as `filter`.
+
+* Example 2: the main type in `Data.List.Relation.Unary.All` is `Any P xs` where
+  `A : Set a`, `P : Pred A p`, `xs : List A`. It therefore may declare variables
+  over `Level`, `Set a`, `A`, `List A`, `Pred A p`. It may not declare, for example,
+  variables of type `Rel` or `Vec`.
 
 ## Naming conventions
 

--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -31,6 +31,9 @@ private
     a b p q r ℓ : Level
     A : Set a
     B : Set b
+    P Q R : Pred A p
+    x : A
+    xs : List A
 
 ------------------------------------------------------------------------
 -- Definitions
@@ -67,68 +70,58 @@ Null = All (λ _ → ⊥)
 ------------------------------------------------------------------------
 -- Operations on All
 
-module _ {P : Pred A p} where
+uncons : All P (x ∷ xs) → P x × All P xs
+uncons (px ∷ pxs) = px , pxs
 
-  uncons : ∀ {x xs} → All P (x ∷ xs) → P x × All P xs
-  uncons (px ∷ pxs) = px , pxs
+head : All P (x ∷ xs) → P x
+head = proj₁ ∘ uncons
 
-  head : ∀ {x xs} → All P (x ∷ xs) → P x
-  head = proj₁ ∘ uncons
+tail : All P (x ∷ xs) → All P xs
+tail = proj₂ ∘ uncons
 
-  tail : ∀ {x xs} → All P (x ∷ xs) → All P xs
-  tail = proj₂ ∘ uncons
+reduce : (f : ∀ {x} → P x → B) → All P xs → List B
+reduce f []         = []
+reduce f (px ∷ pxs) = f px ∷ reduce f pxs
 
-  reduce : (f : ∀ {x} → P x → B) → ∀ {xs} → All P xs → List B
-  reduce f []         = []
-  reduce f (px ∷ pxs) = f px ∷ reduce f pxs
+construct : (f : B → ∃ P) (xs : List B) → ∃ (All P)
+construct f []       = [] , []
+construct f (x ∷ xs) = Prod.zip _∷_ _∷_ (f x) (construct f xs)
 
-  construct : (f : B → ∃ P) (xs : List B) → ∃ (All P)
-  construct f []       = [] , []
-  construct f (x ∷ xs) = Prod.zip _∷_ _∷_ (f x) (construct f xs)
+fromList : (xs : List (∃ P)) → All P (List.map proj₁ xs)
+fromList []              = []
+fromList ((x , p) ∷ xps) = p ∷ fromList xps
 
-  fromList : (xs : List (∃ P)) → All P (List.map proj₁ xs)
-  fromList []              = []
-  fromList ((x , p) ∷ xps) = p ∷ fromList xps
+toList : All P xs → List (∃ P)
+toList pxs = reduce (λ {x} px → x , px) pxs
 
-  toList : ∀ {xs} → All P xs → List (∃ P)
-  toList pxs = reduce (λ {x} px → x , px) pxs
+map : P ⊆ Q → All P ⊆ All Q
+map g []         = []
+map g (px ∷ pxs) = g px ∷ map g pxs
 
-module _ {P : Pred A p} {Q : Pred A q} where
+zipWith : P ∩ Q ⊆ R → All P ∩ All Q ⊆ All R
+zipWith f ([] , [])             = []
+zipWith f (px ∷ pxs , qx ∷ qxs) = f (px , qx) ∷ zipWith f (pxs , qxs)
 
-  map : P ⊆ Q → All P ⊆ All Q
-  map g []         = []
-  map g (px ∷ pxs) = g px ∷ map g pxs
+unzipWith : R ⊆ P ∩ Q → All R ⊆ All P ∩ All Q
+unzipWith f []         = [] , []
+unzipWith f (rx ∷ rxs) = Prod.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
 
-module _ {P : Pred A p} {Q : Pred A q} {R : Pred A r} where
+zip : All P ∩ All Q ⊆ All (P ∩ Q)
+zip = zipWith id
 
-  zipWith : P ∩ Q ⊆ R → All P ∩ All Q ⊆ All R
-  zipWith f ([] , [])             = []
-  zipWith f (px ∷ pxs , qx ∷ qxs) = f (px , qx) ∷ zipWith f (pxs , qxs)
-
-  unzipWith : R ⊆ P ∩ Q → All R ⊆ All P ∩ All Q
-  unzipWith f []         = [] , []
-  unzipWith f (rx ∷ rxs) = Prod.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
-
-module _ {P : Pred A p} {Q : Pred A q} where
-
-  zip : All P ∩ All Q ⊆ All (P ∩ Q)
-  zip = zipWith id
-
-  unzip : All (P ∩ Q) ⊆ All P ∩ All Q
-  unzip = unzipWith id
+unzip : All (P ∩ Q) ⊆ All P ∩ All Q
+unzip = unzipWith id
 
 module _(S : Setoid a ℓ) {P : Pred (Setoid.Carrier S) p} where
   open Setoid S renaming (Carrier to C; refl to refl₁)
   open SetoidMembership S
 
-  tabulateₛ : ∀ {xs} → (∀ {x} → x ∈ xs → P x) → All P xs
+  tabulateₛ : (∀ {x} → x ∈ xs → P x) → All P xs
   tabulateₛ {[]}     hyp = []
   tabulateₛ {x ∷ xs} hyp = hyp (here refl₁) ∷ tabulateₛ (hyp ∘ there)
 
-module _ {P : Pred A p} where
-
-  tabulate : ∀ {xs} → (∀ {x} → x ∈ₚ xs → P x) → All P xs
-  tabulate = tabulateₛ (P.setoid A)
+tabulate : (∀ {x} → x ∈ₚ xs → P x) → All P xs
+tabulate = tabulateₛ (P.setoid _)
 
 self : ∀ {xs : List A} → All (const A) xs
 self = tabulate (λ {x} _ → x)
@@ -136,20 +129,18 @@ self = tabulate (λ {x} _ → x)
 ------------------------------------------------------------------------
 -- (weak) updateAt
 
-module _ {P : Pred A p} where
+infixl 6 _[_]%=_ _[_]≔_
 
-  infixl 6 _[_]%=_ _[_]≔_
+updateAt : x ∈ₚ xs → (P x → P x) → All P xs → All P xs
+updateAt () f []
+updateAt (here refl) f (px ∷ pxs) = f px ∷ pxs
+updateAt (there i)   f (px ∷ pxs) =   px ∷ updateAt i f pxs
 
-  updateAt : ∀ {x xs} → x ∈ₚ xs → (P x → P x) → All P xs → All P xs
-  updateAt () f []
-  updateAt (here refl) f (px ∷ pxs) = f px ∷ pxs
-  updateAt (there i)   f (px ∷ pxs) =   px ∷ updateAt i f pxs
+_[_]%=_ : All P xs → x ∈ₚ xs → (P x → P x) → All P xs
+pxs [ i ]%= f = updateAt i f pxs
 
-  _[_]%=_ : ∀ {x xs} → All P xs → x ∈ₚ xs → (P x → P x) → All P xs
-  pxs [ i ]%= f = updateAt i f pxs
-
-  _[_]≔_ : ∀ {x xs} → All P xs → x ∈ₚ xs → P x → All P xs
-  pxs [ i ]≔ px = pxs [ i ]%= const px
+_[_]≔_ : All P xs → x ∈ₚ xs → P x → All P xs
+pxs [ i ]≔ px = pxs [ i ]%= const px
 
 ------------------------------------------------------------------------
 -- Traversable-like functions
@@ -168,7 +159,7 @@ module _ (p : Level) {A : Set a} {P : Pred A (a ⊔ p)}
   mapA : ∀ {Q : Pred A q} → (Q ⊆ F ∘′ P) → All Q ⊆ (F ∘′ All P)
   mapA f = sequenceA ∘′ map f
 
-  forA : ∀ {Q : Pred A q} {xs} → All Q xs → (Q ⊆ F ∘′ P) → F (All P xs)
+  forA : ∀ {Q : Pred A q} → All Q xs → (Q ⊆ F ∘′ P) → F (All P xs)
   forA qxs f = mapA f qxs
 
 module _ (p : Level) {A : Set a} {P : Pred A (a ⊔ p)}
@@ -184,56 +175,56 @@ module _ (p : Level) {A : Set a} {P : Pred A (a ⊔ p)}
   mapM : ∀ {Q : Pred A q} → (Q ⊆ M ∘′ P) → All Q ⊆ (M ∘′ All P)
   mapM = mapA p App
 
-  forM : ∀ {Q : Pred A q} {xs} → All Q xs → (Q ⊆ M ∘′ P) → M (All P xs)
+  forM : ∀ {Q : Pred A q} → All Q xs → (Q ⊆ M ∘′ P) → M (All P xs)
   forM = forA p App
 
 ------------------------------------------------------------------------
 -- Generalised lookup based on a proof of Any
 
-module _ {P : Pred A p} {Q : Pred A q} where
+lookupAny : All P xs → (i : Any Q xs) → (P ∩ Q) (Any.lookup i)
+lookupAny (px ∷ pxs) (here qx) = px , qx
+lookupAny (px ∷ pxs) (there i) = lookupAny pxs i
 
-  lookupAny : ∀ {xs} → All P xs → (i : Any Q xs) → (P ∩ Q) (Any.lookup i)
-  lookupAny (px ∷ pxs) (here qx) = px , qx
-  lookupAny (px ∷ pxs) (there i) = lookupAny pxs i
+lookupWith : ∀[ P ⇒ Q ⇒ R ] → All P xs → (i : Any Q xs) → R (Any.lookup i)
+lookupWith f pxs i = Prod.uncurry f (lookupAny pxs i)
 
-module _ {P : Pred A p} {Q : Pred A q} {R : Pred A r} where
-
-  lookupWith : ∀[ P ⇒ Q ⇒ R ] → ∀ {xs} → All P xs → (i : Any Q xs) →
-               R (Any.lookup i)
-  lookupWith f pxs i = Prod.uncurry f (lookupAny pxs i)
-
-module _ {P : Pred A p} where
-
-  lookup : ∀ {xs} → All P xs → (∀ {x} → x ∈ₚ xs → P x)
-  lookup pxs = lookupWith (λ { px refl → px }) pxs
+lookup : All P xs → (∀ {x} → x ∈ₚ xs → P x)
+lookup pxs = lookupWith (λ { px refl → px }) pxs
 
 module _(S : Setoid a ℓ) {P : Pred (Setoid.Carrier S) p} where
   open Setoid S renaming (sym to sym₁)
   open SetoidMembership S
 
-  lookupₛ : ∀ {xs} → P Respects _≈_ → All P xs → (∀ {x} → x ∈ xs → P x)
+  lookupₛ : P Respects _≈_ → All P xs → (∀ {x} → x ∈ xs → P x)
   lookupₛ resp pxs = lookupWith (λ py x=y → resp (sym₁ x=y) py) pxs
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by All
 
-module _ {P : Pred A p} where
+all? : Decidable P → Decidable (All P)
+all? p []       = yes []
+all? p (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (p x ×-dec all? p xs)
 
-  all? : Decidable P → Decidable (All P)
-  all? p []       = yes []
-  all? p (x ∷ xs) = Dec.map′ (uncurry _∷_) uncons (p x ×-dec all? p xs)
+universal : Universal P → Universal (All P)
+universal u []       = []
+universal u (x ∷ xs) = u x ∷ universal u xs
 
-  universal : Universal P → Universal (All P)
-  universal u []       = []
-  universal u (x ∷ xs) = u x ∷ universal u xs
+irrelevant : Irrelevant P → Irrelevant (All P)
+irrelevant irr []           []           = P.refl
+irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
+  P.cong₂ _∷_ (irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)
 
-  irrelevant : Irrelevant P → Irrelevant (All P)
-  irrelevant irr []           []           = P.refl
-  irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
-    P.cong₂ _∷_ (irr px₁ px₂) (irrelevant irr pxs₁ pxs₂)
+satisfiable : Satisfiable (All P)
+satisfiable = [] , []
 
-  satisfiable : Satisfiable (All P)
-  satisfiable = [] , []
+
+------------------------------------------------------------------------
+-- DEPRECATED
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.4
 
 all = all?
 {-# WARNING_ON_USAGE all

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -52,82 +52,84 @@ private
     A : Set a
     B : Set b
     C : Set c
+    P : Pred A p
+    Q : Pred B q
+    R : Pred C r
+    x y : A
+    xs ys : List A
 
 ------------------------------------------------------------------------
 -- Properties regarding Null
 
-Null⇒null : ∀ {xs : List A} → Null xs → T (null xs)
+Null⇒null : Null xs → T (null xs)
 Null⇒null [] = _
 
-null⇒Null : ∀ {xs : List A} → T (null xs) → Null xs
+null⇒Null : T (null xs) → Null xs
 null⇒Null {xs = []   } _ = []
 null⇒Null {xs = _ ∷ _} ()
 
 ------------------------------------------------------------------------
 -- Properties of the "points-to" relation _[_]=_
 
-module _ {p} {P : Pred A p} where
+-- Relation _[_]=_ is deterministic: each index points to a single value.
 
-  -- Relation _[_]=_ is deterministic: each index points to a single value.
+[]=-injective : ∀ {px qx : P x} {pxs : All P xs} {i : x ∈ xs} →
+                pxs [ i ]= px →
+                pxs [ i ]= qx →
+                px ≡ qx
+[]=-injective here          here          = refl
+[]=-injective (there x↦px) (there x↦qx) = []=-injective x↦px x↦qx
 
-  []=-injective : ∀ {x xs} {px qx : P x} {pxs : All P xs} {i : x ∈ xs} →
-                  pxs [ i ]= px →
-                  pxs [ i ]= qx →
-                  px ≡ qx
-  []=-injective here          here          = refl
-  []=-injective (there x↦px) (there x↦qx) = []=-injective x↦px x↦qx
-
-  -- See also Data.List.Relation.Unary.All.Properties.WithK.[]=-irrelevant.
+-- See also Data.List.Relation.Unary.All.Properties.WithK.[]=-irrelevant.
 
 ------------------------------------------------------------------------
 -- Lemmas relating Any, All and negation.
 
-module _ {P : A → Set p} where
+¬Any⇒All¬ : ∀ xs → ¬ Any P xs → All (¬_ ∘ P) xs
+¬Any⇒All¬ []       ¬p = []
+¬Any⇒All¬ (x ∷ xs) ¬p = ¬p ∘ here ∷ ¬Any⇒All¬ xs (¬p ∘ there)
 
-  ¬Any⇒All¬ : ∀ xs → ¬ Any P xs → All (¬_ ∘ P) xs
-  ¬Any⇒All¬ []       ¬p = []
-  ¬Any⇒All¬ (x ∷ xs) ¬p = ¬p ∘ here ∷ ¬Any⇒All¬ xs (¬p ∘ there)
+All¬⇒¬Any : ∀ {xs} → All (¬_ ∘ P) xs → ¬ Any P xs
+All¬⇒¬Any (¬p ∷ _)  (here  p) = ¬p p
+All¬⇒¬Any (_  ∷ ¬p) (there p) = All¬⇒¬Any ¬p p
 
-  All¬⇒¬Any : ∀ {xs} → All (¬_ ∘ P) xs → ¬ Any P xs
-  All¬⇒¬Any (¬p ∷ _)  (here  p) = ¬p p
-  All¬⇒¬Any (_  ∷ ¬p) (there p) = All¬⇒¬Any ¬p p
+¬All⇒Any¬ : Decidable P → ∀ xs → ¬ All P xs → Any (¬_ ∘ P) xs
+¬All⇒Any¬ dec []       ¬∀ = ⊥-elim (¬∀ [])
+¬All⇒Any¬ dec (x ∷ xs) ¬∀ with dec x
+... |  true because  [p] = there (¬All⇒Any¬ dec xs (¬∀ ∘ _∷_ (invert [p])))
+... | false because [¬p] = here (invert [¬p])
 
-  ¬All⇒Any¬ : Decidable P → ∀ xs → ¬ All P xs → Any (¬_ ∘ P) xs
-  ¬All⇒Any¬ dec []       ¬∀ = ⊥-elim (¬∀ [])
-  ¬All⇒Any¬ dec (x ∷ xs) ¬∀ with dec x
-  ... |  true because  [p] = there (¬All⇒Any¬ dec xs (¬∀ ∘ _∷_ (invert [p])))
-  ... | false because [¬p] = here (invert [¬p])
+Any¬⇒¬All : ∀ {xs} → Any (¬_ ∘ P) xs → ¬ All P xs
+Any¬⇒¬All (here  ¬p) = ¬p           ∘ All.head
+Any¬⇒¬All (there ¬p) = Any¬⇒¬All ¬p ∘ All.tail
 
-  Any¬⇒¬All : ∀ {xs} → Any (¬_ ∘ P) xs → ¬ All P xs
-  Any¬⇒¬All (here  ¬p) = ¬p           ∘ All.head
-  Any¬⇒¬All (there ¬p) = Any¬⇒¬All ¬p ∘ All.tail
+¬Any↠All¬ : ∀ {xs} → (¬ Any P xs) ↠ All (¬_ ∘ P) xs
+¬Any↠All¬ = surjection (¬Any⇒All¬ _) All¬⇒¬Any to∘from
+  where
+  to∘from : ∀ {xs} (¬p : All (¬_ ∘ P) xs) → ¬Any⇒All¬ xs (All¬⇒¬Any ¬p) ≡ ¬p
+  to∘from []         = refl
+  to∘from (¬p ∷ ¬ps) = cong₂ _∷_ refl (to∘from ¬ps)
 
-  ¬Any↠All¬ : ∀ {xs} → (¬ Any P xs) ↠ All (¬_ ∘ P) xs
-  ¬Any↠All¬ = surjection (¬Any⇒All¬ _) All¬⇒¬Any to∘from
-    where
-    to∘from : ∀ {xs} (¬p : All (¬_ ∘ P) xs) → ¬Any⇒All¬ xs (All¬⇒¬Any ¬p) ≡ ¬p
-    to∘from []         = refl
-    to∘from (¬p ∷ ¬ps) = cong₂ _∷_ refl (to∘from ¬ps)
+  -- If equality of functions were extensional, then the surjection
+  -- could be strengthened to a bijection.
 
-    -- If equality of functions were extensional, then the surjection
-    -- could be strengthened to a bijection.
+  from∘to : Extensionality _ _ →
+            ∀ xs → (¬p : ¬ Any P xs) → All¬⇒¬Any (¬Any⇒All¬ xs ¬p) ≡ ¬p
+  from∘to ext []       ¬p = ext λ ()
+  from∘to ext (x ∷ xs) ¬p = ext λ
+    { (here p)  → refl
+    ; (there p) → cong (λ f → f p) $ from∘to ext xs (¬p ∘ there)
+    }
 
-    from∘to : Extensionality _ _ →
-              ∀ xs → (¬p : ¬ Any P xs) → All¬⇒¬Any (¬Any⇒All¬ xs ¬p) ≡ ¬p
-    from∘to ext []       ¬p = ext λ ()
-    from∘to ext (x ∷ xs) ¬p = ext λ
-      { (here p)  → refl
-      ; (there p) → cong (λ f → f p) $ from∘to ext xs (¬p ∘ there)
-      }
+Any¬⇔¬All : ∀ {xs} → Decidable P → Any (¬_ ∘ P) xs ⇔ (¬ All P xs)
+Any¬⇔¬All dec = equivalence Any¬⇒¬All (¬All⇒Any¬ dec _)
 
-  Any¬⇔¬All : ∀ {xs} → Decidable P → Any (¬_ ∘ P) xs ⇔ (¬ All P xs)
-  Any¬⇔¬All dec = equivalence Any¬⇒¬All (¬All⇒Any¬ dec _)
-    where
-    -- If equality of functions were extensional, then the logical
-    -- equivalence could be strengthened to a surjection.
-    to∘from : Extensionality _ _ →
-              ∀ {xs} (¬∀ : ¬ All P xs) → Any¬⇒¬All (¬All⇒Any¬ dec xs ¬∀) ≡ ¬∀
-    to∘from ext ¬∀ = ext (⊥-elim ∘ ¬∀)
+private
+  -- If equality of functions were extensional, then the logical
+  -- equivalence could be strengthened to a surjection.
+  to∘from : Extensionality _ _ → (dec : Decidable P) →
+            (¬∀ : ¬ All P xs) → Any¬⇒¬All (¬All⇒Any¬ dec xs ¬∀) ≡ ¬∀
+  to∘from ext P ¬∀ = ext (⊥-elim ∘ ¬∀)
 
 module _ {_~_ : REL A B ℓ} where
 
@@ -145,274 +147,250 @@ module _ {_~_ : REL A B ℓ} where
 --
 -- pxs [ i ]= px  if and only if  lookup pxs i = px.
 
-module _ {P : A → Set p} where
+-- `i` points to `lookup pxs i` in `pxs`.
 
-  -- `i` points to `lookup pxs i` in `pxs`.
+[]=lookup : (pxs : All P xs) (i : x ∈ xs) →
+            pxs [ i ]= lookup pxs i
+[]=lookup (px ∷ pxs) (here refl) = here
+[]=lookup (px ∷ pxs) (there i)   = there ([]=lookup pxs i)
 
-  []=lookup : ∀ {x xs} (pxs : All P xs) (i : x ∈ xs) →
-              pxs [ i ]= lookup pxs i
-  []=lookup (px ∷ pxs) (here refl) = here
-  []=lookup (px ∷ pxs) (there i)   = there ([]=lookup pxs i)
+-- If `i` points to `px` in `pxs`, then `lookup pxs i ≡ px`.
 
-  -- If `i` points to `px` in `pxs`, then `lookup pxs i ≡ px`.
+[]=⇒lookup : ∀ {px : P x} {pxs : All P xs} {i : x ∈ xs} →
+             pxs [ i ]= px →
+             lookup pxs i ≡ px
+[]=⇒lookup x↦px = []=-injective ([]=lookup _ _) x↦px
 
-  []=⇒lookup : ∀ {x xs} {px : P x} {pxs : All P xs} {i : x ∈ xs} →
-               pxs [ i ]= px →
-               lookup pxs i ≡ px
-  []=⇒lookup x↦px = []=-injective ([]=lookup _ _) x↦px
+-- If `lookup pxs i ≡ px`, then `i` points to `px` in `pxs`.
 
-  -- If `lookup pxs i ≡ px`, then `i` points to `px` in `pxs`.
-
-  lookup⇒[]= : ∀{x xs} {px : P x} (pxs : All P xs) (i : x ∈ xs) →
-               lookup pxs i ≡ px →
-               pxs [ i ]= px
-  lookup⇒[]= pxs i refl = []=lookup pxs i
+lookup⇒[]= : ∀ {px : P x} (pxs : All P xs) (i : x ∈ xs) →
+             lookup pxs i ≡ px →
+             pxs [ i ]= px
+lookup⇒[]= pxs i refl = []=lookup pxs i
 
 ------------------------------------------------------------------------
 -- Properties of operations over `All`
 ------------------------------------------------------------------------
 -- map
 
-module _ {P : Pred A p} where
+map-id : ∀ (pxs : All P xs) → All.map id pxs ≡ pxs
+map-id []         = refl
+map-id (px ∷ pxs) = cong (px ∷_)  (map-id pxs)
 
-  map-id : ∀ {xs} (pxs : All P xs) → All.map id pxs ≡ pxs
-  map-id []         = refl
-  map-id (px ∷ pxs) = cong (px ∷_)  (map-id pxs)
+map-cong : ∀ {f : P ⋐ Q} {g : P ⋐ Q} (pxs : All P xs) →
+           (∀ {x} → f {x} ≗ g) → All.map f pxs ≡ All.map g pxs
+map-cong []         _   = refl
+map-cong (px ∷ pxs) feq = cong₂ _∷_ (feq px) (map-cong pxs feq)
 
-module _ {P : Pred A p} {Q : Pred A q} {f : P ⋐ Q} where
+map-compose : ∀ {f : P ⋐ Q} {g : Q ⋐ R} (pxs : All P xs) →
+              All.map g (All.map f pxs) ≡ All.map (g ∘ f) pxs
+map-compose []         = refl
+map-compose (px ∷ pxs) = cong (_ ∷_) (map-compose pxs)
 
-  map-cong : ∀ {xs} {g : P ⋐ Q} (pxs : All P xs) →
-             (∀ {x} → f {x} ≗ g) → All.map f pxs ≡ All.map g pxs
-  map-cong []         _   = refl
-  map-cong (px ∷ pxs) feq = cong₂ _∷_ (feq px) (map-cong pxs feq)
-
-  map-compose : ∀ {r} {R : Pred A r} {xs} {g : Q ⋐ R} (pxs : All P xs) →
-                All.map g (All.map f pxs) ≡ All.map (g ∘ f) pxs
-  map-compose []         = refl
-  map-compose (px ∷ pxs) = cong (_ ∷_) (map-compose pxs)
-
-  lookup-map : ∀ {xs x} (pxs : All P xs) (i : x ∈ xs) →
-               lookup (All.map f pxs) i ≡ f (lookup pxs i)
-  lookup-map (px ∷ pxs) (here refl) = refl
-  lookup-map (px ∷ pxs) (there i)   = lookup-map pxs i
+lookup-map : ∀ {f : P ⋐ Q} (pxs : All P xs) (i : x ∈ xs) →
+             lookup (All.map f pxs) i ≡ f (lookup pxs i)
+lookup-map (px ∷ pxs) (here refl) = refl
+lookup-map (px ∷ pxs) (there i)   = lookup-map pxs i
 
 ------------------------------------------------------------------------
 -- _[_]%=_ / updateAt
 
-module _ {P : Pred A p} where
-
   -- Defining properties of updateAt:
 
-  -- (+) updateAt actually updates the element at the given index.
+-- (+) updateAt actually updates the element at the given index.
 
-  updateAt-updates : ∀ {x xs} (i : x ∈ xs) {f : P x → P x} {px : P x} (pxs : All P xs) →
-                     pxs              [ i ]= px →
-                     updateAt i f pxs [ i ]= f px
-  updateAt-updates (here  refl) (px ∷ pxs) here         = here
-  updateAt-updates (there i)    (px ∷ pxs) (there x↦px) =
-    there (updateAt-updates i pxs x↦px)
+updateAt-updates : ∀ (i : x ∈ xs) {f : P x → P x} {px : P x} (pxs : All P xs) →
+                   pxs              [ i ]= px →
+                   updateAt i f pxs [ i ]= f px
+updateAt-updates (here  refl) (px ∷ pxs) here         = here
+updateAt-updates (there i)    (px ∷ pxs) (there x↦px) =
+  there (updateAt-updates i pxs x↦px)
 
-  -- (-) updateAt i does not touch the elements at other indices.
+-- (-) updateAt i does not touch the elements at other indices.
 
-  updateAt-minimal : ∀ {x y xs} (i : x ∈ xs) (j : y ∈ xs) →
-                     ∀ {f : P y → P y} {px : P x} (pxs : All P xs) →
-                     i ≢∈ j →
-                     pxs              [ i ]= px →
-                     updateAt j f pxs [ i ]= px
-  updateAt-minimal (here .refl) (here refl) (px ∷ pxs) i≢j here        =
-    ⊥-elim (i≢j refl refl)
-  updateAt-minimal (here .refl) (there j)   (px ∷ pxs) i≢j here        = here
-  updateAt-minimal (there i)    (here refl) (px ∷ pxs) i≢j (there val) = there val
-  updateAt-minimal (there i)    (there j)   (px ∷ pxs) i≢j (there val) =
-    there (updateAt-minimal i j pxs (there-injective-≢∈ i≢j) val)
+updateAt-minimal : ∀ (i : x ∈ xs) (j : y ∈ xs) →
+                   ∀ {f : P y → P y} {px : P x} (pxs : All P xs) →
+                   i ≢∈ j →
+                   pxs              [ i ]= px →
+                   updateAt j f pxs [ i ]= px
+updateAt-minimal (here .refl) (here refl) (px ∷ pxs) i≢j here        =
+  ⊥-elim (i≢j refl refl)
+updateAt-minimal (here .refl) (there j)   (px ∷ pxs) i≢j here        = here
+updateAt-minimal (there i)    (here refl) (px ∷ pxs) i≢j (there val) = there val
+updateAt-minimal (there i)    (there j)   (px ∷ pxs) i≢j (there val) =
+  there (updateAt-minimal i j pxs (there-injective-≢∈ i≢j) val)
 
-  -- lookup after updateAt reduces.
+-- lookup after updateAt reduces.
 
-  -- For same index this is an easy consequence of updateAt-updates
-  -- using []=↔lookup.
+-- For same index this is an easy consequence of updateAt-updates
+-- using []=↔lookup.
 
-  lookup∘updateAt : ∀ {x xs} (pxs : All P xs) (i : x ∈ xs) {f : P x → P x} →
-                    lookup (updateAt i f pxs) i ≡ f (lookup pxs i)
-  lookup∘updateAt pxs i =
-    []=⇒lookup (updateAt-updates i pxs (lookup⇒[]= pxs i refl))
+lookup∘updateAt : ∀ (pxs : All P xs) (i : x ∈ xs) {f : P x → P x} →
+                  lookup (updateAt i f pxs) i ≡ f (lookup pxs i)
+lookup∘updateAt pxs i =
+  []=⇒lookup (updateAt-updates i pxs (lookup⇒[]= pxs i refl))
 
-  -- For different indices it easily follows from updateAt-minimal.
+-- For different indices it easily follows from updateAt-minimal.
 
-  lookup∘updateAt′ : ∀ {x y xs} (i : x ∈ xs) (j : y ∈ xs) →
-                     ∀ {f : P y → P y} {px : P x} (pxs : All P xs) →
-                     i ≢∈ j →
-                     lookup (updateAt j f pxs) i ≡ lookup pxs i
-  lookup∘updateAt′ i j pxs i≢j =
-    []=⇒lookup (updateAt-minimal i j pxs i≢j (lookup⇒[]= pxs i refl))
+lookup∘updateAt′ : ∀ (i : x ∈ xs) (j : y ∈ xs) →
+                   ∀ {f : P y → P y} {px : P x} (pxs : All P xs) →
+                   i ≢∈ j →
+                   lookup (updateAt j f pxs) i ≡ lookup pxs i
+lookup∘updateAt′ i j pxs i≢j =
+  []=⇒lookup (updateAt-minimal i j pxs i≢j (lookup⇒[]= pxs i refl))
 
-  -- The other properties are consequences of (+) and (-).
-  -- We spell the most natural properties out.
-  -- Direct inductive proofs are in most cases easier than just using
-  -- the defining properties.
+-- The other properties are consequences of (+) and (-).
+-- We spell the most natural properties out.
+-- Direct inductive proofs are in most cases easier than just using
+-- the defining properties.
 
-  -- In the explanations, we make use of shorthand  f = g ↾ x
-  -- meaning that f and g agree at point x, i.e.  f x ≡ g x.
+-- In the explanations, we make use of shorthand  f = g ↾ x
+-- meaning that f and g agree at point x, i.e.  f x ≡ g x.
 
-  -- updateAt (i : x ∈ xs)  is a morphism
-  -- from the monoid of endofunctions  P x → P x
-  -- to the monoid of endofunctions  All P xs → All P xs.
+-- updateAt (i : x ∈ xs)  is a morphism
+-- from the monoid of endofunctions  P x → P x
+-- to the monoid of endofunctions  All P xs → All P xs.
 
-  -- 1a. relative identity:  f = id ↾ (lookup pxs i)
-  --                implies  updateAt i f = id ↾ pxs
+-- 1a. relative identity:  f = id ↾ (lookup pxs i)
+--                implies  updateAt i f = id ↾ pxs
 
-  updateAt-id-relative : ∀ {x xs} (i : x ∈ xs) {f : P x → P x} (pxs : All P xs) →
-                         f (lookup pxs i) ≡ lookup pxs i →
-                         updateAt i f pxs ≡ pxs
-  updateAt-id-relative (here refl)(px ∷ pxs) eq = cong (_∷ pxs) eq
-  updateAt-id-relative (there i)  (px ∷ pxs) eq = cong (px ∷_) (updateAt-id-relative i pxs eq)
+updateAt-id-relative : ∀ (i : x ∈ xs) {f : P x → P x} (pxs : All P xs) →
+                       f (lookup pxs i) ≡ lookup pxs i →
+                       updateAt i f pxs ≡ pxs
+updateAt-id-relative (here refl)(px ∷ pxs) eq = cong (_∷ pxs) eq
+updateAt-id-relative (there i)  (px ∷ pxs) eq = cong (px ∷_) (updateAt-id-relative i pxs eq)
 
-  -- 1b. identity:  updateAt i id ≗ id
+-- 1b. identity:  updateAt i id ≗ id
 
-  updateAt-id : ∀ {x xs} (i : x ∈ xs) (pxs : All P xs) →
-                updateAt i id pxs ≡ pxs
-  updateAt-id i pxs = updateAt-id-relative i pxs refl
+updateAt-id : ∀ (i : x ∈ xs) (pxs : All P xs) → updateAt i id pxs ≡ pxs
+updateAt-id i pxs = updateAt-id-relative i pxs refl
 
-  -- 2a. relative composition:  f ∘ g = h ↾ (lookup i pxs)
-  --                   implies  updateAt i f ∘ updateAt i g = updateAt i h ↾ pxs
+-- 2a. relative composition:  f ∘ g = h ↾ (lookup i pxs)
+--                   implies  updateAt i f ∘ updateAt i g = updateAt i h ↾ pxs
 
-  updateAt-compose-relative : ∀ {x xs} (i : x ∈ xs) {f g h : P x → P x} (pxs : All P xs) →
-                              f (g (lookup pxs i)) ≡ h (lookup pxs i) →
-                              updateAt i f (updateAt i g pxs) ≡ updateAt i h pxs
-  updateAt-compose-relative (here refl) (px ∷ pxs) fg=h = cong (_∷ pxs) fg=h
-  updateAt-compose-relative (there i)   (px ∷ pxs) fg=h =
-    cong (px ∷_) (updateAt-compose-relative i pxs fg=h)
+updateAt-compose-relative : ∀ (i : x ∈ xs) {f g h : P x → P x} (pxs : All P xs) →
+                            f (g (lookup pxs i)) ≡ h (lookup pxs i) →
+                            updateAt i f (updateAt i g pxs) ≡ updateAt i h pxs
+updateAt-compose-relative (here refl) (px ∷ pxs) fg=h = cong (_∷ pxs) fg=h
+updateAt-compose-relative (there i)   (px ∷ pxs) fg=h =
+  cong (px ∷_) (updateAt-compose-relative i pxs fg=h)
 
-  -- 2b. composition:  updateAt i f ∘ updateAt i g ≗ updateAt i (f ∘ g)
+-- 2b. composition:  updateAt i f ∘ updateAt i g ≗ updateAt i (f ∘ g)
 
-  updateAt-compose : ∀ {x xs} (i : x ∈ xs) {f g : P x → P x} →
-                     updateAt {P = P} i f ∘ updateAt i g ≗ updateAt i (f ∘ g)
-  updateAt-compose (here refl) (px ∷ pxs) = refl
-  updateAt-compose (there i)   (px ∷ pxs) = cong (px ∷_) (updateAt-compose i pxs)
+updateAt-compose : ∀ (i : x ∈ xs) {f g : P x → P x} →
+                   updateAt {P = P} i f ∘ updateAt i g ≗ updateAt i (f ∘ g)
+updateAt-compose (here refl) (px ∷ pxs) = refl
+updateAt-compose (there i)   (px ∷ pxs) = cong (px ∷_) (updateAt-compose i pxs)
 
-  -- 3. congruence:  updateAt i  is a congruence wrt. extensional equality.
+-- 3. congruence:  updateAt i  is a congruence wrt. extensional equality.
 
-  -- 3a.  If    f = g ↾ (lookup pxs i)
-  --      then  updateAt i f = updateAt i g ↾ pxs
+-- 3a.  If    f = g ↾ (lookup pxs i)
+--      then  updateAt i f = updateAt i g ↾ pxs
 
-  updateAt-cong-relative : ∀ {x xs} (i : x ∈ xs) {f g : P x → P x} (pxs : All P xs) →
-                           f (lookup pxs i) ≡ g (lookup pxs i) →
-                           updateAt i f pxs ≡ updateAt i g pxs
-  updateAt-cong-relative (here refl) (px ∷ pxs) f=g = cong (_∷ pxs) f=g
-  updateAt-cong-relative (there i)   (px ∷ pxs) f=g = cong (px ∷_) (updateAt-cong-relative i pxs f=g)
+updateAt-cong-relative : ∀ (i : x ∈ xs) {f g : P x → P x} (pxs : All P xs) →
+                         f (lookup pxs i) ≡ g (lookup pxs i) →
+                         updateAt i f pxs ≡ updateAt i g pxs
+updateAt-cong-relative (here refl) (px ∷ pxs) f=g = cong (_∷ pxs) f=g
+updateAt-cong-relative (there i)   (px ∷ pxs) f=g = cong (px ∷_) (updateAt-cong-relative i pxs f=g)
 
-  -- 3b. congruence:  f ≗ g → updateAt i f ≗ updateAt i g
+-- 3b. congruence:  f ≗ g → updateAt i f ≗ updateAt i g
 
-  updateAt-cong : ∀ {x xs} (i : x ∈ xs) {f g : P x → P x} →
-                  f ≗ g →
-                  updateAt i f ≗ updateAt i g
-  updateAt-cong i f≗g pxs = updateAt-cong-relative i pxs (f≗g (lookup pxs i))
+updateAt-cong : ∀ (i : x ∈ xs) {f g : P x → P x} →
+                f ≗ g → updateAt {P = P} i f ≗ updateAt i g
+updateAt-cong i f≗g pxs = updateAt-cong-relative i pxs (f≗g (lookup pxs i))
 
+-- The order of updates at different indices i ≢ j does not matter.
 
-  -- The order of updates at different indices i ≢ j does not matter.
+-- This a consequence of updateAt-updates and updateAt-minimal
+-- but easier to prove inductively.
 
-  -- This a consequence of updateAt-updates and updateAt-minimal
-  -- but easier to prove inductively.
+updateAt-commutes : ∀ (i : x ∈ xs) (j : y ∈ xs) →
+                    ∀ {f : P x → P x} {g : P y → P y} →
+                    i ≢∈ j →
+                    updateAt {P = P} i f ∘ updateAt j g ≗ updateAt j g ∘ updateAt i f
+updateAt-commutes (here refl) (here refl) i≢j (px ∷ pxs) =
+  ⊥-elim (i≢j refl refl)
+updateAt-commutes (here refl) (there j)   i≢j (px ∷ pxs) = refl
+updateAt-commutes (there i)   (here refl) i≢j (px ∷ pxs) = refl
+updateAt-commutes (there i)   (there j)   i≢j (px ∷ pxs) =
+  cong (px ∷_) (updateAt-commutes i j (there-injective-≢∈ i≢j) pxs)
 
-  updateAt-commutes : ∀ {x y xs} (i : x ∈ xs) (j : y ∈ xs) →
-                      ∀ {f : P x → P x} {g : P y → P y} →
-                      i ≢∈ j →
-                      updateAt i f ∘ updateAt j g ≗ updateAt j g ∘ updateAt i f
-  updateAt-commutes (here refl) (here refl) i≢j (px ∷ pxs) =
-    ⊥-elim (i≢j refl refl)
-  updateAt-commutes (here refl) (there j)   i≢j (px ∷ pxs) = refl
-  updateAt-commutes (there i)   (here refl) i≢j (px ∷ pxs) = refl
-  updateAt-commutes (there i)   (there j)   i≢j (px ∷ pxs) =
-    cong (px ∷_) (updateAt-commutes i j (there-injective-≢∈ i≢j) pxs)
-
-module _ {P : Pred A p} {Q : Pred A q} where
-
-  map-updateAt : ∀ {x xs} {f : P ⋐ Q} {g : P x → P x} {h : Q x → Q x}
-                 (pxs : All P xs) (i : x ∈ xs) →
-                 f (g (lookup pxs i)) ≡ h (f (lookup pxs i)) →
-                 All.map f (pxs All.[ i ]%= g) ≡ (All.map f pxs) All.[ i ]%= h
-  map-updateAt (px ∷ pxs) (here refl) = cong (_∷ _)
-  map-updateAt (px ∷ pxs) (there i) feq = cong (_ ∷_) (map-updateAt pxs i feq)
+map-updateAt : ∀ {f : P ⋐ Q} {g : P x → P x} {h : Q x → Q x}
+               (pxs : All P xs) (i : x ∈ xs) →
+               f (g (lookup pxs i)) ≡ h (f (lookup pxs i)) →
+               All.map f (pxs All.[ i ]%= g) ≡ (All.map f pxs) All.[ i ]%= h
+map-updateAt (px ∷ pxs) (here refl) = cong (_∷ _)
+map-updateAt (px ∷ pxs) (there i) feq = cong (_ ∷_) (map-updateAt pxs i feq)
 
 ------------------------------------------------------------------------
 -- Introduction (⁺) and elimination (⁻) rules for list operations
 ------------------------------------------------------------------------
 -- map
 
-module _ {P : B → Set p} {f : A → B} where
+map⁺ : ∀ {f : A → B} → All (P ∘ f) xs → All P (map f xs)
+map⁺ []       = []
+map⁺ (p ∷ ps) = p ∷ map⁺ ps
 
-  map⁺ : ∀ {xs} → All (P ∘ f) xs → All P (map f xs)
-  map⁺ []       = []
-  map⁺ (p ∷ ps) = p ∷ map⁺ ps
-
-  map⁻ : ∀ {xs} → All P (map f xs) → All (P ∘ f) xs
-  map⁻ {xs = []}    []       = []
-  map⁻ {xs = _ ∷ _} (p ∷ ps) = p ∷ map⁻ ps
+map⁻ : ∀ {f : A → B} → All P (map f xs) → All (P ∘ f) xs
+map⁻ {xs = []}    []       = []
+map⁻ {xs = _ ∷ _} (p ∷ ps) = p ∷ map⁻ ps
 
 -- A variant of All.map.
 
-module _ {P : A → Set p} {Q : B → Set q} {f : A → B} where
-
-  gmap : P ⋐ Q ∘ f → All P ⋐ All Q ∘ map f
-  gmap g = map⁺ ∘ All.map g
+gmap : ∀ {f : A → B} → P ⋐ Q ∘ f → All P ⋐ All Q ∘ map f
+gmap g = map⁺ ∘ All.map g
 
 ------------------------------------------------------------------------
 -- mapMaybe
 
-module _ (P : B → Set p) {f : A → Maybe B} where
-
-  mapMaybe⁺ : ∀ {xs} → All (MAll.All P) (map f xs) → All P (mapMaybe f xs)
-  mapMaybe⁺ {[]}     [] = []
-  mapMaybe⁺ {x ∷ xs} (px ∷ pxs) with f x
-  ... | nothing = mapMaybe⁺ pxs
-  ... | just v with px
-  ...   | just pv = pv ∷ mapMaybe⁺ pxs
+mapMaybe⁺ : ∀ {f : A → Maybe B} →
+            All (MAll.All P) (map f xs) → All P (mapMaybe f xs)
+mapMaybe⁺ {xs = []}     {f = f} []         = []
+mapMaybe⁺ {xs = x ∷ xs} {f = f} (px ∷ pxs) with f x
+... | nothing = mapMaybe⁺ pxs
+... | just v with px
+...   | just pv = pv ∷ mapMaybe⁺ pxs
 
 ------------------------------------------------------------------------
 -- _++_
 
-module _ {P : A → Set p} where
+++⁺ : All P xs → All P ys → All P (xs ++ ys)
+++⁺ []         pys = pys
+++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
 
-  ++⁺ : ∀ {xs ys} → All P xs → All P ys → All P (xs ++ ys)
-  ++⁺ []         pys = pys
-  ++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
+++⁻ˡ : ∀ xs → All P (xs ++ ys) → All P xs
+++⁻ˡ []       p          = []
+++⁻ˡ (x ∷ xs) (px ∷ pxs) = px ∷ (++⁻ˡ _ pxs)
 
-  ++⁻ˡ : ∀ xs {ys} → All P (xs ++ ys) → All P xs
-  ++⁻ˡ []       p          = []
-  ++⁻ˡ (x ∷ xs) (px ∷ pxs) = px ∷ (++⁻ˡ _ pxs)
+++⁻ʳ : ∀ xs → All P (xs ++ ys) → All P ys
+++⁻ʳ []       p          = p
+++⁻ʳ (x ∷ xs) (px ∷ pxs) = ++⁻ʳ xs pxs
 
-  ++⁻ʳ : ∀ xs {ys} → All P (xs ++ ys) → All P ys
-  ++⁻ʳ []       p          = p
-  ++⁻ʳ (x ∷ xs) (px ∷ pxs) = ++⁻ʳ xs pxs
+++⁻ : ∀ xs → All P (xs ++ ys) → All P xs × All P ys
+++⁻ []       p          = [] , p
+++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (px ∷_) id (++⁻ _ pxs)
 
-  ++⁻ : ∀ xs {ys} → All P (xs ++ ys) → All P xs × All P ys
-  ++⁻ []       p          = [] , p
-  ++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (px ∷_) id (++⁻ _ pxs)
+++↔ : (All P xs × All P ys) ↔ All P (xs ++ ys)
+++↔ {xs = zs} = inverse (uncurry ++⁺) (++⁻ zs) ++⁻∘++⁺ (++⁺∘++⁻ zs)
+  where
+  ++⁺∘++⁻ : ∀ xs (p : All P (xs ++ ys)) → uncurry′ ++⁺ (++⁻ xs p) ≡ p
+  ++⁺∘++⁻ []       p          = refl
+  ++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
 
-  ++↔ : ∀ {xs ys} → (All P xs × All P ys) ↔ All P (xs ++ ys)
-  ++↔ {xs} = inverse (uncurry ++⁺) (++⁻ xs) ++⁻∘++⁺ (++⁺∘++⁻ xs)
-    where
-    ++⁺∘++⁻ : ∀ xs {ys} (p : All P (xs ++ ys)) →
-              uncurry′ ++⁺ (++⁻ xs p) ≡ p
-    ++⁺∘++⁻ []       p          = refl
-    ++⁺∘++⁻ (x ∷ xs) (px ∷ pxs) = cong (_∷_ px) $ ++⁺∘++⁻ xs pxs
-
-    ++⁻∘++⁺ : ∀ {xs ys} (p : All P xs × All P ys) →
-              ++⁻ xs (uncurry ++⁺ p) ≡ p
-    ++⁻∘++⁺ ([]       , pys) = refl
-    ++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = refl
+  ++⁻∘++⁺ : ∀ (p : All P xs × All P ys) → ++⁻ xs (uncurry ++⁺ p) ≡ p
+  ++⁻∘++⁺ ([]       , pys) = refl
+  ++⁻∘++⁺ (px ∷ pxs , pys) rewrite ++⁻∘++⁺ (pxs , pys) = refl
 
 ------------------------------------------------------------------------
 -- concat
 
-module _ {P : A → Set p} where
+concat⁺ : ∀ {xss} → All (All P) xss → All P (concat xss)
+concat⁺ []           = []
+concat⁺ (pxs ∷ pxss) = ++⁺ pxs (concat⁺ pxss)
 
-  concat⁺ : ∀ {xss} → All (All P) xss → All P (concat xss)
-  concat⁺ []           = []
-  concat⁺ (pxs ∷ pxss) = ++⁺ pxs (concat⁺ pxss)
-
-  concat⁻ : ∀ {xss} → All P (concat xss) → All (All P) xss
-  concat⁻ {[]}       []  = []
-  concat⁻ {xs ∷ xss} pxs = ++⁻ˡ xs pxs ∷ concat⁻ (++⁻ʳ xs pxs)
+concat⁻ : ∀ {xss} → All P (concat xss) → All (All P) xss
+concat⁻ {xss = []}       []  = []
+concat⁻ {xss = xs ∷ xss} pxs = ++⁻ˡ xs pxs ∷ concat⁻ (++⁻ʳ xs pxs)
 
 ------------------------------------------------------------------------
 -- cartesianProductWith and cartesianProduct
@@ -421,7 +399,7 @@ module _ (S₁ : Setoid a ℓ₁) (S₂ : Setoid b ℓ₂) where
   open SetoidMembership S₁ using () renaming (_∈_ to _∈₁_)
   open SetoidMembership S₂ using () renaming (_∈_ to _∈₂_)
 
-  cartesianProductWith⁺ : ∀ {P : Pred C p} f xs ys →
+  cartesianProductWith⁺ : ∀ f xs ys →
                           (∀ {x y} → x ∈₁ xs → y ∈₂ ys → P (f x y)) →
                           All P (cartesianProductWith f xs ys)
   cartesianProductWith⁺ f []       ys pres = []
@@ -429,7 +407,7 @@ module _ (S₁ : Setoid a ℓ₁) (S₂ : Setoid b ℓ₂) where
     (map⁺ (All.tabulateₛ S₂ (pres (here (Setoid.refl S₁)))))
     (cartesianProductWith⁺ f xs ys (pres ∘ there))
 
-  cartesianProduct⁺ : ∀ {P : Pred _ p} xs ys →
+  cartesianProduct⁺ : ∀ xs ys →
                       (∀ {x y} → x ∈₁ xs → y ∈₂ ys → P (x , y)) →
                       All P (cartesianProduct xs ys)
   cartesianProduct⁺ = cartesianProductWith⁺ _,_
@@ -437,79 +415,69 @@ module _ (S₁ : Setoid a ℓ₁) (S₂ : Setoid b ℓ₂) where
 ------------------------------------------------------------------------
 -- take and drop
 
-module _ {P : A → Set p} where
+drop⁺ : ∀ n → All P xs → All P (drop n xs)
+drop⁺ zero    pxs        = pxs
+drop⁺ (suc n) []         = []
+drop⁺ (suc n) (px ∷ pxs) = drop⁺ n pxs
 
-  drop⁺ : ∀ {xs} n → All P xs → All P (drop n xs)
-  drop⁺ zero    pxs        = pxs
-  drop⁺ (suc n) []         = []
-  drop⁺ (suc n) (px ∷ pxs) = drop⁺ n pxs
-
-  take⁺ : ∀ {xs} n → All P xs → All P (take n xs)
-  take⁺ zero    pxs        = []
-  take⁺ (suc n) []         = []
-  take⁺ (suc n) (px ∷ pxs) = px ∷ take⁺ n pxs
+take⁺ : ∀ n → All P xs → All P (take n xs)
+take⁺ zero    pxs        = []
+take⁺ (suc n) []         = []
+take⁺ (suc n) (px ∷ pxs) = px ∷ take⁺ n pxs
 
 ------------------------------------------------------------------------
 -- applyUpTo
 
-module _ {P : A → Set p} where
+applyUpTo⁺₁ : ∀ f n → (∀ {i} → i < n → P (f i)) → All P (applyUpTo f n)
+applyUpTo⁺₁ f zero    Pf = []
+applyUpTo⁺₁ f (suc n) Pf = Pf (s≤s z≤n) ∷ applyUpTo⁺₁ (f ∘ suc) n (Pf ∘ s≤s)
 
-  applyUpTo⁺₁ : ∀ f n → (∀ {i} → i < n → P (f i)) → All P (applyUpTo f n)
-  applyUpTo⁺₁ f zero    Pf = []
-  applyUpTo⁺₁ f (suc n) Pf = Pf (s≤s z≤n) ∷ applyUpTo⁺₁ (f ∘ suc) n (Pf ∘ s≤s)
+applyUpTo⁺₂ : ∀ f n → (∀ i → P (f i)) → All P (applyUpTo f n)
+applyUpTo⁺₂ f n Pf = applyUpTo⁺₁ f n (λ _ → Pf _)
 
-  applyUpTo⁺₂ : ∀ f n → (∀ i → P (f i)) → All P (applyUpTo f n)
-  applyUpTo⁺₂ f n Pf = applyUpTo⁺₁ f n (λ _ → Pf _)
-
-  applyUpTo⁻ : ∀ f n → All P (applyUpTo f n) → ∀ {i} → i < n → P (f i)
-  applyUpTo⁻ f (suc n) (px ∷ _)   (s≤s z≤n)       = px
-  applyUpTo⁻ f (suc n) (_  ∷ pxs) (s≤s (s≤s i<n)) =
-    applyUpTo⁻ (f ∘ suc) n pxs (s≤s i<n)
+applyUpTo⁻ : ∀ f n → All P (applyUpTo f n) → ∀ {i} → i < n → P (f i)
+applyUpTo⁻ f (suc n) (px ∷ _)   (s≤s z≤n)       = px
+applyUpTo⁻ f (suc n) (_  ∷ pxs) (s≤s (s≤s i<n)) =
+  applyUpTo⁻ (f ∘ suc) n pxs (s≤s i<n)
 
 ------------------------------------------------------------------------
 -- applyDownFrom
 
-module _ {P : A → Set p} where
+applyDownFrom⁺₁ : ∀ f n → (∀ {i} → i < n → P (f i)) → All P (applyDownFrom f n)
+applyDownFrom⁺₁ f zero    Pf = []
+applyDownFrom⁺₁ f (suc n) Pf = Pf ≤-refl ∷ applyDownFrom⁺₁ f n (Pf ∘ ≤-step)
 
-  applyDownFrom⁺₁ : ∀ f n → (∀ {i} → i < n → P (f i)) → All P (applyDownFrom f n)
-  applyDownFrom⁺₁ f zero    Pf = []
-  applyDownFrom⁺₁ f (suc n) Pf = Pf ≤-refl ∷ applyDownFrom⁺₁ f n (Pf ∘ ≤-step)
-
-  applyDownFrom⁺₂ : ∀ f n → (∀ i → P (f i)) → All P (applyDownFrom f n)
-  applyDownFrom⁺₂ f n Pf = applyDownFrom⁺₁ f n (λ _ → Pf _)
+applyDownFrom⁺₂ : ∀ f n → (∀ i → P (f i)) → All P (applyDownFrom f n)
+applyDownFrom⁺₂ f n Pf = applyDownFrom⁺₁ f n (λ _ → Pf _)
 
 ------------------------------------------------------------------------
 -- tabulate
 
-module _ {P : A → Set p} where
+tabulate⁺ : ∀ {n} {f : Fin n → A} →
+            (∀ i → P (f i)) → All P (tabulate f)
+tabulate⁺ {n = zero}  Pf = []
+tabulate⁺ {n = suc n} Pf = Pf fzero ∷ tabulate⁺ (Pf ∘ fsuc)
 
-  tabulate⁺ : ∀ {n} {f : Fin n → A} →
-              (∀ i → P (f i)) → All P (tabulate f)
-  tabulate⁺ {zero}  Pf = []
-  tabulate⁺ {suc n} Pf = Pf fzero ∷ tabulate⁺ (Pf ∘ fsuc)
-
-  tabulate⁻ : ∀ {n} {f : Fin n → A} →
-              All P (tabulate f) → (∀ i → P (f i))
-  tabulate⁻ {suc n} (px ∷ _) fzero    = px
-  tabulate⁻ {suc n} (_ ∷ pf) (fsuc i) = tabulate⁻ pf i
+tabulate⁻ : ∀ {n} {f : Fin n → A} →
+            All P (tabulate f) → (∀ i → P (f i))
+tabulate⁻ {n = suc n} (px ∷ _) fzero    = px
+tabulate⁻ {n = suc n} (_ ∷ pf) (fsuc i) = tabulate⁻ pf i
 
 ------------------------------------------------------------------------
 -- remove
 
-module _ {P : A → Set p} {Q : A → Set q} where
+─⁺ : ∀ (p : Any P xs) → All Q xs → All Q (xs Any.─ p)
+─⁺ (here px) (_ ∷ qs) = qs
+─⁺ (there p) (q ∷ qs) = q ∷ ─⁺ p qs
 
-  ─⁺ : ∀ {xs} (p : Any P xs) → All Q xs → All Q (xs Any.─ p)
-  ─⁺ (here px) (_ ∷ qs) = qs
-  ─⁺ (there p) (q ∷ qs) = q ∷ ─⁺ p qs
-
-  ─⁻ : ∀ {xs} (p : Any P xs) → Q (Any.lookup p) → All Q (xs Any.─ p) → All Q xs
-  ─⁻ (here px) q qs        = q ∷ qs
-  ─⁻ (there p) q (q′ ∷ qs) = q′ ∷ ─⁻ p q qs
+─⁻ : ∀ (p : Any P xs) → Q (Any.lookup p) → All Q (xs Any.─ p) → All Q xs
+─⁻ (here px) q qs        = q ∷ qs
+─⁻ (there p) q (q′ ∷ qs) = q′ ∷ ─⁻ p q qs
 
 ------------------------------------------------------------------------
 -- filter
 
-module _ {P : A → Set p} (P? : Decidable P) where
+module _ (P? : Decidable P) where
 
   all-filter : ∀ xs → All P (filter P? xs)
   all-filter []       = []
@@ -517,41 +485,40 @@ module _ {P : A → Set p} (P? : Decidable P) where
   ... |  true because [Px] = invert [Px] ∷ all-filter xs
   ... | false because  _   = all-filter xs
 
-module _ {P : A → Set p} {Q : A → Set q} (P? : Decidable P) where
-
-  filter⁺ : ∀ {xs} → All Q xs → All Q (filter P? xs)
+  filter⁺ : All Q xs → All Q (filter P? xs)
   filter⁺ {xs = _}     [] = []
   filter⁺ {xs = x ∷ _} (Qx ∷ Qxs) with does (P? x)
   ... | false = filter⁺ Qxs
   ... | true  = Qx ∷ filter⁺ Qxs
 
-  filter⁻ : ∀ {xs} → All Q (filter P? xs) → All Q (filter (¬? ∘ P?) xs) → All Q xs
-  filter⁻ {[]}         []          []                           = []
-  filter⁻ {x ∷ xs}       all⁺        all⁻ with P? x  | ¬? (P? x)
-  filter⁻ {x ∷ xs}       all⁺        all⁻  | yes  Px | yes  ¬Px = contradiction Px ¬Px
-  filter⁻ {x ∷ xs} (qx ∷ all⁺)       all⁻  | yes  Px | no  ¬¬Px = qx ∷ filter⁻ all⁺ all⁻
-  filter⁻ {x ∷ xs}       all⁺  (qx ∷ all⁻) | no    _ | yes  ¬Px = qx ∷ filter⁻ all⁺ all⁻
-  filter⁻ {x ∷ xs}       all⁺        all⁻  | no  ¬Px | no  ¬¬Px = contradiction ¬Px ¬¬Px
+  filter⁻ : All Q (filter P? xs) → All Q (filter (¬? ∘ P?) xs) → All Q xs
+  filter⁻ {xs = []}           []          []                           = []
+  filter⁻ {xs = x ∷ xs}       all⁺        all⁻ with P? x  | ¬? (P? x)
+  filter⁻ {xs = x ∷ xs}       all⁺        all⁻  | yes  Px | yes  ¬Px = contradiction Px ¬Px
+  filter⁻ {xs = x ∷ xs} (qx ∷ all⁺)       all⁻  | yes  Px | no  ¬¬Px = qx ∷ filter⁻ all⁺ all⁻
+  filter⁻ {xs = x ∷ xs}       all⁺  (qx ∷ all⁻) | no    _ | yes  ¬Px = qx ∷ filter⁻ all⁺ all⁻
+  filter⁻ {xs = x ∷ xs}       all⁺        all⁻  | no  ¬Px | no  ¬¬Px = contradiction ¬Px ¬¬Px
 
 ------------------------------------------------------------------------
 -- derun and deduplicate
 
-module _ {P : A → Set p} {R : A → A → Set q} (R? : B.Decidable R) where
+module _ {R : A → A → Set q} (R? : B.Decidable R) where
 
-  derun⁺ : ∀ {xs} → All P xs → All P (derun R? xs)
-  derun⁺ {[]} [] = []
-  derun⁺ {x ∷ []} (px ∷ []) = px ∷ []
-  derun⁺ {x ∷ y ∷ xs} (px ∷ all[P,y∷xs]) with does (R? x y)
+  derun⁺ : All P xs → All P (derun R? xs)
+  derun⁺ {xs = []}         []                 = []
+  derun⁺ {xs = x ∷ []}     (px ∷ [])          = px ∷ []
+  derun⁺ {xs = x ∷ y ∷ xs} (px ∷ all[P,y∷xs]) with does (R? x y)
   ... | false = px ∷ derun⁺ all[P,y∷xs]
   ... | true  = derun⁺ all[P,y∷xs]
 
-  deduplicate⁺ : ∀ {xs} → All P xs → All P (deduplicate R? xs)
-  deduplicate⁺ [] = []
-  deduplicate⁺ {x ∷ _} (px ∷ all[P,xs]) = px ∷ filter⁺ (¬? ∘ R? x) (deduplicate⁺ all[P,xs])
+  deduplicate⁺ : All P xs → All P (deduplicate R? xs)
+  deduplicate⁺ []               = []
+  deduplicate⁺ (px ∷ pxs) = px ∷ filter⁺ (¬? ∘ R? _) (deduplicate⁺ pxs)
 
   derun⁻ : P B.Respects (flip R) → ∀ xs → All P (derun R? xs) → All P xs
-  derun⁻ P-resp-R []       []          = []
-  derun⁻ P-resp-R (x ∷ xs) all[P,x∷xs] = aux x xs all[P,x∷xs] where
+  derun⁻ {P = P} P-resp-R []       []          = []
+  derun⁻ {P = P} P-resp-R (x ∷ xs) all[P,x∷xs] = aux x xs all[P,x∷xs]
+    where
     aux : ∀ x xs → All P (derun R? (x ∷ xs)) → All P (x ∷ xs)
     aux x []       (px ∷ []) = px ∷ []
     aux x (y ∷ xs) all[P,x∷y∷xs] with R? x y
@@ -559,97 +526,84 @@ module _ {P : A → Set p} {R : A → A → Set q} (R? : B.Decidable R) where
     aux x (y ∷ xs) all[P,y∷xs]        | yes Rxy | r@(py ∷ _) = P-resp-R Rxy py ∷ r
     aux x (y ∷ xs) (px ∷ all[P,y∷xs]) | no _ = px ∷ aux y xs all[P,y∷xs]
 
-  module _ (P-resp-R : P B.Respects R) where
-
-    deduplicate⁻ : ∀ xs → All P (deduplicate R? xs) → All P xs
-    deduplicate⁻ [] [] = []
-    deduplicate⁻ (x ∷ xs) (px ∷ app[P,dedup[xs]]) = px ∷ deduplicate⁻ xs (filter⁻ (¬? ∘ R? x) app[P,dedup[xs]] (All.tabulate aux)) where
-      aux : ∀ {z} → z ∈ filter (¬? ∘ ¬? ∘ R? x) (deduplicate R? xs) → P z
-      aux {z} z∈filter = P-resp-R (decidable-stable (R? x z) (Prod.proj₂ (∈-filter⁻ (¬? ∘ ¬? ∘ R? x) {z} {deduplicate R? xs} z∈filter))) px
+  deduplicate⁻ : P B.Respects R → ∀ xs → All P (deduplicate R? xs) → All P xs
+  deduplicate⁻ {P = P} resp []       [] = []
+  deduplicate⁻ {P = P} resp (x ∷ xs) (px ∷ pxs!) =
+    px ∷ deduplicate⁻ resp xs (filter⁻ (¬? ∘ R? x) pxs! (All.tabulate aux))
+    where
+    aux : ∀ {z} → z ∈ filter (¬? ∘ ¬? ∘ R? x) (deduplicate R? xs) → P z
+    aux {z = z} z∈filter = resp (decidable-stable (R? x z)
+      (Prod.proj₂ (∈-filter⁻ (¬? ∘ ¬? ∘ R? x) {z} {deduplicate R? xs} z∈filter))) px
 
 ------------------------------------------------------------------------
 -- zipWith
 
-module _ (P : C → Set p) (f : A → B → C) where
-
-  zipWith⁺ : ∀ {xs ys} → Pointwise (λ x y → P (f x y)) xs ys →
-             All P (zipWith f xs ys)
-  zipWith⁺ []              = []
-  zipWith⁺ (Pfxy ∷ Pfxsys) = Pfxy ∷ zipWith⁺ Pfxsys
+zipWith⁺ : ∀ (f : A → B → C) → Pointwise (λ x y → P (f x y)) xs ys →
+           All P (zipWith f xs ys)
+zipWith⁺ f []              = []
+zipWith⁺ f (Pfxy ∷ Pfxsys) = Pfxy ∷ zipWith⁺ f Pfxsys
 
 ------------------------------------------------------------------------
 -- Operations for constructing lists
 ------------------------------------------------------------------------
 -- singleton
 
-module _ {P : A → Set p} where
-
-  singleton⁻ : ∀ {x} → All P [ x ] → P x
-  singleton⁻ (px ∷ []) = px
+singleton⁻ : All P [ x ] → P x
+singleton⁻ (px ∷ []) = px
 
 ------------------------------------------------------------------------
 -- snoc
 
-module _ {P : A → Set p} {x xs} where
+∷ʳ⁺ : All P xs → P x → All P (xs ∷ʳ x)
+∷ʳ⁺ pxs px = ++⁺ pxs (px ∷ [])
 
-  ∷ʳ⁺ : All P xs → P x → All P (xs ∷ʳ x)
-  ∷ʳ⁺ pxs px = ++⁺ pxs (px ∷ [])
-
-  ∷ʳ⁻ : All P (xs ∷ʳ x) → All P xs × P x
-  ∷ʳ⁻ pxs = Prod.map₂ singleton⁻ $ ++⁻ xs pxs
+∷ʳ⁻ : All P (xs ∷ʳ x) → All P xs × P x
+∷ʳ⁻ pxs = Prod.map₂ singleton⁻ $ ++⁻ _ pxs
 
 ------------------------------------------------------------------------
 -- fromMaybe
 
-module _ {P : A → Set p} where
+fromMaybe⁺ : ∀ {mx} → MAll.All P mx → All P (fromMaybe mx)
+fromMaybe⁺ (just px) = px ∷ []
+fromMaybe⁺ nothing   = []
 
-  fromMaybe⁺ : ∀ {mx} → MAll.All P mx → All P (fromMaybe mx)
-  fromMaybe⁺ (just px) = px ∷ []
-  fromMaybe⁺ nothing   = []
-
-  fromMaybe⁻ : ∀ mx → All P (fromMaybe mx) → MAll.All P mx
-  fromMaybe⁻ (just x) (px ∷ []) = just px
-  fromMaybe⁻ nothing  p         = nothing
+fromMaybe⁻ : ∀ mx → All P (fromMaybe mx) → MAll.All P mx
+fromMaybe⁻ (just x) (px ∷ []) = just px
+fromMaybe⁻ nothing  p         = nothing
 
 ------------------------------------------------------------------------
 -- replicate
 
-module _ {P : A → Set p} where
+replicate⁺ : ∀ n → P x → All P (replicate n x)
+replicate⁺ zero    px = []
+replicate⁺ (suc n) px = px ∷ replicate⁺ n px
 
-  replicate⁺ : ∀ n {x} → P x → All P (replicate n x)
-  replicate⁺ zero    px = []
-  replicate⁺ (suc n) px = px ∷ replicate⁺ n px
-
-  replicate⁻ : ∀ {n x} → All P (replicate (suc n) x) → P x
-  replicate⁻ (px ∷ _) = px
+replicate⁻ : ∀ {n} → All P (replicate (suc n) x) → P x
+replicate⁻ (px ∷ _) = px
 
 ------------------------------------------------------------------------
 -- inits
 
-module _ {P : A → Set p} where
+inits⁺ : All P xs → All (All P) (inits xs)
+inits⁺ []         = [] ∷ []
+inits⁺ (px ∷ pxs) = [] ∷ gmap (px ∷_) (inits⁺ pxs)
 
-  inits⁺ : ∀ {xs} → All P xs → All (All P) (inits xs)
-  inits⁺ []         = [] ∷ []
-  inits⁺ (px ∷ pxs) = [] ∷ gmap (px ∷_) (inits⁺ pxs)
-
-  inits⁻ : ∀ xs → All (All P) (inits xs) → All P xs
-  inits⁻ []               pxs                   = []
-  inits⁻ (x ∷ [])         ([] ∷ p[x] ∷ [])      = p[x]
-  inits⁻ (x ∷ xs@(_ ∷ _)) ([] ∷ pxs@(p[x] ∷ _)) =
-    singleton⁻ p[x] ∷ inits⁻ xs (All.map (drop⁺ 1) (map⁻ pxs))
+inits⁻ : ∀ xs → All (All P) (inits xs) → All P xs
+inits⁻ []               pxs                   = []
+inits⁻ (x ∷ [])         ([] ∷ p[x] ∷ [])      = p[x]
+inits⁻ (x ∷ xs@(_ ∷ _)) ([] ∷ pxs@(p[x] ∷ _)) =
+  singleton⁻ p[x] ∷ inits⁻ xs (All.map (drop⁺ 1) (map⁻ pxs))
 
 ------------------------------------------------------------------------
 -- tails
 
-module _ {P : A → Set p} where
+tails⁺ : All P xs → All (All P) (tails xs)
+tails⁺ []             = [] ∷ []
+tails⁺ pxxs@(_ ∷ pxs) = pxxs ∷ tails⁺ pxs
 
-  tails⁺ : ∀ {xs} → All P xs → All (All P) (tails xs)
-  tails⁺ []             = [] ∷ []
-  tails⁺ pxxs@(_ ∷ pxs) = pxxs ∷ tails⁺ pxs
-
-  tails⁻ : ∀ xs → All (All P) (tails xs) → All P xs
-  tails⁻ []       pxs        = []
-  tails⁻ (x ∷ xs) (pxxs ∷ _) = pxxs
+tails⁻ : ∀ xs → All (All P) (tails xs) → All P xs
+tails⁻ []       pxs        = []
+tails⁻ (x ∷ xs) (pxxs ∷ _) = pxxs
 
 ------------------------------------------------------------------------
 -- all
@@ -661,33 +615,31 @@ module _ (p : A → Bool) where
   all⁺ (x ∷ xs) px∷xs with Equivalence.to (T-∧ {p x}) ⟨$⟩ px∷xs
   ... | (px , pxs) = px ∷ all⁺ xs pxs
 
-  all⁻ : ∀ {xs} → All (T ∘ p) xs → T (all p xs)
+  all⁻ : All (T ∘ p) xs → T (all p xs)
   all⁻ []         = _
   all⁻ (px ∷ pxs) = Equivalence.from T-∧ ⟨$⟩ (px , all⁻ pxs)
 
 ------------------------------------------------------------------------
 -- All is anti-monotone.
 
-anti-mono : ∀ {P : A → Set p} {xs ys} → xs ⊆ ys → All P ys → All P xs
+anti-mono : xs ⊆ ys → All P ys → All P xs
 anti-mono xs⊆ys pys = All.tabulate (lookup pys ∘ xs⊆ys)
 
-all-anti-mono : ∀ (p : A → Bool) {xs ys} →
-                xs ⊆ ys → T (all p ys) → T (all p xs)
+all-anti-mono : ∀ (p : A → Bool) → xs ⊆ ys → T (all p ys) → T (all p xs)
 all-anti-mono p xs⊆ys = all⁻ p ∘ anti-mono xs⊆ys ∘ all⁺ p _
 
 ------------------------------------------------------------------------
 -- Interactions with pointwise equality
 ------------------------------------------------------------------------
 
-module _ {c ℓ} (S : Setoid c ℓ) where
+module _ (S : Setoid c ℓ) where
 
   open Setoid S
   open ListEq S
 
-  respects : {P : Pred Carrier p} → P Respects _≈_ → (All P) Respects _≋_
+  respects : P Respects _≈_ → (All P) Respects _≋_
   respects p≈ []            []         = []
   respects p≈ (x≈y ∷ xs≈ys) (px ∷ pxs) = p≈ x≈y px ∷ respects p≈ xs≈ys pxs
-
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -358,15 +358,15 @@ mapMaybe⁺ {xs = x ∷ xs} {f = f} (px ∷ pxs) with f x
 ++⁺ []         pys = pys
 ++⁺ (px ∷ pxs) pys = px ∷ ++⁺ pxs pys
 
-++⁻ˡ : ∀ xs → All P (xs ++ ys) → All P xs
+++⁻ˡ : ∀ xs {ys} → All P (xs ++ ys) → All P xs
 ++⁻ˡ []       p          = []
 ++⁻ˡ (x ∷ xs) (px ∷ pxs) = px ∷ (++⁻ˡ _ pxs)
 
-++⁻ʳ : ∀ xs → All P (xs ++ ys) → All P ys
+++⁻ʳ : ∀ xs {ys} → All P (xs ++ ys) → All P ys
 ++⁻ʳ []       p          = p
 ++⁻ʳ (x ∷ xs) (px ∷ pxs) = ++⁻ʳ xs pxs
 
-++⁻ : ∀ xs → All P (xs ++ ys) → All P xs × All P ys
+++⁻ : ∀ xs {ys} → All P (xs ++ ys) → All P xs × All P ys
 ++⁻ []       p          = [] , p
 ++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (px ∷_) id (++⁻ _ pxs)
 

--- a/src/Data/List/Relation/Unary/Any.agda
+++ b/src/Data/List/Relation/Unary/Any.agda
@@ -24,6 +24,9 @@ private
   variable
     a p q : Level
     A : Set a
+    P Q : Pred A p
+    x : A
+    xs : List A
 
 ------------------------------------------------------------------------
 -- Definition
@@ -39,67 +42,66 @@ data Any {A : Set a} (P : Pred A p) : Pred (List A) (a ⊔ p) where
 ------------------------------------------------------------------------
 -- Operations on Any
 
-module _ {P : Pred A p} {x xs} where
+head : ¬ Any P xs → Any P (x ∷ xs) → P x
+head ¬pxs (here px)   = px
+head ¬pxs (there pxs) = contradiction pxs ¬pxs
 
-  head : ¬ Any P xs → Any P (x ∷ xs) → P x
-  head ¬pxs (here px)   = px
-  head ¬pxs (there pxs) = contradiction pxs ¬pxs
+tail : ¬ P x → Any P (x ∷ xs) → Any P xs
+tail ¬px (here  px)  = ⊥-elim (¬px px)
+tail ¬px (there pxs) = pxs
 
-  tail : ¬ P x → Any P (x ∷ xs) → Any P xs
-  tail ¬px (here  px)  = ⊥-elim (¬px px)
-  tail ¬px (there pxs) = pxs
+map : P ⊆ Q → Any P ⊆ Any Q
+map g (here px)   = here (g px)
+map g (there pxs) = there (map g pxs)
 
-module _ {P : Pred A p} {Q : Pred A q} where
+-- `index x∈xs` is the list position (zero-based) which `x∈xs` points to.
 
-  map : P ⊆ Q → Any P ⊆ Any Q
-  map g (here px)   = here (g px)
-  map g (there pxs) = there (map g pxs)
+index : Any P xs → Fin (List.length xs)
+index (here  px)  = zero
+index (there pxs) = suc (index pxs)
 
-module _ {P : Pred A p} where
+lookup : {P : Pred A p} → Any P xs → A
+lookup {xs = xs} p = List.lookup xs (index p)
 
-  -- `index x∈xs` is the list position (zero-based) which `x∈xs` points to.
+_∷=_ : {P : Pred A p} → Any P xs → A → List A
+_∷=_ {xs = xs} x∈xs v = xs List.[ index x∈xs ]∷= v
 
-  index : ∀ {xs} → Any P xs → Fin (List.length xs)
-  index (here  px)  = zero
-  index (there pxs) = suc (index pxs)
+infixl 4 _─_
+_─_ : {P : Pred A p} → ∀ xs → Any P xs → List A
+xs ─ x∈xs = xs List.─ index x∈xs
 
-  lookup : ∀ {xs} → Any P xs → A
-  lookup {xs} p = List.lookup xs (index p)
+-- If any element satisfies P, then P is satisfied.
 
-  _∷=_ : ∀ {xs} → Any P xs → A → List A
-  _∷=_ {xs} x∈xs v = xs List.[ index x∈xs ]∷= v
+satisfied : Any P xs → ∃ P
+satisfied (here px)   = _ , px
+satisfied (there pxs) = satisfied pxs
 
-  infixl 4 _─_
-  _─_ : ∀ xs → Any P xs → List A
-  xs ─ x∈xs = xs List.─ index x∈xs
+toSum : Any P (x ∷ xs) → P x ⊎ Any P xs
+toSum (here px)   = inj₁ px
+toSum (there pxs) = inj₂ pxs
 
-  -- If any element satisfies P, then P is satisfied.
-
-  satisfied : ∀ {xs} → Any P xs → ∃ P
-  satisfied (here px) = _ , px
-  satisfied (there pxs) = satisfied pxs
-
-module _ {P : Pred A p} {x xs} where
-
-  toSum : Any P (x ∷ xs) → P x ⊎ Any P xs
-  toSum (here px)   = inj₁ px
-  toSum (there pxs) = inj₂ pxs
-
-  fromSum : P x ⊎ Any P xs → Any P (x ∷ xs)
-  fromSum (inj₁ px)  = here px
-  fromSum (inj₂ pxs) = there pxs
+fromSum : P x ⊎ Any P xs → Any P (x ∷ xs)
+fromSum (inj₁ px)  = here px
+fromSum (inj₂ pxs) = there pxs
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by Any
 
-module _ {P : Pred A p} where
+any? : Decidable P → Decidable (Any P)
+any? P? []       = no λ()
+any? P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any? P? xs)
 
-  any? : Decidable P → Decidable (Any P)
-  any? P? []       = no λ()
-  any? P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any? P? xs)
+satisfiable : Satisfiable P → Satisfiable (Any P)
+satisfiable (x , Px) = [ x ] , here Px
 
-  satisfiable : Satisfiable P → Satisfiable (Any P)
-  satisfiable (x , Px) = [ x ] , here Px
+
+------------------------------------------------------------------------
+-- DEPRECATED
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.4
 
 any = any?
 {-# WARNING_ON_USAGE any

--- a/src/Data/List/Relation/Unary/Any/Properties.agda
+++ b/src/Data/List/Relation/Unary/Any/Properties.agda
@@ -347,16 +347,16 @@ module _ {P : A → Set p} where
   ++⁺ˡ (here p)  = here p
   ++⁺ˡ (there p) = there (++⁺ˡ p)
 
-  ++⁺ʳ : ∀ xs → Any P ys → Any P (xs ++ ys)
+  ++⁺ʳ : ∀ xs {ys} → Any P ys → Any P (xs ++ ys)
   ++⁺ʳ []       p = p
   ++⁺ʳ (x ∷ xs) p = there (++⁺ʳ xs p)
 
-  ++⁻ : ∀ xs → Any P (xs ++ ys) → Any P xs ⊎ Any P ys
+  ++⁻ : ∀ xs {ys} → Any P (xs ++ ys) → Any P xs ⊎ Any P ys
   ++⁻ []       p         = inj₂ p
   ++⁻ (x ∷ xs) (here p)  = inj₁ (here p)
   ++⁻ (x ∷ xs) (there p) = Sum.map there id (++⁻ xs p)
 
-  ++⁺∘++⁻ : ∀ xs (p : Any P (xs ++ ys)) → [ ++⁺ˡ , ++⁺ʳ xs ]′ (++⁻ xs p) ≡ p
+  ++⁺∘++⁻ : ∀ xs {ys} (p : Any P (xs ++ ys)) → [ ++⁺ˡ , ++⁺ʳ xs ]′ (++⁻ xs p) ≡ p
   ++⁺∘++⁻ []       p         = refl
   ++⁺∘++⁻ (x ∷ xs) (here  p) = refl
   ++⁺∘++⁻ (x ∷ xs) (there p) with ++⁻ xs p | ++⁺∘++⁻ xs p
@@ -396,7 +396,7 @@ module _ {P : A → Set p} where
   ++↔++ xs ys = inverse (++-comm xs ys) (++-comm ys xs)
                         (++-comm∘++-comm xs) (++-comm∘++-comm ys)
 
-  ++-insert : ∀ xs → P x → Any P (xs ++ [ x ] ++ ys)
+  ++-insert : ∀ xs {ys} → P x → Any P (xs ++ [ x ] ++ ys)
   ++-insert xs Px = ++⁺ʳ xs (++⁺ˡ (singleton⁺ Px))
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Unary/Any/Properties.agda
+++ b/src/Data/List/Relation/Unary/Any/Properties.agda
@@ -56,63 +56,52 @@ private
     A : Set a
     B : Set b
     C : Set c
+    P Q R : Pred A p
+    x y : A
+    xs ys : List A
 
 ------------------------------------------------------------------------
 -- Equality properties
 
-module _ {P : A → Set p} {_≈_ : Rel A ℓ} where
+lift-resp : ∀ {_≈_ : Rel A ℓ} → P Respects _≈_ →
+            (Any P) Respects (Pointwise _≈_)
+lift-resp resp (x≈y ∷ xs≈ys) (here px)   = here (resp x≈y px)
+lift-resp resp (x≈y ∷ xs≈ys) (there pxs) = there (lift-resp resp xs≈ys pxs)
 
-  lift-resp : P Respects _≈_ → (Any P) Respects (Pointwise _≈_)
-  lift-resp resp (x≈y ∷ xs≈ys) (here px)   = here (resp x≈y px)
-  lift-resp resp (x≈y ∷ xs≈ys) (there pxs) =
-    there (lift-resp resp xs≈ys pxs)
+here-injective : ∀ {p q : P x} → here {P = P} {xs = xs} p ≡ here q → p ≡ q
+here-injective refl = refl
 
-module _ {P : A → Set p} {x xs} where
-
-  here-injective : ∀ {p q : P x} →
-                   here {P = P} {xs = xs} p ≡ here q → p ≡ q
-  here-injective refl = refl
-
-  there-injective : ∀ {p q : Any P xs} →
-                    there {x = x} p ≡ there q → p ≡ q
-  there-injective refl = refl
+there-injective : ∀ {p q : Any P xs} → there {x = x} p ≡ there q → p ≡ q
+there-injective refl = refl
 
 ------------------------------------------------------------------------
 -- Misc
 
-module _ {P : A → Set p} where
-
-  ¬Any[] : ¬ Any P []
-  ¬Any[] ()
+¬Any[] : ¬ Any P []
+¬Any[] ()
 
 ------------------------------------------------------------------------
 -- Any is a congruence
 
-module _ {k : Kind} {P : Pred A p} {Q : Pred A q} where
-
-  Any-cong : ∀ {xs ys : List A} →
-             (∀ x → Related k (P x) (Q x)) →
-             (∀ {z} → Related k (z ∈ xs) (z ∈ ys)) →
-             Related k (Any P xs) (Any Q ys)
-  Any-cong {xs} {ys} P↔Q xs≈ys =
-    Any P xs                ↔⟨ SK-sym Any↔ ⟩
-    (∃ λ x → x ∈ xs × P x)  ∼⟨ Σ.cong Inv.id (xs≈ys ×-cong P↔Q _) ⟩
-    (∃ λ x → x ∈ ys × Q x)  ↔⟨ Any↔ ⟩
-    Any Q ys                ∎
-    where open Related.EquationalReasoning
+Any-cong : ∀ {k : Kind} → (∀ x → Related k (P x) (Q x)) →
+           (∀ {z} → Related k (z ∈ xs) (z ∈ ys)) →
+           Related k (Any P xs) (Any Q ys)
+Any-cong {P = P} {Q = Q} {xs = xs} {ys} P↔Q xs≈ys =
+  Any P xs                ↔⟨ SK-sym Any↔ ⟩
+  (∃ λ x → x ∈ xs × P x)  ∼⟨ Σ.cong Inv.id (xs≈ys ×-cong P↔Q _) ⟩
+  (∃ λ x → x ∈ ys × Q x)  ↔⟨ Any↔ ⟩
+  Any Q ys                ∎
+  where open Related.EquationalReasoning
 
 ------------------------------------------------------------------------
 -- Any.map
 
-map-id : ∀ {P : A → Set p} (f : P ⋐ P) {xs} →
-         (∀ {x} (p : P x) → f p ≡ p) →
+map-id : ∀ (f : P ⋐ P) → (∀ {x} (p : P x) → f p ≡ p) →
          (p : Any P xs) → Any.map f p ≡ p
 map-id f hyp (here  p) = P.cong here (hyp p)
 map-id f hyp (there p) = P.cong there $ map-id f hyp p
 
-map-∘ : ∀ {P : A → Set p} {Q : A → Set q} {R : A → Set r}
-        (f : Q ⋐ R) (g : P ⋐ Q)
-        {xs} (p : Any P xs) →
+map-∘ : ∀ (f : Q ⋐ R) (g : P ⋐ Q) (p : Any P xs) →
         Any.map (f ∘ g) p ≡ Any.map f (Any.map g p)
 map-∘ f g (here  p) = refl
 map-∘ f g (there p) = P.cong there $ map-∘ f g p
@@ -120,7 +109,7 @@ map-∘ f g (there p) = P.cong there $ map-∘ f g p
 ------------------------------------------------------------------------
 -- Any.lookup
 
-lookup-result : ∀ {P : Pred A p} {xs} → (p : Any P xs) → P (Any.lookup p)
+lookup-result : ∀ (p : Any P xs) → P (Any.lookup p)
 lookup-result (here px) = px
 lookup-result (there p) = lookup-result p
 
@@ -129,18 +118,18 @@ lookup-result (there p) = lookup-result p
 
 -- Nested occurrences of Any can sometimes be swapped. See also ×↔.
 
-swap : ∀ {P : A → B → Set ℓ} {xs ys} →
+swap : ∀ {P : A → B → Set ℓ} →
        Any (λ x → Any (P x) ys) xs → Any (λ y → Any (flip P y) xs) ys
 swap (here  pys)  = Any.map here pys
 swap (there pxys) = Any.map there (swap pxys)
 
-swap-there : ∀ {P : A → B → Set ℓ} {x xs ys} →
+swap-there : ∀ {P : A → B → Set ℓ} →
              (any : Any (λ x → Any (P x) ys) xs) →
              swap (Any.map (there {x = x}) any) ≡ there (swap any)
 swap-there (here  pys)  = refl
 swap-there (there pxys) = P.cong (Any.map there) (swap-there pxys)
 
-swap-invol : ∀ {P : A → B → Set ℓ} {xs ys} →
+swap-invol : ∀ {P : A → B → Set ℓ} →
              (any : Any (λ x → Any (P x) ys) xs) →
              swap (swap any) ≡ any
 swap-invol (here (here px))   = refl
@@ -149,20 +138,20 @@ swap-invol (here (there pys)) =
 swap-invol (there pxys)       =
   P.trans (swap-there (swap pxys)) (P.cong there (swap-invol pxys))
 
-swap↔ : ∀ {P : A → B → Set ℓ} {xs ys} →
+swap↔ : ∀ {P : A → B → Set ℓ} →
        Any (λ x → Any (P x) ys) xs ↔ Any (λ y → Any (flip P y) xs) ys
 swap↔ = inverse swap swap swap-invol swap-invol
 
 ------------------------------------------------------------------------
 -- Lemmas relating Any to ⊥
 
-⊥↔Any⊥ : ∀ {xs : List A} → ⊥ ↔ Any (const ⊥) xs
-⊥↔Any⊥ {A = A} = inverse (λ()) (λ p → from p) (λ()) (λ p → from p)
+⊥↔Any⊥ : ⊥ ↔ Any (const ⊥) xs
+⊥↔Any⊥ = inverse (λ()) (λ p → from p) (λ()) (λ p → from p)
   where
-  from : {xs : List A} → Any (const ⊥) xs → ∀ {b} {B : Set b} → B
+  from : Any (const ⊥) xs → B
   from (there p) = from p
 
-⊥↔Any[] : ∀ {P : A → Set p} → ⊥ ↔ Any P []
+⊥↔Any[] : ⊥ ↔ Any P []
 ⊥↔Any[] = inverse (λ()) (λ()) (λ()) (λ())
 
 ------------------------------------------------------------------------
@@ -170,7 +159,7 @@ swap↔ = inverse swap swap swap-invol swap-invol
 
 -- These introduction and elimination rules are not inverses, though.
 
-any⁺ : ∀ (p : A → Bool) {xs} → Any (T ∘ p) xs → T (any p xs)
+any⁺ : ∀ (p : A → Bool) → Any (T ∘ p) xs → T (any p xs)
 any⁺ p (here  px)          = Equivalence.from T-∨ ⟨$⟩ inj₁ px
 any⁺ p (there {x = x} pxs) with p x
 ... | true  = _
@@ -181,122 +170,118 @@ any⁻ p (x ∷ xs) px∷xs with p x | inspect p x
 ... | true  | P.[ eq ] = here (Equivalence.from T-≡ ⟨$⟩ eq)
 ... | false | _        = there (any⁻ p xs px∷xs)
 
-any⇔ : ∀ {p : A → Bool} {xs} → Any (T ∘ p) xs ⇔ T (any p xs)
+any⇔ : ∀ {p : A → Bool} → Any (T ∘ p) xs ⇔ T (any p xs)
 any⇔ = equivalence (any⁺ _) (any⁻ _ _)
 
 ------------------------------------------------------------------------
 -- Sums commute with Any
 
-module _ {P : A → Set p} {Q : A → Set q} where
+Any-⊎⁺ : Any P xs ⊎ Any Q xs → Any (λ x → P x ⊎ Q x) xs
+Any-⊎⁺ = [ Any.map inj₁ , Any.map inj₂ ]′
 
-  Any-⊎⁺ : ∀ {xs} → Any P xs ⊎ Any Q xs → Any (λ x → P x ⊎ Q x) xs
-  Any-⊎⁺ = [ Any.map inj₁ , Any.map inj₂ ]′
+Any-⊎⁻ : Any (λ x → P x ⊎ Q x) xs → Any P xs ⊎ Any Q xs
+Any-⊎⁻ (here (inj₁ p)) = inj₁ (here p)
+Any-⊎⁻ (here (inj₂ q)) = inj₂ (here q)
+Any-⊎⁻ (there p)       = Sum.map there there (Any-⊎⁻ p)
 
-  Any-⊎⁻ : ∀ {xs} → Any (λ x → P x ⊎ Q x) xs → Any P xs ⊎ Any Q xs
-  Any-⊎⁻ (here (inj₁ p)) = inj₁ (here p)
-  Any-⊎⁻ (here (inj₂ q)) = inj₂ (here q)
-  Any-⊎⁻ (there p)       = Sum.map there there (Any-⊎⁻ p)
+⊎↔ : (Any P xs ⊎ Any Q xs) ↔ Any (λ x → P x ⊎ Q x) xs
+⊎↔ {P = P} {Q = Q} = inverse Any-⊎⁺ Any-⊎⁻ from∘to to∘from
+  where
+  from∘to : (p : Any P xs ⊎ Any Q xs) → Any-⊎⁻ (Any-⊎⁺ p) ≡ p
+  from∘to (inj₁ (here  p)) = refl
+  from∘to (inj₁ (there p)) rewrite from∘to (inj₁ p) = refl
+  from∘to (inj₂ (here  q)) = refl
+  from∘to (inj₂ (there q)) rewrite from∘to (inj₂ q) = refl
 
-  ⊎↔ : ∀ {xs} → (Any P xs ⊎ Any Q xs) ↔ Any (λ x → P x ⊎ Q x) xs
-  ⊎↔ = inverse Any-⊎⁺ Any-⊎⁻ from∘to to∘from
-    where
-    from∘to : ∀ {xs} (p : Any P xs ⊎ Any Q xs) → Any-⊎⁻ (Any-⊎⁺ p) ≡ p
-    from∘to (inj₁ (here  p)) = refl
-    from∘to (inj₁ (there p)) rewrite from∘to (inj₁ p) = refl
-    from∘to (inj₂ (here  q)) = refl
-    from∘to (inj₂ (there q)) rewrite from∘to (inj₂ q) = refl
-
-    to∘from : ∀ {xs} (p : Any (λ x → P x ⊎ Q x) xs) →
-              Any-⊎⁺ (Any-⊎⁻ p) ≡ p
-    to∘from (here (inj₁ p)) = refl
-    to∘from (here (inj₂ q)) = refl
-    to∘from (there p) with Any-⊎⁻ p | to∘from p
-    to∘from (there .(Any.map inj₁ p)) | inj₁ p | refl = refl
-    to∘from (there .(Any.map inj₂ q)) | inj₂ q | refl = refl
+  to∘from : (p : Any (λ x → P x ⊎ Q x) xs) → Any-⊎⁺ (Any-⊎⁻ p) ≡ p
+  to∘from (here (inj₁ p)) = refl
+  to∘from (here (inj₂ q)) = refl
+  to∘from (there p) with Any-⊎⁻ p | to∘from p
+  to∘from (there .(Any.map inj₁ p)) | inj₁ p | refl = refl
+  to∘from (there .(Any.map inj₂ q)) | inj₂ q | refl = refl
 
 ------------------------------------------------------------------------
 -- Products "commute" with Any.
 
-module _ {P : Pred A p} {Q : Pred B q} where
+Any-×⁺ : Any P xs × Any Q ys → Any (λ x → Any (λ y → P x × Q y) ys) xs
+Any-×⁺ (p , q) = Any.map (λ p → Any.map (λ q → (p , q)) q) p
 
-  Any-×⁺ : ∀ {xs ys} → Any P xs × Any Q ys →
-           Any (λ x → Any (λ y → P x × Q y) ys) xs
-  Any-×⁺ (p , q) = Any.map (λ p → Any.map (λ q → (p , q)) q) p
+Any-×⁻ : Any (λ x → Any (λ y → P x × Q y) ys) xs →
+         Any P xs × Any Q ys
+Any-×⁻ pq with Prod.map₂ (Prod.map₂ find) (find pq)
+... | (x , x∈xs , y , y∈ys , p , q) = lose x∈xs p , lose y∈ys q
 
-  Any-×⁻ : ∀ {xs ys} → Any (λ x → Any (λ y → P x × Q y) ys) xs →
-           Any P xs × Any Q ys
-  Any-×⁻ pq with Prod.map id (Prod.map id find) (find pq)
-  ... | (x , x∈xs , y , y∈ys , p , q) = (lose x∈xs p , lose y∈ys q)
+×↔ : ∀ {xs ys} →
+     (Any P xs × Any Q ys) ↔ Any (λ x → Any (λ y → P x × Q y) ys) xs
+×↔ {P = P} {Q = Q} {xs} {ys} = inverse Any-×⁺ Any-×⁻ from∘to to∘from
+  where
+  open P.≡-Reasoning
 
-  ×↔ : ∀ {xs ys} →
-       (Any P xs × Any Q ys) ↔ Any (λ x → Any (λ y → P x × Q y) ys) xs
-  ×↔ {xs} {ys} = inverse Any-×⁺ Any-×⁻ from∘to to∘from
+  from∘to : ∀ pq → Any-×⁻ (Any-×⁺ pq) ≡ pq
+  from∘to (p , q) =
+
+    Any-×⁻ (Any-×⁺ (p , q))
+
+      ≡⟨⟩
+
+    (let (x , x∈xs , pq)    = find (Any-×⁺ (p , q))
+         (y , y∈ys , p , q) = find pq
+     in  lose x∈xs p , lose y∈ys q)
+
+     ≡⟨ P.cong (λ • → let (x , x∈xs , pq)    = •
+                          (y , y∈ys , p , q) = find pq
+                      in  lose x∈xs p , lose y∈ys q)
+               (find∘map p (λ p → Any.map (p ,_) q)) ⟩
+
+    (let (x , x∈xs , p)     = find p
+         (y , y∈ys , p , q) = find (Any.map (p ,_) q)
+     in  lose x∈xs p , lose y∈ys q)
+
+     ≡⟨ P.cong (λ • → let (x , x∈xs , p)     = find p
+                          (y , y∈ys , p , q) = •
+                      in  lose x∈xs p , lose y∈ys q)
+               (find∘map q (proj₂ (proj₂ (find p)) ,_)) ⟩
+
+    (let (x , x∈xs , p) = find p
+         (y , y∈ys , q) = find q
+     in  lose x∈xs p , lose y∈ys q)
+
+     ≡⟨ P.cong₂ _,_ (lose∘find p) (lose∘find q) ⟩
+
+    (p , q) ∎
     where
-    open P.≡-Reasoning
 
-    from∘to : ∀ pq → Any-×⁻ (Any-×⁺ pq) ≡ pq
-    from∘to (p , q) =
 
-      Any-×⁻ (Any-×⁺ (p , q))
-
-        ≡⟨⟩
-
-      (let (x , x∈xs , pq)    = find (Any-×⁺ (p , q))
-           (y , y∈ys , p , q) = find pq
-       in  lose x∈xs p , lose y∈ys q)
-
-       ≡⟨ P.cong (λ • → let (x , x∈xs , pq)    = •
-                            (y , y∈ys , p , q) = find pq
-                        in  lose x∈xs p , lose y∈ys q)
-                 (find∘map p (λ p → Any.map (p ,_) q)) ⟩
-
-      (let (x , x∈xs , p)     = find p
-           (y , y∈ys , p , q) = find (Any.map (p ,_) q)
-       in  lose x∈xs p , lose y∈ys q)
-
-       ≡⟨ P.cong (λ • → let (x , x∈xs , p)     = find p
-                            (y , y∈ys , p , q) = •
-                        in  lose x∈xs p , lose y∈ys q)
-                 (find∘map q (proj₂ (proj₂ (find p)) ,_)) ⟩
-
-      (let (x , x∈xs , p) = find p
-           (y , y∈ys , q) = find q
-       in  lose x∈xs p , lose y∈ys q)
-
-       ≡⟨ P.cong₂ _,_ (lose∘find p) (lose∘find q) ⟩
-
-      (p , q) ∎
-
-    to∘from : ∀ pq → Any-×⁺ {xs} (Any-×⁻ pq) ≡ pq
-    to∘from pq
-      with find pq
-        | (λ (f : (proj₁ (find pq) ≡_) ⋐ _) → map∘find pq {f})
-    ... | (x , x∈xs , pq′) | lem₁
-      with find pq′
-        | (λ (f : (proj₁ (find pq′) ≡_) ⋐ _) → map∘find pq′ {f})
-    ... | (y , y∈ys , p , q) | lem₂
-      rewrite P.sym $ map-∘ {R = λ x → Any (λ y → P x × Q y) ys}
-                            (λ p → Any.map (λ q → p , q) (lose y∈ys q))
-                            (λ y → P.subst P y p)
-                            x∈xs
-              = lem₁ _ helper
-      where
-      helper : Any.map (λ q → p , q) (lose y∈ys q) ≡ pq′
-      helper rewrite P.sym $ map-∘ (λ q → p , q)
-                                   (λ y → P.subst Q y q)
-                                   y∈ys
-             = lem₂ _ refl
+  to∘from : ∀ pq → Any-×⁺ {xs = xs} (Any-×⁻ pq) ≡ pq
+  to∘from pq
+    with find pq
+      | (λ (f : (proj₁ (find pq) ≡_) ⋐ _) → map∘find pq {f})
+  ... | (x , x∈xs , pq′) | lem₁
+    with find pq′
+      | (λ (f : (proj₁ (find pq′) ≡_) ⋐ _) → map∘find pq′ {f})
+  ... | (y , y∈ys , p , q) | lem₂
+    rewrite P.sym $ map-∘ {R = λ x → Any (λ y → P x × Q y) ys}
+                          (λ p → Any.map (λ q → p , q) (lose y∈ys q))
+                          (λ y → P.subst P y p)
+                          x∈xs
+            = lem₁ _ helper
+    where
+    helper : Any.map (λ q → p , q) (lose y∈ys q) ≡ pq′
+    helper rewrite P.sym $ map-∘ (λ q → p , q)
+                                 (λ y → P.subst Q y q)
+                                 y∈ys
+           = lem₂ _ refl
 
 ------------------------------------------------------------------------
 -- Half-applied product commutes with Any.
 
 module _ {_~_ : REL A B r} where
 
-  Any-Σ⁺ʳ : ∀ {xs} → (∃ λ x → Any (_~ x) xs) → Any (∃ ∘ _~_) xs
+  Any-Σ⁺ʳ : (∃ λ x → Any (_~ x) xs) → Any (∃ ∘ _~_) xs
   Any-Σ⁺ʳ (b , here px) = here (b , px)
   Any-Σ⁺ʳ (b , there pxs) = there (Any-Σ⁺ʳ (b , pxs))
 
-  Any-Σ⁻ʳ : ∀ {xs} → Any (∃ ∘ _~_) xs → ∃ λ x → Any (_~ x) xs
+  Any-Σ⁻ʳ : Any (∃ ∘ _~_) xs → ∃ λ x → Any (_~ x) xs
   Any-Σ⁻ʳ (here (b , x)) = b , here x
   Any-Σ⁻ʳ (there xs) = Prod.map₂ there $ Any-Σ⁻ʳ xs
 
@@ -308,54 +293,47 @@ module _ {_~_ : REL A B r} where
 ------------------------------------------------------------------------
 -- singleton
 
-module _ {P : Pred A p} where
+singleton⁺ : P x → Any P [ x ]
+singleton⁺ Px = here Px
 
-  singleton⁺ : ∀ {x} → P x → Any P [ x ]
-  singleton⁺ Px = here Px
-
-  singleton⁻ : ∀ {x} → Any P [ x ] → P x
-  singleton⁻ (here Px) = Px
+singleton⁻ : Any P [ x ] → P x
+singleton⁻ (here Px) = Px
 
 ------------------------------------------------------------------------
 -- map
 
 module _ {f : A → B} where
 
-  map⁺ : ∀ {P : B → Set p} {xs} → Any (P ∘ f) xs → Any P (List.map f xs)
+  map⁺ : Any (P ∘ f) xs → Any P (List.map f xs)
   map⁺ (here p)  = here p
   map⁺ (there p) = there $ map⁺ p
 
-  map⁻ : ∀ {P : B → Set p} {xs} → Any P (List.map f xs) → Any (P ∘ f) xs
+  map⁻ : Any P (List.map f xs) → Any (P ∘ f) xs
   map⁻ {xs = x ∷ xs} (here p)  = here p
   map⁻ {xs = x ∷ xs} (there p) = there $ map⁻ p
 
-  map⁺∘map⁻ : ∀ {P : B → Set p} {xs} →
-              (p : Any P (List.map f xs)) → map⁺ (map⁻ p) ≡ p
+  map⁺∘map⁻ : (p : Any P (List.map f xs)) → map⁺ (map⁻ p) ≡ p
   map⁺∘map⁻ {xs = x ∷ xs} (here  p) = refl
   map⁺∘map⁻ {xs = x ∷ xs} (there p) = P.cong there (map⁺∘map⁻ p)
 
-  map⁻∘map⁺ : ∀ (P : B → Set p) {xs} →
+  map⁻∘map⁺ : ∀ (P : Pred B p) →
               (p : Any (P ∘ f) xs) → map⁻ {P = P} (map⁺ p) ≡ p
   map⁻∘map⁺ P (here  p) = refl
   map⁻∘map⁺ P (there p) = P.cong there (map⁻∘map⁺ P p)
 
-  map↔ : ∀ {P : B → Set p} {xs} →
-         Any (P ∘ f) xs ↔ Any P (List.map f xs)
+  map↔ : Any (P ∘ f) xs ↔ Any P (List.map f xs)
   map↔ = inverse map⁺ map⁻ (map⁻∘map⁺ _) map⁺∘map⁻
 
-module _ {f : A → B} {P : A → Set p} {Q : B → Set q} where
   gmap : P ⋐ Q ∘ f → Any P ⋐ Any Q ∘ map f
   gmap g = map⁺ ∘ Any.map g
 
 ------------------------------------------------------------------------
 -- mapMaybe
 
-module _ {P : B → Set p} (f : A → Maybe B) where
+module _ (f : A → Maybe B) where
 
-  mapMaybe⁺ : ∀ xs → Any (MAny.Any P) (map f xs) →
-              Any P (mapMaybe f xs)
+  mapMaybe⁺ : ∀ xs → Any (MAny.Any P) (map f xs) → Any P (mapMaybe f xs)
   mapMaybe⁺ (x ∷ xs) ps with f x | ps
-  ... | nothing | here  ()
   ... | nothing | there pxs      = mapMaybe⁺ xs pxs
   ... | just _  | here (just py) = here py
   ... | just _  | there pxs      = there (mapMaybe⁺ xs pxs)
@@ -365,26 +343,25 @@ module _ {P : B → Set p} (f : A → Maybe B) where
 
 module _ {P : A → Set p} where
 
-  ++⁺ˡ : ∀ {xs ys} → Any P xs → Any P (xs ++ ys)
+  ++⁺ˡ : Any P xs → Any P (xs ++ ys)
   ++⁺ˡ (here p)  = here p
   ++⁺ˡ (there p) = there (++⁺ˡ p)
 
-  ++⁺ʳ : ∀ xs {ys} → Any P ys → Any P (xs ++ ys)
+  ++⁺ʳ : ∀ xs → Any P ys → Any P (xs ++ ys)
   ++⁺ʳ []       p = p
   ++⁺ʳ (x ∷ xs) p = there (++⁺ʳ xs p)
 
-  ++⁻ : ∀ xs {ys} → Any P (xs ++ ys) → Any P xs ⊎ Any P ys
+  ++⁻ : ∀ xs → Any P (xs ++ ys) → Any P xs ⊎ Any P ys
   ++⁻ []       p         = inj₂ p
   ++⁻ (x ∷ xs) (here p)  = inj₁ (here p)
   ++⁻ (x ∷ xs) (there p) = Sum.map there id (++⁻ xs p)
 
-  ++⁺∘++⁻ : ∀ xs {ys} (p : Any P (xs ++ ys)) →
-            [ ++⁺ˡ , ++⁺ʳ xs ]′ (++⁻ xs p) ≡ p
+  ++⁺∘++⁻ : ∀ xs (p : Any P (xs ++ ys)) → [ ++⁺ˡ , ++⁺ʳ xs ]′ (++⁻ xs p) ≡ p
   ++⁺∘++⁻ []       p         = refl
   ++⁺∘++⁻ (x ∷ xs) (here  p) = refl
   ++⁺∘++⁻ (x ∷ xs) (there p) with ++⁻ xs p | ++⁺∘++⁻ xs p
-  ++⁺∘++⁻ (x ∷ xs) (there p) | inj₁ p′ | ih = P.cong there ih
-  ++⁺∘++⁻ (x ∷ xs) (there p) | inj₂ p′ | ih = P.cong there ih
+  ... | inj₁ p′ | ih = P.cong there ih
+  ... | inj₂ p′ | ih = P.cong there ih
 
   ++⁻∘++⁺ : ∀ xs {ys} (p : Any P xs ⊎ Any P ys) →
             ++⁻ xs ([ ++⁺ˡ , ++⁺ʳ xs ]′ p) ≡ p
@@ -409,17 +386,17 @@ module _ {P : A → Set p} where
   ++-comm∘++-comm (x ∷ xs) {ys} (there .([ ++⁺ʳ xs , ++⁺ˡ ]′ (++⁻ ys (++⁺ʳ ys p))))
     | inj₁ p | refl
     rewrite ++⁻∘++⁺ ys (inj₂                 p)
-            | ++⁻∘++⁺ ys (inj₂ $ there {x = x} p) = refl
+          | ++⁻∘++⁺ ys (inj₂ $ there {x = x} p) = refl
   ++-comm∘++-comm (x ∷ xs) {ys} (there .([ ++⁺ʳ xs , ++⁺ˡ ]′ (++⁻ ys (++⁺ˡ p))))
     | inj₂ p | refl
     rewrite ++⁻∘++⁺ ys {ys =     xs} (inj₁ p)
-            | ++⁻∘++⁺ ys {ys = x ∷ xs} (inj₁ p) = refl
+          | ++⁻∘++⁺ ys {ys = x ∷ xs} (inj₁ p) = refl
 
   ++↔++ : ∀ xs ys → Any P (xs ++ ys) ↔ Any P (ys ++ xs)
   ++↔++ xs ys = inverse (++-comm xs ys) (++-comm ys xs)
                         (++-comm∘++-comm xs) (++-comm∘++-comm ys)
 
-  ++-insert : ∀ xs {ys x} → P x → Any P (xs ++ [ x ] ++ ys)
+  ++-insert : ∀ xs → P x → Any P (xs ++ [ x ] ++ ys)
   ++-insert xs Px = ++⁺ʳ xs (++⁺ˡ (singleton⁺ Px))
 
 ------------------------------------------------------------------------
@@ -453,9 +430,9 @@ module _ {P : A → Set p} where
   concat⁺∘concat⁻ ([]       ∷ xss) p         = concat⁺∘concat⁻ xss p
   concat⁺∘concat⁻ ((x ∷ xs) ∷ xss) (here p)  = refl
   concat⁺∘concat⁻ ((x ∷ xs) ∷ xss) (there p)
-                with concat⁻ (xs ∷ xss) p | concat⁺∘concat⁻ (xs ∷ xss) p
-  concat⁺∘concat⁻ ((x ∷ xs) ∷ xss) (there .(++⁺ˡ p′))              | here  p′ | refl = refl
-  concat⁺∘concat⁻ ((x ∷ xs) ∷ xss) (there .(++⁺ʳ xs (concat⁺ p′))) | there p′ | refl = refl
+    with p | concat⁻ (xs ∷ xss) p | concat⁺∘concat⁻ (xs ∷ xss) p
+  ... | .(++⁺ˡ p′)              | here  p′ | refl = refl
+  ... | .(++⁺ʳ xs (concat⁺ p′)) | there p′ | refl = refl
 
   concat⁻∘concat⁺ : ∀ {xss} (p : Any (Any P) xss) → concat⁻ xss (concat⁺ p) ≡ p
   concat⁻∘concat⁺ (here                      p) = concat⁻∘++⁺ˡ _ p
@@ -469,9 +446,9 @@ module _ {P : A → Set p} where
 ------------------------------------------------------------------------
 -- cartesianProductWith
 
-module _ {P : Pred A p} {Q : Pred B q} {R : Pred C r} (f : A → B → C) where
+module _ (f : A → B → C) where
 
-  cartesianProductWith⁺ : (∀ {x y} → P x → Q y → R (f x y)) → ∀ {xs ys} →
+  cartesianProductWith⁺ : (∀ {x y} → P x → Q y → R (f x y)) →
                           Any P xs → Any Q ys →
                           Any R (cartesianProductWith f xs ys)
   cartesianProductWith⁺ pres (here  px)  qys = ++⁺ˡ (map⁺ (Any.map (pres px) qys))
@@ -484,109 +461,103 @@ module _ {P : Pred A p} {Q : Pred B q} {R : Pred C r} (f : A → B → C) where
   cartesianProductWith⁻ resp (x ∷ xs) ys Rxsys | inj₁ Rfxys with map⁻ Rfxys
   ... | Rxys = here (proj₁ (resp (proj₂ (Any.satisfied Rxys)))) , Any.map (proj₂ ∘ resp) Rxys
   cartesianProductWith⁻ resp (x ∷ xs) ys Rxsys | inj₂ Rc with cartesianProductWith⁻ resp xs ys Rc
-  ... | (pxs , qys) = there pxs , qys
+  ... | pxs , qys = there pxs , qys
 
 ------------------------------------------------------------------------
 -- cartesianProduct
 
-module _ {P : Pred A p} {Q : Pred B q} where
+cartesianProduct⁺ : Any P xs → Any Q ys →
+                    Any (P ⟨×⟩ Q) (cartesianProduct xs ys)
+cartesianProduct⁺ = cartesianProductWith⁺ _,_ _,_
 
-  cartesianProduct⁺ : ∀ {xs ys} → Any P xs → Any Q ys →
-                      Any (P ⟨×⟩ Q) (cartesianProduct xs ys)
-  cartesianProduct⁺ = cartesianProductWith⁺ _,_ _,_
-
-  cartesianProduct⁻ : ∀ xs ys → Any (P ⟨×⟩ Q) (cartesianProduct xs ys) →
-                      Any P xs × Any Q ys
-  cartesianProduct⁻ = cartesianProductWith⁻ _,_ id
+cartesianProduct⁻ : ∀ xs ys → Any (P ⟨×⟩ Q) (cartesianProduct xs ys) →
+                    Any P xs × Any Q ys
+cartesianProduct⁻ = cartesianProductWith⁻ _,_ id
 
 ------------------------------------------------------------------------
 -- applyUpTo
 
-module _ {P : A → Set p} where
+applyUpTo⁺ : ∀ f {i n} → P (f i) → i < n → Any P (applyUpTo f n)
+applyUpTo⁺ _ p (s≤s z≤n)       = here p
+applyUpTo⁺ f p (s≤s (s≤s i<n)) =
+  there (applyUpTo⁺ (f ∘ suc) p (s≤s i<n))
 
-  applyUpTo⁺ : ∀ f {i n} → P (f i) → i < n → Any P (applyUpTo f n)
-  applyUpTo⁺ _ p (s≤s z≤n)       = here p
-  applyUpTo⁺ f p (s≤s (s≤s i<n)) =
-    there (applyUpTo⁺ (f ∘ suc) p (s≤s i<n))
-
-  applyUpTo⁻ : ∀ f {n} → Any P (applyUpTo f n) →
-               ∃ λ i → i < n × P (f i)
-  applyUpTo⁻ f {suc n} (here p)  = zero , s≤s z≤n , p
-  applyUpTo⁻ f {suc n} (there p) with applyUpTo⁻ (f ∘ suc) p
-  ... | i , i<n , q = suc i , s≤s i<n , q
+applyUpTo⁻ : ∀ f {n} → Any P (applyUpTo f n) →
+             ∃ λ i → i < n × P (f i)
+applyUpTo⁻ f {suc n} (here p)  = zero , s≤s z≤n , p
+applyUpTo⁻ f {suc n} (there p) with applyUpTo⁻ (f ∘ suc) p
+... | i , i<n , q = suc i , s≤s i<n , q
 
 ------------------------------------------------------------------------
 -- tabulate
 
-module _ {P : A → Set p} where
+tabulate⁺ : ∀ {n} {f : Fin n → A} i → P (f i) → Any P (tabulate f)
+tabulate⁺ fzero    p = here p
+tabulate⁺ (fsuc i) p = there (tabulate⁺ i p)
 
-  tabulate⁺ : ∀ {n} {f : Fin n → A} i → P (f i) → Any P (tabulate f)
-  tabulate⁺ fzero    p = here p
-  tabulate⁺ (fsuc i) p = there (tabulate⁺ i p)
-
-  tabulate⁻ : ∀ {n} {f : Fin n → A} →
-              Any P (tabulate f) → ∃ λ i → P (f i)
-  tabulate⁻ {suc n} (here p)   = fzero , p
-  tabulate⁻ {suc n} (there p) = Prod.map fsuc id (tabulate⁻ p)
+tabulate⁻ : ∀ {n} {f : Fin n → A} → Any P (tabulate f) → ∃ λ i → P (f i)
+tabulate⁻ {n = suc n} (here p)   = fzero , p
+tabulate⁻ {n = suc n} (there p) = Prod.map fsuc id (tabulate⁻ p)
 
 ------------------------------------------------------------------------
 -- filter
 
-module _ {P : A → Set p} {Q : A → Set q} (Q? : U.Decidable Q) where
+module _ (Q? : U.Decidable Q) where
 
-  filter⁺ : ∀ {xs} → (p : Any P xs) → Any P (filter Q? xs) ⊎ ¬ Q (Any.lookup p)
-  filter⁺ {x ∷ xs} (here px) with Q? x
+  filter⁺ : (p : Any P xs) → Any P (filter Q? xs) ⊎ ¬ Q (Any.lookup p)
+  filter⁺ {xs = x ∷ _} (here px) with Q? x
   ... | true  because _       = inj₁ (here px)
   ... | false because ofⁿ ¬Qx = inj₂ ¬Qx
-  filter⁺ {x ∷ xs} (there p) with Q? x
-  ... | true  because _       = Sum.map₁ there (filter⁺ p)
-  ... | false because _       = filter⁺ p
+  filter⁺ {xs = x ∷ _} (there p) with does (Q? x)
+  ... | true  = Sum.map₁ there (filter⁺ p)
+  ... | false = filter⁺ p
 
-  filter⁻ : ∀ {xs} → Any P (filter Q? xs) → Any P xs
-  filter⁻ {x ∷ xs} p with does (Q? x)
-  filter⁻ {x ∷ xs} (here px) | true  = here px
-  filter⁻ {x ∷ xs} (there p) | true  = there (filter⁻ p)
-  filter⁻ {x ∷ xs} p         | false = there (filter⁻ p)
+  filter⁻ : Any P (filter Q? xs) → Any P xs
+  filter⁻ {xs = x ∷ xs} p with does (Q? x) | p
+  ... | true  | here px   = here px
+  ... | true  | there pxs = there (filter⁻ pxs)
+  ... | false | pxs       = there (filter⁻ pxs)
 
 ------------------------------------------------------------------------
 -- derun and deduplicate
 
-module _ {P : A → Set p} {R : A → A → Set r} (R? : B.Decidable R) where
+module _ {R : A → A → Set r} (R? : B.Decidable R) where
 
   private
     derun⁺-aux : ∀ x xs → P Respects R → P x → Any P (derun R? (x ∷ xs))
-    derun⁺-aux x [] P-resp-R Px = here Px
-    derun⁺-aux x (y ∷ xs) P-resp-R Px with R? x y
-    ... | true  because ofʸ Rxy = derun⁺-aux y xs P-resp-R (P-resp-R Rxy Px)
+    derun⁺-aux x [] resp Px = here Px
+    derun⁺-aux x (y ∷ xs) resp Px with R? x y
+    ... | true  because ofʸ Rxy = derun⁺-aux y xs resp (resp Rxy Px)
     ... | false because _       = here Px
 
-  derun⁺ : ∀ {xs} → P Respects R → Any P xs → Any P (derun R? xs)
-  derun⁺ {x ∷ xs} P-resp-R (here px) = derun⁺-aux x xs P-resp-R px
-  derun⁺ {x ∷ y ∷ xs} P-resp-R (there any[P,xs]) with R? x y
-  ... | true  because _ = derun⁺ P-resp-R any[P,xs]
-  ... | false because _ = there (derun⁺ P-resp-R any[P,xs])
+  derun⁺ : P Respects R → Any P xs → Any P (derun R? xs)
+  derun⁺ {xs = x ∷ xs}     resp (here px)   = derun⁺-aux x xs resp px
+  derun⁺ {xs = x ∷ y ∷ xs} resp (there pxs) with does (R? x y)
+  ... | true  = derun⁺ resp pxs
+  ... | false = there (derun⁺ resp pxs)
 
   deduplicate⁺ : ∀ {xs} → P Respects (flip R) → Any P xs → Any P (deduplicate R? xs)
-  deduplicate⁺ {x ∷ xs} P-resp-R (here px) = here px
-  deduplicate⁺ {x ∷ xs} P-resp-R (there any[P,xs]) with filter⁺ (¬? ∘ R? x) (deduplicate⁺ {xs} P-resp-R any[P,xs])
+  deduplicate⁺ {xs = x ∷ xs} resp (here px)   = here px
+  deduplicate⁺ {xs = x ∷ xs} resp (there pxs)
+    with filter⁺ (¬? ∘ R? x) (deduplicate⁺ resp pxs)
   ... | inj₁ p = there p
-  ... | inj₂ ¬¬q with decidable-stable (R? x (Any.lookup (deduplicate⁺ P-resp-R any[P,xs]))) ¬¬q
-  ...  | q = here (P-resp-R q (lookup-result (deduplicate⁺ P-resp-R any[P,xs])))
+  ... | inj₂ ¬¬q with decidable-stable (R? x (Any.lookup (deduplicate⁺ resp pxs))) ¬¬q
+  ...  | q = here (resp q (lookup-result (deduplicate⁺ resp pxs)))
 
   private
-    derun⁻-aux : ∀ {x xs} → Any P (derun R? (x ∷ xs)) → Any P (x ∷ xs)
-    derun⁻-aux {x} {[]} (here px) = here px
-    derun⁻-aux {x} {y ∷ xs} any[P,derun[x∷y∷xs]] with R? x y
-    derun⁻-aux {x} {y ∷ xs} any[P,derun[y∷xs]]         | true  because _ = there (derun⁻-aux any[P,derun[y∷xs]])
-    derun⁻-aux {x} {y ∷ xs} (here px)                  | false because _ = here px
-    derun⁻-aux {x} {y ∷ xs} (there any[P,derun[y∷xs]]) | false because _ = there (derun⁻-aux any[P,derun[y∷xs]])
+    derun⁻-aux : Any P (derun R? (x ∷ xs)) → Any P (x ∷ xs)
+    derun⁻-aux {x = x} {[]}    (here px) = here px
+    derun⁻-aux {x = x} {y ∷ _} p[x∷y∷xs] with does (R? x y) | p[x∷y∷xs]
+    ... | true  | p[y∷xs]        = there (derun⁻-aux p[y∷xs])
+    ... | false | here px        = here px
+    ... | false | there p[y∷xs]! = there (derun⁻-aux p[y∷xs]!)
 
-  derun⁻ : ∀ {xs} → Any P (derun R? xs) → Any P xs
-  derun⁻ {x ∷ xs} any[P,derun[x∷xs]] = derun⁻-aux any[P,derun[x∷xs]]
+  derun⁻ : Any P (derun R? xs) → Any P xs
+  derun⁻ {xs = x ∷ xs} p[x∷xs]! = derun⁻-aux p[x∷xs]!
 
-  deduplicate⁻ : ∀ {xs} → Any P (deduplicate R? xs) → Any P xs
-  deduplicate⁻ {x ∷ xs} (here px) = here px
-  deduplicate⁻ {x ∷ xs} (there any[P,dedup[xs]]) = there (deduplicate⁻ (filter⁻ (¬? ∘ R? x) any[P,dedup[xs]]))
+  deduplicate⁻ : Any P (deduplicate R? xs) → Any P xs
+  deduplicate⁻ {xs = x ∷ _} (here px)    = here px
+  deduplicate⁻ {xs = x ∷ _} (there pxs!) = there (deduplicate⁻ (filter⁻ (¬? ∘ R? x) pxs!))
 
 ------------------------------------------------------------------------
 -- map-with-∈.
@@ -605,10 +576,10 @@ module _ {P : B → Set p} where
                 ∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)
   map-with-∈⁻ (y ∷ xs) f (here  p) = (y , here refl , p)
   map-with-∈⁻ (y ∷ xs) f (there p) =
-    Prod.map id (Prod.map there id) $ map-with-∈⁻ xs (f ∘ there) p
+    Prod.map₂ (Prod.map there id) $ map-with-∈⁻ xs (f ∘ there) p
 
-  map-with-∈↔ : ∀  {xs : List A} {f : ∀ {x} → x ∈ xs → B} →
-    (∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)) ↔ Any P (map-with-∈ xs f)
+  map-with-∈↔ : ∀ {xs : List A} {f : ∀ {x} → x ∈ xs → B} →
+                (∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)) ↔ Any P (map-with-∈ xs f)
   map-with-∈↔ = inverse (map-with-∈⁺ _) (map-with-∈⁻ _ _) (from∘to _) (to∘from _ _)
     where
     from∘to : ∀ {xs : List A} (f : ∀ {x} → x ∈ xs → B)
@@ -628,41 +599,40 @@ module _ {P : B → Set p} where
 ------------------------------------------------------------------------
 -- reverse
 
-module _ {P : A → Set p} where
-  reverseAcc⁺ : ∀ acc xs → Any P acc ⊎ Any P xs → Any P (reverseAcc acc xs)
-  reverseAcc⁺ acc [] (inj₁ ps) = ps
-  reverseAcc⁺ acc (x ∷ xs) (inj₁ ps) = reverseAcc⁺ (x ∷ acc) xs (inj₁ (there ps))
-  reverseAcc⁺ acc (x ∷ xs) (inj₂ (here px)) = reverseAcc⁺ (x ∷ acc) xs (inj₁ (here px))
-  reverseAcc⁺ acc (x ∷ xs) (inj₂ (there y)) = reverseAcc⁺ (x ∷ acc) xs (inj₂ y)
+reverseAcc⁺ : ∀ acc xs → Any P acc ⊎ Any P xs → Any P (reverseAcc acc xs)
+reverseAcc⁺ acc []       (inj₁ ps)        = ps
+reverseAcc⁺ acc (x ∷ xs) (inj₁ ps)        = reverseAcc⁺ (x ∷ acc) xs (inj₁ (there ps))
+reverseAcc⁺ acc (x ∷ xs) (inj₂ (here px)) = reverseAcc⁺ (x ∷ acc) xs (inj₁ (here px))
+reverseAcc⁺ acc (x ∷ xs) (inj₂ (there y)) = reverseAcc⁺ (x ∷ acc) xs (inj₂ y)
 
-  reverseAcc⁻ : ∀ acc xs → Any P (reverseAcc acc xs) -> Any P acc ⊎ Any P xs
-  reverseAcc⁻ acc [] ps = inj₁ ps
-  reverseAcc⁻ acc (x ∷ xs) ps rewrite ʳ++-defn xs {x ∷ acc} with ++⁻ (reverseAcc [] xs) {x ∷ acc} ps
-  reverseAcc⁻ acc (x ∷ xs) ps | inj₁ ps' with reverseAcc⁻ [] xs ps'
-  reverseAcc⁻ acc (x ∷ xs) ps | inj₁ ps' | inj₂ ps'' = inj₂ (there ps'')
-  reverseAcc⁻ acc (x ∷ xs) ps | inj₂ (here p') = inj₂ (here p')
-  reverseAcc⁻ acc (x ∷ xs) ps | inj₂ (there ps') = inj₁ ps'
+reverseAcc⁻ : ∀ acc xs → Any P (reverseAcc acc xs) → Any P acc ⊎ Any P xs
+reverseAcc⁻ acc []       ps = inj₁ ps
+reverseAcc⁻ acc (x ∷ xs) ps rewrite ʳ++-defn xs {x ∷ acc} with ++⁻ (reverseAcc [] xs) ps
+... | inj₂ (here p') = inj₂ (here p')
+... | inj₂ (there ps') = inj₁ ps'
+... | inj₁ ps' with reverseAcc⁻ [] xs ps'
+...   | inj₂ ps'' = inj₂ (there ps'')
 
-  reverse⁺ : ∀ {xs} → Any P xs → Any P (reverse xs)
-  reverse⁺ ps = reverseAcc⁺ [] _ (inj₂ ps)
+reverse⁺ : Any P xs → Any P (reverse xs)
+reverse⁺ ps = reverseAcc⁺ [] _ (inj₂ ps)
 
-  reverse⁻ : ∀ {xs} → Any P (reverse xs) → Any P xs
-  reverse⁻ ps with reverseAcc⁻ [] _ ps
-  reverse⁻ ps | inj₂ ps' = ps'
+reverse⁻ : Any P (reverse xs) → Any P xs
+reverse⁻ ps with reverseAcc⁻ [] _ ps
+... | inj₂ ps' = ps'
 
 ------------------------------------------------------------------------
 -- return
 
-module _ {P : A → Set p} {x : A} where
+module _ {P : A → Set p} where
 
   return⁺ : P x → Any P (return x)
   return⁺ = here
 
   return⁻ : Any P (return x) → P x
-  return⁻ (here p)   = p
+  return⁻ (here p) = p
 
   return⁺∘return⁻ : (p : Any P (return x)) → return⁺ (return⁻ p) ≡ p
-  return⁺∘return⁻ (here p)   = refl
+  return⁺∘return⁻ (here p) = refl
 
   return⁻∘return⁺ : (p : P x) → return⁻ (return⁺ p) ≡ p
   return⁻∘return⁺ p = refl
@@ -675,8 +645,8 @@ module _ {P : A → Set p} {x : A} where
 
 module _ (P : Pred A p) where
 
-  ∷↔ : ∀ {x xs} → (P x ⊎ Any P xs) ↔ Any P (x ∷ xs)
-  ∷↔ {x} {xs} =
+  ∷↔ : (P x ⊎ Any P xs) ↔ Any P (x ∷ xs)
+  ∷↔ {x = x} {xs} =
     (P x         ⊎ Any P xs)  ↔⟨ return↔ {P = P} ⊎-cong (Any P xs ∎) ⟩
     (Any P [ x ] ⊎ Any P xs)  ↔⟨ ++↔ {P = P} {xs = [ x ]} ⟩
     Any P (x ∷ xs)            ∎
@@ -687,8 +657,8 @@ module _ (P : Pred A p) where
 
 module _ {A B : Set ℓ} {P : B → Set p} {f : A → List B} where
 
-  >>=↔ : ∀ {xs} → Any (Any P ∘ f) xs ↔ Any P (xs >>= f)
-  >>=↔ {xs} =
+  >>=↔ : Any (Any P ∘ f) xs ↔ Any P (xs >>= f)
+  >>=↔ {xs = xs} =
     Any (Any P ∘ f) xs           ↔⟨ map↔ ⟩
     Any (Any P) (List.map f xs)  ↔⟨ concat↔ ⟩
     Any P (xs >>= f)             ∎


### PR DESCRIPTION
This PR updates the standard library's policy for using the `variable` keyword in the style guide as per the discussion in #1325. I've tried it out on `Data.List.Relation.Unary.(Any/All)` and I think I'm happy that the result improves readability without harming understandability too much. Comments welcome obviously!