### PR TITLE
Remove redundancy in ring morphisms etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Non-backwards compatible changes
   `IsRelHomomorphism`. Similarly, `IsLatticeHomomorphism` is now built as
   `IsRelHomomorphism` along with proofs that `_∧_` and `_∨_` are homorphic.
 
+  Also, `⁻¹-homo` in `IsRingHomomorphism` has been renamed to `-‿homo`.
+
+
 * In `Text.Pretty`, `Doc` is now a record rather than a type alias. This
   helps Agda reconstruct the `width` parameter when the module is opened
   without it being applied. In particular this allows users to write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Bug-fixes
 Non-backwards compatible changes
 --------------------------------
 
+* In `Algebra.Morphism.Structures`, `IsNearSemiringHomomorphism`,
+  `IsSemiringHomomorphism`, and `IsRingHomomorphism` have been redeisgned to
+  build up from `IsMonoidHomomorphism`, `IsNearSemiringHomomorphism`, and
+  `IsSemiringHomomorphism` respectively, adding a single property at each step.
+  This means that they no longer need to have two separate proofs of
+  `IsRelHomomorphism`. Similarly, `IsLatticeHomomorphism` is now built as
+  `IsRelHomomorphism` along with proofs that `_∧_` and `_∨_` are homorphic.
+
 * In `Text.Pretty`, `Doc` is now a record rather than a type alias. This
   helps Agda reconstruct the `width` parameter when the module is opened
   without it being applied. In particular this allows users to write
@@ -122,6 +130,22 @@ Other minor additions
   ∧-isCommutativeSemigroup : IsCommutativeSemigroup ∧
   ```
   and their corresponding algebraic substructures.
+
+* Added new definitions and proofs in `Data.Rational.Properties`:
+  ```agda
+  +-*-rawNearSemiring : RawNearSemiring 0ℓ 0ℓ
+  +-*-rawSemiring : RawSemiring 0ℓ 0ℓ
+  toℚᵘ-isNearSemiringHomomorphism-+-* : IsNearSemiringHomomorphism +-*-rawNearSemiring ℚᵘ.+-*-rawNearSemiring toℚᵘ
+  toℚᵘ-isNearSemiringMonomorphism-+-* : IsNearSemiringMonomorphism +-*-rawNearSemiring ℚᵘ.+-*-rawNearSemiring toℚᵘ
+  toℚᵘ-isSemiringHomomorphism-+-* : IsSemiringHomomorphism +-*-rawSemiring ℚᵘ.+-*-rawSemiring toℚᵘ
+  toℚᵘ-isSemiringMonomorphism-+-* : IsSemiringMonomorphism +-*-rawSemiring ℚᵘ.+-*-rawSemiring toℚᵘ
+  ```
+
+* Added new definitions in `Data.Rational.Unnormalised.Properties`:
+  ```agda
+  +-*-rawNearSemiring : RawNearSemiring 0ℓ 0ℓ
+  +-*-rawSemiring : RawSemiring 0ℓ 0ℓ
+  ```
 
 * Added new proofs in `Data.String.Properties`:
   ```

--- a/src/Algebra/Morphism/Construct/Composition.agda
+++ b/src/Algebra/Morphism/Construct/Composition.agda
@@ -160,7 +160,7 @@ module _ {R₁ : RawNearSemiring a ℓ₁}
     → IsNearSemiringHomomorphism R₁ R₃ (g ∘ f)
   isNearSemiringHomomorphism f-homo g-homo = record
     { +-isMonoidHomomorphism = isMonoidHomomorphism ≈₃-trans F.+-isMonoidHomomorphism G.+-isMonoidHomomorphism
-    ; *-isMagmaHomomorphism  = isMagmaHomomorphism  ≈₃-trans F.*-isMagmaHomomorphism  G.*-isMagmaHomomorphism
+    ; *-homo = λ x y → ≈₃-trans (G.⟦⟧-cong (F.*-homo x y)) (G.*-homo (f x) (f y))
     } where module F = IsNearSemiringHomomorphism f-homo; module G = IsNearSemiringHomomorphism g-homo
 
   isNearSemiringMonomorphism
@@ -201,8 +201,8 @@ module _
     → IsSemiringHomomorphism R₂ R₃ g
     → IsSemiringHomomorphism R₁ R₃ (g ∘ f)
   isSemiringHomomorphism f-homo g-homo = record
-    { +-isMonoidHomomorphism = isMonoidHomomorphism ≈₃-trans F.+-isMonoidHomomorphism G.+-isMonoidHomomorphism
-    ; *-isMonoidHomomorphism = isMonoidHomomorphism ≈₃-trans F.*-isMonoidHomomorphism G.*-isMonoidHomomorphism
+    { isNearSemiringHomomorphism = isNearSemiringHomomorphism ≈₃-trans F.isNearSemiringHomomorphism G.isNearSemiringHomomorphism
+    ; 1#-homo                    = ≈₃-trans (G.⟦⟧-cong F.1#-homo) G.1#-homo
     } where module F = IsSemiringHomomorphism f-homo; module G = IsSemiringHomomorphism g-homo
 
   isSemiringMonomorphism
@@ -242,8 +242,8 @@ module _ {R₁ : RawRing a ℓ₁}
     → IsRingHomomorphism R₂ R₃ g
     → IsRingHomomorphism R₁ R₃ (g ∘ f)
   isRingHomomorphism f-homo g-homo = record
-    { +-isGroupHomomorphism = isGroupHomomorphism   ≈₃-trans F.+-isGroupHomomorphism  G.+-isGroupHomomorphism
-    ; *-isMonoidHomomorphism = isMonoidHomomorphism ≈₃-trans F.*-isMonoidHomomorphism G.*-isMonoidHomomorphism
+    { isSemiringHomomorphism = isSemiringHomomorphism ≈₃-trans F.isSemiringHomomorphism G.isSemiringHomomorphism
+    ; -‿homo                 = λ x → ≈₃-trans (G.⟦⟧-cong (F.-‿homo x)) (G.-‿homo (f x))
     } where module F = IsRingHomomorphism f-homo; module G = IsRingHomomorphism g-homo
 
   isRingMonomorphism
@@ -282,8 +282,9 @@ module _ {L₁ : RawLattice a ℓ₁}
     → IsLatticeHomomorphism L₂ L₃ g
     → IsLatticeHomomorphism L₁ L₃ (g ∘ f)
   isLatticeHomomorphism f-homo g-homo = record
-    { ∧-isMagmaHomomorphism = isMagmaHomomorphism ≈₃-trans F.∧-isMagmaHomomorphism G.∧-isMagmaHomomorphism
-    ; ∨-isMagmaHomomorphism = isMagmaHomomorphism ≈₃-trans F.∨-isMagmaHomomorphism G.∨-isMagmaHomomorphism
+    { isRelHomomorphism = isRelHomomorphism F.isRelHomomorphism G.isRelHomomorphism
+    ; ∧-homo            = λ x y → ≈₃-trans (G.⟦⟧-cong (F.∧-homo x y)) (G.∧-homo (f x) (f y))
+    ; ∨-homo            = λ x y → ≈₃-trans (G.⟦⟧-cong (F.∨-homo x y)) (G.∨-homo (f x) (f y))
     } where module F = IsLatticeHomomorphism f-homo; module G = IsLatticeHomomorphism g-homo
 
   isLatticeMonomorphism

--- a/src/Algebra/Morphism/Construct/Identity.agda
+++ b/src/Algebra/Morphism/Construct/Identity.agda
@@ -97,7 +97,7 @@ module _ (R : RawNearSemiring c ℓ) (open RawNearSemiring R) (refl : Reflexive 
   isNearSemiringHomomorphism : IsNearSemiringHomomorphism id
   isNearSemiringHomomorphism = record
     { +-isMonoidHomomorphism = isMonoidHomomorphism _ refl
-    ; *-isMagmaHomomorphism  = isMagmaHomomorphism  _ refl
+    ; *-homo                 = λ _ _ → refl
     }
 
   isNearSemiringMonomorphism : IsNearSemiringMonomorphism id
@@ -117,8 +117,8 @@ module _ (R : RawSemiring c ℓ) (open RawSemiring R) (refl : Reflexive _≈_) w
 
   isSemiringHomomorphism : IsSemiringHomomorphism id
   isSemiringHomomorphism = record
-    { +-isMonoidHomomorphism = isMonoidHomomorphism _ refl
-    ; *-isMonoidHomomorphism = isMonoidHomomorphism _ refl
+    { isNearSemiringHomomorphism = isNearSemiringHomomorphism _ refl
+    ; 1#-homo                    = refl
     }
 
   isSemiringMonomorphism : IsSemiringMonomorphism id
@@ -138,8 +138,8 @@ module _ (R : RawRing c ℓ) (open RawRing R) (refl : Reflexive _≈_) where
 
   isRingHomomorphism : IsRingHomomorphism id
   isRingHomomorphism = record
-    { +-isGroupHomomorphism  = isGroupHomomorphism  _ refl
-    ; *-isMonoidHomomorphism = isMonoidHomomorphism _ refl
+    { isSemiringHomomorphism = isSemiringHomomorphism _ refl
+    ; -‿homo                 = λ _ → refl
     }
 
   isRingMonomorphism : IsRingMonomorphism id
@@ -159,8 +159,9 @@ module _ (L : RawLattice c ℓ) (open RawLattice L) (refl : Reflexive _≈_) whe
 
   isLatticeHomomorphism : IsLatticeHomomorphism id
   isLatticeHomomorphism = record
-    { ∧-isMagmaHomomorphism = isMagmaHomomorphism _ refl
-    ; ∨-isMagmaHomomorphism = isMagmaHomomorphism _ refl
+    { isRelHomomorphism = isRelHomomorphism _
+    ; ∧-homo            = λ _ _ → refl
+    ; ∨-homo            = λ _ _ → refl
     }
 
   isLatticeMonomorphism : IsLatticeMonomorphism id

--- a/src/Algebra/Morphism/RingMonomorphism.agda
+++ b/src/Algebra/Morphism/RingMonomorphism.agda
@@ -123,19 +123,19 @@ module _ (+-isGroup : IsGroup _≈₂_ _⊕_ 0#₂ ⊝_)
 
   neg-distribˡ-* : (∀ x y → (⊝ (x ⊛ y)) ≈₂ ((⊝ x) ⊛ y)) → (∀ x y → (- (x * y)) ≈₁ ((- x) * y))
   neg-distribˡ-* neg-distribˡ-* x y = injective (begin
-    ⟦ - (x * y) ⟧     ≈⟨ ⁻¹-homo (x * y) ⟩
+    ⟦ - (x * y) ⟧     ≈⟨ -‿homo (x * y) ⟩
     ⊝ ⟦ x * y ⟧       ≈⟨ ⁻¹-cong (*-homo x y) ⟩
     ⊝ (⟦ x ⟧ ⊛ ⟦ y ⟧) ≈⟨ neg-distribˡ-* ⟦ x ⟧ ⟦ y ⟧ ⟩
-    ⊝ ⟦ x ⟧ ⊛ ⟦ y ⟧   ≈⟨ ◦-cong (sym (⁻¹-homo x)) refl ⟩
+    ⊝ ⟦ x ⟧ ⊛ ⟦ y ⟧   ≈⟨ ◦-cong (sym (-‿homo x)) refl ⟩
     ⟦ - x ⟧ ⊛ ⟦ y ⟧   ≈⟨ sym (*-homo (- x) y) ⟩
     ⟦ - x * y ⟧       ∎)
 
   neg-distribʳ-* : (∀ x y → (⊝ (x ⊛ y)) ≈₂ (x ⊛ (⊝ y))) → (∀ x y → (- (x * y)) ≈₁ (x * (- y)))
   neg-distribʳ-* neg-distribʳ-* x y = injective (begin
-    ⟦ - (x * y) ⟧     ≈⟨ ⁻¹-homo (x * y) ⟩
+    ⟦ - (x * y) ⟧     ≈⟨ -‿homo (x * y) ⟩
     ⊝ ⟦ x * y ⟧       ≈⟨ ⁻¹-cong (*-homo x y) ⟩
     ⊝ (⟦ x ⟧ ⊛ ⟦ y ⟧) ≈⟨ neg-distribʳ-* ⟦ x ⟧ ⟦ y ⟧ ⟩
-    ⟦ x ⟧ ⊛ ⊝ ⟦ y ⟧   ≈⟨ ◦-cong refl (sym (⁻¹-homo y)) ⟩
+    ⟦ x ⟧ ⊛ ⊝ ⟦ y ⟧   ≈⟨ ◦-cong refl (sym (-‿homo y)) ⟩
     ⟦ x ⟧ ⊛ ⟦ - y ⟧   ≈⟨ sym (*-homo x (- y)) ⟩
     ⟦ x * - y ⟧       ∎)
 

--- a/src/Algebra/Morphism/Structures.agda
+++ b/src/Algebra/Morphism/Structures.agda
@@ -164,7 +164,7 @@ module GroupMorphisms (G₁ : RawGroup a ℓ₁) (G₂ : RawGroup b ℓ₂) wher
       }
 
     open IsMonoidMonomorphism isMonoidMonomorphism public
-      using (isRelMonomorphism)
+      using (isRelMonomorphism; isMagmaMonomorphism)
 
 
   record IsGroupIsomorphism (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
@@ -181,7 +181,7 @@ module GroupMorphisms (G₁ : RawGroup a ℓ₁) (G₂ : RawGroup b ℓ₂) wher
       }
 
     open IsMonoidIsomorphism isMonoidIsomorphism public
-      using (isRelIsomorphism)
+      using (isRelIsomorphism; isMagmaIsomorphism)
 
 
 ------------------------------------------------------------------------
@@ -193,11 +193,13 @@ module NearSemiringMorphisms (R₁ : RawNearSemiring a ℓ₁) (R₂ : RawNearSe
   open RawNearSemiring R₁ renaming
     ( Carrier to A; _≈_ to _≈₁_
     ; +-rawMonoid to +-rawMonoid₁
+    ; _*_ to _*₁_
     ; *-rawMagma to *-rawMagma₁)
 
   open RawNearSemiring R₂ renaming
     ( Carrier to B; _≈_ to _≈₂_
     ; +-rawMonoid to +-rawMonoid₂
+    ; _*_ to _*₂_
     ; *-rawMagma to *-rawMagma₂)
 
   private
@@ -211,14 +213,16 @@ module NearSemiringMorphisms (R₁ : RawNearSemiring a ℓ₁) (R₂ : RawNearSe
   record IsNearSemiringHomomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
       +-isMonoidHomomorphism : +.IsMonoidHomomorphism ⟦_⟧
-      *-isMagmaHomomorphism  : *.IsMagmaHomomorphism ⟦_⟧
+      *-homo : Homomorphic₂ ⟦_⟧ _*₁_ _*₂_
 
     open +.IsMonoidHomomorphism +-isMonoidHomomorphism public
-      renaming (homo to +-homo; ε-homo to 0#-homo)
+      renaming (homo to +-homo; ε-homo to 0#-homo; isMagmaHomomorphism to +-isMagmaHomomorphism)
 
-    open *.IsMagmaHomomorphism *-isMagmaHomomorphism public
-      renaming (homo to *-homo) hiding (⟦⟧-cong)
-
+    *-isMagmaHomomorphism : *.IsMagmaHomomorphism ⟦_⟧
+    *-isMagmaHomomorphism = record
+      { isRelHomomorphism = isRelHomomorphism
+      ; homo = *-homo
+      }
 
   record IsNearSemiringMonomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
@@ -233,15 +237,15 @@ module NearSemiringMorphisms (R₁ : RawNearSemiring a ℓ₁) (R₂ : RawNearSe
       ; injective            = injective
       }
 
+    open +.IsMonoidMonomorphism +-isMonoidMonomorphism public
+      using (isRelMonomorphism)
+      renaming (isMagmaMonomorphism to +-isMagmaMonomorphsm)
+
     *-isMagmaMonomorphism : *.IsMagmaMonomorphism ⟦_⟧
     *-isMagmaMonomorphism = record
       { isMagmaHomomorphism = *-isMagmaHomomorphism
       ; injective           = injective
       }
-
-    open *.IsMagmaMonomorphism *-isMagmaMonomorphism public
-      using (isRelMonomorphism)
-
 
   record IsNearSemiringIsomorphism (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
@@ -256,15 +260,15 @@ module NearSemiringMorphisms (R₁ : RawNearSemiring a ℓ₁) (R₂ : RawNearSe
       ; surjective           = surjective
       }
 
+    open +.IsMonoidIsomorphism +-isMonoidIsomorphism public
+      using (isRelIsomorphism)
+      renaming (isMagmaIsomorphism to +-isMagmaIsomorphism)
+
     *-isMagmaIsomorphism : *.IsMagmaIsomorphism ⟦_⟧
     *-isMagmaIsomorphism = record
       { isMagmaMonomorphism = *-isMagmaMonomorphism
       ; surjective          = surjective
       }
-
-    open *.IsMagmaIsomorphism *-isMagmaIsomorphism public
-      using (isRelIsomorphism)
-
 
 ------------------------------------------------------------------------
 -- Morphisms over semiring-like structures
@@ -274,33 +278,35 @@ module SemiringMorphisms (R₁ : RawSemiring a ℓ₁) (R₂ : RawSemiring b ℓ
 
   open RawSemiring R₁ renaming
     ( Carrier to A; _≈_ to _≈₁_
-    ; +-rawMonoid to +-rawMonoid₁
+    ; 1# to 1#₁
+    ; rawNearSemiring to rawNearSemiring₁
     ; *-rawMonoid to *-rawMonoid₁)
 
   open RawSemiring R₂ renaming
     ( Carrier to B; _≈_ to _≈₂_
-    ; +-rawMonoid to +-rawMonoid₂
+    ; 1# to 1#₂
+    ; rawNearSemiring to rawNearSemiring₂
     ; *-rawMonoid to *-rawMonoid₂)
 
   private
-    module + = MonoidMorphisms +-rawMonoid₁ +-rawMonoid₂
     module * = MonoidMorphisms *-rawMonoid₁ *-rawMonoid₂
 
   open MorphismDefinitions A B _≈₂_
   open FunctionDefinitions _≈₁_ _≈₂_
-
+  open NearSemiringMorphisms rawNearSemiring₁ rawNearSemiring₂
 
   record IsSemiringHomomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      +-isMonoidHomomorphism : +.IsMonoidHomomorphism ⟦_⟧
-      *-isMonoidHomomorphism : *.IsMonoidHomomorphism ⟦_⟧
+      isNearSemiringHomomorphism : IsNearSemiringHomomorphism ⟦_⟧
+      1#-homo : Homomorphic₀ ⟦_⟧ 1#₁ 1#₂
 
-    open +.IsMonoidHomomorphism +-isMonoidHomomorphism public
-      renaming (homo to +-homo; ε-homo to 0#-homo)
+    open IsNearSemiringHomomorphism isNearSemiringHomomorphism public
 
-    open *.IsMonoidHomomorphism *-isMonoidHomomorphism public
-      renaming (homo to *-homo; ε-homo to 1#-homo) hiding (⟦⟧-cong)
-
+    *-isMonoidHomomorphism : *.IsMonoidHomomorphism ⟦_⟧
+    *-isMonoidHomomorphism = record
+      { isMagmaHomomorphism = *-isMagmaHomomorphism
+      ; ε-homo = 1#-homo
+      }
 
   record IsSemiringMonomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
@@ -309,21 +315,20 @@ module SemiringMorphisms (R₁ : RawSemiring a ℓ₁) (R₂ : RawSemiring b ℓ
 
     open IsSemiringHomomorphism isSemiringHomomorphism public
 
-    +-isMonoidMonomorphism : +.IsMonoidMonomorphism ⟦_⟧
-    +-isMonoidMonomorphism = record
-      { isMonoidHomomorphism = +-isMonoidHomomorphism
-      ; injective            = injective
+    isNearSemiringMonomorphism : IsNearSemiringMonomorphism ⟦_⟧
+    isNearSemiringMonomorphism = record
+      { isNearSemiringHomomorphism = isNearSemiringHomomorphism
+      ; injective = injective
       }
+
+    open IsNearSemiringMonomorphism isNearSemiringMonomorphism public
+      using (+-isMonoidMonomorphism; *-isMagmaMonomorphism)
 
     *-isMonoidMonomorphism : *.IsMonoidMonomorphism ⟦_⟧
     *-isMonoidMonomorphism = record
       { isMonoidHomomorphism = *-isMonoidHomomorphism
       ; injective            = injective
       }
-
-    open *.IsMonoidMonomorphism *-isMonoidMonomorphism public
-      using (isRelMonomorphism)
-
 
   record IsSemiringIsomorphism (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
@@ -332,21 +337,20 @@ module SemiringMorphisms (R₁ : RawSemiring a ℓ₁) (R₂ : RawSemiring b ℓ
 
     open IsSemiringMonomorphism isSemiringMonomorphism public
 
-    +-isMonoidIsomorphism : +.IsMonoidIsomorphism ⟦_⟧
-    +-isMonoidIsomorphism = record
-      { isMonoidMonomorphism = +-isMonoidMonomorphism
-      ; surjective           = surjective
+    isNearSemiringIsomorphism : IsNearSemiringIsomorphism ⟦_⟧
+    isNearSemiringIsomorphism = record
+      { isNearSemiringMonomorphism = isNearSemiringMonomorphism
+      ; surjective = surjective
       }
+
+    open IsNearSemiringIsomorphism isNearSemiringIsomorphism public
+      using (+-isMonoidIsomorphism; *-isMagmaIsomorphism)
 
     *-isMonoidIsomorphism : *.IsMonoidIsomorphism ⟦_⟧
     *-isMonoidIsomorphism = record
       { isMonoidMonomorphism = *-isMonoidMonomorphism
       ; surjective           = surjective
       }
-
-    open *.IsMonoidIsomorphism *-isMonoidIsomorphism public
-      using (isRelIsomorphism)
-
 
 ------------------------------------------------------------------------
 -- Morphisms over ring-like structures
@@ -356,11 +360,15 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
 
   open RawRing R₁ renaming
     ( Carrier to A; _≈_ to _≈₁_
+    ; -_ to -₁_
+    ; rawSemiring to rawSemiring₁
     ; *-rawMonoid to *-rawMonoid₁
     ; +-rawGroup to +-rawGroup₁)
 
   open RawRing R₂ renaming
     ( Carrier to B; _≈_ to _≈₂_
+    ; -_ to -₂_
+    ; rawSemiring to rawSemiring₂
     ; *-rawMonoid to *-rawMonoid₂
     ; +-rawGroup to +-rawGroup₂)
 
@@ -369,19 +377,21 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
 
   open MorphismDefinitions A B _≈₂_
   open FunctionDefinitions _≈₁_ _≈₂_
+  open SemiringMorphisms rawSemiring₁ rawSemiring₂
 
 
   record IsRingHomomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      +-isGroupHomomorphism  : +.IsGroupHomomorphism  ⟦_⟧
-      *-isMonoidHomomorphism : *.IsMonoidHomomorphism ⟦_⟧
+      isSemiringHomomorphism : IsSemiringHomomorphism ⟦_⟧
+      -‿homo : Homomorphic₁ ⟦_⟧ -₁_ -₂_
 
-    open +.IsGroupHomomorphism +-isGroupHomomorphism public
-      renaming (homo to +-homo; ε-homo to 0#-homo)
+    open IsSemiringHomomorphism isSemiringHomomorphism public
 
-    open *.IsMonoidHomomorphism *-isMonoidHomomorphism public
-      renaming (homo to *-homo; ε-homo to 1#-homo) hiding (⟦⟧-cong)
-
+    +-isGroupHomomorphism : +.IsGroupHomomorphism ⟦_⟧
+    +-isGroupHomomorphism = record
+      { isMonoidHomomorphism = +-isMonoidHomomorphism
+      ; ⁻¹-homo = -‿homo
+      }
 
   record IsRingMonomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
@@ -390,11 +400,23 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
 
     open IsRingHomomorphism isRingHomomorphism public
 
+    isSemiringMonomorphism : IsSemiringMonomorphism ⟦_⟧
+    isSemiringMonomorphism = record
+      { isSemiringHomomorphism = isSemiringHomomorphism
+      ; injective = injective
+      }
+
     +-isGroupMonomorphism : +.IsGroupMonomorphism ⟦_⟧
     +-isGroupMonomorphism = record
       { isGroupHomomorphism = +-isGroupHomomorphism
       ; injective           = injective
       }
+
+    open +.IsGroupMonomorphism +-isGroupMonomorphism
+      using (isRelMonomorphism)
+      renaming ( isMagmaMonomorphism to +-isMagmaMonomorphism
+               ; isMonoidMonomorphism to +-isMonoidMonomorphism
+               )
 
     *-isMonoidMonomorphism : *.IsMonoidMonomorphism ⟦_⟧
     *-isMonoidMonomorphism = record
@@ -403,7 +425,8 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
       }
 
     open *.IsMonoidMonomorphism *-isMonoidMonomorphism public
-      using (isRelMonomorphism)
+      using ()
+      renaming (isMagmaMonomorphism to *-isMagmaMonomorphism)
 
 
   record IsRingIsomorphism (⟦_⟧ : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
@@ -413,11 +436,24 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
 
     open IsRingMonomorphism isRingMonomorphism public
 
+    isSemiringIsomorphism : IsSemiringIsomorphism ⟦_⟧
+    isSemiringIsomorphism = record
+      { isSemiringMonomorphism = isSemiringMonomorphism
+      ; surjective = surjective
+      }
+
     +-isGroupIsomorphism : +.IsGroupIsomorphism ⟦_⟧
     +-isGroupIsomorphism = record
       { isGroupMonomorphism = +-isGroupMonomorphism
       ; surjective          = surjective
       }
+
+    open +.IsGroupIsomorphism +-isGroupIsomorphism
+      using (isRelIsomorphism)
+      renaming ( isMagmaIsomorphism to +-isMagmaIsomorphism
+               ; isMonoidIsomorphism to +-isMonoidIsomorphisn
+               )
+      
 
     *-isMonoidIsomorphism : *.IsMonoidIsomorphism ⟦_⟧
     *-isMonoidIsomorphism = record
@@ -426,8 +462,8 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
       }
 
     open *.IsMonoidIsomorphism *-isMonoidIsomorphism public
-      using (isRelIsomorphism)
-
+      using ()
+      renaming (isMagmaIsomorphism to *-isMagmaIsomorphisn)
 
 ------------------------------------------------------------------------
 -- Morphisms over lattice-like structures
@@ -437,11 +473,13 @@ module LatticeMorphisms (L₁ : RawLattice a ℓ₁) (L₂ : RawLattice b ℓ₂
 
   open RawLattice L₁ renaming
     ( Carrier to A; _≈_ to _≈₁_
+    ; _∧_ to _∧₁_; _∨_ to _∨₁_
     ; ∧-rawMagma to ∧-rawMagma₁
     ; ∨-rawMagma to ∨-rawMagma₁)
 
   open RawLattice L₂ renaming
     ( Carrier to B; _≈_ to _≈₂_
+    ; _∧_ to _∧₂_; _∨_ to _∨₂_
     ; ∧-rawMagma to ∧-rawMagma₂
     ; ∨-rawMagma to ∨-rawMagma₂)
 
@@ -454,15 +492,24 @@ module LatticeMorphisms (L₁ : RawLattice a ℓ₁) (L₂ : RawLattice b ℓ₂
 
   record IsLatticeHomomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      ∨-isMagmaHomomorphism : ∨.IsMagmaHomomorphism ⟦_⟧
-      ∧-isMagmaHomomorphism : ∧.IsMagmaHomomorphism ⟦_⟧
+      isRelHomomorphism : IsRelHomomorphism _≈₁_ _≈₂_ ⟦_⟧
+      ∧-homo            : Homomorphic₂ ⟦_⟧ _∧₁_ _∧₂_
+      ∨-homo            : Homomorphic₂ ⟦_⟧ _∨₁_ _∨₂_
 
-    open ∨.IsMagmaHomomorphism ∨-isMagmaHomomorphism public
-      renaming (homo to ∨-homo)
+    open IsRelHomomorphism isRelHomomorphism public
+      renaming (cong to ⟦⟧-cong)
 
-    open ∧.IsMagmaHomomorphism ∧-isMagmaHomomorphism public
-      renaming (homo to ∧-homo) hiding (⟦⟧-cong)
+    ∧-isMagmaHomomorphism : ∧.IsMagmaHomomorphism ⟦_⟧
+    ∧-isMagmaHomomorphism = record
+      { isRelHomomorphism = isRelHomomorphism
+      ; homo = ∧-homo
+      }
 
+    ∨-isMagmaHomomorphism : ∨.IsMagmaHomomorphism ⟦_⟧
+    ∨-isMagmaHomomorphism = record
+      { isRelHomomorphism = isRelHomomorphism
+      ; homo = ∨-homo
+      }
 
   record IsLatticeMonomorphism (⟦_⟧ : A → B) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
     field

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -785,6 +785,23 @@ private
   ; _⁻¹ = -_
   }
 
++-*-rawNearSemiring : RawNearSemiring 0ℓ 0ℓ
++-*-rawNearSemiring = record
+  { _≈_ = _≡_
+  ; _+_ = _+_
+  ; _*_ = _*_
+  ; 0#  = 0ℚ
+  }
+
++-*-rawSemiring : RawSemiring 0ℓ 0ℓ
++-*-rawSemiring = record
+  { _≈_ = _≡_
+  ; _+_ = _+_
+  ; _*_ = _*_
+  ; 0#  = 0ℚ
+  ; 1#  = 1ℚ
+  }
+
 +-*-rawRing : RawRing 0ℓ 0ℓ
 +-*-rawRing = record
   { _≈_ = _≡_
@@ -1068,10 +1085,36 @@ toℚᵘ-isMonoidMonomorphism-* = record
   ; injective            = toℚᵘ-injective
   }
 
+toℚᵘ-isNearSemiringHomomorphism-+-* : IsNearSemiringHomomorphism +-*-rawNearSemiring ℚᵘ.+-*-rawNearSemiring toℚᵘ
+toℚᵘ-isNearSemiringHomomorphism-+-* = record
+  { +-isMonoidHomomorphism = toℚᵘ-isMonoidHomomorphism-+
+  ; *-homo                 = toℚᵘ-homo-*
+  }
+
+toℚᵘ-isNearSemiringMonomorphism-+-* : IsNearSemiringMonomorphism +-*-rawNearSemiring ℚᵘ.+-*-rawNearSemiring toℚᵘ
+toℚᵘ-isNearSemiringMonomorphism-+-* = record
+  { isNearSemiringHomomorphism = toℚᵘ-isNearSemiringHomomorphism-+-*
+  ; injective                  = toℚᵘ-injective
+  }
+
+toℚᵘ-isSemiringHomomorphism-+-* : IsSemiringHomomorphism +-*-rawSemiring ℚᵘ.+-*-rawSemiring toℚᵘ
+toℚᵘ-isSemiringHomomorphism-+-* = record
+  { isNearSemiringHomomorphism = toℚᵘ-isNearSemiringHomomorphism-+-*
+  ; 1#-homo                    = ℚᵘ.≃-refl
+  }
+
+toℚᵘ-isSemiringMonomorphism-+-* : IsSemiringMonomorphism +-*-rawSemiring ℚᵘ.+-*-rawSemiring toℚᵘ
+toℚᵘ-isSemiringMonomorphism-+-* = record
+  { isSemiringHomomorphism = toℚᵘ-isSemiringHomomorphism-+-*
+  ; injective              = toℚᵘ-injective
+  }
+
 toℚᵘ-isRingHomomorphism-+-* : IsRingHomomorphism +-*-rawRing ℚᵘ.+-*-rawRing toℚᵘ
 toℚᵘ-isRingHomomorphism-+-* = record
-  { +-isGroupHomomorphism  = toℚᵘ-isGroupHomomorphism-+
-  ; *-isMonoidHomomorphism = toℚᵘ-isMonoidHomomorphism-*
+  -- { +-isGroupHomomorphism  = toℚᵘ-isGroupHomomorphism-+
+  --; *-isMonoidHomomorphism = toℚᵘ-isMonoidHomomorphism-*
+  { isSemiringHomomorphism = toℚᵘ-isSemiringHomomorphism-+-*
+  ; -‿homo                 = toℚᵘ-homo‿-
   }
 
 toℚᵘ-isRingMonomorphism-+-* : IsRingMonomorphism +-*-rawRing ℚᵘ.+-*-rawRing toℚᵘ

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -1111,8 +1111,6 @@ toℚᵘ-isSemiringMonomorphism-+-* = record
 
 toℚᵘ-isRingHomomorphism-+-* : IsRingHomomorphism +-*-rawRing ℚᵘ.+-*-rawRing toℚᵘ
 toℚᵘ-isRingHomomorphism-+-* = record
-  -- { +-isGroupHomomorphism  = toℚᵘ-isGroupHomomorphism-+
-  --; *-isMonoidHomomorphism = toℚᵘ-isMonoidHomomorphism-*
   { isSemiringHomomorphism = toℚᵘ-isSemiringHomomorphism-+-*
   ; -‿homo                 = toℚᵘ-homo‿-
   }

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -579,6 +579,25 @@ nonNeg∧nonPos⇒0 {mkℚᵘ +0 _} _ _ = *≡* refl
   ; _⁻¹ = -_
   }
 
++-*-rawNearSemiring : RawNearSemiring 0ℓ 0ℓ
++-*-rawNearSemiring = record
+  { Carrier = ℚᵘ
+  ; _≈_ = _≃_
+  ; _+_ = _+_
+  ; _*_ = _*_
+  ; 0# = 0ℚᵘ
+  }
+
++-*-rawSemiring : RawSemiring 0ℓ 0ℓ
++-*-rawSemiring = record
+  { Carrier = ℚᵘ
+  ; _≈_ = _≃_
+  ; _+_ = _+_
+  ; _*_ = _*_
+  ; 0# = 0ℚᵘ
+  ; 1# = 1ℚᵘ
+  }
+
 +-*-rawRing : RawRing 0ℓ 0ℓ
 +-*-rawRing = record
   { Carrier = ℚᵘ


### PR DESCRIPTION
This redefines NearSemiring, Semiring, and Ring homomorphisms so that
they each build up by adding a single new property to a smaller
structure. This ensures there's only one proof that they're a Rel
homomorphism. For the same reason, Lattice homomorphisms are defined
directly rather than showing it's two magma homomorphisms.

I've tried to make it so that each of these structures provides any
smaller structure at its top level, so if we have a RingMonomorphism we
can easily say that it's a MagmaHomomorphism by multiplication or
whatever, but I might have missed one or two.

Closes #1539 