### PR TITLE
Add cong₃

### DIFF
--- a/src/Relation/Binary/PropositionalEquality/Core.agda
+++ b/src/Relation/Binary/PropositionalEquality/Core.agda
@@ -21,7 +21,7 @@ open import Relation.Nullary using (¬_)
 private
   variable
     a b ℓ : Level
-    A B C : Set a
+    A B C D : Set a
 
 ------------------------------------------------------------------------
 -- Propositional equality
@@ -54,6 +54,9 @@ icong′ _ = refl
 
 cong₂ : ∀ (f : A → B → C) {x y u v} → x ≡ y → u ≡ v → f x u ≡ f y v
 cong₂ f refl refl = refl
+
+cong₃ : ∀ (f : A → B → C → D) {x y u v w z} → x ≡ y → u ≡ v → w ≡ z → f x u w ≡ f y v z
+cong₃ f refl refl refl = refl
 
 cong-app : ∀ {A : Set a} {B : A → Set b} {f g : (x : A) → B x} →
            f ≡ g → (x : A) → f x ≡ g x

--- a/src/Relation/Binary/PropositionalEquality/Core.agda
+++ b/src/Relation/Binary/PropositionalEquality/Core.agda
@@ -77,6 +77,9 @@ subst P refl p = p
 subst₂ : ∀ (_∼_ : REL A B ℓ) {x y u v} → x ≡ y → u ≡ v → x ∼ u → y ∼ v
 subst₂ _ refl refl p = p
 
+subst₃ : ∀ (_≤_≤_ : A → B → C → Set ℓ) {x y u v w z} → x ≡ y → u ≡ v → w ≡ z → x ≤ u ≤ w → y ≤ v ≤ z
+subst₃ _ refl refl refl p = p
+
 resp : ∀ (P : A → Set ℓ) → P Respects _≡_
 resp P refl p = p
 


### PR DESCRIPTION
Too many times I find myself in need of congruence for ternary constructors, but I also know we cannot have infinitely many definitions of n-ary `cong`, so if there's a better solution than adding `cong₃` I'm open for suggestions.