### PR TITLE
Generalised ordering relations in `Fin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@ Non-backwards compatible changes
   exported by `Data.Rational.Base`. You will have to open `Data.Integer(.Base)`
   directly to use them.
 
+* The relations `_≤_` `_≥_` `_<_` `_>_` in `Data.Fin.Base` have been
+  generalised so they can now relate `Fin` terms with different indices.
+  Should be mostly backwards compatible, but very occasionally when proving
+  properties about the orderings themselves the second index must be provided
+  explicitly.
+
 Deprecated modules
 ------------------
 

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -23,6 +23,7 @@ open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable.Core using (True; toWitness)
 open import Relation.Binary.Core
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
+open import Relation.Binary.Indexed.Heterogeneous using (IRel)
 
 ------------------------------------------------------------------------
 -- Types
@@ -252,17 +253,17 @@ pinch {suc n} (suc i) (suc j) = suc (pinch i j)
 
 infix 4 _≤_ _≥_ _<_ _>_
 
-_≤_ : ∀ {n} → Rel (Fin n) 0ℓ
-_≤_ = ℕ._≤_ on toℕ
+_≤_ : IRel Fin 0ℓ
+i ≤ j = toℕ i ℕ.≤ toℕ j
 
-_≥_ : ∀ {n} → Rel (Fin n) 0ℓ
-_≥_ = ℕ._≥_ on toℕ
+_≥_ : IRel Fin 0ℓ
+i ≥ j = toℕ i ℕ.≥ toℕ j
 
-_<_ : ∀ {n} → Rel (Fin n) 0ℓ
-_<_ = ℕ._<_ on toℕ
+_<_ : IRel Fin 0ℓ
+i < j = toℕ i ℕ.< toℕ j
 
-_>_ : ∀ {n} → Rel (Fin n) 0ℓ
-_>_ = ℕ._>_ on toℕ
+_>_ : IRel Fin 0ℓ
+i > j = toℕ i ℕ.> toℕ j
 
 
 data _≺_ : ℕ → ℕ → Set where

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -221,15 +221,15 @@ toℕ-cast {n = suc n} eq (suc k) = cong suc (toℕ-cast (cong ℕ.pred eq) k)
 ≤-total : ∀ {n} → Total (_≤_ {n})
 ≤-total x y = ℕₚ.≤-total (toℕ x) (toℕ y)
 
-≤-irrelevant : ∀ {n} → Irrelevant (_≤_ {n})
+≤-irrelevant : ∀ {m n} → Irrelevant (_≤_ {m} {n})
 ≤-irrelevant = ℕₚ.≤-irrelevant
 
 infix 4 _≤?_ _<?_
 
-_≤?_ : ∀ {n} → B.Decidable (_≤_ {n})
+_≤?_ : ∀ {m n} → B.Decidable (_≤_ {m} {n})
 a ≤? b = toℕ a ℕₚ.≤? toℕ b
 
-_<?_ : ∀ {n} → B.Decidable (_<_ {n})
+_<?_ : ∀ {m n} → B.Decidable (_<_ {m} {n})
 m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 
 ------------------------------------------------------------------------
@@ -247,7 +247,6 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
   { isPreorder = ≤-isPreorder
   ; antisym    = ≤-antisym
   }
-
 
 ≤-isTotalOrder : ∀ {n} → IsTotalOrder _≡_ (_≤_ {n})
 ≤-isTotalOrder = record
@@ -308,16 +307,16 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 ... | tri> i≮j i≢j j<i = tri> (i≮j ∘ ℕₚ.≤-pred) (i≢j ∘ suc-injective) (s≤s j<i)
 ... | tri≈ i≮j i≡j j≮i = tri≈ (i≮j ∘ ℕₚ.≤-pred) (cong suc i≡j)        (j≮i ∘ ℕₚ.≤-pred)
 
-<-respˡ-≡ : ∀ {n} → (_<_ {n}) Respectsˡ _≡_
+<-respˡ-≡ : ∀ {m n} → (_<_ {m} {n}) Respectsˡ _≡_
 <-respˡ-≡ refl x≤y = x≤y
 
-<-respʳ-≡ : ∀ {n} → (_<_ {n}) Respectsʳ _≡_
+<-respʳ-≡ : ∀ {m n} → (_<_ {m} {n}) Respectsʳ _≡_
 <-respʳ-≡ refl x≤y = x≤y
 
 <-resp₂-≡ : ∀ {n} → (_<_ {n}) Respects₂ _≡_
 <-resp₂-≡ = <-respʳ-≡ , <-respˡ-≡
 
-<-irrelevant : ∀ {n} → Irrelevant (_<_ {n})
+<-irrelevant : ∀ {m n} → Irrelevant (_<_ {m} {n})
 <-irrelevant = ℕₚ.<-irrelevant
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1440. They can now be used to relate terms of types `Fin m` and `Fin n` rather than just types `Fin n` and `Fin n`