### PR TITLE
add `diagonal` and some properties about `Vec`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,23 @@ Other minor additions
   ≤-decTotalOrder-≈   :  DecTotalOrder _ _ _
   ```
 
+* In `Data.Vec.Base`:
+  ```agda
+  diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
+  _>>=′_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
+  ```
+  In `Data.Vec.Categorical`:
+  ```agda
+  monad : RawMonad (λ (A : Set a) → Vec A n)
+  ```
+  In `Data.Vec.Properties`:
+  ```agda
+  map-const : ∀ {n} (xs : Vec A n) (x : B) → map {n = n} (const x) xs ≡ replicate x
+  map-⊛ : ∀ {n} (f : A → B → C) (g : A → B) (xs : Vec A n) → (map f xs ⊛ map g xs) ≡ map (f ˢ g) xs
+  ⊛-is->>=′ : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs >>=′ flip map xs)
+  transpose-replicate : ∀ {m n} (xs : Vec A m) → transpose (replicate {n = n} xs) ≡ map replicate xs
+  ```
+
 * In `IO`:
   ```
   Colist.forM  : Colist A → (A → IO B) → IO (Colist B)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ Non-backwards compatible changes
 
   Also, `⁻¹-homo` in `IsRingHomomorphism` has been renamed to `-‿homo`.
 
-* move definition of `_>>=_` under `Data.Vec.Base` to its submodule `Product`
-  in order to keep another definition of `_>>=_`, located in `Diagonal`
+* move definition of `_>>=_` under `Data.Vec.Base` to its submodule `CartesianBind`
+  in order to keep another new definition of `_>>=_`, located in `DiagonalBind`
   which is also a submodule of `Data.Vec.Base`.
 
 * In `Text.Pretty`, `Doc` is now a record rather than a type alias. This
@@ -171,7 +171,7 @@ Other minor additions
 * Added new definitions in `Data.Vec.Base`:
   ```agda
   diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
-  Diagonal._>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
+  DiagonalBind._>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
   ```
   
 * Added new instance in `Data.Vec.Categorical`:
@@ -183,7 +183,7 @@ Other minor additions
   ```agda
   map-const : ∀ {n} (xs : Vec A n) (x : B) → map {n = n} (const x) xs ≡ replicate x
   map-⊛ : ∀ {n} (f : A → B → C) (g : A → B) (xs : Vec A n) → (map f xs ⊛ map g xs) ≡ map (f ˢ g) xs
-  ⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs Diagonal.>>= flip map xs)
+  ⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs DiagonalBind.>>= flip map xs)
   transpose-replicate : ∀ {m n} (xs : Vec A m) → transpose (replicate {n = n} xs) ≡ map replicate xs
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Non-backwards compatible changes
 
   Also, `⁻¹-homo` in `IsRingHomomorphism` has been renamed to `-‿homo`.
 
+* move definition of `_>>=_` under `Data.Vec.Base` to its submodule `Product`
+  in order to keep another definition of `_>>=_`, located in `Diagonal`
+  which is also a submodule of `Data.Vec.Base`.
 
 * In `Text.Pretty`, `Doc` is now a record rather than a type alias. This
   helps Agda reconstruct the `width` parameter when the module is opened
@@ -168,7 +171,7 @@ Other minor additions
 * Added new definitions in `Data.Vec.Base`:
   ```agda
   diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
-  _>>=′_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
+  Diagonal._>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
   ```
   
 * Added new instance in `Data.Vec.Categorical`:
@@ -180,7 +183,7 @@ Other minor additions
   ```agda
   map-const : ∀ {n} (xs : Vec A n) (x : B) → map {n = n} (const x) xs ≡ replicate x
   map-⊛ : ∀ {n} (f : A → B → C) (g : A → B) (xs : Vec A n) → (map f xs ⊛ map g xs) ≡ map (f ˢ g) xs
-  ⊛-is->>=′ : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs >>=′ flip map xs)
+  ⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs Diagonal.>>= flip map xs)
   transpose-replicate : ∀ {m n} (xs : Vec A m) → transpose (replicate {n = n} xs) ≡ map replicate xs
   ```
 

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -167,6 +167,17 @@ fs ⊛* xs = fs >>= λ f → map f xs
 allPairs : ∀ {m n} → Vec A m → Vec B n → Vec (A × B) (m * n)
 allPairs xs ys = map _,_ xs ⊛* ys
 
+-- Diagonal
+
+diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
+diagonal [] = []
+diagonal (xs ∷ xss) = head xs ∷ diagonal (map tail xss)
+
+infixl 1 _>>=′_
+
+_>>=′_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
+xs >>=′ f = diagonal (map f xs)
+
 ------------------------------------------------------------------------
 -- Operations for reducing vectors
 

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -154,15 +154,16 @@ _⊛_ : ∀ {n} → Vec (A → B) n → Vec A n → Vec B n
 
 -- Multiplication
 
-infixl 1 _>>=_
+module Product where
+  infixl 1 _>>=_
 
-_>>=_ : ∀ {m n} → Vec A m → (A → Vec B n) → Vec B (m * n)
-xs >>= f = concat (map f xs)
+  _>>=_ : ∀ {m n} → Vec A m → (A → Vec B n) → Vec B (m * n)
+  xs >>= f = concat (map f xs)
 
 infixl 4 _⊛*_
 
 _⊛*_ : ∀ {m n} → Vec (A → B) m → Vec A n → Vec B (m * n)
-fs ⊛* xs = fs >>= λ f → map f xs
+fs ⊛* xs = fs Product.>>= λ f → map f xs
 
 allPairs : ∀ {m n} → Vec A m → Vec B n → Vec (A × B) (m * n)
 allPairs xs ys = map _,_ xs ⊛* ys
@@ -173,10 +174,11 @@ diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
 diagonal [] = []
 diagonal (xs ∷ xss) = head xs ∷ diagonal (map tail xss)
 
-infixl 1 _>>=′_
+module Diagonal where
+  infixl 1 _>>=_
 
-_>>=′_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
-xs >>=′ f = diagonal (map f xs)
+  _>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
+  xs >>= f = diagonal (map f xs)
 
 ------------------------------------------------------------------------
 -- Operations for reducing vectors

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -154,7 +154,7 @@ _⊛_ : ∀ {n} → Vec (A → B) n → Vec A n → Vec B n
 
 -- Multiplication
 
-module Product where
+module CartesianBind where
   infixl 1 _>>=_
 
   _>>=_ : ∀ {m n} → Vec A m → (A → Vec B n) → Vec B (m * n)
@@ -163,7 +163,7 @@ module Product where
 infixl 4 _⊛*_
 
 _⊛*_ : ∀ {m n} → Vec (A → B) m → Vec A n → Vec B (m * n)
-fs ⊛* xs = fs Product.>>= λ f → map f xs
+fs ⊛* xs = fs CartesianBind.>>= λ f → map f xs
 
 allPairs : ∀ {m n} → Vec A m → Vec B n → Vec (A × B) (m * n)
 allPairs xs ys = map _,_ xs ⊛* ys
@@ -174,7 +174,7 @@ diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
 diagonal [] = []
 diagonal (xs ∷ xss) = head xs ∷ diagonal (map tail xss)
 
-module Diagonal where
+module DiagonalBind where
   infixl 1 _>>=_
 
   _>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n

--- a/src/Data/Vec/Categorical.agda
+++ b/src/Data/Vec/Categorical.agda
@@ -35,7 +35,7 @@ applicative = record
 monad : RawMonad (λ (A : Set a) → Vec A n)
 monad = record
   { return = replicate
-  ; _>>=_ = _>>=′_
+  ; _>>=_ = Diagonal._>>=_
   }
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Categorical.agda
+++ b/src/Data/Vec/Categorical.agda
@@ -32,6 +32,12 @@ applicative = record
   ; _⊛_  = Vec._⊛_
   }
 
+monad : RawMonad (λ (A : Set a) → Vec A n)
+monad = record
+  { return = replicate
+  ; _>>=_ = _>>=′_
+  }
+
 ------------------------------------------------------------------------
 -- Get access to other monadic functions
 

--- a/src/Data/Vec/Categorical.agda
+++ b/src/Data/Vec/Categorical.agda
@@ -35,7 +35,7 @@ applicative = record
 monad : RawMonad (λ (A : Set a) → Vec A n)
 monad = record
   { return = replicate
-  ; _>>=_ = Diagonal._>>=_
+  ; _>>=_ = DiagonalBind._>>=_
   }
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -645,7 +645,7 @@ zipWith-is-⊛ f []       []       = refl
 zipWith-is-⊛ f (x ∷ xs) (y ∷ ys) = P.cong (_ ∷_) (zipWith-is-⊛ f xs ys)
 
 ⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) →
-           (fs ⊛ xs) ≡ (fs Diagonal.>>= flip map xs)
+           (fs ⊛ xs) ≡ (fs DiagonalBind.>>= flip map xs)
 ⊛-is->>= [] [] = refl
 ⊛-is->>= (f ∷ fs) (x ∷ xs) = P.cong (f x ∷_) $ begin
   fs ⊛ xs                                          ≡⟨ ⊛-is->>= fs xs ⟩

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -644,11 +644,11 @@ zipWith-is-⊛ : ∀ {n} (f : A → B → C) (xs : Vec A n) (ys : Vec B n) →
 zipWith-is-⊛ f []       []       = refl
 zipWith-is-⊛ f (x ∷ xs) (y ∷ ys) = P.cong (_ ∷_) (zipWith-is-⊛ f xs ys)
 
-⊛-is->>=′ : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) →
-            (fs ⊛ xs) ≡ (fs >>=′ flip map xs)
-⊛-is->>=′ [] [] = refl
-⊛-is->>=′ (f ∷ fs) (x ∷ xs) = P.cong (f x ∷_) $ begin
-  fs ⊛ xs                                          ≡⟨ ⊛-is->>=′ fs xs ⟩
+⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) →
+           (fs ⊛ xs) ≡ (fs Diagonal.>>= flip map xs)
+⊛-is->>= [] [] = refl
+⊛-is->>= (f ∷ fs) (x ∷ xs) = P.cong (f x ∷_) $ begin
+  fs ⊛ xs                                          ≡⟨ ⊛-is->>= fs xs ⟩
   diagonal (map (flip map xs) fs)                  ≡⟨⟩
   diagonal (map (tail ∘ flip map (x ∷ xs)) fs)     ≡⟨ P.cong diagonal (map-∘ _ _ _) ⟩
   diagonal (map tail (map (flip map (x ∷ xs)) fs)) ∎

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -364,6 +364,10 @@ map-id : ∀ {n} → map {A = A} {n = n} id ≗ id
 map-id []       = refl
 map-id (x ∷ xs) = P.cong (x ∷_) (map-id xs)
 
+map-const : ∀ {n} (xs : Vec A n) (y : B) → map {n = n} (const y) xs ≡ replicate y
+map-const [] _ = refl
+map-const (_ ∷ xs) y = P.cong (y ∷_) (map-const xs y)
+
 map-cong : ∀ {n} {f g : A → B} → f ≗ g → map {n = n} f ≗ map g
 map-cong f≗g []       = refl
 map-cong f≗g (x ∷ xs) = P.cong₂ _∷_ (f≗g x) (map-cong f≗g xs)
@@ -388,6 +392,11 @@ map-updateAt (x ∷ xs) (suc i) eq = P.cong (_ ∷_) (map-updateAt xs i eq)
 map-[]≔ : ∀ {n} (f : A → B) (xs : Vec A n) (i : Fin n) {x : A} →
           map f (xs [ i ]≔ x) ≡ map f xs [ i ]≔ f x
 map-[]≔ f xs i = map-updateAt xs i refl
+
+map-⊛ : ∀ {n} (f : A → B → C) (g : A → B) (xs : Vec A n) →
+        (map f xs ⊛ map g xs) ≡ map (f ˢ g) xs
+map-⊛ f g [] = refl
+map-⊛ f g (x ∷ xs) = P.cong (f x (g x) ∷_) (map-⊛ f g xs)
 
 ------------------------------------------------------------------------
 -- _++_
@@ -635,6 +644,16 @@ zipWith-is-⊛ : ∀ {n} (f : A → B → C) (xs : Vec A n) (ys : Vec B n) →
 zipWith-is-⊛ f []       []       = refl
 zipWith-is-⊛ f (x ∷ xs) (y ∷ ys) = P.cong (_ ∷_) (zipWith-is-⊛ f xs ys)
 
+⊛-is->>=′ : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) →
+            (fs ⊛ xs) ≡ (fs >>=′ flip map xs)
+⊛-is->>=′ [] [] = refl
+⊛-is->>=′ (f ∷ fs) (x ∷ xs) = P.cong (f x ∷_) $ begin
+  fs ⊛ xs                                          ≡⟨ ⊛-is->>=′ fs xs ⟩
+  diagonal (map (flip map xs) fs)                  ≡⟨⟩
+  diagonal (map (tail ∘ flip map (x ∷ xs)) fs)     ≡⟨ P.cong diagonal (map-∘ _ _ _) ⟩
+  diagonal (map tail (map (flip map (x ∷ xs)) fs)) ∎
+  where open P.≡-Reasoning
+
 ------------------------------------------------------------------------
 -- foldr
 
@@ -694,6 +713,15 @@ map-replicate :  ∀ (f : A → B) (x : A) n →
                  map f (replicate x) ≡ replicate {n = n} (f x)
 map-replicate f x zero = refl
 map-replicate f x (suc n) = P.cong (f x ∷_) (map-replicate f x n)
+
+transpose-replicate : ∀ {m n} (xs : Vec A m) → transpose (replicate {n = n} xs) ≡ map replicate xs
+transpose-replicate {n = zero} _ = P.sym (map-const _ [])
+transpose-replicate {n = suc n} xs = begin
+  transpose (replicate xs)                        ≡⟨⟩
+  (replicate _∷_ ⊛ xs ⊛ transpose (replicate xs)) ≡⟨ P.cong₂ _⊛_ (P.sym (map-is-⊛ _∷_ xs)) (transpose-replicate xs) ⟩
+  (map _∷_ xs ⊛ map replicate xs)                 ≡⟨ map-⊛ _∷_ replicate xs ⟩
+  map replicate xs                                ∎
+  where open P.≡-Reasoning
 
 zipWith-replicate : ∀ {n : ℕ} (_⊕_ : A → B → C) (x : A) (y : B) →
                     zipWith {n = n} _⊕_ (replicate x) (replicate y) ≡ replicate (x ⊕ y)

--- a/src/Data/Vec/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Any/Properties.agda
@@ -415,7 +415,7 @@ module _ {P : Pred B p} where
 
 module _ {A B : Set a} {P : Pred B p} {m} {f : A → Vec B m} where
 
-  open Product
+  open CartesianBind
 
   >>=↔ : ∀ {n} {xs : Vec A n} → Any (Any P ∘ f) xs ↔ Any P (xs >>= f)
   >>=↔ = concat↔ ∘↔ map↔

--- a/src/Data/Vec/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Any/Properties.agda
@@ -415,5 +415,7 @@ module _ {P : Pred B p} where
 
 module _ {A B : Set a} {P : Pred B p} {m} {f : A → Vec B m} where
 
+  open Product
+
   >>=↔ : ∀ {n} {xs : Vec A n} → Any (Any P ∘ f) xs ↔ Any P (xs >>= f)
   >>=↔ = concat↔ ∘↔ map↔


### PR DESCRIPTION
I added some function and properties about `Vec`.
The `diagonal` function is a join for monad instance of `Vec` (that is compatible for zip applicative instance of `Vec`), so I added it to `Data.Vec.Categorical`
Though it seems correct monad instance, I couldn't proof that `diagonal` satisfies associative law for monad in agda yet.