### PR TITLE
Fix broken link to the "low-hanging-fruit" tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ If you would like to suggest improvements, feel free to use the `Issues` tab.
 Even better, if you would like to make the improvements yourself, we have instructions
 in [HACKING](https://github.com/agda/agda-stdlib/blob/master/HACKING.md) to help
 you get started. For those who would simply like to help out, issues marked with
-the [status:low-hanging-fruit](https://github.com/agda/agda-stdlib/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+low-hanging-fruit%22) tag are a good starting point.
+the [low-hanging-fruit](https://github.com/agda/agda-stdlib/issues?q=is%3Aopen+is%3Aissue+label%3Alow-hanging-fruit) tag are a good starting point.


### PR DESCRIPTION
The `low-hanging-fruit` tag doesn't have the prefix `status:` anymore, so the link in the `README.md` was broken. This PR fixes that.