### PR TITLE
[ Improved fix #1510 ] Get rid of `error`, use `throwError` and `die`.

### DIFF
--- a/agda-stdlib-utils.cabal
+++ b/agda-stdlib-utils.cabal
@@ -16,10 +16,12 @@ executable GenerateEverything
   hs-source-dirs:   .
   main-is:          GenerateEverything.hs
   default-language: Haskell2010
+  default-extensions: PatternGuards, PatternSynonyms
   build-depends:      base >= 4.9.0.0 && < 4.16
                     , directory >= 1.0.0.0 && < 1.4
                     , filemanip >= 0.3.6.2 && < 0.4
                     , filepath >= 1.4.1.0 && < 1.5
+                    , mtl      >= 2.2.2   && < 2.3
 
 executable AllNonAsciiChars
   hs-source-dirs:   .


### PR DESCRIPTION
Solidifying the fix of #1510.  Just don't use `error` for reporting errors to the user.

The discussion at https://gitlab.haskell.org/ghc/ghc/-/issues/19917 strongly discouraged me from ever considering `error` as a means to report errors to the user.  I already knew it was bad style, but now I know that it is not guaranteed to deliver the correct message at all.