### PR TITLE
[ refactor ] Clean up the dependency graph

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,8 +23,7 @@ Everything.agda:
 # command `cabal install` is needed by cabal-install <= 2.4.*. I did
 # not found any problem running both commands with different versions
 # of cabal-install. See Issue #1001.
-	cabal clean && cabal build && cabal install
-	cabal exec -- GenerateEverything
+	cabal run GenerateEverything
 
 .PHONY: listings
 listings: Everything.agda

--- a/GenerateEverything.hs
+++ b/GenerateEverything.hs
@@ -26,6 +26,7 @@ unsafeModules :: [FilePath]
 unsafeModules = map modToFile
   [ "Codata.Musical.Cofin"
   , "Codata.Musical.Colist"
+  , "Codata.Musical.Colist.Base"
   , "Codata.Musical.Colist.Infinite-merge"
   , "Codata.Musical.Conat"
   , "Codata.Musical.Costring"

--- a/README/IO.agda
+++ b/README/IO.agda
@@ -11,7 +11,7 @@ module README.IO where
 open import Level
 open import Data.Nat.Base
 open import Data.Nat.Show using (show)
-open import Data.String.Base using (String; _++_; lines)
+open import Data.String using (String; _++_; lines)
 open import Data.Unit.Polymorphic
 open import IO
 

--- a/src/Codata/Colist.agda
+++ b/src/Codata/Colist.agda
@@ -10,7 +10,7 @@ module Codata.Colist where
 
 open import Level using (Level)
 open import Size
-open import Data.Unit
+open import Data.Unit.Base
 open import Data.Nat.Base
 open import Data.Product using (_×_ ; _,_)
 open import Data.These.Base using (These; this; that; these)
@@ -18,8 +18,8 @@ open import Data.Maybe.Base using (Maybe; nothing; just)
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
-open import Data.Vec.Bounded as Vec≤ using (Vec≤)
-open import Function
+open import Data.Vec.Bounded.Base as Vec≤ using (Vec≤)
+open import Function.Base using (_$′_; _∘′_; id; _∘_)
 
 open import Codata.Thunk using (Thunk; force)
 open import Codata.Conat as Conat using (Conat ; zero ; suc)

--- a/src/Codata/Cowriter.agda
+++ b/src/Codata/Cowriter.agda
@@ -17,15 +17,15 @@ open import Codata.Thunk using (Thunk; force)
 open import Codata.Conat
 open import Codata.Delay using (Delay; later; now)
 open import Codata.Stream as Stream using (Stream; _∷_)
-open import Data.Unit
+open import Data.Unit.Base
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.NonEmpty using (List⁺; _∷_)
 open import Data.Nat.Base as Nat using (ℕ; zero; suc)
 open import Data.Product as Prod using (_×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Data.Vec.Base using (Vec; []; _∷_)
-open import Data.Vec.Bounded as Vec≤ using (Vec≤; _,_)
-open import Function
+open import Data.Vec.Bounded.Base as Vec≤ using (Vec≤; _,_)
+open import Function.Base using (_$_; _∘′_; id)
 
 private
   variable

--- a/src/Codata/Delay.agda
+++ b/src/Codata/Delay.agda
@@ -19,7 +19,7 @@ open import Data.Maybe.Base hiding (map ; fromMaybe ; zipWith ; alignWith ; zip 
 open import Data.Product as P hiding (map ; zip)
 open import Data.Sum.Base as S hiding (map)
 open import Data.These.Base as T using (These; this; that; these)
-open import Function
+open import Function.Base using (id)
 
 ------------------------------------------------------------------------
 -- Definition

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -38,25 +38,23 @@ open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Nullary.Negation
 
+------------------------------------------------------------------------
+-- Re-export type and basic definitions
+
+open import Codata.Musical.Colist.Base public
+
+------------------------------------------------------------------------
+-- More operations
+
+take : ∀ {a} {A : Set a} (n : ℕ) → Colist A → Vec≤ A n
+take zero    xs       = Vec≤.[]
+take (suc n) []       = Vec≤.[]
+take (suc n) (x ∷ xs) = x Vec≤.∷ take n (♭ xs)
+
+
 module ¬¬Monad {p} where
   open RawMonad (¬¬-Monad {p}) public
 open ¬¬Monad  -- we don't want the RawMonad content to be opened publicly
-
-------------------------------------------------------------------------
--- The type
-
-infixr 5 _∷_
-
-data Colist {a} (A : Set a) : Set a where
-  []  : Colist A
-  _∷_ : (x : A) (xs : ∞ (Colist A)) → Colist A
-
-{-# FOREIGN GHC
-  data AgdaColist a    = Nil | Cons a (MAlonzo.RTE.Inf (AgdaColist a))
-  type AgdaColist' l a = AgdaColist a
-  #-}
-{-# COMPILE GHC Colist = data AgdaColist' (Nil | Cons) #-}
-{-# COMPILE UHC Colist = data __LIST__ (__NIL__ | __CONS__) #-}
 
 module Colist-injective {a} {A : Set a} where
 
@@ -96,42 +94,6 @@ module All-injective {a p} {A : Set a} {P : A → Set p} where
 
 ------------------------------------------------------------------------
 -- Some operations
-
-null : ∀ {a} {A : Set a} → Colist A → Bool
-null []      = true
-null (_ ∷ _) = false
-
-length : ∀ {a} {A : Set a} → Colist A → Coℕ
-length []       = zero
-length (x ∷ xs) = suc (♯ length (♭ xs))
-
-map : ∀ {a b} {A : Set a} {B : Set b} → (A → B) → Colist A → Colist B
-map f []       = []
-map f (x ∷ xs) = f x ∷ ♯ map f (♭ xs)
-
-fromList : ∀ {a} {A : Set a} → List A → Colist A
-fromList []       = []
-fromList (x ∷ xs) = x ∷ ♯ fromList xs
-
-take : ∀ {a} {A : Set a} (n : ℕ) → Colist A → Vec≤ A n
-take zero    xs       = Vec≤.[]
-take (suc n) []       = Vec≤.[]
-take (suc n) (x ∷ xs) = x Vec≤.∷ take n (♭ xs)
-
-replicate : ∀ {a} {A : Set a} → Coℕ → A → Colist A
-replicate zero    x = []
-replicate (suc n) x = x ∷ ♯ replicate (♭ n) x
-
-lookup : ∀ {a} {A : Set a} → ℕ → Colist A → Maybe A
-lookup n       []       = nothing
-lookup zero    (x ∷ xs) = just x
-lookup (suc n) (x ∷ xs) = lookup n (♭ xs)
-
-infixr 5 _++_
-
-_++_ : ∀ {a} {A : Set a} → Colist A → Colist A → Colist A
-[]       ++ ys = ys
-(x ∷ xs) ++ ys = x ∷ ♯ (♭ xs ++ ys)
 
 -- Interleaves the two colists (until the shorter one, if any, has
 -- been exhausted).

--- a/src/Codata/Musical/Colist/Base.agda
+++ b/src/Codata/Musical/Colist/Base.agda
@@ -1,0 +1,66 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Coinductive lists: base type and functions
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --sized-types --guardedness #-}
+
+module Codata.Musical.Colist.Base where
+
+open import Codata.Musical.Notation
+open import Codata.Musical.Conat.Base using (Coℕ; zero; suc)
+open import Data.Bool.Base using (Bool; true; false)
+open import Data.List.Base using (List; []; _∷_)
+open import Data.Maybe.Base using (Maybe; nothing; just)
+open import Data.Nat.Base using (ℕ; zero; suc)
+
+------------------------------------------------------------------------
+-- The type
+
+infixr 5 _∷_
+
+data Colist {a} (A : Set a) : Set a where
+  []  : Colist A
+  _∷_ : (x : A) (xs : ∞ (Colist A)) → Colist A
+
+{-# FOREIGN GHC
+  data AgdaColist a    = Nil | Cons a (MAlonzo.RTE.Inf (AgdaColist a))
+  type AgdaColist' l a = AgdaColist a
+  #-}
+{-# COMPILE GHC Colist = data AgdaColist' (Nil | Cons) #-}
+{-# COMPILE UHC Colist = data __LIST__ (__NIL__ | __CONS__) #-}
+
+------------------------------------------------------------------------
+-- Some operations
+
+null : ∀ {a} {A : Set a} → Colist A → Bool
+null []      = true
+null (_ ∷ _) = false
+
+length : ∀ {a} {A : Set a} → Colist A → Coℕ
+length []       = zero
+length (x ∷ xs) = suc (♯ length (♭ xs))
+
+map : ∀ {a b} {A : Set a} {B : Set b} → (A → B) → Colist A → Colist B
+map f []       = []
+map f (x ∷ xs) = f x ∷ ♯ map f (♭ xs)
+
+fromList : ∀ {a} {A : Set a} → List A → Colist A
+fromList []       = []
+fromList (x ∷ xs) = x ∷ ♯ fromList xs
+
+replicate : ∀ {a} {A : Set a} → Coℕ → A → Colist A
+replicate zero    x = []
+replicate (suc n) x = x ∷ ♯ replicate (♭ n) x
+
+lookup : ∀ {a} {A : Set a} → ℕ → Colist A → Maybe A
+lookup n       []       = nothing
+lookup zero    (x ∷ xs) = just x
+lookup (suc n) (x ∷ xs) = lookup n (♭ xs)
+
+infixr 5 _++_
+
+_++_ : ∀ {a} {A : Set a} → Colist A → Colist A → Colist A
+[]       ++ ys = ys
+(x ∷ xs) ++ ys = x ∷ ♯ (♭ xs ++ ys)

--- a/src/Codata/Musical/Conat.agda
+++ b/src/Codata/Musical/Conat.agda
@@ -10,45 +10,26 @@ module Codata.Musical.Conat where
 
 open import Codata.Musical.Notation
 open import Data.Nat.Base using (ℕ; zero; suc)
-open import Function
+open import Function.Base using (_∋_)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 
 ------------------------------------------------------------------------
--- The type
+-- Re-exporting the type and basic operations
 
-data Coℕ : Set where
-  zero : Coℕ
-  suc  : (n : ∞ Coℕ) → Coℕ
+open import Codata.Musical.Conat.Base public
+
+------------------------------------------------------------------------
+-- Some properties
 
 module Coℕ-injective where
 
  suc-injective : ∀ {m n} → (Coℕ ∋ suc m) ≡ suc n → m ≡ n
  suc-injective P.refl = P.refl
 
-------------------------------------------------------------------------
--- Some operations
-
-pred : Coℕ → Coℕ
-pred zero    = zero
-pred (suc n) = ♭ n
-
-fromℕ : ℕ → Coℕ
-fromℕ zero    = zero
-fromℕ (suc n) = suc (♯ fromℕ n)
-
 fromℕ-injective : ∀ {m n} → fromℕ m ≡ fromℕ n → m ≡ n
 fromℕ-injective {zero}  {zero}  eq = P.refl
 fromℕ-injective {suc m} {suc n} eq = P.cong suc (fromℕ-injective (P.cong pred eq))
-
-∞ℕ : Coℕ
-∞ℕ = suc (♯ ∞ℕ)
-
-infixl 6 _+_
-
-_+_ : Coℕ → Coℕ → Coℕ
-zero  + n = n
-suc m + n = suc (♯ (♭ m + n))
 
 ------------------------------------------------------------------------
 -- Equality

--- a/src/Codata/Musical/Conat/Base.agda
+++ b/src/Codata/Musical/Conat/Base.agda
@@ -1,0 +1,40 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Coinductive "natural" numbers: base type and operations
+------------------------------------------------------------------------
+
+{-# OPTIONS --safe --without-K --guardedness #-}
+
+module Codata.Musical.Conat.Base where
+
+open import Codata.Musical.Notation
+open import Data.Nat.Base using (ℕ; zero; suc)
+open import Function.Base using (_∋_)
+
+------------------------------------------------------------------------
+-- The type
+
+data Coℕ : Set where
+  zero : Coℕ
+  suc  : (n : ∞ Coℕ) → Coℕ
+
+------------------------------------------------------------------------
+-- Some operations
+
+pred : Coℕ → Coℕ
+pred zero    = zero
+pred (suc n) = ♭ n
+
+fromℕ : ℕ → Coℕ
+fromℕ zero    = zero
+fromℕ (suc n) = suc (♯ fromℕ n)
+
+∞ℕ : Coℕ
+∞ℕ = suc (♯ ∞ℕ)
+
+infixl 6 _+_
+
+_+_ : Coℕ → Coℕ → Coℕ
+zero  + n = n
+suc m + n = suc (♯ (♭ m + n))

--- a/src/Codata/Musical/Costring.agda
+++ b/src/Codata/Musical/Costring.agda
@@ -8,9 +8,9 @@
 
 module Codata.Musical.Costring where
 
-open import Codata.Musical.Colist as Colist using (Colist)
-open import Data.Char using (Char)
-open import Data.String as String using (String)
+open import Codata.Musical.Colist.Base as Colist using (Colist)
+open import Data.Char.Base using (Char)
+open import Data.String.Base as String using (String)
 open import Function.Base using (_∘_)
 
 -- Possibly infinite strings.

--- a/src/Codata/Musical/Stream.agda
+++ b/src/Codata/Musical/Stream.agda
@@ -10,7 +10,7 @@ module Codata.Musical.Stream where
 
 open import Codata.Musical.Notation
 open import Codata.Musical.Colist using (Colist; []; _∷_)
-open import Data.Vec    using (Vec;    []; _∷_)
+open import Data.Vec.Base using (Vec; []; _∷_)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -11,6 +11,7 @@ module Data.Bool.Base where
 open import Data.Unit.Base using (⊤)
 open import Data.Empty
 open import Level using (Level)
+open import Relation.Nullary using (Dec; does; proof; ofʸ; ofⁿ)
 
 private
   variable
@@ -72,3 +73,7 @@ T : Bool → Set
 T true  = ⊤
 T false = ⊥
 
+T? : ∀ b → Dec (T b)
+does  (T? b) = b
+proof (T? true ) = ofʸ _
+proof (T? false) = ofⁿ λ()

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -655,11 +655,6 @@ T-∨ {false} {false} = equivalence inj₁ [ id , id ]
 T-irrelevant : U.Irrelevant T
 T-irrelevant {true}  _  _  = refl
 
-T? : U.Decidable T
-does  (T? b) = b
-proof (T? true ) = ofʸ _
-proof (T? false) = ofⁿ λ()
-
 T?-diag : ∀ b → T b → True (T? b)
 T?-diag true  _ = _
 

--- a/src/Data/Char/Base.agda
+++ b/src/Data/Char/Base.agda
@@ -10,9 +10,10 @@ module Data.Char.Base where
 
 open import Level using (zero)
 import Data.Nat.Base as ℕ
-open import Function
-open import Relation.Binary using (Rel)
-open import Relation.Binary.PropositionalEquality
+open import Data.Bool.Base using (Bool)
+open import Function.Base using (_on_)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.PropositionalEquality.Core
 open import Relation.Binary.Construct.Closure.Reflexive
 
 ------------------------------------------------------------------------
@@ -46,6 +47,10 @@ _≈_ = _≡_ on toℕ
 
 _≉_ : Rel Char zero
 _≉_ = _≢_ on toℕ
+
+infix 4 _≈ᵇ_
+_≈ᵇ_ : (c d : Char) → Bool
+c ≈ᵇ d = toℕ c ℕ.≡ᵇ toℕ d
 
 infix 4 _<_
 _<_ : Rel Char zero

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -22,10 +22,11 @@ open import Data.These.Base as These using (These; this; that; these)
 open import Function.Base using (id; _∘_ ; _∘′_; const; flip)
 open import Level using (Level)
 open import Relation.Nullary using (does)
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary.Negation.Core using (¬?)
 open import Relation.Unary using (Pred; Decidable)
 open import Relation.Unary.Properties using (∁?)
-open import Relation.Binary as B using (Rel)
+open import Relation.Binary.Core using (Rel)
+import Relation.Binary.Definitions as B
 
 private
   variable

--- a/src/Data/List/Extrema.agda
+++ b/src/Data/List/Extrema.agda
@@ -26,10 +26,9 @@ open import Function.Base using (id; flip; _on_; _∘_)
 open import Level using (Level)
 open import Relation.Unary using (Pred)
 import Relation.Binary.Construct.NonStrictToStrict as NonStrictToStrict
-open import Relation.Binary.PropositionalEquality
+open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; sym; subst) renaming (refl to ≡-refl)
 import Relation.Binary.Construct.On as On
-
 
 ------------------------------------------------------------------------------
 -- Setup

--- a/src/Data/List/NonEmpty.agda
+++ b/src/Data/List/NonEmpty.agda
@@ -16,9 +16,9 @@ open import Data.List.Base as List using (List; []; _∷_)
 open import Data.Maybe.Base using (Maybe ; nothing; just)
 open import Data.Nat.Base as ℕ
 open import Data.Product as Prod using (∃; _×_; proj₁; proj₂; _,_; -,_)
-open import Data.These.Base as These using (These; this; that; these)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
-open import Data.Unit
+open import Data.These.Base as These using (These; this; that; these)
+open import Data.Unit.Base using (tt)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Function.Base
 open import Function.Equality using (_⟨$⟩_)
@@ -35,171 +35,12 @@ private
     C : Set c
 
 ------------------------------------------------------------------------
--- Non-empty lists
+-- Re-export basic type and operations
 
-infixr 5 _∷_
-
-record List⁺ (A : Set a) : Set a where
-  constructor _∷_
-  field
-    head : A
-    tail : List A
-
-open List⁺ public
-
--- Basic combinators
-
-uncons : List⁺ A → A × List A
-uncons (hd ∷ tl) = hd , tl
-
-[_] : A → List⁺ A
-[ x ] = x ∷ []
-
-infixr 5 _∷⁺_
-
-_∷⁺_ : A → List⁺ A → List⁺ A
-x ∷⁺ y ∷ xs = x ∷ y ∷ xs
-
-length : List⁺ A → ℕ
-length (x ∷ xs) = suc (List.length xs)
+open import Data.List.NonEmpty.Base public
 
 ------------------------------------------------------------------------
--- Conversion
-
-toList : List⁺ A → List A
-toList (x ∷ xs) = x ∷ xs
-
-fromList : List A → Maybe (List⁺ A)
-fromList []       = nothing
-fromList (x ∷ xs) = just (x ∷ xs)
-
-fromVec : ∀ {n} → Vec A (suc n) → List⁺ A
-fromVec (x ∷ xs) = x ∷ Vec.toList xs
-
-toVec : (xs : List⁺ A) → Vec A (length xs)
-toVec (x ∷ xs) = x ∷ Vec.fromList xs
-
-lift : (∀ {m} → Vec A (suc m) → ∃ λ n → Vec B (suc n)) →
-       List⁺ A → List⁺ B
-lift f xs = fromVec (proj₂ (f (toVec xs)))
-
-------------------------------------------------------------------------
--- Other operations
-
-map : (A → B) → List⁺ A → List⁺ B
-map f (x ∷ xs) = (f x ∷ List.map f xs)
-
-replicate : ∀ n → n ≢ 0 → A → List⁺ A
-replicate n n≢0 a = a ∷ List.replicate (pred n) a
-
--- Right fold. Note that s is only applied to the last element (see
--- the examples below).
-
-foldr : (A → B → B) → (A → B) → List⁺ A → B
-foldr {A = A} {B = B} c s (x ∷ xs) = foldr′ x xs
-  where
-  foldr′ : A → List A → B
-  foldr′ x []       = s x
-  foldr′ x (y ∷ xs) = c x (foldr′ y xs)
-
--- Right fold.
-
-foldr₁ : (A → A → A) → List⁺ A → A
-foldr₁ f = foldr f id
-
--- Left fold. Note that s is only applied to the first element (see
--- the examples below).
-
-foldl : (B → A → B) → (A → B) → List⁺ A → B
-foldl c s (x ∷ xs) = List.foldl c (s x) xs
-
--- Left fold.
-
-foldl₁ : (A → A → A) → List⁺ A → A
-foldl₁ f = foldl f id
-
--- Append (several variants).
-
-infixr 5 _⁺++⁺_ _++⁺_ _⁺++_
-
-_⁺++⁺_ : List⁺ A → List⁺ A → List⁺ A
-(x ∷ xs) ⁺++⁺ (y ∷ ys) = x ∷ (xs List.++ y ∷ ys)
-
-_⁺++_ : List⁺ A → List A → List⁺ A
-(x ∷ xs) ⁺++ ys = x ∷ (xs List.++ ys)
-
-_++⁺_ : List A → List⁺ A → List⁺ A
-xs ++⁺ ys = List.foldr _∷⁺_ ys xs
-
-concat : List⁺ (List⁺ A) → List⁺ A
-concat (xs ∷ xss) = xs ⁺++ List.concat (List.map toList xss)
-
-concatMap : (A → List⁺ B) → List⁺ A → List⁺ B
-concatMap f = concat ∘′ map f
-
--- Reverse
-
-reverse : List⁺ A → List⁺ A
-reverse = lift (-,_ ∘′ Vec.reverse)
-
--- Align and Zip
-
-alignWith : (These A B → C) → List⁺ A → List⁺ B → List⁺ C
-alignWith f (a ∷ as) (b ∷ bs) = f (these a b) ∷ List.alignWith f as bs
-
-zipWith : (A → B → C) → List⁺ A → List⁺ B → List⁺ C
-zipWith f (a ∷ as) (b ∷ bs) = f a b ∷ List.zipWith f as bs
-
-unalignWith : (A → These B C) → List⁺ A → These (List⁺ B) (List⁺ C)
-unalignWith f = foldr (These.alignWith mcons mcons ∘′ f)
-                    (These.map [_] [_] ∘′ f)
-
-  where mcons : ∀ {e} {E : Set e} → These E (List⁺ E) → List⁺ E
-        mcons = These.fold [_] id _∷⁺_
-
-unzipWith : (A → B × C) → List⁺ A → List⁺ B × List⁺ C
-unzipWith f (a ∷ as) = Prod.zip _∷_ _∷_ (f a) (List.unzipWith f as)
-
-align : List⁺ A → List⁺ B → List⁺ (These A B)
-align = alignWith id
-
-zip : List⁺ A → List⁺ B → List⁺ (A × B)
-zip = zipWith _,_
-
-unalign : List⁺ (These A B) → These (List⁺ A) (List⁺ B)
-unalign = unalignWith id
-
-unzip : List⁺ (A × B) → List⁺ A × List⁺ B
-unzip = unzipWith id
-
--- Snoc.
-
-infixl 5 _∷ʳ_ _⁺∷ʳ_
-
-_∷ʳ_ : List A → A → List⁺ A
-[]       ∷ʳ y = [ y ]
-(x ∷ xs) ∷ʳ y = x ∷ (xs List.∷ʳ y)
-
-_⁺∷ʳ_ : List⁺ A → A → List⁺ A
-xs ⁺∷ʳ x = toList xs ∷ʳ x
-
--- A snoc-view of non-empty lists.
-
-infixl 5 _∷ʳ′_
-
-data SnocView {A : Set a} : List⁺ A → Set a where
-  _∷ʳ′_ : (xs : List A) (x : A) → SnocView (xs ∷ʳ x)
-
-snocView : (xs : List⁺ A) → SnocView xs
-snocView (x ∷ xs)              with List.initLast xs
-snocView (x ∷ .[])             | []            = []       ∷ʳ′ x
-snocView (x ∷ .(xs List.∷ʳ y)) | xs List.∷ʳ′ y = (x ∷ xs) ∷ʳ′ y
-
--- The last element in the list.
-
-last : List⁺ A → A
-last xs with snocView xs
-last .(ys ∷ʳ y) | ys ∷ʳ′ y = y
+-- More operations
 
 -- Groups all contiguous elements for which the predicate returns the
 -- same result into lists.

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -1,0 +1,195 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Non-empty lists: base type and operations
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.List.NonEmpty.Base where
+
+open import Level using (Level)
+open import Data.Bool.Base using (Bool; false; true; not; T)
+open import Data.List.Base as List using (List; []; _∷_)
+open import Data.Maybe.Base using (Maybe ; nothing; just)
+open import Data.Nat.Base as ℕ
+open import Data.Product as Prod using (∃; _×_; proj₁; proj₂; _,_; -,_)
+open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
+open import Data.These.Base as These using (These; this; that; these)
+open import Data.Vec.Base as Vec using (Vec; []; _∷_)
+open import Function.Base
+open import Relation.Binary.PropositionalEquality.Core using (_≢_)
+
+private
+  variable
+    a b c : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Non-empty lists
+
+infixr 5 _∷_
+
+record List⁺ (A : Set a) : Set a where
+  constructor _∷_
+  field
+    head : A
+    tail : List A
+
+open List⁺ public
+
+-- Basic combinators
+
+uncons : List⁺ A → A × List A
+uncons (hd ∷ tl) = hd , tl
+
+[_] : A → List⁺ A
+[ x ] = x ∷ []
+
+infixr 5 _∷⁺_
+
+_∷⁺_ : A → List⁺ A → List⁺ A
+x ∷⁺ y ∷ xs = x ∷ y ∷ xs
+
+length : List⁺ A → ℕ
+length (x ∷ xs) = suc (List.length xs)
+
+------------------------------------------------------------------------
+-- Conversion
+
+toList : List⁺ A → List A
+toList (x ∷ xs) = x ∷ xs
+
+fromList : List A → Maybe (List⁺ A)
+fromList []       = nothing
+fromList (x ∷ xs) = just (x ∷ xs)
+
+fromVec : ∀ {n} → Vec A (suc n) → List⁺ A
+fromVec (x ∷ xs) = x ∷ Vec.toList xs
+
+toVec : (xs : List⁺ A) → Vec A (length xs)
+toVec (x ∷ xs) = x ∷ Vec.fromList xs
+
+lift : (∀ {m} → Vec A (suc m) → ∃ λ n → Vec B (suc n)) →
+       List⁺ A → List⁺ B
+lift f xs = fromVec (proj₂ (f (toVec xs)))
+
+------------------------------------------------------------------------
+-- Other operations
+
+map : (A → B) → List⁺ A → List⁺ B
+map f (x ∷ xs) = (f x ∷ List.map f xs)
+
+replicate : ∀ n → n ≢ 0 → A → List⁺ A
+replicate n n≢0 a = a ∷ List.replicate (pred n) a
+
+-- Right fold. Note that s is only applied to the last element (see
+-- the examples below).
+
+foldr : (A → B → B) → (A → B) → List⁺ A → B
+foldr {A = A} {B = B} c s (x ∷ xs) = foldr′ x xs
+  where
+  foldr′ : A → List A → B
+  foldr′ x []       = s x
+  foldr′ x (y ∷ xs) = c x (foldr′ y xs)
+
+-- Right fold.
+
+foldr₁ : (A → A → A) → List⁺ A → A
+foldr₁ f = foldr f id
+
+-- Left fold. Note that s is only applied to the first element (see
+-- the examples below).
+
+foldl : (B → A → B) → (A → B) → List⁺ A → B
+foldl c s (x ∷ xs) = List.foldl c (s x) xs
+
+-- Left fold.
+
+foldl₁ : (A → A → A) → List⁺ A → A
+foldl₁ f = foldl f id
+
+-- Append (several variants).
+
+infixr 5 _⁺++⁺_ _++⁺_ _⁺++_
+
+_⁺++⁺_ : List⁺ A → List⁺ A → List⁺ A
+(x ∷ xs) ⁺++⁺ (y ∷ ys) = x ∷ (xs List.++ y ∷ ys)
+
+_⁺++_ : List⁺ A → List A → List⁺ A
+(x ∷ xs) ⁺++ ys = x ∷ (xs List.++ ys)
+
+_++⁺_ : List A → List⁺ A → List⁺ A
+xs ++⁺ ys = List.foldr _∷⁺_ ys xs
+
+concat : List⁺ (List⁺ A) → List⁺ A
+concat (xs ∷ xss) = xs ⁺++ List.concat (List.map toList xss)
+
+concatMap : (A → List⁺ B) → List⁺ A → List⁺ B
+concatMap f = concat ∘′ map f
+
+-- Reverse
+
+reverse : List⁺ A → List⁺ A
+reverse = lift (-,_ ∘′ Vec.reverse)
+
+-- Align and Zip
+
+alignWith : (These A B → C) → List⁺ A → List⁺ B → List⁺ C
+alignWith f (a ∷ as) (b ∷ bs) = f (these a b) ∷ List.alignWith f as bs
+
+zipWith : (A → B → C) → List⁺ A → List⁺ B → List⁺ C
+zipWith f (a ∷ as) (b ∷ bs) = f a b ∷ List.zipWith f as bs
+
+unalignWith : (A → These B C) → List⁺ A → These (List⁺ B) (List⁺ C)
+unalignWith f = foldr (These.alignWith mcons mcons ∘′ f)
+                    (These.map [_] [_] ∘′ f)
+
+  where mcons : ∀ {e} {E : Set e} → These E (List⁺ E) → List⁺ E
+        mcons = These.fold [_] id _∷⁺_
+
+unzipWith : (A → B × C) → List⁺ A → List⁺ B × List⁺ C
+unzipWith f (a ∷ as) = Prod.zip _∷_ _∷_ (f a) (List.unzipWith f as)
+
+align : List⁺ A → List⁺ B → List⁺ (These A B)
+align = alignWith id
+
+zip : List⁺ A → List⁺ B → List⁺ (A × B)
+zip = zipWith _,_
+
+unalign : List⁺ (These A B) → These (List⁺ A) (List⁺ B)
+unalign = unalignWith id
+
+unzip : List⁺ (A × B) → List⁺ A × List⁺ B
+unzip = unzipWith id
+
+-- Snoc.
+
+infixl 5 _∷ʳ_ _⁺∷ʳ_
+
+_∷ʳ_ : List A → A → List⁺ A
+[]       ∷ʳ y = [ y ]
+(x ∷ xs) ∷ʳ y = x ∷ (xs List.∷ʳ y)
+
+_⁺∷ʳ_ : List⁺ A → A → List⁺ A
+xs ⁺∷ʳ x = toList xs ∷ʳ x
+
+-- A snoc-view of non-empty lists.
+
+infixl 5 _∷ʳ′_
+
+data SnocView {A : Set a} : List⁺ A → Set a where
+  _∷ʳ′_ : (xs : List A) (x : A) → SnocView (xs ∷ʳ x)
+
+snocView : (xs : List⁺ A) → SnocView xs
+snocView (x ∷ xs)              with List.initLast xs
+snocView (x ∷ .[])             | []            = []       ∷ʳ′ x
+snocView (x ∷ .(xs List.∷ʳ y)) | xs List.∷ʳ′ y = (x ∷ xs) ∷ʳ′ y
+
+-- The last element in the list.
+
+last : List⁺ A → A
+last xs with snocView xs
+last .(ys ∷ʳ y) | ys ∷ʳ′ y = y

--- a/src/Data/List/Relation/Binary/Lex.agda
+++ b/src/Data/List/Relation/Binary/Lex.agda
@@ -1,0 +1,92 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Lexicographic ordering of lists
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.List.Relation.Binary.Lex where
+
+open import Data.Empty using (⊥; ⊥-elim)
+open import Data.Unit.Base using (⊤; tt)
+open import Data.Product using (_×_; _,_; proj₁; proj₂; uncurry)
+open import Data.List.Base using (List; []; _∷_)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_])
+open import Function.Base using (_∘_; flip; id)
+open import Function.Equivalence using (_⇔_; equivalence)
+open import Level using (_⊔_)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
+import Relation.Nullary.Decidable as Dec
+open import Relation.Nullary.Product using (_×-dec_)
+open import Relation.Nullary.Sum using (_⊎-dec_)
+open import Relation.Binary hiding (_⇔_)
+open import Data.List.Relation.Binary.Pointwise.Core
+   using (Pointwise; []; _∷_; head; tail)
+
+------------------------------------------------------------------------
+-- Re-exporting the core definitions and properties
+
+open import Data.List.Relation.Binary.Lex.Core public
+
+------------------------------------------------------------------------
+
+-- Properties
+
+module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
+         {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
+
+  private
+    _≋_ = Pointwise _≈_
+    _<_ = Lex P _≈_ _≺_
+
+  transitive : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → Transitive _≺_ →
+               Transitive _<_
+  transitive eq resp tr = trans
+    where
+    trans : Transitive (Lex P _≈_ _≺_)
+    trans (base p)         (base _)         = base p
+    trans (base y)         halt             = halt
+    trans halt             (this y≺z)       = halt
+    trans halt             (next y≈z ys<zs) = halt
+    trans (this x≺y)       (this y≺z)       = this (tr x≺y y≺z)
+    trans (this x≺y)       (next y≈z ys<zs) = this (proj₁ resp y≈z x≺y)
+    trans (next x≈y xs<ys) (this y≺z)       =
+      this (proj₂ resp (IsEquivalence.sym eq x≈y) y≺z)
+    trans (next x≈y xs<ys) (next y≈z ys<zs) =
+      next (IsEquivalence.trans eq x≈y y≈z) (trans xs<ys ys<zs)
+
+  respects₂ : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → _<_ Respects₂ _≋_
+  respects₂ eq (resp₁ , resp₂) = resp¹ , resp²
+    where
+    open IsEquivalence eq using (sym; trans)
+    resp¹ : ∀ {xs} → Lex P _≈_ _≺_ xs Respects _≋_
+    resp¹ []            xs<[]            = xs<[]
+    resp¹ (_   ∷ _)     halt             = halt
+    resp¹ (x≈y ∷ _)     (this z≺x)       = this (resp₁ x≈y z≺x)
+    resp¹ (x≈y ∷ xs≋ys) (next z≈x zs<xs) =
+      next (trans z≈x x≈y) (resp¹ xs≋ys zs<xs)
+
+    resp² : ∀ {ys} → flip (Lex P _≈_ _≺_) ys Respects _≋_
+    resp² []            []<ys            = []<ys
+    resp² (x≈z ∷ _)     (this x≺y)       = this (resp₂ x≈z x≺y)
+    resp² (x≈z ∷ xs≋zs) (next x≈y xs<ys) =
+      next (trans (sym x≈z) x≈y) (resp² xs≋zs xs<ys)
+
+
+  []<[]-⇔ : P ⇔ [] < []
+  []<[]-⇔ = equivalence base (λ { (base p) → p })
+
+
+  ∷<∷-⇔ : ∀ {x y xs ys} → (x ≺ y ⊎ (x ≈ y × xs < ys)) ⇔ (x ∷ xs) < (y ∷ ys)
+  ∷<∷-⇔ = equivalence [ this , uncurry next ] toSum
+
+  module _ (dec-P : Dec P) (dec-≈ : Decidable _≈_) (dec-≺ : Decidable _≺_)
+    where
+
+    decidable : Decidable _<_
+    decidable []       []       = Dec.map []<[]-⇔ dec-P
+    decidable []       (y ∷ ys) = yes halt
+    decidable (x ∷ xs) []       = no λ()
+    decidable (x ∷ xs) (y ∷ ys) =
+      Dec.map ∷<∷-⇔ (dec-≺ x y ⊎-dec (dec-≈ x y ×-dec decidable xs ys))

--- a/src/Data/List/Relation/Binary/Lex/Core.agda
+++ b/src/Data/List/Relation/Binary/Lex/Core.agda
@@ -12,16 +12,13 @@ open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤; tt)
 open import Data.Product using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Data.List.Base using (List; []; _∷_)
-open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_])
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base using (_∘_; flip; id)
 open import Level using (_⊔_)
-open import Relation.Nullary using (Dec; yes; no; ¬_)
-import Relation.Nullary.Decidable as Dec
-open import Relation.Nullary.Product using (_×-dec_)
-open import Relation.Nullary.Sum using (_⊎-dec_)
-open import Relation.Binary hiding (_⇔_)
-open import Data.List.Relation.Binary.Pointwise
+open import Relation.Nullary using (¬_)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.Definitions
+open import Data.List.Relation.Binary.Pointwise.Core
    using (Pointwise; []; _∷_; head; tail)
 
 -- The lexicographic ordering itself can be either strict or non-strict,
@@ -55,22 +52,6 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
   ¬≤-next x≮y xs≮ys (this x≺y)     = x≮y x≺y
   ¬≤-next x≮y xs≮ys (next _ xs<ys) = xs≮ys xs<ys
 
-  transitive : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → Transitive _≺_ →
-               Transitive _<_
-  transitive eq resp tr = trans
-    where
-    trans : Transitive (Lex P _≈_ _≺_)
-    trans (base p)         (base _)         = base p
-    trans (base y)         halt             = halt
-    trans halt             (this y≺z)       = halt
-    trans halt             (next y≈z ys<zs) = halt
-    trans (this x≺y)       (this y≺z)       = this (tr x≺y y≺z)
-    trans (this x≺y)       (next y≈z ys<zs) = this (proj₁ resp y≈z x≺y)
-    trans (next x≈y xs<ys) (this y≺z)       =
-      this (proj₂ resp (IsEquivalence.sym eq x≈y) y≺z)
-    trans (next x≈y xs<ys) (next y≈z ys<zs) =
-      next (IsEquivalence.trans eq x≈y y≈z) (trans xs<ys ys<zs)
-
   antisymmetric : Symmetric _≈_ → Irreflexive _≈_ _≺_ →
                   Asymmetric _≺_ → Antisymmetric _≋_ _<_
   antisymmetric sym ir asym = as
@@ -82,39 +63,6 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
     as (next x≈y xs<ys) (this y≺x)       = ⊥-elim (ir (sym x≈y) y≺x)
     as (next x≈y xs<ys) (next y≈x ys<xs) = x≈y ∷ as xs<ys ys<xs
 
-  respects₂ : IsEquivalence _≈_ → _≺_ Respects₂ _≈_ → _<_ Respects₂ _≋_
-  respects₂ eq (resp₁ , resp₂) = resp¹ , resp²
-    where
-    open IsEquivalence eq using (sym; trans)
-    resp¹ : ∀ {xs} → Lex P _≈_ _≺_ xs Respects _≋_
-    resp¹ []            xs<[]            = xs<[]
-    resp¹ (_   ∷ _)     halt             = halt
-    resp¹ (x≈y ∷ _)     (this z≺x)       = this (resp₁ x≈y z≺x)
-    resp¹ (x≈y ∷ xs≋ys) (next z≈x zs<xs) =
-      next (trans z≈x x≈y) (resp¹ xs≋ys zs<xs)
-
-    resp² : ∀ {ys} → flip (Lex P _≈_ _≺_) ys Respects _≋_
-    resp² []            []<ys            = []<ys
-    resp² (x≈z ∷ _)     (this x≺y)       = this (resp₂ x≈z x≺y)
-    resp² (x≈z ∷ xs≋zs) (next x≈y xs<ys) =
-      next (trans (sym x≈z) x≈y) (resp² xs≋zs xs<ys)
-
-  []<[]-⇔ : P ⇔ [] < []
-  []<[]-⇔ = equivalence base (λ { (base p) → p })
-
   toSum : ∀ {x y xs ys} → (x ∷ xs) < (y ∷ ys) → (x ≺ y ⊎ (x ≈ y × xs < ys))
   toSum (this x≺y) = inj₁ x≺y
   toSum (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
-
-  ∷<∷-⇔ : ∀ {x y xs ys} → (x ≺ y ⊎ (x ≈ y × xs < ys)) ⇔ (x ∷ xs) < (y ∷ ys)
-  ∷<∷-⇔ = equivalence [ this , uncurry next ] toSum
-
-  module _ (dec-P : Dec P) (dec-≈ : Decidable _≈_) (dec-≺ : Decidable _≺_)
-    where
-
-    decidable : Decidable _<_
-    decidable []       []       = Dec.map []<[]-⇔ dec-P
-    decidable []       (y ∷ ys) = yes halt
-    decidable (x ∷ xs) []       = no λ()
-    decidable (x ∷ xs) (y ∷ ys) =
-      Dec.map ∷<∷-⇔ (dec-≺ x y ⊎-dec (dec-≈ x y ×-dec decidable xs ys))

--- a/src/Data/List/Relation/Binary/Lex/NonStrict.agda
+++ b/src/Data/List/Relation/Binary/Lex/NonStrict.agda
@@ -23,10 +23,12 @@ open import Relation.Nullary
 open import Relation.Binary
 import Relation.Binary.Construct.NonStrictToStrict as Conv
 
+import Data.List.Relation.Binary.Lex as Core
+
 ------------------------------------------------------------------------
 -- Publically re-export definitions from Core
 
-open import Data.List.Relation.Binary.Lex.Core as Core public
+open import Data.List.Relation.Binary.Lex.Core public
   using (base; halt; this; next; ¬≤-this; ¬≤-next)
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/List/Relation/Binary/Lex/Strict.agda
@@ -24,17 +24,17 @@ open import Relation.Binary.Consequences
 open import Data.List.Relation.Binary.Pointwise as Pointwise
    using (Pointwise; []; _∷_; head; tail)
 
-open import Data.List.Relation.Binary.Lex.Core as Core public
-  using (base; halt; this; next; ¬≤-this; ¬≤-next)
+import Data.List.Relation.Binary.Lex as Core
+
+----------------------------------------------------------------------
+-- Re-exporting core definitions
+
+open import Data.List.Relation.Binary.Lex.Strict.Core public
 
 ----------------------------------------------------------------------
 -- Strict lexicographic ordering.
 
 module _ {a ℓ₁ ℓ₂} {A : Set a} where
-
-  Lex-< : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
-          Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
-  Lex-< = Core.Lex ⊥
 
   -- Properties
 
@@ -132,10 +132,6 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
 -- Non-strict lexicographic ordering.
 
 module _ {a ℓ₁ ℓ₂} {A : Set a} where
-
-  Lex-≤ : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
-          Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
-  Lex-≤ = Core.Lex ⊤
 
   -- Properties
 

--- a/src/Data/List/Relation/Binary/Lex/Strict/Core.agda
+++ b/src/Data/List/Relation/Binary/Lex/Strict/Core.agda
@@ -1,0 +1,36 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Lexicographic ordering of lists
+------------------------------------------------------------------------
+
+-- The definitions of lexicographic ordering used here are suitable if
+-- the argument order is a strict partial order.
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.List.Relation.Binary.Lex.Strict.Core where
+
+open import Data.Empty using (⊥)
+open import Data.List.Base using (List)
+open import Data.Unit.Base using (⊤)
+open import Level
+open import Relation.Binary.Core using (Rel)
+
+open import Data.List.Relation.Binary.Lex.Core as Core public
+  using (base; halt; this; next; ¬≤-this; ¬≤-next)
+
+private
+  variable
+    a ℓ₁ ℓ₂ : Level
+
+----------------------------------------------------------------------
+-- Strict lexicographic ordering.
+
+Lex-< : {A : Set a} (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
+        Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
+Lex-< = Core.Lex ⊥
+
+Lex-≤ : {A : Set a} (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
+        Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
+Lex-≤ = Core.Lex ⊤

--- a/src/Data/List/Relation/Binary/Pointwise.agda
+++ b/src/Data/List/Relation/Binary/Pointwise.agda
@@ -23,7 +23,7 @@ open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Nat.Properties
 open import Level
 open import Relation.Nullary hiding (Irrelevant)
-open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Negation.Core using (contradiction)
 import Relation.Nullary.Decidable as Dec using (map′)
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Unary as U using (Pred)
@@ -39,79 +39,14 @@ private
     R S T : REL A B ℓ
 
 ------------------------------------------------------------------------
--- Definition
+-- Re-exporting the definition and basic operations
 ------------------------------------------------------------------------
 
-infixr 5 _∷_
-
-data Pointwise {A : Set a} {B : Set b} (R : REL A B ℓ)
-               : List A → List B → Set (a ⊔ b ⊔ ℓ) where
-  []  : Pointwise R [] []
-  _∷_ : (x∼y : R x y) (xs∼ys : Pointwise R xs ys) →
-        Pointwise R (x ∷ xs) (y ∷ ys)
-
-------------------------------------------------------------------------
--- Operations
-------------------------------------------------------------------------
-
-head : Pointwise R (x ∷ xs) (y ∷ ys) → R x y
-head (x∼y ∷ xs∼ys) = x∼y
-
-tail : Pointwise R (x ∷ xs) (y ∷ ys) → Pointwise R xs ys
-tail (x∼y ∷ xs∼ys) = xs∼ys
-
-uncons : Pointwise R (x ∷ xs) (y ∷ ys) → R x y × Pointwise R xs ys
-uncons = < head , tail >
-
-rec : ∀ (P : ∀ {xs ys} → Pointwise R xs ys → Set c) →
-      (∀ {x y xs ys} {Rxsys : Pointwise R xs ys} →
-        (Rxy : R x y) → P Rxsys → P (Rxy ∷ Rxsys)) →
-      P [] →
-      ∀ {xs ys} (Rxsys : Pointwise R xs ys) → P Rxsys
-rec P c n []            = n
-rec P c n (Rxy ∷ Rxsys) = c Rxy (rec P c n Rxsys)
-
-map : R ⇒ S → Pointwise R ⇒ Pointwise S
-map R⇒S []            = []
-map R⇒S (Rxy ∷ Rxsys) = R⇒S Rxy ∷ map R⇒S Rxsys
+open import Data.List.Relation.Binary.Pointwise.Core public
 
 ------------------------------------------------------------------------
 -- Relational properties
 ------------------------------------------------------------------------
-
-reflexive : R ⇒ S → Pointwise R ⇒ Pointwise S
-reflexive = map
-
-refl : Reflexive R → Reflexive (Pointwise R)
-refl rfl {[]}     = []
-refl rfl {x ∷ xs} = rfl ∷ refl rfl
-
-symmetric : Sym R S → Sym (Pointwise R) (Pointwise S)
-symmetric sym []            = []
-symmetric sym (x∼y ∷ xs∼ys) = sym x∼y ∷ symmetric sym xs∼ys
-
-transitive : Trans R S T →
-             Trans (Pointwise R) (Pointwise S) (Pointwise T)
-transitive trans []            []            = []
-transitive trans (x∼y ∷ xs∼ys) (y∼z ∷ ys∼zs) =
-  trans x∼y y∼z ∷ transitive trans xs∼ys ys∼zs
-
-antisymmetric : Antisym R S T →
-                Antisym (Pointwise R) (Pointwise S) (Pointwise T)
-antisymmetric antisym []            []            = []
-antisymmetric antisym (x∼y ∷ xs∼ys) (y∼x ∷ ys∼xs) =
-  antisym x∼y y∼x ∷ antisymmetric antisym xs∼ys ys∼xs
-
-respʳ : R Respectsʳ S → (Pointwise R) Respectsʳ (Pointwise S)
-respʳ resp []            []            = []
-respʳ resp (x≈y ∷ xs≈ys) (z∼x ∷ zs∼xs) = resp x≈y z∼x ∷ respʳ resp xs≈ys zs∼xs
-
-respˡ : R Respectsˡ S → (Pointwise R) Respectsˡ (Pointwise S)
-respˡ resp []            []            = []
-respˡ resp (x≈y ∷ xs≈ys) (x∼z ∷ xs∼zs) = resp x≈y x∼z ∷ respˡ resp xs≈ys xs∼zs
-
-respects₂ : R Respects₂ S → (Pointwise R) Respects₂ (Pointwise S)
-respects₂ (rʳ , rˡ) = respʳ rʳ , respˡ rˡ
 
 decidable : Decidable R → Decidable (Pointwise R)
 decidable _  []       []       = yes []

--- a/src/Data/List/Relation/Binary/Pointwise/Core.agda
+++ b/src/Data/List/Relation/Binary/Pointwise/Core.agda
@@ -1,0 +1,98 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Pointwise lifting of relations to lists
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.List.Relation.Binary.Pointwise.Core where
+
+open import Data.Product using (_×_; _,_; <_,_>)
+open import Data.List.Base as List hiding (map; head; tail; uncons)
+open import Level
+open import Relation.Binary.Core using (REL; _⇒_)
+open import Relation.Binary.Definitions
+
+private
+  variable
+    a b c d p q ℓ ℓ₁ ℓ₂ : Level
+    A B C D : Set d
+    x y z : A
+    ws xs ys zs : List A
+    R S T : REL A B ℓ
+
+------------------------------------------------------------------------
+-- Definition
+------------------------------------------------------------------------
+
+infixr 5 _∷_
+
+data Pointwise {A : Set a} {B : Set b} (R : REL A B ℓ)
+               : List A → List B → Set (a ⊔ b ⊔ ℓ) where
+  []  : Pointwise R [] []
+  _∷_ : (x∼y : R x y) (xs∼ys : Pointwise R xs ys) →
+        Pointwise R (x ∷ xs) (y ∷ ys)
+
+------------------------------------------------------------------------
+-- Operations
+------------------------------------------------------------------------
+
+head : Pointwise R (x ∷ xs) (y ∷ ys) → R x y
+head (x∼y ∷ xs∼ys) = x∼y
+
+tail : Pointwise R (x ∷ xs) (y ∷ ys) → Pointwise R xs ys
+tail (x∼y ∷ xs∼ys) = xs∼ys
+
+uncons : Pointwise R (x ∷ xs) (y ∷ ys) → R x y × Pointwise R xs ys
+uncons = < head , tail >
+
+rec : ∀ (P : ∀ {xs ys} → Pointwise R xs ys → Set c) →
+      (∀ {x y xs ys} {Rxsys : Pointwise R xs ys} →
+        (Rxy : R x y) → P Rxsys → P (Rxy ∷ Rxsys)) →
+      P [] →
+      ∀ {xs ys} (Rxsys : Pointwise R xs ys) → P Rxsys
+rec P c n []            = n
+rec P c n (Rxy ∷ Rxsys) = c Rxy (rec P c n Rxsys)
+
+map : R ⇒ S → Pointwise R ⇒ Pointwise S
+map R⇒S []            = []
+map R⇒S (Rxy ∷ Rxsys) = R⇒S Rxy ∷ map R⇒S Rxsys
+
+------------------------------------------------------------------------
+-- Relational properties
+------------------------------------------------------------------------
+
+reflexive : R ⇒ S → Pointwise R ⇒ Pointwise S
+reflexive = map
+
+refl : Reflexive R → Reflexive (Pointwise R)
+refl rfl {[]}     = []
+refl rfl {x ∷ xs} = rfl ∷ refl rfl
+
+symmetric : Sym R S → Sym (Pointwise R) (Pointwise S)
+symmetric sym []            = []
+symmetric sym (x∼y ∷ xs∼ys) = sym x∼y ∷ symmetric sym xs∼ys
+
+transitive : Trans R S T →
+             Trans (Pointwise R) (Pointwise S) (Pointwise T)
+transitive trans []            []            = []
+transitive trans (x∼y ∷ xs∼ys) (y∼z ∷ ys∼zs) =
+  trans x∼y y∼z ∷ transitive trans xs∼ys ys∼zs
+
+antisymmetric : Antisym R S T →
+                Antisym (Pointwise R) (Pointwise S) (Pointwise T)
+antisymmetric antisym []            []            = []
+antisymmetric antisym (x∼y ∷ xs∼ys) (y∼x ∷ ys∼xs) =
+  antisym x∼y y∼x ∷ antisymmetric antisym xs∼ys ys∼xs
+
+respʳ : R Respectsʳ S → (Pointwise R) Respectsʳ (Pointwise S)
+respʳ resp []            []            = []
+respʳ resp (x≈y ∷ xs≈ys) (z∼x ∷ zs∼xs) = resp x≈y z∼x ∷ respʳ resp xs≈ys zs∼xs
+
+respˡ : R Respectsˡ S → (Pointwise R) Respectsˡ (Pointwise S)
+respˡ resp []            []            = []
+respˡ resp (x≈y ∷ xs≈ys) (x∼z ∷ xs∼zs) = resp x≈y x∼z ∷ respˡ resp xs≈ys xs∼zs
+
+respects₂ : R Respects₂ S → (Pointwise R) Respects₂ (Pointwise S)
+respects₂ (rʳ , rˡ) = respʳ rʳ , respˡ rˡ

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -19,7 +19,7 @@ open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl)
 open import Relation.Nullary using (¬_)
-open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Negation.Core using (contradiction)
 open import Relation.Unary using (Pred)
 
 ------------------------------------------------------------------------

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -17,8 +17,7 @@ open import Algebra.Morphism
 open import Algebra.Consequences.Propositional
 open import Algebra.Construct.NaturalChoice.Base
 import Algebra.Construct.NaturalChoice.MinMaxOp as MinMaxOp
-open import Data.Bool.Base using (Bool; false; true; T)
-open import Data.Bool.Properties using (T?)
+open import Data.Bool.Base using (Bool; false; true; T; T?)
 open import Data.Empty using (⊥)
 open import Data.Nat.Base
 open import Data.Product using (_×_; _,_)

--- a/src/Data/String.agda
+++ b/src/Data/String.agda
@@ -8,9 +8,28 @@
 
 module Data.String where
 
-open import Data.Vec.Base as Vec using (Vec)
+open import Data.Bool using (true; false; T?)
 open import Data.Char as Char using (Char)
 open import Function.Base
+open import Data.Nat.Base as ℕ using (ℕ; _∸_; ⌊_/2⌋; ⌈_/2⌉)
+import Data.Nat.Properties as ℕₚ
+open import Data.List.Base as List using (List; _∷_; []; [_])
+open import Data.List.NonEmpty as NE using (List⁺)
+open import Data.List.Extrema ℕₚ.≤-totalOrder
+open import Data.List.Relation.Binary.Pointwise using (Pointwise)
+open import Data.List.Relation.Binary.Lex.Strict using (Lex-<; Lex-≤)
+open import Data.Vec.Base as Vec using (Vec)
+open import Data.Char.Base as Char using (Char)
+import Data.Char.Properties as Char using (_≟_)
+open import Function
+open import Relation.Binary using (Rel)
+open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Nullary using (does)
+open import Relation.Unary using (Pred; Decidable)
+
+open import Data.List.Membership.DecPropositional Char._≟_
+
+
 
 ------------------------------------------------------------------------
 -- Re-export contents of base, and decidability of equality
@@ -19,10 +38,65 @@ open import Data.String.Base public
 open import Data.String.Properties using (_≈?_; _≟_; _<?_; _==_) public
 
 ------------------------------------------------------------------------
--- Operations
+-- Conversion functions
 
 toVec : (s : String) → Vec Char (length s)
 toVec s = Vec.fromList (toList s)
 
 fromVec : ∀ {n} → Vec Char n → String
 fromVec = fromList ∘ Vec.toList
+
+
+-- enclose string with parens if it contains a space character
+parensIfSpace : String → String
+parensIfSpace s with does (' ' ∈? toList s)
+... | true  = parens s
+... | false = s
+
+------------------------------------------------------------------------
+-- Splitting strings
+
+wordsBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
+wordsBy P? = List.map fromList ∘ List.wordsBy P? ∘ toList
+
+words : String → List String
+words = wordsBy (T? ∘ Char.isSpace)
+
+-- `words` ignores contiguous whitespace
+_ : words " abc  b   " ≡ "abc" ∷ "b" ∷ []
+_ = refl
+
+linesBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
+linesBy P? = List.map fromList ∘ List.linesBy P? ∘ toList
+
+lines : String → List String
+lines = linesBy ('\n' Char.≟_)
+
+-- `lines` preserves empty lines
+_ : lines "\nabc\n\nb\n\n\n" ≡ "" ∷ "abc" ∷ "" ∷ "b" ∷ "" ∷ "" ∷ []
+_ = refl
+
+------------------------------------------------------------------------
+-- Rectangle
+
+-- Build a rectangular column by:
+-- Given a vector of cells and a padding function for each one
+-- Compute the max of the widths, and pad the strings accordingly.
+
+rectangle : ∀ {n} → Vec (ℕ → String → String) n →
+            Vec String n → Vec String n
+rectangle pads cells = Vec.zipWith (λ p c → p width c) pads cells where
+
+  sizes = List.map length (Vec.toList cells)
+  width = max 0 sizes
+
+-- Special cases for left, center, and right alignment
+
+rectangleˡ : ∀ {n} → Char → Vec String n → Vec String n
+rectangleˡ c = rectangle (Vec.replicate $ padLeft c)
+
+rectangleʳ : ∀ {n} → Char → Vec String n → Vec String n
+rectangleʳ c = rectangle (Vec.replicate $ padRight c)
+
+rectangleᶜ : ∀ {n} → Char → Char → Vec String n → Vec String n
+rectangleᶜ cₗ cᵣ = rectangle (Vec.replicate $ padBoth cₗ cᵣ)

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -10,24 +10,18 @@ module Data.String.Base where
 
 open import Level using (zero)
 open import Data.Bool.Base using (true; false)
-open import Data.Bool.Properties using (T?)
-open import Data.Nat.Base as ℕ using (ℕ; _∸_; ⌊_/2⌋; ⌈_/2⌉)
-import Data.Nat.Properties as ℕₚ
-open import Data.List.Base as List using (List; _∷_; []; [_])
-open import Data.List.NonEmpty as NE using (List⁺)
-open import Data.List.Extrema ℕₚ.≤-totalOrder
-open import Data.List.Relation.Binary.Pointwise using (Pointwise)
-open import Data.List.Relation.Binary.Lex.Strict using (Lex-<; Lex-≤)
-open import Data.Vec.Base as Vec using (Vec)
 open import Data.Char.Base as Char using (Char)
-import Data.Char.Properties as Char using (_≟_)
-open import Function
-open import Relation.Binary using (Rel)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
-open import Relation.Nullary using (does)
-open import Relation.Unary using (Pred; Decidable)
+open import Data.List.Base as List using (List; [_]; _∷_; [])
+open import Data.List.NonEmpty.Base as NE using (List⁺)
+open import Data.List.Relation.Binary.Pointwise.Core using (Pointwise)
+open import Data.List.Relation.Binary.Lex.Strict.Core using (Lex-<; Lex-≤)
+open import Data.Nat.Base using (ℕ; _∸_; ⌊_/2⌋; ⌈_/2⌉)
 
-open import Data.List.Membership.DecPropositional Char._≟_
+open import Function.Base using (_on_; _∘′_; _∘_)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
+open import Relation.Unary using (Pred; Decidable)
+open import Relation.Nullary using (does)
 
 ------------------------------------------------------------------------
 -- From Agda.Builtin: type and renamed primitives
@@ -92,42 +86,14 @@ concat = List.foldr _++_ ""
 intersperse : String → List String → String
 intersperse sep = concat ∘′ (List.intersperse sep)
 
--- String-specific functions
-
-wordsBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
-wordsBy P? = List.map fromList ∘ List.wordsBy P? ∘ toList
-
-words : String → List String
-words = wordsBy (T? ∘ Char.isSpace)
-
--- `words` ignores contiguous whitespace
-_ : words " abc  b   " ≡ "abc" ∷ "b" ∷ []
-_ = refl
-
 unwords : List String → String
 unwords = intersperse " "
-
-linesBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
-linesBy P? = List.map fromList ∘ List.linesBy P? ∘ toList
-
-lines : String → List String
-lines = linesBy ('\n' Char.≟_)
-
--- `lines` preserves empty lines
-_ : lines "\nabc\n\nb\n\n\n" ≡ "" ∷ "abc" ∷ "" ∷ "b" ∷ "" ∷ "" ∷ []
-_ = refl
 
 unlines : List String → String
 unlines = intersperse "\n"
 
 parens : String → String
 parens s = "(" ++ s ++ ")"
-
--- enclose string with parens if it contains a space character
-parensIfSpace : String → String
-parensIfSpace s with does (' ' ∈? toList s)
-... | true  = parens s
-... | false = s
 
 braces : String → String
 braces s = "{" ++ s ++ "}"
@@ -180,28 +146,3 @@ fromAlignment : Alignment → ℕ → String → String
 fromAlignment Left   = padRight ' '
 fromAlignment Center = padBoth ' ' ' '
 fromAlignment Right  = padLeft ' '
-
-------------------------------------------------------------------------
--- Rectangle
-
--- Build a rectangular column by:
--- Given a vector of cells and a padding function for each one
--- Compute the max of the widths, and pad the strings accordingly.
-
-rectangle : ∀ {n} → Vec (ℕ → String → String) n →
-            Vec String n → Vec String n
-rectangle pads cells = Vec.zipWith (λ p c → p width c) pads cells where
-
-  sizes = List.map length (Vec.toList cells)
-  width = max 0 sizes
-
--- Special cases for left, center, and right alignment
-
-rectangleˡ : ∀ {n} → Char → Vec String n → Vec String n
-rectangleˡ c = rectangle (Vec.replicate $ padLeft c)
-
-rectangleʳ : ∀ {n} → Char → Vec String n → Vec String n
-rectangleʳ c = rectangle (Vec.replicate $ padRight c)
-
-rectangleᶜ : ∀ {n} → Char → Char → Vec String n → Vec String n
-rectangleᶜ cₗ cᵣ = rectangle (Vec.replicate $ padBoth cₗ cᵣ)

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -14,9 +14,9 @@ open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List)
 open import Data.Product as Prod using (∃; ∃₂; _×_; _,_)
 open import Data.These.Base as These using (These; this; that; these)
-open import Function
+open import Function.Base using (const; _∘′_; id; _∘_)
 open import Level using (Level)
-open import Relation.Binary.PropositionalEquality using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 open import Relation.Nullary using (does)
 open import Relation.Unary using (Pred; Decidable)
 

--- a/src/IO.agda
+++ b/src/IO.agda
@@ -10,10 +10,10 @@ module IO where
 
 open import Codata.Musical.Notation
 open import Codata.Musical.Costring
-open import Data.Unit.Polymorphic
-open import Data.String
-import Data.Unit as Unit0
-open import Function
+open import Data.Unit.Polymorphic.Base
+open import Data.String.Base
+import Data.Unit.Base as Unit0
+open import Function.Base using (_∘_)
 import IO.Primitive as Prim
 open import Level
 
@@ -82,7 +82,7 @@ Main = Prim.IO {0ℓ} ⊤
 
 module Colist where
 
-  open import Codata.Musical.Colist
+  open import Codata.Musical.Colist.Base
 
   module _  {A : Set a} where
 

--- a/src/IO/Primitive.agda
+++ b/src/IO/Primitive.agda
@@ -11,7 +11,7 @@ module IO.Primitive where
 open import Codata.Musical.Costring
 open import Data.Char.Base
 open import Data.String.Base
-open import Data.Unit using () renaming (⊤ to Unit)
+open import Data.Unit.Base using () renaming (⊤ to Unit)
 
 ------------------------------------------------------------------------
 -- The IO monad
@@ -68,15 +68,15 @@ postulate
                                                  (\_ -> System.IO.hFileSize h)
     Data.Text.IO.hGetContents h
 
-  fromColist :: MAlonzo.Code.Codata.Musical.Colist.AgdaColist a -> [a]
-  fromColist MAlonzo.Code.Codata.Musical.Colist.Nil         = []
-  fromColist (MAlonzo.Code.Codata.Musical.Colist.Cons x xs) =
+  fromColist :: MAlonzo.Code.Codata.Musical.Colist.Base.AgdaColist a -> [a]
+  fromColist MAlonzo.Code.Codata.Musical.Colist.Base.Nil         = []
+  fromColist (MAlonzo.Code.Codata.Musical.Colist.Base.Cons x xs) =
     x : fromColist (MAlonzo.RTE.flat xs)
 
-  toColist :: [a] -> MAlonzo.Code.Codata.Musical.Colist.AgdaColist a
-  toColist []       = MAlonzo.Code.Codata.Musical.Colist.Nil
+  toColist :: [a] -> MAlonzo.Code.Codata.Musical.Colist.Base.AgdaColist a
+  toColist []       = MAlonzo.Code.Codata.Musical.Colist.Base.Nil
   toColist (x : xs) =
-    MAlonzo.Code.Codata.Musical.Colist.Cons x (MAlonzo.RTE.Sharp (toColist xs))
+    MAlonzo.Code.Codata.Musical.Colist.Base.Cons x (MAlonzo.RTE.Sharp (toColist xs))
 #-}
 
 {-# COMPILE GHC getLine        = fmap Data.Text.pack getLine                        #-}

--- a/src/Relation/Binary/Construct/Closure/Reflexive.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive.agda
@@ -8,12 +8,13 @@
 
 module Relation.Binary.Construct.Closure.Reflexive where
 
-open import Data.Unit
+open import Data.Unit.Base
 open import Level
-open import Function
-open import Relation.Binary
-open import Relation.Binary.Construct.Constant using (Const)
-open import Relation.Binary.PropositionalEquality using (_≡_ ; refl)
+open import Function.Base using (_∋_)
+open import Relation.Binary.Core using (Rel; _=[_]⇒_; _⇒_)
+open import Relation.Binary.Definitions using (Reflexive)
+open import Relation.Binary.Construct.Constant.Core using (Const)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_ ; refl)
 
 private
   variable

--- a/src/Relation/Binary/Construct/Constant.agda
+++ b/src/Relation/Binary/Construct/Constant.agda
@@ -8,13 +8,19 @@
 
 module Relation.Binary.Construct.Constant where
 
+open import Level
 open import Relation.Binary
 
-------------------------------------------------------------------------
--- Definition
+private
+  variable
+    a b c : Level
+    A : Set a
+    B : Set b
 
-Const : ∀ {a b c} {A : Set a} {B : Set b} → Set c → REL A B c
-Const I = λ _ _ → I
+------------------------------------------------------------------------
+-- Re-export definition
+
+open import Relation.Binary.Construct.Constant.Core public
 
 ------------------------------------------------------------------------
 -- Properties

--- a/src/Relation/Binary/Construct/Constant/Core.agda
+++ b/src/Relation/Binary/Construct/Constant/Core.agda
@@ -1,0 +1,24 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The binary relation defined by a constant
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Binary.Construct.Constant.Core where
+
+open import Level
+open import Relation.Binary.Core using (REL)
+
+private
+  variable
+    a b c : Level
+    A : Set a
+    B : Set b
+
+------------------------------------------------------------------------
+-- Definition
+
+Const : Set c → REL A B c
+Const I = λ _ _ → I

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -11,8 +11,8 @@
 module Relation.Nullary where
 
 open import Agda.Builtin.Equality
+open import Agda.Builtin.Bool
 
-open import Data.Bool.Base
 open import Data.Empty hiding (⊥-elim)
 open import Data.Empty.Irrelevant
 open import Level

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -29,70 +29,9 @@ private
     Whatever : Set w
 
 ------------------------------------------------------------------------
--- Uses of negation
+-- Re-export public definitions
 
-contradiction : P → ¬ P → Whatever
-contradiction p ¬p = ⊥-elim (¬p p)
-
-contraposition : (P → Q) → ¬ Q → ¬ P
-contraposition f ¬q p = contradiction (f p) ¬q
-
--- Note also the following use of flip:
-
-private
-  note : (P → ¬ Q) → Q → ¬ P
-  note = flip
-
--- If we can decide P, then we can decide its negation.
-
-¬-reflects : ∀ {b} → Reflects P b → Reflects (¬ P) (not b)
-¬-reflects (ofʸ  p) = ofⁿ (_$ p)
-¬-reflects (ofⁿ ¬p) = ofʸ ¬p
-
-¬? : Dec P → Dec (¬ P)
-does  (¬? p?) = not (does p?)
-proof (¬? p?) = ¬-reflects (proof p?)
-
-------------------------------------------------------------------------
--- Quantifier juggling
-
-module _ {P : Pred A p} where
-
-  ∃⟶¬∀¬ : ∃ P → ¬ (∀ x → ¬ P x)
-  ∃⟶¬∀¬ = flip uncurry
-
-  ∀⟶¬∃¬ : (∀ x → P x) → ¬ ∃ λ x → ¬ P x
-  ∀⟶¬∃¬ ∀xPx (x , ¬Px) = ¬Px (∀xPx x)
-
-  ¬∃⟶∀¬ : ¬ ∃ (λ x → P x) → ∀ x → ¬ P x
-  ¬∃⟶∀¬ = curry
-
-  ∀¬⟶¬∃ : (∀ x → ¬ P x) → ¬ ∃ (λ x → P x)
-  ∀¬⟶¬∃ = uncurry
-
-  ∃¬⟶¬∀ : ∃ (λ x → ¬ P x) → ¬ (∀ x → P x)
-  ∃¬⟶¬∀ = flip ∀⟶¬∃¬
-
-------------------------------------------------------------------------
--- Double-negation
-
-¬¬-map : (P → Q) → ¬ ¬ P → ¬ ¬ Q
-¬¬-map f = contraposition (contraposition f)
-
--- Stability under double-negation.
-
-Stable : Set p → Set p
-Stable P = ¬ ¬ P → P
-
--- Everything is stable in the double-negation monad.
-
-stable : ¬ ¬ Stable P
-stable ¬[¬¬p→p] = ¬[¬¬p→p] (λ ¬¬p → ⊥-elim (¬¬p (¬[¬¬p→p] ∘ const)))
-
--- Negated predicates are stable.
-
-negated-stable : Stable (¬ P)
-negated-stable ¬¬¬P P = ¬¬¬P (λ ¬P → ¬P P)
+open import Relation.Nullary.Negation.Core public
 
 -- Decidable predicates are stable.
 

--- a/src/Relation/Nullary/Negation/Core.agda
+++ b/src/Relation/Nullary/Negation/Core.agda
@@ -1,0 +1,91 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Core properties related to negation
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Nullary.Negation.Core where
+
+open import Data.Bool.Base using (not)
+open import Data.Empty
+open import Data.Product
+open import Function.Base using (flip; _$_; _∘_; const)
+open import Level
+open import Relation.Nullary
+open import Relation.Unary using (Pred)
+
+private
+  variable
+    a p q w : Level
+    A : Set a
+    P : Set p
+    Q : Set q
+    Whatever : Set w
+
+------------------------------------------------------------------------
+-- Uses of negation
+
+contradiction : P → ¬ P → Whatever
+contradiction p ¬p = ⊥-elim (¬p p)
+
+contraposition : (P → Q) → ¬ Q → ¬ P
+contraposition f ¬q p = contradiction (f p) ¬q
+
+-- Note also the following use of flip:
+
+private
+  note : (P → ¬ Q) → Q → ¬ P
+  note = flip
+
+-- If we can decide P, then we can decide its negation.
+
+¬-reflects : ∀ {b} → Reflects P b → Reflects (¬ P) (not b)
+¬-reflects (ofʸ  p) = ofⁿ (_$ p)
+¬-reflects (ofⁿ ¬p) = ofʸ ¬p
+
+¬? : Dec P → Dec (¬ P)
+does  (¬? p?) = not (does p?)
+proof (¬? p?) = ¬-reflects (proof p?)
+
+------------------------------------------------------------------------
+-- Quantifier juggling
+
+module _ {P : Pred A p} where
+
+  ∃⟶¬∀¬ : ∃ P → ¬ (∀ x → ¬ P x)
+  ∃⟶¬∀¬ = flip uncurry
+
+  ∀⟶¬∃¬ : (∀ x → P x) → ¬ ∃ λ x → ¬ P x
+  ∀⟶¬∃¬ ∀xPx (x , ¬Px) = ¬Px (∀xPx x)
+
+  ¬∃⟶∀¬ : ¬ ∃ (λ x → P x) → ∀ x → ¬ P x
+  ¬∃⟶∀¬ = curry
+
+  ∀¬⟶¬∃ : (∀ x → ¬ P x) → ¬ ∃ (λ x → P x)
+  ∀¬⟶¬∃ = uncurry
+
+  ∃¬⟶¬∀ : ∃ (λ x → ¬ P x) → ¬ (∀ x → P x)
+  ∃¬⟶¬∀ = flip ∀⟶¬∃¬
+
+------------------------------------------------------------------------
+-- Double-negation
+
+¬¬-map : (P → Q) → ¬ ¬ P → ¬ ¬ Q
+¬¬-map f = contraposition (contraposition f)
+
+-- Stability under double-negation.
+
+Stable : Set p → Set p
+Stable P = ¬ ¬ P → P
+
+-- Everything is stable in the double-negation monad.
+
+stable : ¬ ¬ Stable P
+stable ¬[¬¬p→p] = ¬[¬¬p→p] (λ ¬¬p → ⊥-elim (¬¬p (¬[¬¬p→p] ∘ const)))
+
+-- Negated predicates are stable.
+
+negated-stable : Stable (¬ P)
+negated-stable ¬¬¬P P = ¬¬¬P (λ ¬P → ¬P P)

--- a/src/Relation/Nullary/Product.agda
+++ b/src/Relation/Nullary/Product.agda
@@ -10,7 +10,7 @@ module Relation.Nullary.Product where
 
 open import Data.Bool.Base
 open import Data.Product
-open import Function
+open import Function.Base using (_∘_)
 open import Level
 open import Relation.Nullary.Reflects
 open import Relation.Nullary

--- a/src/Relation/Unary/Properties.agda
+++ b/src/Relation/Unary/Properties.agda
@@ -10,7 +10,7 @@ module Relation.Unary.Properties where
 
 open import Data.Product using (_×_; _,_; swap; proj₁)
 open import Data.Sum.Base using (inj₁; inj₂)
-open import Data.Unit using (tt)
+open import Data.Unit.Base using (tt)
 open import Level
 open import Relation.Binary.Core
 open import Relation.Binary.Definitions hiding (Decidable; Universal)
@@ -18,7 +18,7 @@ open import Relation.Unary
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Nullary.Sum using (_⊎-dec_)
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary.Negation.Core using (¬?)
 open import Function.Base using (_$_; _∘_)
 
 private

--- a/src/Text/Tabular/Vec.agda
+++ b/src/Text/Tabular/Vec.agda
@@ -10,7 +10,7 @@ module Text.Tabular.Vec where
 
 open import Data.List.Base using (List)
 open import Data.Product as Prod using (uncurry)
-open import Data.String.Base using (String; rectangle; fromAlignment)
+open import Data.String using (String; rectangle; fromAlignment)
 open import Data.Vec.Base
 open import Function.Base
 


### PR DESCRIPTION
Following https://github.com/agda/agda/issues/5231#issuecomment-783772927
I investigated using Agda's `--dependency-graph` option and managed to
reorganise the dependency graph quite a bit.

We now only need to compile 34 library modules (of which 12 are Builtin
modules!) to run hello world.