### PR TITLE
Add Data.Fin.combine as inverse of quotRem, and properties thereof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,19 @@ Other minor additions
   /-cancelˡ     : ((m * n) / (m * o)) {mo≢0} ≡ (n / o) {o≢0}
   ```
 
+* Added new operations to `Data.Fin.Base`:
+  ```agda
+  remQuot : remQuot : ∀ k → Fin (n * k) → Fin n × Fin k
+  combine : Fin n → Fin k → Fin (n * k)
+  ```
+
+* Added new proofs to `Data.Fin.Properties`:
+  ```agda
+  remQuot-combine : ∀ x y → remQuot k (combine x y) ≡ (x , y)
+  combine-remQuot : ∀ k i → uncurry combine (remQuot k i) ≡ i
+  *↔× : Fin (m * n) ↔ (Fin m × Fin n)
+  ```
+
 * Added new operations to `Data.Fin.Subset`:
   ```
   _─_ : Op₂ (Subset n)

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -143,10 +143,14 @@ quotRem {suc n} k i with splitAt k i
 ... | inj₁ j = j , zero
 ... | inj₂ j = Product.map₂ suc (quotRem {n} k j)
 
--- inverse of above function
-combine : ∀ {n k} → Fin k → Fin n → Fin (n ℕ.* k)
-combine {suc n} {k} x zero = inject+ (n ℕ.* k) x
-combine {suc n} {k} x (suc y) = raise k (combine x y)
+-- a variant of quotRem the type of whose result matches the order of multiplication
+remQuot : ∀ {n} k → Fin (n ℕ.* k) → Fin n × Fin k
+remQuot k = Product.swap ∘ quotRem k
+
+-- inverse of remQuot
+combine : ∀ {n k} → Fin n → Fin k → Fin (n ℕ.* k)
+combine {suc n} {k} zero y = inject+ (n ℕ.* k) y
+combine {suc n} {k} (suc x) y = raise k (combine x y)
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -145,8 +145,8 @@ quotRem {suc n} k i with splitAt k i
 
 -- inverse of above function
 combine : ∀ {n k} → Fin k → Fin n → Fin (n ℕ.* k)
-combine x zero = inject+ _ x
-combine x (suc y) = raise _ (combine x y)
+combine {suc n} {k} x zero = inject+ (n ℕ.* k) x
+combine {suc n} {k} x (suc y) = raise k (combine x y)
 
 ------------------------------------------------------------------------
 -- Operations

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -143,6 +143,11 @@ quotRem {suc n} k i with splitAt k i
 ... | inj₁ j = j , zero
 ... | inj₂ j = Product.map₂ suc (quotRem {n} k j)
 
+-- inverse of above function
+combine : ∀ {n k} → Fin k → Fin n → Fin (n ℕ.* k)
+combine x zero = inject+ _ x
+combine x (suc y) = raise _ (combine x y)
+
 ------------------------------------------------------------------------
 -- Operations
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -18,7 +18,7 @@ open import Data.Fin.Patterns
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
-open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁; uncurry; <_,_>)
+open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁; proj₂; uncurry; <_,_>)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_)
@@ -529,6 +529,35 @@ splitAt-≥ (suc m) (suc i) (s≤s i≥m) = cong (Sum.map suc id) (splitAt-≥ m
 
 +↔⊎ : ∀ {m n} → Fin (m ℕ.+ n) ↔ (Fin m ⊎ Fin n)
 +↔⊎ {m} {n} = mk↔′ (splitAt m {n}) (join m n) (splitAt-join m n) (join-splitAt m n)
+
+------------------------------------------------------------------------
+-- quotRem
+------------------------------------------------------------------------
+
+-- Fin (m * n) ↔ Fin m × Fin n
+
+quotRem-combine : ∀ {n k} x (y : Fin n) → quotRem k (combine x y) ≡ (x , y)
+quotRem-combine {suc n} {k} y 0F rewrite splitAt-inject+ k (n ℕ.* k) y = refl
+quotRem-combine {suc n} {k} x (suc y) rewrite splitAt-raise k (n ℕ.* k) (combine x y) = cong (Data.Product.map₂ suc) (quotRem-combine x y)
+
+combine-quotRem : ∀ {n} k (i : Fin (n ℕ.* k)) → uncurry combine (quotRem {n} k i) ≡ i
+combine-quotRem {suc n} k i with splitAt k i | P.inspect (splitAt k) i
+... | inj₁ j | P.[ eq ] = begin
+  join k (n ℕ.* k) (inj₁ j)      ≡˘⟨ cong (join k (n ℕ.* k)) eq ⟩
+  join k (n ℕ.* k) (splitAt k i) ≡⟨ join-splitAt k (n ℕ.* k) i ⟩
+  i                              ∎
+  where open ≡-Reasoning
+... | inj₂ j | P.[ eq ] = begin
+  raise {n ℕ.* k} k (uncurry combine (quotRem {n} k j)) ≡⟨ cong (raise k) (combine-quotRem {n} k j) ⟩
+  join k (n ℕ.* k) (inj₂ j)                             ≡˘⟨ cong (join k (n ℕ.* k)) eq ⟩
+  join k (n ℕ.* k) (splitAt k i)                        ≡⟨ join-splitAt k (n ℕ.* k) i ⟩
+  i                                                     ∎
+  where open ≡-Reasoning
+
+------------------------------------------------------------------------
+-- Bundles
+*↔× : ∀ {m n} → Fin (m ℕ.* n) ↔ (Fin n × Fin m)
+*↔× {m} {n} = mk↔′ (quotRem {m} n) (uncurry combine) (uncurry quotRem-combine) (combine-quotRem {m} n)
 
 ------------------------------------------------------------------------
 -- lift

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -531,24 +531,24 @@ splitAt-≥ (suc m) (suc i) (s≤s i≥m) = cong (Sum.map suc id) (splitAt-≥ m
 +↔⊎ {m} {n} = mk↔′ (splitAt m {n}) (join m n) (splitAt-join m n) (join-splitAt m n)
 
 ------------------------------------------------------------------------
--- quotRem
+-- remQuot
 ------------------------------------------------------------------------
 
 -- Fin (m * n) ↔ Fin m × Fin n
 
-quotRem-combine : ∀ {n k} x (y : Fin n) → quotRem k (combine x y) ≡ (x , y)
-quotRem-combine {suc n} {k} y 0F rewrite splitAt-inject+ k (n ℕ.* k) y = refl
-quotRem-combine {suc n} {k} x (suc y) rewrite splitAt-raise k (n ℕ.* k) (combine x y) = cong (Data.Product.map₂ suc) (quotRem-combine x y)
+remQuot-combine : ∀ {n k} (x : Fin n) y → remQuot k (combine x y) ≡ (x , y)
+remQuot-combine {suc n} {k} 0F y rewrite splitAt-inject+ k (n ℕ.* k) y = refl
+remQuot-combine {suc n} {k} (suc x) y rewrite splitAt-raise k (n ℕ.* k) (combine x y) = cong (Data.Product.map₁ suc) (remQuot-combine x y)
 
-combine-quotRem : ∀ {n} k (i : Fin (n ℕ.* k)) → uncurry combine (quotRem {n} k i) ≡ i
-combine-quotRem {suc n} k i with splitAt k i | P.inspect (splitAt k) i
+combine-remQuot : ∀ {n} k (i : Fin (n ℕ.* k)) → uncurry combine (remQuot {n} k i) ≡ i
+combine-remQuot {suc n} k i with splitAt k i | P.inspect (splitAt k) i
 ... | inj₁ j | P.[ eq ] = begin
   join k (n ℕ.* k) (inj₁ j)      ≡˘⟨ cong (join k (n ℕ.* k)) eq ⟩
   join k (n ℕ.* k) (splitAt k i) ≡⟨ join-splitAt k (n ℕ.* k) i ⟩
   i                              ∎
   where open ≡-Reasoning
 ... | inj₂ j | P.[ eq ] = begin
-  raise {n ℕ.* k} k (uncurry combine (quotRem {n} k j)) ≡⟨ cong (raise k) (combine-quotRem {n} k j) ⟩
+  raise {n ℕ.* k} k (uncurry combine (remQuot {n} k j)) ≡⟨ cong (raise k) (combine-remQuot {n} k j) ⟩
   join k (n ℕ.* k) (inj₂ j)                             ≡˘⟨ cong (join k (n ℕ.* k)) eq ⟩
   join k (n ℕ.* k) (splitAt k i)                        ≡⟨ join-splitAt k (n ℕ.* k) i ⟩
   i                                                     ∎
@@ -556,8 +556,8 @@ combine-quotRem {suc n} k i with splitAt k i | P.inspect (splitAt k) i
 
 ------------------------------------------------------------------------
 -- Bundles
-*↔× : ∀ {m n} → Fin (m ℕ.* n) ↔ (Fin n × Fin m)
-*↔× {m} {n} = mk↔′ (quotRem {m} n) (uncurry combine) (uncurry quotRem-combine) (combine-quotRem {m} n)
+*↔× : ∀ {m n} → Fin (m ℕ.* n) ↔ (Fin m × Fin n)
+*↔× {m} {n} = mk↔′ (remQuot {m} n) (uncurry combine) (uncurry remQuot-combine) (combine-remQuot {m} n)
 
 ------------------------------------------------------------------------
 -- lift

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -18,7 +18,7 @@ open import Data.Fin.Patterns
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
-open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁; proj₂; uncurry; <_,_>)
+open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁; uncurry; <_,_>)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_)


### PR DESCRIPTION
See also #1422 

There has been discussion about whether the type of `combine` should be altered to match the multiplication and the return type. Currently it matches the type of `quotRem`. I'm not certain how to resolve this.