### PR TITLE
Added weak-induction schemes for `Data.Fin` and `Data.Nat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,22 @@ New modules
 
 Other minor additions
 ---------------------
+
+* Added new relations to `Data.Fin.Base`:
+  ```agda
+  _≥_ = ℕ._≥_ on toℕ
+  _>_ = ℕ._>_ on toℕ
+  ```
+
+* Added new proofs to `Data.Fin.Induction`:
+  ```agda
+  >-wellFounded   : WellFounded {A = Fin n} _>_
+  
+  <-weakInduction : P zero      → (∀ i → P (inject₁ i) → P (suc i)) → ∀ i → P i
+  >-weakInduction : P (fromℕ n) → (∀ i → P (suc i) → P (inject₁ i)) → ∀ i → P i
+  ```
+
+* Added new proofs to `Data.Nat.Induction`:
+  ```agda
+  <-weakInduction : P zero → (∀ i → P i → P (suc i)) → ∀ i → P i
+  ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,3 @@ Other minor additions
   <-weakInduction : P zero      → (∀ i → P (inject₁ i) → P (suc i)) → ∀ i → P i
   >-weakInduction : P (fromℕ n) → (∀ i → P (suc i) → P (inject₁ i)) → ∀ i → P i
   ```
-
-* Added new proofs to `Data.Nat.Induction`:
-  ```agda
-  <-weakInduction : P zero → (∀ i → P i → P (suc i)) → ∀ i → P i
-  ```

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -18,7 +18,7 @@ open import Data.Nat.Properties.Core using (≤-pred)
 open import Data.Product as Product using (_×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Function.Base using (id; _∘_; _on_)
-open import Level using () renaming (zero to ℓ₀)
+open import Level using (0ℓ)
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable.Core using (True; toWitness)
 open import Relation.Binary.Core
@@ -243,13 +243,20 @@ punchIn (suc i) (suc j) = suc (punchIn i j)
 ------------------------------------------------------------------------
 -- Order relations
 
-infix 4 _≤_ _<_
+infix 4 _≤_ _≥_ _<_ _>_
 
-_≤_ : ∀ {n} → Rel (Fin n) ℓ₀
+_≤_ : ∀ {n} → Rel (Fin n) 0ℓ
 _≤_ = ℕ._≤_ on toℕ
 
-_<_ : ∀ {n} → Rel (Fin n) ℓ₀
+_≥_ : ∀ {n} → Rel (Fin n) 0ℓ
+_≥_ = ℕ._≥_ on toℕ
+
+_<_ : ∀ {n} → Rel (Fin n) 0ℓ
 _<_ = ℕ._<_ on toℕ
+
+_>_ : ∀ {n} → Rel (Fin n) 0ℓ
+_>_ = ℕ._>_ on toℕ
+
 
 data _≺_ : ℕ → ℕ → Set where
   _≻toℕ_ : ∀ n (i : Fin n) → toℕ i ≺ n

--- a/src/Data/Fin/Induction.agda
+++ b/src/Data/Fin/Induction.agda
@@ -6,15 +6,25 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-module Data.Fin.Induction where
-
-open import Data.Fin.Base using (Fin; toℕ; _<_; _≺_)
-open import Data.Fin.Properties using (≺⇒<′)
-open import Data.Nat.Base using (ℕ)
+open import Data.Fin.Base
+open import Data.Fin.Properties
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s; _∸_)
 import Data.Nat.Induction as ℕ
+import Data.Nat.Properties as ℕ
 open import Induction
 open import Induction.WellFounded as WF
+open import Level using (Level)
 import Relation.Binary.Construct.On as On
+open import Relation.Unary using (Pred)
+open import Relation.Nullary using (yes; no)
+open import Relation.Binary.PropositionalEquality
+
+module Data.Fin.Induction where
+
+private
+  variable
+    ℓ : Level
+    n : ℕ
 
 ------------------------------------------------------------------------
 -- Re-export accessability
@@ -22,15 +32,49 @@ import Relation.Binary.Construct.On as On
 open WF public using (Acc; acc)
 
 ------------------------------------------------------------------------
--- Complete induction for _<_
+-- Induction over _<_
 
-<-wellFounded : ∀ {n} → WellFounded {A = Fin n} _<_
+<-wellFounded : WellFounded {A = Fin n} _<_
 <-wellFounded = On.wellFounded toℕ ℕ.<-wellFounded
 
-------------------------------------------------------------------------
--- Complete induction for on _≺_
+<-weakInduction : (P : Pred (Fin (suc n)) ℓ) →
+                  P zero →
+                  (∀ i → P (inject₁ i) → P (suc i)) →
+                  ∀ i → P i
+<-weakInduction P P₀ Pᵢ⇒Pᵢ₊₁ i = induct (<-wellFounded i)
+  where
+  induct : ∀ {i} → Acc _<_ i → P i
+  induct {zero}  _         = P₀
+  induct {suc i} (acc rec) = Pᵢ⇒Pᵢ₊₁ i (induct (rec (inject₁ i) i<i+1))
+    where i<i+1 = s≤s (ℕ.≤-reflexive (toℕ-inject₁ i))
 
-≺-Rec : ∀ {ℓ} → RecStruct ℕ ℓ ℓ
+------------------------------------------------------------------------
+-- Induction over _>_
+
+private
+  acc-map : ∀ {x : Fin n} → Acc ℕ._<_ (n ∸ toℕ x) → Acc _>_ x
+  acc-map {n} (acc rs) = acc (λ y y>x →
+    acc-map (rs (n ∸ toℕ y) (ℕ.∸-monoʳ-< y>x (toℕ≤n y))))
+
+>-wellFounded : WellFounded {A = Fin n} _>_
+>-wellFounded {n} x = acc-map (ℕ.<-wellFounded (n ∸ toℕ x))
+
+>-weakInduction : (P : Pred (Fin (suc n)) ℓ) →
+                  P (fromℕ n) →
+                  (∀ i → P (suc i) → P (inject₁ i)) →
+                  ∀ i → P i
+>-weakInduction {n = n} P Pₙ Pᵢ₊₁⇒Pᵢ i = induct (>-wellFounded i)
+  where
+  induct : ∀ {i} → Acc _>_ i → P i
+  induct {i} (acc rec) with n ℕ.≟ toℕ i
+  ... | yes n≡i = subst P (toℕ-injective (trans (toℕ-fromℕ n) n≡i)) Pₙ
+  ... | no  n≢i = subst P (inject₁-lower₁ i n≢i) (Pᵢ₊₁⇒Pᵢ _ Pᵢ₊₁)
+    where Pᵢ₊₁ = induct (rec _ (s≤s (ℕ.≤-reflexive (sym (toℕ-lower₁ i n≢i)))))
+
+------------------------------------------------------------------------
+-- Induction over _≺_
+
+≺-Rec : RecStruct ℕ ℓ ℓ
 ≺-Rec = WfRec _≺_
 
 ≺-wellFounded : WellFounded _≺_
@@ -43,6 +87,7 @@ module _ {ℓ} where
     ; wfRec        to ≺-rec
     )
     hiding (wfRec-builder)
+
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/Nat/Induction.agda
+++ b/src/Data/Nat/Induction.agda
@@ -104,16 +104,6 @@ module _ {ℓ} where
   <-wellFounded-skip (suc k) zero    = <-wellFounded 0
   <-wellFounded-skip (suc k) (suc n) = acc (λ m _ → <-wellFounded-skip k m)
 
-<-weakInduction : (P : Pred ℕ ℓ) →
-                  P zero →
-                  (∀ i → P i → P (suc i)) →
-                  ∀ i → P i
-<-weakInduction P P₀ Pᵢ⇒Pᵢ₊₁ i = induct (<-wellFounded-fast i)
-  where
-  induct : ∀ {i} → Acc _<_ i → P i
-  induct {zero}  _         = P₀
-  induct {suc i} (acc rec) = Pᵢ⇒Pᵢ₊₁ i (induct (rec i (n<1+n i)))
-
 module _ {ℓ} where
   open WF.All <-wellFounded ℓ public
     renaming ( wfRecBuilder to <-recBuilder

--- a/src/Data/Nat/Induction.agda
+++ b/src/Data/Nat/Induction.agda
@@ -10,13 +10,18 @@ module Data.Nat.Induction where
 
 open import Function
 open import Data.Nat.Base
-open import Data.Nat.Properties using (≤⇒≤′)
+open import Data.Nat.Properties using (≤⇒≤′; n<1+n)
 open import Data.Product
 open import Data.Unit.Polymorphic
 open import Induction
 open import Induction.WellFounded as WF
+open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Unary
+
+private
+  variable
+    ℓ : Level
 
 ------------------------------------------------------------------------
 -- Re-export accessability
@@ -98,6 +103,16 @@ module _ {ℓ} where
   <-wellFounded-skip zero    n       = <-wellFounded n
   <-wellFounded-skip (suc k) zero    = <-wellFounded 0
   <-wellFounded-skip (suc k) (suc n) = acc (λ m _ → <-wellFounded-skip k m)
+
+<-weakInduction : (P : Pred ℕ ℓ) →
+                  P zero →
+                  (∀ i → P i → P (suc i)) →
+                  ∀ i → P i
+<-weakInduction P P₀ Pᵢ⇒Pᵢ₊₁ i = induct (<-wellFounded-fast i)
+  where
+  induct : ∀ {i} → Acc _<_ i → P i
+  induct {zero}  _         = P₀
+  induct {suc i} (acc rec) = Pᵢ⇒Pᵢ₊₁ i (induct (rec i (n<1+n i)))
 
 module _ {ℓ} where
   open WF.All <-wellFounded ℓ public

--- a/src/Induction/Nat.agda
+++ b/src/Induction/Nat.agda
@@ -10,7 +10,8 @@
 module Induction.Nat where
 
 open import Data.Nat.Induction public
-open import Data.Fin.Induction public hiding (<-wellFounded)
+open import Data.Fin.Induction public
+  using (≺-Rec; ≺-recBuilder; ≺-rec; ≺-wellFounded)
 
 {-# WARNING_ON_IMPORT
 "Induction.Nat was deprecated in v1.1.


### PR DESCRIPTION
At the moment, if you want to prove something by induction that the termination checker doesn't agree is terminating you are forced to pollute the type of your proof with an `Acc` predicate. These new proofs internalise the `Acc` predicate which often makes them much easier and shorter to use, in particular the `Fin` variants which often require a lot of messing around with `inject` and `lower`.

I've left the predicate arguments explicit (to help readability?) but let me know if you think they should be implicit.