### PR TITLE
Define 'pinch' as a counterpart to 'punchIn'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,13 @@ Other minor additions
   <-weakInduction : P zero      → (∀ i → P (inject₁ i) → P (suc i)) → ∀ i → P i
   >-weakInduction : P (fromℕ n) → (∀ i → P (suc i) → P (inject₁ i)) → ∀ i → P i
   ```
+
+* Added new function to `Data.Fin.Base`:
+  ```agda
+  pinch : ∀ {n} → Fin n → Fin (suc n) → Fin n
+  ```
+* Added new proofs to `Data.Fin.Properties`:
+  ```agda
+  pinch-surjective : ∀ {m} (i : Fin m) → Surjective _≡_ (pinch i)
+  pinch-mono-≤ : ∀ {m} (i : Fin m) → (pinch i) Preserves _≤_ ⟶ _≤_
+  ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,4 @@ Other minor additions
   ```agda
   pinch-surjective : ∀ {m} (i : Fin m) → Surjective _≡_ (pinch i)
   pinch-mono-≤ : ∀ {m} (i : Fin m) → (pinch i) Preserves _≤_ ⟶ _≤_
+  ```

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -240,13 +240,12 @@ punchIn zero    j       = suc j
 punchIn (suc i) zero    = zero
 punchIn (suc i) (suc j) = suc (punchIn i j)
 
--- The surjection f(i,j) such that f(i,i) = f(i,i+1) = i
+-- The function f(i,j) such that f(i,j) = if j≤i then j else j-1
 
-pinch : ∀ {m} → Fin m → Fin (suc m) → Fin m
-pinch zero zero = zero
-pinch zero (suc j) = j
-pinch (suc i) zero = zero
-pinch (suc i) (suc j) = suc (pinch i j)
+pinch : ∀ {n} → Fin n → Fin (suc n) → Fin n
+pinch {suc n} _       zero    = zero
+pinch {suc n} zero    (suc j) = j
+pinch {suc n} (suc i) (suc j) = suc (pinch i j)
 
 ------------------------------------------------------------------------
 -- Order relations

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -240,6 +240,14 @@ punchIn zero    j       = suc j
 punchIn (suc i) zero    = zero
 punchIn (suc i) (suc j) = suc (punchIn i j)
 
+-- The surjection f(i,j) such that f(i,i) = f(i,i+1) = i
+
+pinch : ∀ {m} → Fin m → Fin (suc m) → Fin m
+pinch zero zero = zero
+pinch zero (suc j) = j
+pinch (suc i) zero = zero
+pinch (suc i) (suc j) = suc (pinch i j)
+
 ------------------------------------------------------------------------
 -- Order relations
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -18,7 +18,7 @@ open import Data.Fin.Patterns
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; s≤s; z≤n; _∸_)
 import Data.Nat.Properties as ℕₚ
 open import Data.Unit using (tt)
-open import Data.Product using (∃; ∃₂; ∄; _×_; _,_; map; proj₁; uncurry; <_,_>)
+open import Data.Product using (Σ-syntax; ∃; ∃₂; ∄; _×_; _,_; map; proj₁; uncurry; <_,_>)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_)
@@ -674,6 +674,23 @@ punchOut-punchIn (suc i) {suc j} = cong suc (begin
   punchOut (punchInᵢ≢i i j ∘ sym)                             ≡⟨ punchOut-punchIn i ⟩
   j                                                           ∎)
   where open ≡-Reasoning
+
+
+------------------------------------------------------------------------
+-- pinch
+------------------------------------------------------------------------
+
+pinch-surjective : ∀ {m} i (j : Fin m) → Σ[ k ∈ Fin (suc m) ] (pinch i k ≡ j)
+pinch-surjective 0F 0F = zero , refl
+pinch-surjective 0F (suc j) = (suc (suc j)) , refl
+pinch-surjective (suc i) 0F = zero , refl
+pinch-surjective (suc i) (suc j) = map suc (cong suc) (pinch-surjective i j)
+
+pinch-mono-≤ : ∀ {m} (i : Fin m) → (pinch i) Preserves _≤_ ⟶ _≤_
+pinch-mono-≤ 0F {0F} {k} 0≤n = z≤n
+pinch-mono-≤ 0F {suc j} {suc k} (s≤s j≤k) = j≤k
+pinch-mono-≤ (suc i) {0F} {k} 0≤n = z≤n
+pinch-mono-≤ (suc i) {suc j} {suc k} (s≤s j≤k) = s≤s (pinch-mono-≤ i j≤k)
 
 ------------------------------------------------------------------------
 -- Quantification

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -23,6 +23,7 @@ open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_)
 open import Function.Bundles using (_↔_; mk↔′)
+open import Function.Definitions.Core2 using (Surjective)
 open import Function.Equivalence using (_⇔_; equivalence)
 open import Function.Injection using (_↣_)
 open import Relation.Binary as B hiding (Decidable; _⇔_)
@@ -680,16 +681,15 @@ punchOut-punchIn (suc i) {suc j} = cong suc (begin
 -- pinch
 ------------------------------------------------------------------------
 
-pinch-surjective : ∀ {m} i (j : Fin m) → Σ[ k ∈ Fin (suc m) ] (pinch i k ≡ j)
-pinch-surjective 0F 0F = zero , refl
-pinch-surjective 0F (suc j) = (suc (suc j)) , refl
-pinch-surjective (suc i) 0F = zero , refl
+pinch-surjective : ∀ {m} (i : Fin m) → Surjective _≡_ (pinch i)
+pinch-surjective _       zero    = zero , refl
+pinch-surjective zero    (suc j) = suc (suc j) , refl
 pinch-surjective (suc i) (suc j) = map suc (cong suc) (pinch-surjective i j)
 
 pinch-mono-≤ : ∀ {m} (i : Fin m) → (pinch i) Preserves _≤_ ⟶ _≤_
-pinch-mono-≤ 0F {0F} {k} 0≤n = z≤n
-pinch-mono-≤ 0F {suc j} {suc k} (s≤s j≤k) = j≤k
-pinch-mono-≤ (suc i) {0F} {k} 0≤n = z≤n
+pinch-mono-≤ 0F      {0F}    {k}     0≤n       = z≤n
+pinch-mono-≤ 0F      {suc j} {suc k} (s≤s j≤k) = j≤k
+pinch-mono-≤ (suc i) {0F}    {k}     0≤n       = z≤n
 pinch-mono-≤ (suc i) {suc j} {suc k} (s≤s j≤k) = s≤s (pinch-mono-≤ i j≤k)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
## Patch Description

During the process of implementing https://github.com/agda/agda-categories/pull/274, @JacquesCarette pointed out that one of the functions I implemented existed in the stdlib under the name `punchIn`. However, this injective function has a surjective counterpart that seems to be missing. This PR adds this function under the name `pinch`, and proves some simple properties about it.

## Notes
I'm not 100% attached to the name, perhaps `pinchIn` would be more appropriate to highlight the connection to `punchIn`. There are also a handful of identities that we can prove relating `pinch` to `punchIn` (See https://en.wikipedia.org/wiki/Simplicial_set#Face_and_degeneracy_maps and https://github.com/agda/agda-categories/pull/274/files#diff-d758c95623d24b748cbba2280dcde56f96e72c64c271bab9afdc4e068efe8117R114), though these seem a bit domain specific for the stdlib.

Furthermore, any map `Fin m -> Fin n` can be factored into a canonical form of a bunch of calls to `pinch` followed a bunch of calls to `punchIn`, though after some preliminary attempts this is proving to be Very Difficult. Perhaps someone braver than I could give it a go.