### PR TITLE
[ new ] Data.Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,15 +69,15 @@ Non-backwards compatible changes
 
 ### Strict functions
 
-* The module `Strict` has been deprecated in favour of `Function.Strict` 
+* The module `Strict` has been deprecated in favour of `Function.Strict`
   and the definitions of strict application, `_$!_` and `_$!′_`, have been
   moved from `Function.Base` to `Function.Strict`.
-  
+
 * The contents of `Function.Strict` is now re-exported by `Function`.
 
 ### Other
 
-* The constructors `+0` and `+[1+_]` from `Data.Integer.Base` are no longer 
+* The constructors `+0` and `+[1+_]` from `Data.Integer.Base` are no longer
   exported by `Data.Rational.Base`. You will have to open `Data.Integer(.Base)`
   directly to use them.
 
@@ -122,6 +122,11 @@ New modules
 * A golden testing library with test pools, an options parser, a runner:
   ```
   Test.Golden
+  ```
+
+* A small library for function arguments with default values:
+  ```
+  Data.Default
   ```
 
 Other minor additions
@@ -183,12 +188,12 @@ Other minor additions
   diagonal : ∀ {n} → Vec (Vec A n) n → Vec A n
   DiagonalBind._>>=_ : ∀ {n} → Vec A n → (A → Vec B n) → Vec B n
   ```
-  
+
 * Added new instance in `Data.Vec.Categorical`:
   ```agda
   monad : RawMonad (λ (A : Set a) → Vec A n)
   ```
-  
+
 * Added new proofs in `Data.Vec.Properties`:
   ```agda
   map-const : ∀ {n} (xs : Vec A n) (x : B) → map {n = n} (const x) xs ≡ replicate x

--- a/README/Data.agda
+++ b/README/Data.agda
@@ -219,3 +219,8 @@ import README.Data.Container.Indexed
 -- remembers the things being related.
 
 import README.Data.Wrap
+
+-- Specifying the default value a function's argument should take if it
+-- is not passed explicitly.
+
+import README.Data.Default

--- a/README/Data/Default.agda
+++ b/README/Data/Default.agda
@@ -1,0 +1,34 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- An example showing how to define a function taking an optional
+-- argument that default to a specified value if none is passed.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module README.Data.Default where
+
+open import Data.Default
+open import Data.Nat.Base
+open import Relation.Binary.PropositionalEquality
+
+-- An argument of type `WithDefault {a} {A} x` is an argument of type
+-- `A` that happens to default to `x` if no other value is specified
+
+-- Note that you will only get this behaviour if the `default` instance
+-- is in scope so you should either import `Data.Default` in your client
+-- modules or publicly re-export the type and the instance!
+
+-- `inc` increments its argument by the value `step`, defaulting to 1
+inc : {{step : WithDefault 1}} → ℕ → ℕ
+inc {{step}} n = step .value + n
+
+-- and indeed incrementing 2 gives you 3
+_ : inc 2 ≡ 3
+_ = refl
+
+-- but you can also insist that you want to use a bigger increment by
+-- passing the `step` argument explicitly
+_ : inc {{10 !}} 2 ≡ 12
+_ = refl

--- a/src/Data/Default.agda
+++ b/src/Data/Default.agda
@@ -1,0 +1,48 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- A way to specify that a function's argument takes a default value
+-- if the argument is not passed explicitly.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Default where
+
+-- An argument of type `WithDefault {a} {A} x` is an argument of type
+-- `A` that happens to default to `x` if no other value is specified
+-- (as long as the `default` instance is in scope)
+
+infixl 0 _!
+record WithDefault {a} {A : Set a} (x : A) : Set a where
+  constructor _!
+  field value : A
+open WithDefault public
+
+instance
+  default : ∀ {a} {A : Set a} {x : A} → WithDefault x
+  default {x = x} .value = x
+
+
+
+------------------------------------------------------------------------
+-- Example
+------------------------------------------------------------------------
+
+private
+
+  open import Agda.Builtin.Nat
+  open import Agda.Builtin.Equality
+
+  -- `inc` increments its argument by the value `step`, defaulting to 1
+  inc : {{step : WithDefault 1}} → Nat → Nat
+  inc {{step}} n = step .value + n
+
+  -- and indeed incrementing 2 gives you 3
+  _ : inc 2 ≡ 3
+  _ = refl
+
+  -- but you can also insist that you want to use a bigger increment by
+  -- passing the `step` argument explicitly
+  _ : inc {{10 !}} 2 ≡ 12
+  _ = refl

--- a/src/Data/Default.agda
+++ b/src/Data/Default.agda
@@ -23,26 +23,4 @@ instance
   default : ∀ {a} {A : Set a} {x : A} → WithDefault x
   default {x = x} .value = x
 
-
-
-------------------------------------------------------------------------
--- Example
-------------------------------------------------------------------------
-
-private
-
-  open import Agda.Builtin.Nat
-  open import Agda.Builtin.Equality
-
-  -- `inc` increments its argument by the value `step`, defaulting to 1
-  inc : {{step : WithDefault 1}} → Nat → Nat
-  inc {{step}} n = step .value + n
-
-  -- and indeed incrementing 2 gives you 3
-  _ : inc 2 ≡ 3
-  _ = refl
-
-  -- but you can also insist that you want to use a bigger increment by
-  -- passing the `step` argument explicitly
-  _ : inc {{10 !}} 2 ≡ 12
-  _ = refl
+-- See README.Data.Default for an example


### PR DESCRIPTION
Essentially:

```agda
  -- `inc` increments its argument by the value `step`, defaulting to 1
  inc : {{step : WithDefault 1}} → Nat → Nat
  inc {{step}} n = step .value + n

  -- and indeed incrementing 2 gives you 3
  _ : inc 2 ≡ 3
  _ = refl

  -- but you can also insist that you want to use a bigger increment by
  -- passing the `step` argument explicitly
  _ : inc {{10 !}} 2 ≡ 12
  _ = refl
```