### PR TITLE
IO.Finite.putStrLn: actually do putStrLn

### DIFF
--- a/src/IO/Finite.agda
+++ b/src/IO/Finite.agda
@@ -55,4 +55,4 @@ putStr : String → IO {a} ⊤
 putStr s = lift′ (Prim.putStr s)
 
 putStrLn : String → IO {a} ⊤
-putStrLn s = lift′ (Prim.putStr s)
+putStrLn s = lift′ (Prim.putStrLn s)


### PR DESCRIPTION
It looks like it was made `putStr` by mistake