### PR TITLE
The start of a small matrix library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ New modules
   Algebra.Morphism.Construct.Identity
   ```
 
+* The start of a small section about matrices
+  ```
+  Data.Matrix
+  ```
+
 Other minor additions
 ---------------------
 
@@ -46,3 +51,14 @@ Other minor additions
 
 Other minor additions
 ---------------------
+
+* Added new operation in `Data.Fin.Base`:
+  ```agda
+  _≡ᵇ_ : Fin m → Fin n → Bool
+  ```
+
+* Added new operation in `Data.Vec.Functional`:
+  ```agda
+  foldr+ : Op₂ A → Vector A (suc n) → A
+  foldl+ : Op₂ A → Vector A (suc n) → A
+  ```

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -12,6 +12,7 @@
 
 module Data.Fin.Base where
 
+open import Data.Bool.Base using (Bool)
 open import Data.Empty using (⊥-elim)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s)
 open import Data.Nat.Properties.Core using (≤-pred)
@@ -246,6 +247,15 @@ pinch : ∀ {n} → Fin n → Fin (suc n) → Fin n
 pinch {suc n} _       zero    = zero
 pinch {suc n} zero    (suc j) = j
 pinch {suc n} (suc i) (suc j) = suc (pinch i j)
+
+------------------------------------------------------------------------
+-- Equality relations
+
+-- Note that unlike other boolean `_≡ᵇ_` tests, this test is *not*
+-- efficient as it first converts the unary representation to `ℕ`.
+infix 4 _≡ᵇ_
+_≡ᵇ_ : ∀ {m n} → Fin m → Fin n → Bool
+i ≡ᵇ j = toℕ i ℕ.≡ᵇ toℕ j
 
 ------------------------------------------------------------------------
 -- Order relations

--- a/src/Data/Matrix.agda
+++ b/src/Data/Matrix.agda
@@ -1,0 +1,87 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Matrices
+------------------------------------------------------------------------
+
+open import Algebra.Core using (Op₂)
+open import Data.Bool.Base using (if_then_else_)
+open import Data.Fin.Base using (Fin; _≡ᵇ_)
+open import Data.Nat.Base using (ℕ; suc)
+open import Data.Product using (_×_; _,_)
+open import Data.Vec.Functional as Vector using (Vector)
+open import Function.Base using (_$_)
+open import Level using (Level)
+
+module Data.Matrix where
+
+private
+  variable
+    a : Level
+    A B C : Set a
+    m n o : ℕ
+
+------------------------------------------------------------------------
+-- Definition
+
+-- Matrices are defined as maps from finite indices to values. This
+-- definition is equivalent to `Vector (Vector A m) n`, and consequently
+-- many of the operations, relations and proofs about `Vector`s can be
+-- lifted to matrices.
+
+Matrix : Set a → ℕ → ℕ → Set a
+Matrix A m n = Fin m → Fin n → A
+
+SquareMatrix : Set a → ℕ → Set a
+SquareMatrix A n = Matrix A n n
+
+------------------------------------------------------------------------
+-- Operations for deconstructing matrices
+
+row : Matrix A m n → Fin m → Vector A n
+row M i = M i
+
+col : Matrix A m n → Fin n → Vector A m
+col M j = λ i → M i j
+
+------------------------------------------------------------------------
+-- Operations for constructing matrices
+
+[] : SquareMatrix A 0
+[] ()
+
+[_] : A → SquareMatrix A 1
+[ x ] i j = x
+
+constant : A → Matrix A m n
+constant x i j = x
+
+diagonal : A → A → SquareMatrix A n
+diagonal 1# 0# i j = if i ≡ᵇ j then 1# else 0#
+
+------------------------------------------------------------------------
+-- Operations for transforming matrices
+
+map : (A → B) → Matrix A m n → Matrix B m n
+map f M i j = f (M i j)
+
+zipWith : (A → B → C) → Matrix A m n → Matrix B m n → Matrix C m n
+zipWith f M N i j = f (M i j) (N i j)
+
+zip : Matrix A m n → Matrix B m n → Matrix (A × B) m n
+zip = zipWith _,_
+
+_⊛_ : Matrix (A → B) m n → Matrix A m n → Matrix B m n
+_⊛_ = zipWith _$_
+
+_ᵀ : Matrix A m n → Matrix A n m
+(M ᵀ) i j = M j i
+
+add : Op₂ A → Op₂ (Matrix A m n)
+add _+_ = zipWith _+_
+
+multiply : Op₂ C → (A → B → C) → C → Matrix A m n → Matrix B n o → Matrix C m o
+multiply _+_ _×_ 1# M N i j = Vector.foldr _+_ 1# (λ k → M i k × N k j)
+
+multiply+ : Op₂ C → (A → B → C) → Matrix A m (suc n) → Matrix B (suc n) o → Matrix C m o
+multiply+ _+_ _×_ M N i j = Vector.foldr+ _+_ (λ k → M i k × N k j)

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -15,13 +15,14 @@
 
 module Data.Vec.Functional where
 
+open import Algebra.Core using (Op₂)
 open import Data.Fin.Base
 open import Data.List.Base as L using (List)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc)
 open import Data.Product using (Σ; ∃; _×_; _,_; proj₁; proj₂; uncurry)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec.Base as V using (Vec)
-open import Function.Base
+open import Function.Base using (id; const; flip; _∘_; _ˢ_)
 open import Level using (Level)
 
 infixr 5 _∷_ _++_
@@ -34,6 +35,7 @@ private
     A : Set a
     B : Set b
     C : Set c
+    m n : ℕ
 
 ------------------------------------------------------------------------
 -- Definition
@@ -44,13 +46,13 @@ Vector A n = Fin n → A
 ------------------------------------------------------------------------
 -- Conversion
 
-toVec : ∀ {n} → Vector A n → Vec A n
+toVec : Vector A n → Vec A n
 toVec = V.tabulate
 
-fromVec : ∀ {n} → Vec A n → Vector A n
+fromVec : Vec A n → Vector A n
 fromVec = V.lookup
 
-toList : ∀ {n} → Vector A n → List A
+toList : Vector A n → List A
 toList = L.tabulate
 
 fromList : ∀ (xs : List A) → Vector A (L.length xs)
@@ -62,79 +64,85 @@ fromList = L.lookup
 [] : Vector A zero
 [] ()
 
-_∷_ : ∀ {n} → A → Vector A n → Vector A (suc n)
+_∷_ : A → Vector A n → Vector A (suc n)
 (x ∷ xs) zero    = x
 (x ∷ xs) (suc i) = xs i
 
-length : ∀ {n} → Vector A n → ℕ
+length : Vector A n → ℕ
 length {n = n} _ = n
 
-head : ∀ {n} → Vector A (suc n) → A
+head : Vector A (suc n) → A
 head xs = xs zero
 
-tail : ∀ {n} → Vector A (suc n) → Vector A n
+tail : Vector A (suc n) → Vector A n
 tail xs = xs ∘ suc
 
-uncons : ∀ {n} → Vector A (suc n) → A × Vector A n
+uncons : Vector A (suc n) → A × Vector A n
 uncons xs = head xs , tail xs
 
-replicate : ∀ {n} → A → Vector A n
+replicate : A → Vector A n
 replicate = const
 
-insert : ∀ {n} → Vector A n → Fin (suc n) → A → Vector A (suc n)
-insert {n = n}     xs zero    v zero    = v
-insert {n = n}     xs zero    v (suc j) = xs j
+insert : Vector A n → Fin (suc n) → A → Vector A (suc n)
+insert {n = _}     xs zero    v zero    = v
+insert {n = _}     xs zero    v (suc j) = xs j
 insert {n = suc n} xs (suc i) v zero    = head xs
 insert {n = suc n} xs (suc i) v (suc j) = insert (tail xs) i v j
 
-remove : ∀ {n} → Fin (suc n) → Vector A (suc n) → Vector A n
+remove : Fin (suc n) → Vector A (suc n) → Vector A n
 remove i t = t ∘ punchIn i
 
-updateAt : ∀ {n} → Fin n → (A → A) → Vector A n → Vector A n
-updateAt {n = suc n} zero    f xs zero    = f (head xs)
-updateAt {n = suc n} zero    f xs (suc j) = xs (suc j)
-updateAt {n = suc n} (suc i) f xs zero    = head xs
-updateAt {n = suc n} (suc i) f xs (suc j) = updateAt i f (tail xs) j
+updateAt : Fin n → (A → A) → Vector A n → Vector A n
+updateAt zero    f xs zero    = f (head xs)
+updateAt zero    f xs (suc j) = xs (suc j)
+updateAt (suc i) f xs zero    = head xs
+updateAt (suc i) f xs (suc j) = updateAt i f (tail xs) j
 
 ------------------------------------------------------------------------
 -- Transformations
 
-map : (A → B) → ∀ {n} → Vector A n → Vector B n
+map : (A → B) → Vector A n → Vector B n
 map f xs = f ∘ xs
 
-_++_ : ∀ {m n} → Vector A m → Vector A n → Vector A (m ℕ.+ n)
+_++_ : Vector A m → Vector A n → Vector A (m ℕ.+ n)
 _++_ {m = m} xs ys i = [ xs , ys ] (splitAt m i)
 
-concat : ∀ {m n} → Vector (Vector A m) n → Vector A (n ℕ.* m)
+concat : Vector (Vector A m) n → Vector A (n ℕ.* m)
 concat {m = m} xss i = uncurry (flip xss) (quotRem m i)
 
-foldr : (A → B → B) → B → ∀ {n} → Vector A n → B
-foldr f z {n = zero}  xs = z
-foldr f z {n = suc n} xs = f (head xs) (foldr f z (tail xs))
+foldr : (A → B → B) → B → Vector A n → B
+foldr {n = zero}  f z xs = z
+foldr {n = suc n} f z xs = f (head xs) (foldr f z (tail xs))
 
-foldl : (B → A → B) → B → ∀ {n} → Vector A n → B
-foldl f z {n = zero}  xs = z
-foldl f z {n = suc n} xs = foldl f (f z (head xs)) (tail xs)
+foldr+ : Op₂ A → Vector A (suc n) → A
+foldr+ f xs = foldr f (head xs) (tail xs)
 
-rearrange : ∀ {m n} → (Fin m → Fin n) → Vector A n → Vector A m
+foldl : (B → A → B) → B → Vector A n → B
+foldl {n = zero}  f z xs = z
+foldl {n = suc n} f z xs = foldl f (f z (head xs)) (tail xs)
+
+foldl+ : Op₂ A → Vector A (suc n) → A
+foldl+ f xs = foldl f (head xs) (tail xs)
+
+rearrange : (Fin m → Fin n) → Vector A n → Vector A m
 rearrange r xs = xs ∘ r
 
-_⊛_ : ∀ {n} → Vector (A → B) n → Vector A n → Vector B n
+_⊛_ : Vector (A → B) n → Vector A n → Vector B n
 _⊛_ = _ˢ_
 
-_>>=_ : ∀ {m n} → Vector A m → (A → Vector B n) → Vector B (m ℕ.* n)
+_>>=_ : Vector A m → (A → Vector B n) → Vector B (m ℕ.* n)
 xs >>= f = concat (map f xs)
 
-zipWith : (A → B → C) → ∀ {n} → Vector A n → Vector B n → Vector C n
+zipWith : (A → B → C) → Vector A n → Vector B n → Vector C n
 zipWith f xs ys i = f (xs i) (ys i)
 
-unzipWith : ∀ {n} → (A → B × C) → Vector A n → Vector B n × Vector C n
+unzipWith : (A → B × C) → Vector A n → Vector B n × Vector C n
 unzipWith f xs = proj₁ ∘ f ∘ xs , proj₂ ∘ f ∘ xs
 
-zip : ∀ {n} → Vector A n → Vector B n → Vector (A × B) n
+zip : Vector A n → Vector B n → Vector (A × B) n
 zip = zipWith _,_
 
-unzip : ∀ {n} → Vector (A × B) n → Vector A n × Vector B n
+unzip : Vector (A × B) n → Vector A n × Vector B n
 unzip = unzipWith id
 
 take : ∀ m {n} → Vector A (m ℕ.+ n) → Vector A m
@@ -143,14 +151,14 @@ take _ {n = n} xs = xs ∘ inject+ n
 drop : ∀ m {n} → Vector A (m ℕ.+ n) → Vector A n
 drop m xs = xs ∘ raise m
 
-reverse : ∀ {n} → Vector A n → Vector A n
+reverse : Vector A n → Vector A n
 reverse xs = xs ∘ opposite
 
-init : ∀ {n} → Vector A (suc n) → Vector A n
+init : Vector A (suc n) → Vector A n
 init xs = xs ∘ inject₁
 
-last : ∀ {n} → Vector A (suc n) → A
+last : Vector A (suc n) → A
 last {n = n} xs = xs (fromℕ n)
 
-transpose : ∀ {m n} → Vector (Vector A n) m → Vector (Vector A m) n
+transpose : Vector (Vector A n) m → Vector (Vector A m) n
 transpose = flip


### PR DESCRIPTION
Someone on the mailing list was asking about matrices, so I thought I'd start the process of porting some of what I have. This is the first very small step.

My main question is that I'm using `Fin` indexed functions as the basic representation. Vectors which use a similar representation live in the `Data.Vec.Functional`. Do people think that we should therefore have these matrices live under `Data.Matrix.Functional` in case we ever want to add a representation based-off of `Data.Vec`?

My instinct is no. When I was a novice Agda user I wasted several months trying to get a matrix library off the ground using `Data.Vec` and it was unbelievably hard. As 99% of the time is spent querying into matrices and you almost never want to alter their size (inductively), I think that the argument for a `Data.Vec` based matrix library is pretty weak. Nonetheless I thought I'd pose the question?