### PR TITLE
Add bundles for morphisms over binary relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Non-backwards compatible changes
   `rectangle`, `rectangleˡ`, `rectangleʳ`, `rectangleᶜ`) have been moved to
   `Data.String`.
 
+* The new modules `Relation.Binary.Morphism.(Constant/Identity/Composition)` that
+  were added in the last release no longer have module-level arguments. This is in order
+  to allow proofs about newly added morphism bundles to be added to these files.
+
 Deprecated modules
 ------------------
 
@@ -201,6 +205,11 @@ New modules
   ```
   Data.Tree.Rose.Show
   Data.Tree.Binary.Show
+  ```
+
+* Bundles for binary relation morphisms
+  ```
+  Relation.Binary.Morphism.Bundles
   ```
 
 Other minor additions
@@ -948,6 +957,33 @@ Other minor additions
   ```agda
   totalPreorder   : TotalPreorder a ℓ₁ ℓ₂ → TotalPreorder a ℓ₁ ℓ₂
   isTotalPreorder : IsTotalPreorder ≈ ∼  → IsTotalPreorder ≈ (flip ∼)
+  ```
+
+
+* Added new proofs to `Relation.Binary.Morphism.Construct.Constant`:
+  ```agda
+  setoidHomomorphism : (S : Setoid a ℓ₁) (T : Setoid b ℓ₂) → ∀ x → SetoidHomomorphism S T
+  preorderHomomorphism : (P : Preorder a ℓ₁ ℓ₂) (Q : Preorder b ℓ₃ ℓ₄) → ∀ x → PreorderHomomorphism P Q
+  ```
+
+* Added new proofs to `Relation.Binary.Morphism.Construct.Composition`:
+  ```agda
+  setoidHomomorphism : SetoidHomomorphism S T → SetoidHomomorphism T U → SetoidHomomorphism S U
+  setoidMonomorphism : SetoidMonomorphism S T → SetoidMonomorphism T U → SetoidMonomorphism S U
+  setoidIsomorphism  : SetoidIsomorphism S T → SetoidIsomorphism T U → SetoidIsomorphism S U
+  
+  preorderHomomorphism : PreorderHomomorphism P Q → PreorderHomomorphism Q R → PreorderHomomorphism P R
+  posetHomomorphism    : PosetHomomorphism P Q → PosetHomomorphism Q R → PosetHomomorphism P R
+  ```
+
+* Added new proofs to `Relation.Binary.Morphism.Construct.Identity`:
+  ```agda
+  setoidHomomorphism : (S : Setoid a ℓ₁) → SetoidHomomorphism S S
+  setoidMonomorphism : (S : Setoid a ℓ₁) → SetoidMonomorphism S S
+  setoidIsomorphism  : (S : Setoid a ℓ₁) → SetoidIsomorphism S S
+  
+  preorderHomomorphism : (P : Preorder a ℓ₁ ℓ₂) → PreorderHomomorphism P P
+  posetHomomorphism    : (P : Poset a ℓ₁ ℓ₂) → PosetHomomorphism P P
   ```
 
 * Added new proofs to `Relation.Nullary.Negation`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -949,8 +949,8 @@ Other minor additions
 
 * Added new proofs to `Relation.Binary.Consequences`:
   ```agda
-  mono⇒cong     : Symmetric _≈_ → _≈_ ⇒ _≤_ → Antisymmetric _≈_ _≤_ → f Preserves _≤_ ⟶ _≤_ → f Preserves _≈_ ⟶ _≈_
-  antimono⇒cong : Symmetric _≈_ → _≈_ ⇒ _≤_ → Antisymmetric _≈_ _≤_ → f Preserves _≤_ ⟶ (flip _≤_) → f Preserves _≈_ ⟶ _≈_
+  mono⇒cong     : Symmetric ≈₁ → ≈₁ ⇒ ≤₁ → Antisymmetric ≈₂ ≤₂ → ∀ {f} → f Preserves ≤₁ ⟶ ≤₂        → f Preserves ≈₁ ⟶ ≈₂
+  antimono⇒cong : Symmetric ≈₁ → ≈₁ ⇒ ≤₁ → Antisymmetric ≈₂ ≤₂ → ∀ {f} → f Preserves ≤₁ ⟶ (flip ≤₂) → f Preserves ≈₁ ⟶ ≈₂
   ```
 
 * Added new proofs to `Relation.Binary.Construct.Converse`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,9 @@ Non-backwards compatible changes
 
 * The new modules `Relation.Binary.Morphism.(Constant/Identity/Composition)` that
   were added in the last release no longer have module-level arguments. This is in order
-  to allow proofs about newly added morphism bundles to be added to these files.
+  to allow proofs about newly added morphism bundles to be added to these files. This is
+  only a breaking change if you were supplying the module arguments upon import, in which
+  case you will have to change to supplying them upon application of the proofs.
 
 Deprecated modules
 ------------------

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -317,10 +317,10 @@ p ≤? q = Dec.map′ *≤* drop-*≤* (↥ p ℤ.* ↧ q ℤ.≤? ↥ q ℤ.* �
 -- Other properties of _≤_
 
 mono⇒cong : ∀ {f} → f Preserves _≤_ ⟶ _≤_ → f Preserves _≃_ ⟶ _≃_
-mono⇒cong = BC.mono⇒cong _ ≃-sym ≤-reflexive ≤-antisym
+mono⇒cong = BC.mono⇒cong _≃_ _≃_ ≃-sym ≤-reflexive ≤-antisym
 
 antimono⇒cong : ∀ {f} → f Preserves _≤_ ⟶ _≥_ → f Preserves _≃_ ⟶ _≃_
-antimono⇒cong = BC.antimono⇒cong _ ≃-sym ≤-reflexive ≤-antisym
+antimono⇒cong = BC.antimono⇒cong _≃_ _≃_ ≃-sym ≤-reflexive ≤-antisym
 
 ------------------------------------------------------------------------
 -- Properties of _≤ᵇ_

--- a/src/Relation/Binary/Consequences.agda
+++ b/src/Relation/Binary/Consequences.agda
@@ -22,9 +22,8 @@ open import Relation.Unary using (∁; Pred)
 
 private
   variable
-    a b ℓ ℓ₁ ℓ₂ p : Level
-    A : Set a
-    B : Set b
+    a ℓ ℓ₁ ℓ₂ ℓ₃ ℓ₄ p : Level
+    A B : Set a
 
 ------------------------------------------------------------------------
 -- Substitutive properties
@@ -62,19 +61,19 @@ module _ {_≈_ : Rel A ℓ₁} {_≤_ : Rel A ℓ₂} where
   ... | inj₁ x≤y = yes x≤y
   ... | inj₂ y≤x = map′ refl (flip antisym y≤x) (x ≟ y)
 
-mono⇒cong : (_≈_ : Rel A ℓ₁) {_≤_ : Rel A ℓ₂} →
-            Symmetric _≈_ → _≈_ ⇒ _≤_ → Antisymmetric _≈_ _≤_ →
-            ∀ {f} → f Preserves _≤_ ⟶ _≤_ → f Preserves _≈_ ⟶ _≈_
-mono⇒cong _ sym reflexive antisym mono x≈y = antisym
-  (mono (reflexive x≈y))
-  (mono (reflexive (sym x≈y)))
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) {≤₁ : Rel A ℓ₃} {≤₂ : Rel B ℓ₄} where
 
-antimono⇒cong : (_≈_ : Rel A ℓ₁) {_≤_ : Rel A ℓ₂} →
-                Symmetric _≈_ → _≈_ ⇒ _≤_ → Antisymmetric _≈_ _≤_ →
-                ∀ {f} → f Preserves _≤_ ⟶ (flip _≤_) → f Preserves _≈_ ⟶ _≈_
-antimono⇒cong _ sym reflexive antisym antimono p≈q = antisym
-  (antimono (reflexive (sym p≈q)))
-  (antimono (reflexive p≈q))
+  mono⇒cong : Symmetric ≈₁ → ≈₁ ⇒ ≤₁ → Antisymmetric ≈₂ ≤₂ →
+              ∀ {f} → f Preserves ≤₁ ⟶ ≤₂ → f Preserves ≈₁ ⟶ ≈₂
+  mono⇒cong sym reflexive antisym mono x≈y = antisym
+    (mono (reflexive x≈y))
+    (mono (reflexive (sym x≈y)))
+
+  antimono⇒cong : Symmetric ≈₁ → ≈₁ ⇒ ≤₁ → Antisymmetric ≈₂ ≤₂ →
+                  ∀ {f} → f Preserves ≤₁ ⟶ (flip ≤₂) → f Preserves ≈₁ ⟶ ≈₂
+  antimono⇒cong sym reflexive antisym antimono p≈q = antisym
+    (antimono (reflexive (sym p≈q)))
+    (antimono (reflexive p≈q))
 
 ------------------------------------------------------------------------
 -- Proofs for strict orders

--- a/src/Relation/Binary/Morphism.agda
+++ b/src/Relation/Binary/Morphism.agda
@@ -15,3 +15,4 @@ module Relation.Binary.Morphism where
 
 open import Relation.Binary.Morphism.Definitions public
 open import Relation.Binary.Morphism.Structures public
+open import Relation.Binary.Morphism.Bundles public

--- a/src/Relation/Binary/Morphism/Bundles.agda
+++ b/src/Relation/Binary/Morphism/Bundles.agda
@@ -1,14 +1,16 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Order morphisms bundles
+-- Bundles for morphisms between binary relations
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
 open import Level
+open import Relation.Binary.Core using (_Preserves_⟶_)
 open import Relation.Binary.Bundles
 open import Relation.Binary.Morphism.Structures
+open import Relation.Binary.Consequences using (mono⇒cong)
 
 module Relation.Binary.Morphism.Bundles where
 
@@ -17,7 +19,7 @@ private
     ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅ ℓ₆ : Level
 
 ------------------------------------------------------------------------
--- Relations
+-- Setoids
 ------------------------------------------------------------------------
 
 module _ (S₁ : Setoid ℓ₁ ℓ₂) (S₂ : Setoid ℓ₃ ℓ₄) where
@@ -59,7 +61,7 @@ module _ (S₁ : Setoid ℓ₁ ℓ₂) (S₂ : Setoid ℓ₃ ℓ₄) where
 
 
 ------------------------------------------------------------------------
--- Orders
+-- Preorders
 ------------------------------------------------------------------------
 
 record PreorderHomomorphism (S₁ : Preorder ℓ₁ ℓ₂ ℓ₃)
@@ -72,13 +74,31 @@ record PreorderHomomorphism (S₁ : Preorder ℓ₁ ℓ₂ ℓ₃)
 
   open IsOrderHomomorphism isOrderHomomorphism public
 
+------------------------------------------------------------------------
+-- Posets
+------------------------------------------------------------------------
 
-record PosetHomomorphism (S₁ : Poset ℓ₁ ℓ₂ ℓ₃)
-                         (S₂ : Poset ℓ₄ ℓ₅ ℓ₆)
-                         : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄ ⊔ ℓ₅ ⊔ ℓ₆) where
-  open Poset
-  field
-    ⟦_⟧                 : Carrier S₁ → Carrier S₂
-    isOrderHomomorphism : IsOrderHomomorphism (_≈_ S₁) (_≈_ S₂) (_≤_ S₁) (_≤_ S₂) ⟦_⟧
+module _ (P : Poset ℓ₁ ℓ₂ ℓ₃) (Q : Poset ℓ₄ ℓ₅ ℓ₆) where
 
-  open IsOrderHomomorphism isOrderHomomorphism public
+  private
+    module P = Poset P
+    module Q = Poset Q
+
+  record PosetHomomorphism : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄ ⊔ ℓ₅ ⊔ ℓ₆) where
+    field
+      ⟦_⟧                 : P.Carrier → Q.Carrier
+      isOrderHomomorphism : IsOrderHomomorphism P._≈_ Q._≈_ P._≤_ Q._≤_ ⟦_⟧
+
+    open IsOrderHomomorphism isOrderHomomorphism public
+
+
+  -- Smart constructor that automatically constructs the congruence proof
+  -- from the monotonicity proof
+  mkPosetHomo : ∀ f → f Preserves P._≤_ ⟶ Q._≤_ → PosetHomomorphism
+  mkPosetHomo f mono = record
+    { ⟦_⟧ = f
+    ; isOrderHomomorphism = record
+      { cong = mono⇒cong P._≈_ Q._≈_ P.Eq.sym P.reflexive Q.antisym mono
+      ; mono = mono
+      }
+    }

--- a/src/Relation/Binary/Morphism/Bundles.agda
+++ b/src/Relation/Binary/Morphism/Bundles.agda
@@ -1,0 +1,84 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Order morphisms bundles
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+open import Relation.Binary.Bundles
+open import Relation.Binary.Morphism.Structures
+
+module Relation.Binary.Morphism.Bundles where
+
+private
+  variable
+    ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅ ℓ₆ : Level
+
+------------------------------------------------------------------------
+-- Relations
+------------------------------------------------------------------------
+
+module _ (S₁ : Setoid ℓ₁ ℓ₂) (S₂ : Setoid ℓ₃ ℓ₄) where
+
+  record SetoidHomomorphism : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄) where
+    open Setoid
+    field
+      ⟦_⟧               : Carrier S₁ → Carrier S₂
+      isRelHomomorphism : IsRelHomomorphism (_≈_ S₁) (_≈_ S₂) ⟦_⟧
+
+    open IsRelHomomorphism isRelHomomorphism public
+
+
+  record SetoidMonomorphism : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄) where
+    open Setoid
+    field
+      ⟦_⟧               : Carrier S₁ → Carrier S₂
+      isRelMonomorphism : IsRelMonomorphism (_≈_ S₁) (_≈_ S₂) ⟦_⟧
+
+    open IsRelMonomorphism isRelMonomorphism public
+
+    homomorphism : SetoidHomomorphism
+    homomorphism = record { isRelHomomorphism = isHomomorphism }
+
+
+  record SetoidIsomorphism : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄) where
+    open Setoid
+    field
+      ⟦_⟧              : Carrier S₁ → Carrier S₂
+      isRelIsomorphism : IsRelIsomorphism (_≈_ S₁) (_≈_ S₂) ⟦_⟧
+
+    open IsRelIsomorphism isRelIsomorphism public
+
+    monomorphism : SetoidMonomorphism
+    monomorphism = record { isRelMonomorphism = isMonomorphism }
+
+    open SetoidMonomorphism monomorphism public
+      using (homomorphism)
+
+
+------------------------------------------------------------------------
+-- Orders
+------------------------------------------------------------------------
+
+record PreorderHomomorphism (S₁ : Preorder ℓ₁ ℓ₂ ℓ₃)
+                            (S₂ : Preorder ℓ₄ ℓ₅ ℓ₆)
+                            : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄ ⊔ ℓ₅ ⊔ ℓ₆) where
+  open Preorder
+  field
+    ⟦_⟧                 : Carrier S₁ → Carrier S₂
+    isOrderHomomorphism : IsOrderHomomorphism (_≈_ S₁) (_≈_ S₂) (_∼_ S₁) (_∼_ S₂) ⟦_⟧
+
+  open IsOrderHomomorphism isOrderHomomorphism public
+
+
+record PosetHomomorphism (S₁ : Poset ℓ₁ ℓ₂ ℓ₃)
+                         (S₂ : Poset ℓ₄ ℓ₅ ℓ₆)
+                         : Set (ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃ ⊔ ℓ₄ ⊔ ℓ₅ ⊔ ℓ₆) where
+  open Poset
+  field
+    ⟦_⟧                 : Carrier S₁ → Carrier S₂
+    isOrderHomomorphism : IsOrderHomomorphism (_≈_ S₁) (_≈_ S₂) (_≤_ S₁) (_≤_ S₂) ⟦_⟧
+
+  open IsOrderHomomorphism isOrderHomomorphism public

--- a/src/Relation/Binary/Morphism/Construct/Composition.agda
+++ b/src/Relation/Binary/Morphism/Construct/Composition.agda
@@ -6,21 +6,26 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Data.Product using (_,_)
-open import Function.Base using (id; _∘_)
-open import Function.Definitions using (Congruent)
+open import Function.Base using (_∘_)
 open import Function.Construct.Composition using (surjective)
+open import Level using (Level)
 open import Relation.Binary
+open import Relation.Binary.Morphism.Bundles
 open import Relation.Binary.Morphism.Structures
 
-module Relation.Binary.Morphism.Construct.Composition
-  {a b c ℓ₁ ℓ₂ ℓ₃} {A : Set a} {B : Set b} {C : Set c}
-  {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
-  {f : A → B} {g : B → C} where
+module Relation.Binary.Morphism.Construct.Composition where
+
+private
+  variable
+    a b c ℓ₁ ℓ₂ ℓ₃ ℓ₄ ℓ₅ ℓ₆ : Level
+    A B C : Set a
+    ≈₁ ≈₂ ≈₃ ∼₁ ∼₂ ∼₃ : Rel A ℓ₁
+    f g : A → B
 
 ------------------------------------------------------------------------
 -- Relations
 ------------------------------------------------------------------------
+-- Structures
 
 isRelHomomorphism : IsRelHomomorphism ≈₁ ≈₂ f →
                     IsRelHomomorphism ≈₂ ≈₃ g →
@@ -41,39 +46,85 @@ isRelIsomorphism : Transitive ≈₃ →
                    IsRelIsomorphism ≈₁ ≈₂ f →
                    IsRelIsomorphism ≈₂ ≈₃ g →
                    IsRelIsomorphism ≈₁ ≈₃ (g ∘ f)
-isRelIsomorphism ≈₃-trans m₁ m₂ = record
+isRelIsomorphism {≈₁ = ≈₁} ≈₃-trans m₁ m₂ = record
   { isMonomorphism = isRelMonomorphism F.isMonomorphism G.isMonomorphism
-  ; surjective     = surjective ≈₁ ≈₂ ≈₃ ≈₃-trans G.cong F.surjective G.surjective
+  ; surjective     = surjective ≈₁ _ _ ≈₃-trans G.cong F.surjective G.surjective
   } where module F = IsRelIsomorphism m₁; module G = IsRelIsomorphism m₂
+
+------------------------------------------------------------------------
+-- Bundles
+
+module _ {S : Setoid a ℓ₁} {T : Setoid b ℓ₂} {U : Setoid c ℓ₃} where
+
+  setoidHomomorphism : SetoidHomomorphism S T →
+                       SetoidHomomorphism T U →
+                       SetoidHomomorphism S U
+  setoidHomomorphism ST TU = record
+    { isRelHomomorphism = isRelHomomorphism ST.isRelHomomorphism TU.isRelHomomorphism
+    } where module ST = SetoidHomomorphism ST; module TU = SetoidHomomorphism TU
+
+  setoidMonomorphism : SetoidMonomorphism S T →
+                       SetoidMonomorphism T U →
+                       SetoidMonomorphism S U
+  setoidMonomorphism ST TU = record
+    { isRelMonomorphism = isRelMonomorphism ST.isRelMonomorphism TU.isRelMonomorphism
+    } where module ST = SetoidMonomorphism ST; module TU = SetoidMonomorphism TU
+
+  setoidIsomorphism : SetoidIsomorphism S T →
+                      SetoidIsomorphism T U →
+                      SetoidIsomorphism S U
+  setoidIsomorphism ST TU = record
+    { isRelIsomorphism = isRelIsomorphism (Setoid.trans U) ST.isRelIsomorphism TU.isRelIsomorphism
+    } where module ST = SetoidIsomorphism ST; module TU = SetoidIsomorphism TU
 
 ------------------------------------------------------------------------
 -- Orders
 ------------------------------------------------------------------------
+-- Structures
 
-module _ {ℓ₄ ℓ₅ ℓ₆} {∼₁ : Rel A ℓ₄} {∼₂ : Rel B ℓ₅} {∼₃ : Rel C ℓ₆} where
+isOrderHomomorphism : IsOrderHomomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                      IsOrderHomomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                      IsOrderHomomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+isOrderHomomorphism m₁ m₂ = record
+  { cong = G.cong ∘ F.cong
+  ; mono = G.mono ∘ F.mono
+  } where module F = IsOrderHomomorphism m₁; module G = IsOrderHomomorphism m₂
 
-  isOrderHomomorphism : IsOrderHomomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
-                        IsOrderHomomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
-                        IsOrderHomomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
-  isOrderHomomorphism m₁ m₂ = record
-    { cong = G.cong ∘ F.cong
-    ; mono = G.mono ∘ F.mono
-    } where module F = IsOrderHomomorphism m₁; module G = IsOrderHomomorphism m₂
+isOrderMonomorphism : IsOrderMonomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                      IsOrderMonomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                      IsOrderMonomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+isOrderMonomorphism m₁ m₂ = record
+  { isOrderHomomorphism = isOrderHomomorphism F.isOrderHomomorphism G.isOrderHomomorphism
+  ; injective           = F.injective ∘ G.injective
+  ; cancel              = F.cancel ∘ G.cancel
+  } where module F = IsOrderMonomorphism m₁; module G = IsOrderMonomorphism m₂
 
-  isOrderMonomorphism : IsOrderMonomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
-                        IsOrderMonomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
-                        IsOrderMonomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
-  isOrderMonomorphism m₁ m₂ = record
-    { isOrderHomomorphism = isOrderHomomorphism F.isOrderHomomorphism G.isOrderHomomorphism
-    ; injective           = F.injective ∘ G.injective
-    ; cancel              = F.cancel ∘ G.cancel
-    } where module F = IsOrderMonomorphism m₁; module G = IsOrderMonomorphism m₂
+isOrderIsomorphism : Transitive ≈₃ →
+                     IsOrderIsomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
+                     IsOrderIsomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
+                     IsOrderIsomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
+isOrderIsomorphism {≈₁ = ≈₁} ≈₃-trans m₁ m₂ = record
+  { isOrderMonomorphism = isOrderMonomorphism F.isOrderMonomorphism G.isOrderMonomorphism
+  ; surjective          = surjective ≈₁ _ _ ≈₃-trans G.cong F.surjective G.surjective
+  } where module F = IsOrderIsomorphism m₁; module G = IsOrderIsomorphism m₂
 
-  isOrderIsomorphism : Transitive ≈₃ →
-                       IsOrderIsomorphism ≈₁ ≈₂ ∼₁ ∼₂ f →
-                       IsOrderIsomorphism ≈₂ ≈₃ ∼₂ ∼₃ g →
-                       IsOrderIsomorphism ≈₁ ≈₃ ∼₁ ∼₃ (g ∘ f)
-  isOrderIsomorphism ≈₃-trans m₁ m₂ = record
-    { isOrderMonomorphism = isOrderMonomorphism F.isOrderMonomorphism G.isOrderMonomorphism
-    ; surjective          = surjective ≈₁ ≈₂ ≈₃ ≈₃-trans G.cong F.surjective G.surjective
-    } where module F = IsOrderIsomorphism m₁; module G = IsOrderIsomorphism m₂
+------------------------------------------------------------------------
+-- Bundles
+
+module _ {P : Preorder a ℓ₁ ℓ₂} {Q : Preorder b ℓ₃ ℓ₄} {R : Preorder c ℓ₅ ℓ₆} where
+
+  preorderHomomorphism : PreorderHomomorphism P Q →
+                         PreorderHomomorphism Q R →
+                         PreorderHomomorphism P R
+  preorderHomomorphism PQ QR = record
+    { isOrderHomomorphism = isOrderHomomorphism PQ.isOrderHomomorphism QR.isOrderHomomorphism
+    } where module PQ = PreorderHomomorphism PQ; module QR = PreorderHomomorphism QR
+
+module _ {P : Poset a ℓ₁ ℓ₂} {Q : Poset b ℓ₃ ℓ₄} {R : Poset c ℓ₅ ℓ₆} where
+
+  posetHomomorphism : PosetHomomorphism P Q →
+                      PosetHomomorphism Q R →
+                      PosetHomomorphism P R
+  posetHomomorphism PQ QR = record
+    { isOrderHomomorphism = isOrderHomomorphism PQ.isOrderHomomorphism QR.isOrderHomomorphism
+    } where module PQ = PosetHomomorphism PQ; module QR = PosetHomomorphism QR

--- a/src/Relation/Binary/Morphism/Construct/Constant.agda
+++ b/src/Relation/Binary/Morphism/Construct/Constant.agda
@@ -6,36 +6,54 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Data.Product using (_,_)
-open import Function.Base using (const; _∘_)
-open import Function.Definitions using (Congruent)
-open import Function.Construct.Composition using (surjective)
+open import Function.Base using (const)
+open import Level using (Level)
 open import Relation.Binary
 open import Relation.Binary.Morphism.Structures
+open import Relation.Binary.Morphism.Bundles
 
-module Relation.Binary.Morphism.Construct.Constant
-  {a b ℓ₁ ℓ₂} {A : Set a} {B : Set b}
-  (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (≈-refl : Reflexive ≈₂)
-  where
+module Relation.Binary.Morphism.Construct.Constant where
+
+private
+  variable
+    a b ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
+    A B : Set a
 
 ------------------------------------------------------------------------
 -- Relations
 ------------------------------------------------------------------------
 
-isRelHomomorphism : ∀ x → IsRelHomomorphism ≈₁ ≈₂ (const x)
-isRelHomomorphism x = record
-  { cong = const ≈-refl
-  }
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) where
+
+  isRelHomomorphism : Reflexive ≈₂ →
+                      ∀ x → IsRelHomomorphism ≈₁ ≈₂ (const x)
+  isRelHomomorphism refl x = record
+    { cong = const refl
+    }
+
+module _ (S : Setoid a ℓ₁) (T : Setoid b ℓ₂) where
+
+  setoidHomomorphism : ∀ x → SetoidHomomorphism S T
+  setoidHomomorphism x = record
+    { isRelHomomorphism = isRelHomomorphism _ _ T.refl x
+    } where module T = Setoid T
 
 ------------------------------------------------------------------------
 -- Orders
 ------------------------------------------------------------------------
 
-module _ {ℓ₃ ℓ₄} (∼₁ : Rel A ℓ₃) (∼₂ : Rel B ℓ₄) where
+module _ (≈₁ : Rel A ℓ₁) (≈₂ : Rel B ℓ₂) (∼₁ : Rel A ℓ₃) (∼₂ : Rel B ℓ₄) where
 
-  isOrderHomomorphism : Reflexive ∼₂ →
+  isOrderHomomorphism : Reflexive ≈₂ → Reflexive ∼₂ →
                         ∀ x → IsOrderHomomorphism ≈₁ ≈₂ ∼₁ ∼₂ (const x)
-  isOrderHomomorphism ∼-refl x = record
+  isOrderHomomorphism ≈-refl ∼-refl x = record
     { cong = const ≈-refl
     ; mono = const ∼-refl
     }
+
+module _ (P : Preorder a ℓ₁ ℓ₂) (Q : Preorder b ℓ₃ ℓ₄) where
+
+  preorderHomomorphism : ∀ x → PreorderHomomorphism P Q
+  preorderHomomorphism x = record
+    { isOrderHomomorphism = isOrderHomomorphism _ _ _ _ Q.Eq.refl Q.refl x
+    } where module Q = Preorder Q

--- a/src/Relation/Binary/Morphism/Construct/Identity.agda
+++ b/src/Relation/Binary/Morphism/Construct/Identity.agda
@@ -8,38 +8,64 @@
 
 open import Data.Product using (_,_)
 open import Function.Base using (id)
+open import Level using (Level)
 open import Relation.Binary
 open import Relation.Binary.Morphism.Structures
+open import Relation.Binary.Morphism.Bundles
 
-module Relation.Binary.Morphism.Construct.Identity
-  {a ℓ} {A : Set a} (≈ : Rel A ℓ) where
+module Relation.Binary.Morphism.Construct.Identity where
+
+private
+  variable
+    a ℓ₁ ℓ₂ : Level
+    A : Set a
 
 ------------------------------------------------------------------------
 -- Relations
 ------------------------------------------------------------------------
+-- Structures
 
-isRelHomomorphism : IsRelHomomorphism ≈ ≈ id
-isRelHomomorphism = record
-  { cong = id
-  }
+module _ (≈ : Rel A ℓ₁) where
 
-isRelMonomorphism : IsRelMonomorphism ≈ ≈ id
-isRelMonomorphism = record
-  { isHomomorphism = isRelHomomorphism
-  ; injective      = id
-  }
+  isRelHomomorphism : IsRelHomomorphism ≈ ≈ id
+  isRelHomomorphism = record
+    { cong = id
+    }
 
-isRelIsomorphism : Reflexive ≈ → IsRelIsomorphism ≈ ≈ id
-isRelIsomorphism refl = record
-  { isMonomorphism = isRelMonomorphism
-  ; surjective     = λ y → y , refl
-  }
+  isRelMonomorphism : IsRelMonomorphism ≈ ≈ id
+  isRelMonomorphism = record
+    { isHomomorphism = isRelHomomorphism
+    ; injective      = id
+    }
+
+  isRelIsomorphism : Reflexive ≈ → IsRelIsomorphism ≈ ≈ id
+  isRelIsomorphism refl = record
+    { isMonomorphism = isRelMonomorphism
+    ; surjective     = λ y → y , refl
+    }
+
+------------------------------------------------------------------------
+-- Bundles
+
+module _ (S : Setoid a ℓ₁) where
+
+  open Setoid S
+
+  setoidHomomorphism : SetoidHomomorphism S S
+  setoidHomomorphism = record { isRelHomomorphism = isRelHomomorphism _≈_ }
+
+  setoidMonomorphism : SetoidMonomorphism S S
+  setoidMonomorphism = record { isRelMonomorphism = isRelMonomorphism _≈_ }
+
+  setoidIsomorphism : SetoidIsomorphism S S
+  setoidIsomorphism = record { isRelIsomorphism = isRelIsomorphism _ refl }
 
 ------------------------------------------------------------------------
 -- Orders
 ------------------------------------------------------------------------
+-- Structures
 
-module _ {ℓ₂} (∼ : Rel A ℓ₂) where
+module _ (≈ : Rel A ℓ₁) (∼ : Rel A ℓ₂) where
 
   isOrderHomomorphism : IsOrderHomomorphism ≈ ≈ ∼ ∼ id
   isOrderHomomorphism = record
@@ -59,3 +85,16 @@ module _ {ℓ₂} (∼ : Rel A ℓ₂) where
     { isOrderMonomorphism = isOrderMonomorphism
     ; surjective          = λ y → y , refl
     }
+
+------------------------------------------------------------------------
+-- Bundles
+
+module _ (P : Preorder a ℓ₁ ℓ₂) where
+
+  preorderHomomorphism : PreorderHomomorphism P P
+  preorderHomomorphism = record { isOrderHomomorphism = isOrderHomomorphism _ _ }
+
+module _ (P : Poset a ℓ₁ ℓ₂) where
+
+  posetHomomorphism : PosetHomomorphism P P
+  posetHomomorphism = record { isOrderHomomorphism = isOrderHomomorphism _ _ }

--- a/src/Relation/Binary/Properties/Poset.agda
+++ b/src/Relation/Binary/Properties/Poset.agda
@@ -109,10 +109,10 @@ open StrictPartialOrder <-strictPartialOrder public
 -- Other properties
 
 mono⇒cong : ∀ {f} → f Preserves _≤_ ⟶ _≤_ → f Preserves _≈_ ⟶ _≈_
-mono⇒cong = Consequences.mono⇒cong _ Eq.sym reflexive antisym
+mono⇒cong = Consequences.mono⇒cong _≈_ _≈_ Eq.sym reflexive antisym
 
 antimono⇒cong : ∀ {f} → f Preserves _≤_ ⟶ _≥_ → f Preserves _≈_ ⟶ _≈_
-antimono⇒cong = Consequences.antimono⇒cong _ Eq.sym reflexive antisym
+antimono⇒cong = Consequences.antimono⇒cong _≈_ _≈_ Eq.sym reflexive antisym
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES


### PR DESCRIPTION
Fixes #1407. 

Pinging @JacquesCarette and @sstucki to let you know that this can be used to undo some of the ugliness I introduced in https://github.com/agda/agda-categories/pull/243 when `v1.6` releases.

Unfortunately I had to remove the module-level arguments in the files I introduced last release, but I think it's unlikely anyone has got round to using them seriously yet!