### PR TITLE
add variant of `first?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -448,6 +448,11 @@ Other minor additions
   all-upTo           : All (_< n) (upTo n)
   ```
 
+* Added new proof in `Data.List.Relation.Unary.First.Properties`:
+  ```agda
+  cofirst? : Decidable P → Decidable (First (∁ P) P)
+  ```
+
 * Added new operations in `Data.List.Relation.Unary.Linked`:
   ```agda
   head′ : Linked R (x ∷ xs) → Connected R (just x) (head xs)

--- a/src/Data/List/Relation/Unary/First/Properties.agda
+++ b/src/Data/List/Relation/Unary/First/Properties.agda
@@ -85,6 +85,11 @@ module _ {a p} {A : Set a} {P : Pred A p} where
                $ Sum.map₂ (All⇒¬First contradiction)
                $ first (Sum.fromDec ∘ P?) xs
 
+  cofirst? : Decidable P → Decidable (First (∁ P) P)
+  cofirst? P? xs = Sum.toDec
+                 $ Sum.map₂ (All⇒¬First id)
+                 $ first (Sum.swap ∘ Sum.fromDec ∘ P?) xs
+
 ------------------------------------------------------------------------
 -- Conversion to Any
 


### PR DESCRIPTION
`first?` works on `First P (∁ P)` but it seems there is no equivalent for `First (∁ P) P`.
So I added `first?′` which is a swapped variant of `first?`.

I'll request better name for `first?′`, by the way.