### PR TITLE
(Semi)Ring instances for DirectProduct 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,17 @@ Other minor additions
   ```
   and their corresponding algebraic subbundles.
 
+* Added new functions to `Algebra.Constructs.DirectProduct`:
+  ```agda
+  rawSemiring : RawSemiring a ℓ₁ → RawSemiring b ℓ₂ → RawSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  semiringWithoutAnnihilatingZero : SemiringWithoutAnnihilatingZero a ℓ₁ →
+                                    SemiringWithoutAnnihilatingZero b ℓ₂ →
+                                    SemiringWithoutAnnihilatingZero (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+ semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+ commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
+                       CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+ ```
+	
 * Added new definitions to `Algebra.Structures`:
   ```agda
   record IsUnitalMagma (_∙_ : Op₂ A) (ε : A) : Set (a ⊔ ℓ)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,15 +136,15 @@ Other minor additions
   ```
   and their corresponding algebraic subbundles.
 
-* Added new functions to `Algebra.Constructs.DirectProduct`:
+* Added new functions to `Algebra.Construct.DirectProduct`:
   ```agda
   rawSemiring : RawSemiring a ℓ₁ → RawSemiring b ℓ₂ → RawSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   semiringWithoutAnnihilatingZero : SemiringWithoutAnnihilatingZero a ℓ₁ →
                                     SemiringWithoutAnnihilatingZero b ℓ₂ →
                                     SemiringWithoutAnnihilatingZero (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
- semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
- commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
-                       CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+   semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+   commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
+                         CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
  ```
 	
 * Added new definitions to `Algebra.Structures`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,12 +139,16 @@ Other minor additions
 * Added new functions to `Algebra.Construct.DirectProduct`:
   ```agda
   rawSemiring : RawSemiring a ℓ₁ → RawSemiring b ℓ₂ → RawSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  rawRing : RawRing a ℓ₁ → RawRing b ℓ₂ → RawRing (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   semiringWithoutAnnihilatingZero : SemiringWithoutAnnihilatingZero a ℓ₁ →
                                     SemiringWithoutAnnihilatingZero b ℓ₂ →
                                     SemiringWithoutAnnihilatingZero (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-   semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-   commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
-                         CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
+                        CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  ring : Ring a ℓ₁ → Ring b ℓ₂ → Ring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  commutativeRing : CommutativeRing a ℓ₁ → CommutativeRing b ℓ₂ →
+                    CommutativeRing (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
  ```
 	
 * Added new definitions to `Algebra.Structures`:

--- a/src/Algebra/Construct/DirectProduct.agda
+++ b/src/Algebra/Construct/DirectProduct.agda
@@ -61,6 +61,17 @@ rawSemiring R S = record
   ; 1#      = R.1# , S.1#
   } where module R = RawSemiring R; module S = RawSemiring S
 
+rawRing : RawRing a ℓ₁ → RawRing b ℓ₂ → RawRing (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+rawRing R S = record
+  { Carrier = R.Carrier × S.Carrier
+  ; _≈_     = Pointwise R._≈_ S._≈_
+  ; _+_     = zip R._+_ S._+_
+  ; _*_     = zip R._*_ S._*_
+  ; -_      = map R.-_ S.-_
+  ; 0#      = R.0# , S.0#
+  ; 1#      = R.1# , S.1#
+  } where module R = RawRing R; module S = RawRing S
+
 ------------------------------------------------------------------------
 -- Bundles
 
@@ -201,3 +212,27 @@ commutativeSemiring R S = record
       }
   } where module R = CommutativeSemiring R;  module S = CommutativeSemiring S
 
+ring : Ring a ℓ₁ → Ring b ℓ₂ → Ring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+ring R S = record
+  { -_     = uncurry (λ x y → R.-_ x , S.-_ y)
+  ; isRing = record
+      { +-isAbelianGroup = AbelianGroup.isAbelianGroup A
+      ; *-isMonoid       = Semiring.*-isMonoid Semi
+      ; distrib          = Semiring.distrib Semi
+      ; zero             = Semiring.zero Semi
+      }
+  }
+  where
+  module R = Ring R
+  module S = Ring S
+  Semi = semiring R.semiring S.semiring
+  A    = abelianGroup R.+-abelianGroup S.+-abelianGroup
+
+commutativeRing : CommutativeRing a ℓ₁ → CommutativeRing b ℓ₂ →
+                  CommutativeRing (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+commutativeRing R S = record
+  { isCommutativeRing = record
+      { isRing = Ring.isRing (ring R.ring S.ring)
+      ; *-comm = λ x y → (R.*-comm , S.*-comm) <*> x <*> y
+      }
+  } where module R = CommutativeRing R; module S = CommutativeRing S

--- a/src/Algebra/Construct/DirectProduct.agda
+++ b/src/Algebra/Construct/DirectProduct.agda
@@ -171,28 +171,19 @@ semiringWithoutAnnihilatingZero R S = record
                                   (commutativeMonoid R.+-commutativeMonoid
                                                      S.+-commutativeMonoid)
       ; *-isMonoid = Monoid.isMonoid (monoid R.*-monoid S.*-monoid)
-      ; distrib    = distribˡ , distribʳ
+      ; distrib    = (λ x y z → (R.distribˡ , S.distribˡ) <*> x <*> y <*> z)
+                   , (λ x y z → (R.distribʳ , S.distribʳ) <*> x <*> y <*> z)
       }
-  }
-  where
-  module R = SemiringWithoutAnnihilatingZero R
-  module S = SemiringWithoutAnnihilatingZero S
-  _≈_ = Pointwise R._≈_ S._≈_
-  _+_ = zip R._+_ S._+_
-  _*_ = zip R._*_ S._*_
-
-  distribˡ : _DistributesOverˡ_ _≈_ _*_ _+_
-  distribˡ (x , y) (z₁ , z₂) (u₁ , u₂) = R.distribˡ x z₁ u₁ , S.distribˡ y z₂ u₂
-
-  distribʳ : _DistributesOverʳ_ _≈_ _*_ _+_
-  distribʳ (x , y) (z₁ , z₂) (u₁ , u₂) = R.distribʳ x z₁ u₁ , S.distribʳ y z₂ u₂
+  } where module R = SemiringWithoutAnnihilatingZero R
+          module S = SemiringWithoutAnnihilatingZero S
 
 semiring : Semiring a ℓ₁ → Semiring b ℓ₂ → Semiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
 semiring R S = record
   { isSemiring = record
       { isSemiringWithoutAnnihilatingZero =
           SemiringWithoutAnnihilatingZero.isSemiringWithoutAnnihilatingZero U
-      ; zero = zeroˡ , zeroʳ
+      ; zero = uncurry (λ x y → R.zeroˡ x , S.zeroˡ y)
+             , uncurry (λ x y → R.zeroʳ x , S.zeroʳ y)
       }
   }
   where
@@ -200,34 +191,13 @@ semiring R S = record
   module S = Semiring S
   U = semiringWithoutAnnihilatingZero R.semiringWithoutAnnihilatingZero
                                       S.semiringWithoutAnnihilatingZero
-  _≈_ = Pointwise R._≈_ S._≈_
-  zr  = R.0# , S.0#
-  _*_ = zip R._*_ S._*_
-
-  zeroˡ : LeftZero _≈_ zr _*_
-  zeroˡ (x , y) = R.zeroˡ x , S.zeroˡ y
-
-  zeroʳ : RightZero _≈_ zr _*_
-  zeroʳ (x , y) = R.zeroʳ x , S.zeroʳ y
 
 commutativeSemiring : CommutativeSemiring a ℓ₁ → CommutativeSemiring b ℓ₂ →
                       CommutativeSemiring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
 commutativeSemiring R S = record
   { isCommutativeSemiring = record
-      { isSemiring = record
-          { isSemiringWithoutAnnihilatingZero =
-              Semiring.isSemiringWithoutAnnihilatingZero U
-          ; zero = Semiring.zero U
-          }
-      ; *-comm = *-comm
+      { isSemiring = Semiring.isSemiring (semiring R.semiring S.semiring)
+      ; *-comm     = λ x y → (R.*-comm , S.*-comm) <*> x <*> y
       }
-  }
-  where
-  module R = CommutativeSemiring R
-  module S = CommutativeSemiring S
-  U   = semiring R.semiring S.semiring
-  _≈_ = Pointwise R._≈_ S._≈_
-  _*_ = zip R._*_ S._*_
+  } where module R = CommutativeSemiring R;  module S = CommutativeSemiring S
 
-  *-comm : Commutative _≈_ _*_
-  *-comm (x , y) (z , u) = R.*-comm x z , S.*-comm y u

--- a/src/Algebra/Morphism/Structures.agda
+++ b/src/Algebra/Morphism/Structures.agda
@@ -454,7 +454,6 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
                ; isMonoidIsomorphism to +-isMonoidIsomorphisn
                )
 
-
     *-isMonoidIsomorphism : *.IsMonoidIsomorphism ⟦_⟧
     *-isMonoidIsomorphism = record
       { isMonoidMonomorphism = *-isMonoidMonomorphism

--- a/src/Algebra/Morphism/Structures.agda
+++ b/src/Algebra/Morphism/Structures.agda
@@ -453,7 +453,7 @@ module RingMorphisms (R₁ : RawRing a ℓ₁) (R₂ : RawRing b ℓ₂) where
       renaming ( isMagmaIsomorphism to +-isMagmaIsomorphism
                ; isMonoidIsomorphism to +-isMonoidIsomorphisn
                )
-      
+
 
     *-isMonoidIsomorphism : *.IsMonoidIsomorphism ⟦_⟧
     *-isMonoidIsomorphism = record

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -264,7 +264,7 @@ n≤0⇒n≡0 z≤n = refl
 -- Relationships between the various relations
 
 <⇒≤ : _<_ ⇒ _≤_
-<⇒≤ (s≤s m≤n) = ≤-trans m≤n (≤-step ≤-refl)
+<⇒≤ (s≤s m≤n) = ≤-step m≤n
 
 <⇒≢ : _<_ ⇒ _≢_
 <⇒≢ m<n refl = 1+n≰n m<n


### PR DESCRIPTION
This is the project of adding to `src/Algebra/Construct/DirectProduct.agda` 
the following instances for the direct product of two (semi)rings:
``(Semi)Ring, Commutative(Semi)Ring``.
Currently it has  ``rawSemiring, semiringWithoutAnnihilatingZero, semiring, commutativeSemiring``.   
If and after it is accepted, the `(Commutative)Ring` instance could be added there.

changed:      CHANGELOG.md
changed:      src/Algebra/Construct/DirectProduct.agda
changed:      src/Algebra/Morphism/Structures.agda