### PR TITLE
Move `Strict` to `Function.Strict` and move `_$!_` there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ Non-backwards compatible changes
 Deprecated modules
 ------------------
 
+* The module `Strict` has been deprecated in favour of `Function.Strict` 
+  and the definitions of `_$!_` and `_$!′_` have been moved from `Function.Base`
+  to `Function.Strict` (although they continue to be re-exported by `Function.Base`
+  for compatibility).
+
 Deprecated names
 ----------------
 
@@ -137,6 +142,12 @@ Other minor additions
   bijection     : Bijection R S → Congruent IB.Eq₂._≈_ IB.Eq₁._≈_ f⁻¹ → Bijection S R
   bijection-≡   : Bijection R (setoid B) → Bijection (setoid B) R
   sym-⤖        : A ⤖ B → B ⤖ A
+  ```
+
+* Added new operations in `Function.Strict`:
+  ```
+  _!|>_  : (a : A) → (∀ a → B a) → B a
+  _!|>′_ : A → (A → B) → B
   ```
 
 * Added new operations in `IO`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,13 +53,16 @@ Non-backwards compatible changes
   So `[a-zA-Z]+.agdai?` run on "the path _build/Main.agdai corresponds to"
   will return "Main.agdai" when it used to be happy to just return "n.agda".
 
-Deprecated modules
-------------------
+### Strict functions
 
 * The module `Strict` has been deprecated in favour of `Function.Strict` 
-  and the definitions of `_$!_` and `_$!′_` have been moved from `Function.Base`
-  to `Function.Strict` (although they continue to be re-exported by `Function.Base`
-  for compatibility).
+  and the definitions of strict application, `_$!_` and `_$!′_`, have been
+  moved from `Function.Base` to `Function.Strict`.
+  
+* The contents of `Function.Strict` is now re-exported by `Function`.
+
+Deprecated modules
+------------------
 
 Deprecated names
 ----------------

--- a/src/Codata/Cofin.agda
+++ b/src/Codata/Cofin.agda
@@ -15,14 +15,14 @@ open import Codata.Conat as Conat
 open import Codata.Conat.Bisimilarity as Bisim using (_⊢_≲_ ; s≲s)
 open import Data.Nat.Base
 open import Data.Fin.Base as Fin hiding (fromℕ; fromℕ≤; fromℕ<; toℕ)
-open import Function
+open import Function.Base using (_∋_)
 open import Relation.Binary.PropositionalEquality
 
 ------------------------------------------------------------------------
 -- The type
 
--- Note that `Cofin infnity` is /not/ finite. Note also that this is not a
--- coinductive type, but it is indexed on a coinductive type.
+-- Note that `Cofin infinity` is /not/ finite. Note also that this is
+-- not a coinductive type, but it is indexed on a coinductive type.
 
 data Cofin : Conat ∞ → Set where
   zero : ∀ {n} → Cofin (suc n)

--- a/src/Codata/Conat/Properties.agda
+++ b/src/Codata/Conat/Properties.agda
@@ -13,7 +13,7 @@ open import Data.Nat.Base using (ℕ; zero; suc)
 open import Codata.Thunk
 open import Codata.Conat
 open import Codata.Conat.Bisimilarity
-open import Function
+open import Function.Base using (_∋_)
 open import Relation.Nullary
 open import Relation.Nullary.Decidable using (map′)
 open import Relation.Binary

--- a/src/Codata/Covec.agda
+++ b/src/Codata/Covec.agda
@@ -17,7 +17,7 @@ open import Codata.Conat.Properties
 open import Codata.Cofin as Cofin using (Cofin; zero; suc)
 open import Codata.Colist as Colist using (Colist ; [] ; _∷_)
 open import Codata.Stream as Stream using (Stream ; _∷_)
-open import Function
+open import Function.Base using (_∘′_)
 
 data Covec {ℓ} (A : Set ℓ) (i : Size) : Conat ∞ → Set ℓ where
   []  : Covec A i zero

--- a/src/Codata/Covec/Properties.agda
+++ b/src/Codata/Covec/Properties.agda
@@ -13,7 +13,7 @@ open import Codata.Thunk using (Thunk; force)
 open import Codata.Conat
 open import Codata.Covec
 open import Codata.Covec.Bisimilarity
-open import Function
+open import Function.Base using (id; _∘_)
 open import Relation.Binary.PropositionalEquality as Eq
 
 -- Functor laws

--- a/src/Codata/Delay/Properties.agda
+++ b/src/Codata/Delay/Properties.agda
@@ -16,7 +16,7 @@ open import Codata.Conat
 open import Codata.Conat.Bisimilarity as Coℕ using (zero ; suc)
 open import Codata.Delay
 open import Codata.Delay.Bisimilarity
-open import Function
+open import Function.Base using (id; _∘′_)
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_)
 
 module _ {a} {A : Set a} where
@@ -102,6 +102,6 @@ module _ {a} {A B : Set a} where
       (d⇓ : d ⇓) → (f⇓ : f (extract d⇓) ⇓) →
       toℕ (length-⇓ bind⇓) ≡ toℕ (length-⇓ d⇓) ℕ.+ toℕ (length-⇓ f⇓)
   bind⇓-length {f = f} bind⇓ d⇓@(now s') f⇓ =
-    Eq.cong (toℕ ∘ length-⇓) (⇓-unique bind⇓ f⇓)
+    Eq.cong (toℕ ∘′ length-⇓) (⇓-unique bind⇓ f⇓)
   bind⇓-length {d = d@(later dt)} {f = f} bind⇓@(later bind'⇓) d⇓@(later r) f⇓ =
     Eq.cong ℕ.suc (bind⇓-length bind'⇓ r f⇓)

--- a/src/Codata/M/Bisimilarity.agda
+++ b/src/Codata/M/Bisimilarity.agda
@@ -15,7 +15,7 @@ open import Codata.M
 open import Data.Container.Core
 open import Data.Container.Relation.Binary.Pointwise using (Pointwise; _,_)
 open import Data.Product using (_,_)
-open import Function.Base
+open import Function.Base using (_∋_)
 open import Relation.Binary
 import Relation.Binary.PropositionalEquality as P
 

--- a/src/Codata/M/Properties.agda
+++ b/src/Codata/M/Properties.agda
@@ -17,7 +17,7 @@ open import Data.Container.Core as C hiding (map)
 import Data.Container.Morphism as Mp
 open import Data.Product as Prod using (_,_)
 open import Data.Product.Properties hiding (map-cong)
-open import Function
+open import Function.Base using (_$′_; _∘′_)
 import Relation.Binary.PropositionalEquality as P
 
 open import Data.Container.Relation.Binary.Pointwise using (_,_)

--- a/src/Codata/Musical/Cofin.agda
+++ b/src/Codata/Musical/Cofin.agda
@@ -13,7 +13,7 @@ open import Codata.Musical.Conat as Conat using (Coℕ; suc; ∞ℕ)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Relation.Binary.PropositionalEquality using (_≡_ ; refl)
-open import Function
+open import Function.Base using (_∋_)
 
 ------------------------------------------------------------------------
 -- The type

--- a/src/Codata/Musical/M/Indexed.agda
+++ b/src/Codata/Musical/M/Indexed.agda
@@ -13,7 +13,7 @@ open import Level
 open import Codata.Musical.Notation
 open import Data.Product
 open import Data.Container.Indexed.Core
-open import Function
+open import Function.Base using (_∘_)
 open import Relation.Unary
 
 -- The family of indexed M-types.

--- a/src/Codata/Stream/Categorical.agda
+++ b/src/Codata/Stream/Categorical.agda
@@ -10,7 +10,7 @@ module Codata.Stream.Categorical where
 
 open import Data.Product using (<_,_>)
 open import Codata.Stream
-open import Function
+open import Function.Base
 open import Category.Functor
 open import Category.Applicative
 open import Category.Comonad

--- a/src/Codata/Stream/Properties.agda
+++ b/src/Codata/Stream/Properties.agda
@@ -23,7 +23,7 @@ import Data.List.Relation.Binary.Equality.Propositional as Eq
 open import Data.Product as Prod using (_,_)
 open import Data.Vec.Base as Vec using (_∷_)
 
-open import Function
+open import Function.Base using (id; _$_; _∘′_; const)
 open import Relation.Binary.PropositionalEquality as P using (_≡_; _≢_)
 
 private
@@ -93,7 +93,7 @@ module _ {a b} {A : Set a} {B : Set b} where
 map-identity : ∀ (as : Stream A ∞) → i ⊢ map id as ≈ as
 map-identity (a ∷ as) = P.refl ∷ λ where .force → map-identity (as .force)
 
-map-map-fusion : ∀ (f : A → B) (g : B → C) as → i ⊢ map g (map f as) ≈ map (g ∘ f) as
+map-map-fusion : ∀ (f : A → B) (g : B → C) as → i ⊢ map g (map f as) ≈ map (g ∘′ f) as
 map-map-fusion f g (a ∷ as) = P.refl ∷ λ where .force → map-map-fusion f g (as .force)
 
 

--- a/src/Function.agda
+++ b/src/Function.agda
@@ -10,6 +10,7 @@ module Function where
 
 open import Function.Core public
 open import Function.Base public
+open import Function.Strict public
 open import Function.Definitions public
 open import Function.Structures public
 open import Function.Bundles public

--- a/src/Function/Base.agda
+++ b/src/Function/Base.agda
@@ -5,13 +5,14 @@
 ------------------------------------------------------------------------
 
 -- The contents of this file can be accessed from `Function`.
+-- See `Function.Strict` for strict versions of these combinators.
 
 {-# OPTIONS --without-K --safe #-}
 
 module Function.Base where
 
 open import Level
-open import Strict
+import Function.Strict
 
 private
   variable
@@ -44,7 +45,7 @@ infixr 9 _∘_ _∘₂_
 infixl 8 _ˢ_
 infixl 0 _|>_
 infix  0 case_return_of_
-infixr -1 _$_ _$!_
+infixr -1 _$_
 
 -- Composition
 
@@ -77,12 +78,6 @@ _$_ : ∀ {A : Set a} {B : A → Set b} →
       ((x : A) → B x) → ((x : A) → B x)
 f $ x = f x
 {-# INLINE _$_ #-}
-
--- Strict (call-by-value) application
-
-_$!_ : ∀ {A : Set a} {B : A → Set b} →
-       ((x : A) → B x) → ((x : A) → B x)
-_$!_ = flip force
 
 -- Flipped application (aka pipe-forward)
 
@@ -132,7 +127,7 @@ case x return B of f = f x
 infixr 9 _∘′_ _∘₂′_
 infixl 0 _|>′_
 infix  0 case_of_
-infixr -1 _$′_ _$!′_
+infixr -1 _$′_
 
 -- Composition
 
@@ -146,11 +141,6 @@ f ∘₂′ g = _∘₂_ f g
 
 _$′_ : (A → B) → (A → B)
 _$′_ = _$_
-
--- Strict (call-by-value) application
-
-_$!′_ : (A → B) → (A → B)
-_$!′_ = _$!_
 
 -- Flipped application (aka pipe-forward)
 
@@ -249,6 +239,13 @@ _*_ on₂ f = f -⟪ _*_ ⟫- f
 
 _on_ : (B → B → C) → (A → B) → (A → A → C)
 _*_ on f = f -⟨ _*_ ⟩- f
+
+
+------------------------------------------------------------------------
+-- Deprecated
+
+open Function.Strict public
+  using (_$!_; _$!′_)
 
 _-[_]-_ = _-⟪_⟫-_
 {-# WARNING_ON_USAGE _-[_]-_

--- a/src/Function/Base.agda
+++ b/src/Function/Base.agda
@@ -4,15 +4,15 @@
 -- Simple combinators working solely on and with functions
 ------------------------------------------------------------------------
 
--- The contents of this file can be accessed from `Function`.
--- See `Function.Strict` for strict versions of these combinators.
+-- The contents of this module is also accessible via the `Function`
+-- module. See `Function.Strict` for strict versions of these
+-- combinators.
 
 {-# OPTIONS --without-K --safe #-}
 
 module Function.Base where
 
-open import Level
-import Function.Strict
+open import Level using (Level)
 
 private
   variable
@@ -243,9 +243,6 @@ _*_ on f = f -⟨ _*_ ⟩- f
 
 ------------------------------------------------------------------------
 -- Deprecated
-
-open Function.Strict public
-  using (_$!_; _$!′_)
 
 _-[_]-_ = _-⟪_⟫-_
 {-# WARNING_ON_USAGE _-[_]-_

--- a/src/Function/Core.agda
+++ b/src/Function/Core.agda
@@ -4,7 +4,7 @@
 -- Core definitions for Functions
 ------------------------------------------------------------------------
 
--- The contents of this file should usually be accessed from `Function`.
+-- The contents of this file should always be accessed from `Function`.
 
 {-# OPTIONS --without-K --safe #-}
 

--- a/src/Function/Strict.agda
+++ b/src/Function/Strict.agda
@@ -4,12 +4,16 @@
 -- Strict combinators (i.e. that use call-by-value)
 ------------------------------------------------------------------------
 
+-- The contents of this module is also accessible via the `Function`
+-- module.
+
 {-# OPTIONS --without-K --safe #-}
 
 module Function.Strict where
 
-open import Level using (Level)
 open import Agda.Builtin.Equality using (_≡_)
+open import Function.Base using (flip)
+open import Level using (Level)
 
 private
   variable
@@ -39,7 +43,7 @@ f $! x = force x f
 -- Flipped application
 _!|>_ : ∀ {A : Set a} {B : A → Set b} →
        (a : A) → (∀ a → B a) → B a
-x !|> f = f $! x
+_!|>_ = flip _$!_
 
 ------------------------------------------------------------------------
 -- Non-dependent combinators

--- a/src/Function/Strict.agda
+++ b/src/Function/Strict.agda
@@ -1,0 +1,71 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Strict combinators (i.e. that use call-by-value)
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Function.Strict where
+
+open import Level using (Level)
+open import Agda.Builtin.Equality using (_≡_)
+
+private
+  variable
+    a b : Level
+    A B : Set a
+
+infixl 0 _!|>′_ _!|>′_
+infixr -1 _$!_ _$!′_
+
+------------------------------------------------------------------------
+-- Dependent combinators
+
+-- These are functions whose output has a type that depends on the
+-- value of the input to the function.
+
+open import Agda.Builtin.Strict public
+  renaming
+  ( primForce      to force
+  ; primForceLemma to force-≡
+  )
+
+-- Application
+_$!_ : ∀ {A : Set a} {B : A → Set b} →
+       ((x : A) → B x) → ((x : A) → B x)
+f $! x = force x f
+
+-- Flipped application
+_!|>_ : ∀ {A : Set a} {B : A → Set b} →
+       (a : A) → (∀ a → B a) → B a
+x !|> f = f $! x
+
+------------------------------------------------------------------------
+-- Non-dependent combinators
+
+-- Any of the above operations for dependent functions will also work
+-- for non-dependent functions but sometimes Agda has difficulty
+-- inferring the non-dependency. Primed (′ = \prime) versions of the
+-- operations are therefore provided below that sometimes have better
+-- inference properties.
+
+seq : A → B → B
+seq a b = force a (λ _ → b)
+
+seq-≡ : (a : A) (b : B) → seq a b ≡ b
+seq-≡ a b = force-≡ a (λ _ → b)
+
+force′ : A → (A → B) → B
+force′ = force
+
+force′-≡ : (a : A) (f : A → B) → force′ a f ≡ f a
+force′-≡ = force-≡
+
+-- Application
+_$!′_ : (A → B) → (A → B)
+_$!′_ = _$!_
+
+-- Flipped application
+_!|>′_ : A → (A → B) → B
+_!|>′_ = _!|>_

--- a/src/Strict.agda
+++ b/src/Strict.agda
@@ -1,31 +1,20 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Strictness combinators
+-- This module is DEPRECATED, please use `Data.Record` directly.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
 module Strict where
 
-open import Level
-open import Agda.Builtin.Equality
+{-# WARNING_ON_IMPORT
+"Strict was deprecated in v1.8.
+Use Function.Strict instead."
+#-}
 
-open import Agda.Builtin.Strict
-     renaming ( primForce to force
-              ; primForceLemma to force-≡) public
-
--- Derived combinators
-module _ {ℓ ℓ′ : Level} {A : Set ℓ} {B : Set ℓ′} where
-
-  force′ : A → (A → B) → B
-  force′ = force
-
-  force′-≡ : (a : A) (f : A → B) → force′ a f ≡ f a
-  force′-≡ = force-≡
-
-  seq : A → B → B
-  seq a b = force a (λ _ → b)
-
-  seq-≡ : (a : A) (b : B) → seq a b ≡ b
-  seq-≡ a b = force-≡ a (λ _ → b)
+open import Function.Strict public
+  using
+  ( force ; force-≡ ; force′ ; force′-≡
+  ; seq   ; seq-≡
+  )

--- a/src/Strict.agda
+++ b/src/Strict.agda
@@ -10,7 +10,7 @@ module Strict where
 
 {-# WARNING_ON_IMPORT
 "Strict was deprecated in v1.8.
-Use `Function.Strict` instead (also re-exported by `Function`)."
+Use `Function.Strict instead (also re-exported by `Function`)."
 #-}
 
 open import Function.Strict public

--- a/src/Strict.agda
+++ b/src/Strict.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- This module is DEPRECATED, please use `Data.Record` directly.
+-- This module is DEPRECATED, please use `Function.Strict` directly.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -10,7 +10,7 @@ module Strict where
 
 {-# WARNING_ON_IMPORT
 "Strict was deprecated in v1.8.
-Use Function.Strict instead."
+Use `Function.Strict` instead (also re-exported by `Function`)."
 #-}
 
 open import Function.Strict public

--- a/src/Text/Format/Generic.agda
+++ b/src/Text/Format/Generic.agda
@@ -23,7 +23,7 @@ open import Data.String.Base
 import Data.Sum.Categorical.Left as Sumₗ
 open import Function
 open import Function.Nary.NonDependent using (0ℓs; Sets)
-open import Strict
+open import Function.Strict
 
 ------------------------------------------------------------------------
 -- Format specifications.

--- a/src/Text/Printf.agda
+++ b/src/Text/Printf.agda
@@ -18,7 +18,7 @@ open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Data.Unit using (⊤)
 open import Function.Nary.NonDependent
 open import Function
-open import Strict
+open import Function.Strict
 
 import Data.Char.Base    as Cₛ
 import Data.Integer.Show as ℤₛ


### PR DESCRIPTION
In response to #1486. Haven't yet cut the dependency of `Function.Base` on `Function.Strict` in order to preserve backwards compatibility.