### PR TITLE
Use `NonZero` instance arguments through `Data.Rational`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,16 @@ Non-backwards compatible changes
     - In `Data.Nat.DivMod`: `_/_`, `_%_`, `_div_`, `_mod_`
 	- In `Data.Nat.Pseudorandom.LCG`: `Generator`
 	- In `Data.Integer.DivMod`: `_divℕ_`, `_div_`, `_modℕ_`, `_mod_`
-  
+	- In `Data.Rational`: `mkℚ+`, `normalize`, `_/_`, `1/_`
+	- In `Data.Rational.Unnormalised`: `_/_`, `1/_`, `_÷_`
+
+* Consequently the definition of `_≢0` has been removed from `Data.Rational.Unnormalised.Base`
+  and the following proofs about it have been removed from `Data.Rational.Unnormalised.Properties`:
+  ```
+  p≄0⇒∣↥p∣≢0 : ∀ p → p ≠ 0ℚᵘ → ℤ.∣ (↥ p) ∣ ≢0
+  ∣↥p∣≢0⇒p≄0 : ∀ p → ℤ.∣ (↥ p) ∣ ≢0 → p ≠ 0ℚᵘ
+  ```
+
 * At the moment, there are 4 different ways such instance arguments can be provided,
   listed in order of convenience and clarity:
     1. By default there is always an instance of `NonZero (suc n)` for any `n` which 
@@ -199,6 +208,12 @@ Deprecated modules
 
 Deprecated names
 ----------------
+
+* In `Data.Rational.Unnormalised.Properties`:
+  ```
+  ↥[p/q]≡p = ↥[n/d]≡n
+  ↧[p/q]≡q = ↧[n/d]≡d
+  ```
 
 New modules
 -----------

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -62,10 +62,6 @@ open import Algebra.Definitions {A = ℚ} _≡_
 open import Algebra.Structures  {A = ℚ} _≡_
 
 private
-  infix 4 _≢0
-  _≢0 : ℕ → Set
-  n ≢0 = False (n ℕ.≟ 0)
-
   variable
     p q r : ℚ
 
@@ -87,9 +83,11 @@ mkℚ-injective refl = refl , refl
 
 infix 4 _≟_
 
-_≟_ : Decidable {A = ℚ} _≡_
-mkℚ n₁ d₁ _ ≟ mkℚ n₂ d₂ _ =
-  map′ (λ uv → uncurry mkℚ-cong uv) mkℚ-injective (n₁ ℤ.≟ n₂ ×-dec d₁ ℕ.≟ d₂)
+_≟_ : DecidableEquality ℚ
+mkℚ n₁ d₁ _ ≟ mkℚ n₂ d₂ _ = map′
+  (uncurry mkℚ-cong)
+  mkℚ-injective
+  (n₁ ℤ.≟ n₂ ×-dec d₁ ℕ.≟ d₂)
 
 ≡-setoid : Setoid 0ℓ 0ℓ
 ≡-setoid = setoid ℚ
@@ -101,33 +99,33 @@ mkℚ n₁ d₁ _ ≟ mkℚ n₂ d₂ _ =
 -- mkℚ+
 ------------------------------------------------------------------------
 
-mkℚ+-cong : ∀ {n₁ n₂ d₁ d₂} d₁≢0 d₂≢0
+mkℚ+-cong : ∀ {n₁ n₂ d₁ d₂} .{{_ : ℕ.NonZero d₁}} .{{_ : ℕ.NonZero d₂}}
            .{c₁ : Coprime n₁ d₁}
            .{c₂ : Coprime n₂ d₂} →
            n₁ ≡ n₂ → d₁ ≡ d₂ →
-           mkℚ+ n₁ d₁ {d₁≢0} c₁ ≡ mkℚ+ n₂ d₂ {d₂≢0} c₂
-mkℚ+-cong _ _ refl refl = refl
+           mkℚ+ n₁ d₁ c₁ ≡ mkℚ+ n₂ d₂ c₂
+mkℚ+-cong refl refl = refl
 
-mkℚ+-injective : ∀ {n₁ n₂ d₁ d₂} d₁≢0 d₂≢0
+mkℚ+-injective : ∀ {n₁ n₂ d₁ d₂} .{{_ : ℕ.NonZero d₁}} .{{_ : ℕ.NonZero d₂}}
            .{c₁ : Coprime n₁ d₁}
            .{c₂ : Coprime n₂ d₂} →
-           mkℚ+ n₁ d₁ {d₁≢0} c₁ ≡ mkℚ+ n₂ d₂ {d₂≢0} c₂ →
+           mkℚ+ n₁ d₁ c₁ ≡ mkℚ+ n₂ d₂ c₂ →
            n₁ ≡ n₂ × d₁ ≡ d₂
-mkℚ+-injective {d₁ = suc _} {suc _} _ _ refl = refl , refl
+mkℚ+-injective {d₁ = suc _} {suc _} refl = refl , refl
 
-↥-mkℚ+ : ∀ n d {d≢0} .{c : Coprime n d} → ↥ (mkℚ+ n d {d≢0} c) ≡ + n
+↥-mkℚ+ : ∀ n d .{{_ : ℕ.NonZero d}} .{c : Coprime n d} → ↥ (mkℚ+ n d c) ≡ + n
 ↥-mkℚ+ n (suc d) = refl
 
-↧-mkℚ+ : ∀ n d {d≢0} .{c : Coprime n d} → ↧ (mkℚ+ n d {d≢0} c) ≡ + d
+↧-mkℚ+ : ∀ n d .{{_ : ℕ.NonZero d}} .{c : Coprime n d} → ↧ (mkℚ+ n d c) ≡ + d
 ↧-mkℚ+ n (suc d) = refl
 
-mkℚ+-nonNeg : ∀ n d {d≢0} .{c : Coprime n d} →
-              NonNegative (mkℚ+ n d {d≢0} c)
+mkℚ+-nonNeg : ∀ n d .{{_ : ℕ.NonZero d}} .{c : Coprime n d} →
+              NonNegative (mkℚ+ n d c)
 mkℚ+-nonNeg n (suc d) = _
 
-mkℚ+-pos : ∀ n d {d≢0} .{c : Coprime n d} → ℕ.NonZero n →
-           Positive (mkℚ+ n d {d≢0} c)
-mkℚ+-pos (suc n) (suc d) nz = _
+mkℚ+-pos : ∀ n d .{{_ : ℕ.NonZero n}} .{{_ : ℕ.NonZero d}}
+           .{c : Coprime n d} → Positive (mkℚ+ n d c)
+mkℚ+-pos (suc n) (suc d) = _
 
 ------------------------------------------------------------------------
 -- Numerator and denominator equality
@@ -222,81 +220,80 @@ neg-pos {mkℚ +[1+ _ ] _ _} _ = _
 normalize-coprime : ∀ {n d-1} .(c : Coprime n (suc d-1)) →
                     normalize n (suc d-1) ≡ mkℚ (+ n) d-1 c
 normalize-coprime {n} {d-1} c = begin
-  normalize n d              ≡⟨⟩
-  mkℚ+ (n ℕ./ g) (d ℕ./ g) _ ≡⟨ mkℚ+-cong n/g≢0 d/1≢0 {c₂ = c₂} (ℕ./-congʳ g≡1) (ℕ./-congʳ g≡1) ⟩
-  mkℚ+ (n ℕ./ 1) (d ℕ./ 1) _ ≡⟨ mkℚ+-cong d/1≢0 _ {c₂ = c} (ℕ.n/1≡n n) (ℕ.n/1≡n d) ⟩
-  mkℚ+ n d _                 ≡⟨⟩
-  mkℚ (+ n) d-1 _            ∎
+  normalize n d                                  ≡⟨⟩
+  mkℚ+ ((n ℕ./ g) {{g≢0}}) ((d ℕ./ g) {{g≢0}}) _ ≡⟨ mkℚ+-cong {c₂ = c₂} (ℕ./-congʳ {{g≢0}} g≡1) (ℕ./-congʳ {{g≢0}} g≡1) ⟩
+  mkℚ+ (n ℕ./ 1) (d ℕ./ 1) _                     ≡⟨ mkℚ+-cong {c₂ = c} (ℕ.n/1≡n n) (ℕ.n/1≡n d) ⟩
+  mkℚ+ n d _                                     ≡⟨⟩
+  mkℚ (+ n) d-1 _                                ∎
   where
   open ≡-Reasoning; d = suc d-1; g = ℕ.gcd n d
   c′ = C.recompute c
   c₂ : Coprime (n ℕ./ 1) (d ℕ./ 1)
   c₂ = subst₂ Coprime (sym (ℕ.n/1≡n n)) (sym (ℕ.n/1≡n d)) c′
   g≡1 = C.coprime⇒gcd≡1 c′
-  instance g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 n d (inj₂ λ()))
-  n/g≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 n d)
-  d/1≢0 = fromWitnessFalse (subst (_≢ 0) (sym (ℕ.n/1≡n d)) λ())
+  instance
+    g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 n d (inj₂ λ()))
+    n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 n d {{_}} {{g≢0}})
+    d/1≢0 = ℕ.≢-nonZero (subst (_≢ 0) (sym (ℕ.n/1≡n d)) λ())
 
-↥-normalize : ∀ i n {n≢0} → ↥ (normalize i n {n≢0}) ℤ.* gcd (+ i) (+ n) ≡ + i
-↥-normalize i n@(suc n-1) = begin
-  ↥ (normalize i n) ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↥-mkℚ+ _ (n ℕ./ g) {n/g≢0}) ⟩
-  + (i ℕ./ g)       ℤ.* + g  ≡⟨⟩
-  S.+ ◃ i ℕ./ g     ℕ.* g    ≡⟨ cong (S.+ ◃_) (ℕ.m/n*n≡m (ℕ.gcd[m,n]∣m i n)) ⟩
+↥-normalize : ∀ i n .{{_ : ℕ.NonZero n}} → ↥ (normalize i n) ℤ.* gcd (+ i) (+ n) ≡ + i
+↥-normalize i n {{n≢0}} = begin
+  ↥ (normalize i n) ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↥-mkℚ+ _ ((n ℕ./ g) {{g≢0}})) ⟩
+  + i/g     ℤ.* + g          ≡⟨⟩
+  S.+ ◃ i/g ℕ.* g            ≡⟨ cong (S.+ ◃_) (ℕ.m/n*n≡m {{g≢0}} (ℕ.gcd[m,n]∣m i n)) ⟩
   S.+ ◃ i                    ≡⟨ ℤ.+◃n≡+n i ⟩
   + i                        ∎
   where
   open ≡-Reasoning
   g     = ℕ.gcd i n
-  instance g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 i n (inj₂ λ()))
-  n/g≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 i n)
+  g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 i n (inj₂ (ℕ.≢-nonZero⁻¹ n≢0)))
+  instance n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 i n {{n≢0}} {{g≢0}})
+  i/g = (i ℕ./ g) {{g≢0}}
 
-↧-normalize : ∀ i n {n≢0} → ↧ (normalize i n {n≢0}) ℤ.* gcd (+ i) (+ n) ≡ + n
-↧-normalize i n@(suc n-1) = begin
-  ↧ (normalize i n) ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↧-mkℚ+ _ (n ℕ./ g) {n/g≢0}) ⟩
+↧-normalize : ∀ i n .{{_ : ℕ.NonZero n}} → ↧ (normalize i n) ℤ.* gcd (+ i) (+ n) ≡ + n
+↧-normalize i n {{n≢0}} = begin
+  ↧ (normalize i n) ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↧-mkℚ+ _ ((n ℕ./ g) {{g≢0}})) ⟩
   + (n ℕ./ g)       ℤ.* + g  ≡⟨⟩
   S.+ ◃ n ℕ./ g     ℕ.* g    ≡⟨ cong (S.+ ◃_) (ℕ.m/n*n≡m (ℕ.gcd[m,n]∣n i n)) ⟩
   S.+ ◃ n                    ≡⟨ ℤ.+◃n≡+n n ⟩
   + n                        ∎
   where
   open ≡-Reasoning
-  g     = ℕ.gcd i n
-  instance g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 i n (inj₂ λ()))
-  n/g≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 i n)
+  g = ℕ.gcd i n
+  instance g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0   i n (inj₂ (ℕ.≢-nonZero⁻¹ n≢0)))
+  instance n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 i n {{n≢0}} {{g≢0}})
 
-normalize-cong : ∀ {m₁ n₁ m₂ n₂ n₁≢0 n₂≢0} → m₁ ≡ m₂ → n₁ ≡ n₂ →
-                 normalize m₁ n₁ {n₁≢0} ≡ normalize m₂ n₂ {n₂≢0}
-normalize-cong {m} {n} {.m} {.n} {n≢0₁} {n≢0₂} refl refl =
-  mkℚ+-cong n/g₁≢0 n/g₂≢0 (ℕ./-congʳ {n = g} {g} refl) (ℕ./-congʳ {n = g} {g} refl)
+normalize-cong : ∀ {m₁ n₁ m₂ n₂} .{{_ : ℕ.NonZero n₁}} .{{_ : ℕ.NonZero n₂}} →
+                 m₁ ≡ m₂ → n₁ ≡ n₂ → normalize m₁ n₁ ≡ normalize m₂ n₂
+normalize-cong {m} {n} {{n₁≢0}} {{n₂≢0}} refl refl =
+  mkℚ+-cong (ℕ./-congʳ {n = g} refl) (ℕ./-congʳ {n = g} refl)
   where
   g = ℕ.gcd m n
-  n≢0₁′ = toWitnessFalse n≢0₁
-  n≢0₂′ = toWitnessFalse n≢0₂
-  instance g₁≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ n≢0₁′))
-  instance g₂≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ n≢0₂′))
-  n/g₁ = n ℕ./ g
-  n/g₂ = n ℕ./ g
-  n/g₁≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 m n {{ℕ.≢-nonZero n≢0₁′}})
-  n/g₂≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 m n {{ℕ.≢-nonZero n≢0₂′}})
+  instance
+    g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ (ℕ.≢-nonZero⁻¹ n₂≢0)))
+    n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m n {{n₁≢0}} {{g≢0}})
 
-normalize-nonNeg : ∀ m n {n≢0} → NonNegative (normalize m n {n≢0})
-normalize-nonNeg m n {n≢0} = mkℚ+-nonNeg (m ℕ./ ℕ.gcd m n) (n ℕ./ ℕ.gcd m n) {n/g≢0}
+normalize-nonNeg : ∀ m n .{{_ : ℕ.NonZero n}} → NonNegative (normalize m n)
+normalize-nonNeg m n {{n≢0}} = mkℚ+-nonNeg ((m ℕ./ g) {{g≢0}}) ((n ℕ./ g) {{g≢0}})
   where
-  n≢0′ = toWitnessFalse n≢0
-  instance g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ n≢0′))
-  n/g≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 m n {{ℕ.≢-nonZero n≢0′}})
+  g = ℕ.gcd m n
+  instance
+    g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ (ℕ.≢-nonZero⁻¹ n≢0)))
+    n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m n {{n≢0}} {{g≢0}})
 
-normalize-pos : ∀ m n {n≢0} → ℕ.NonZero m → Positive (normalize m n {n≢0})
-normalize-pos m@(suc _) n {n≢0} m≢0 = mkℚ+-pos (m ℕ./ ℕ.gcd m n) (n ℕ./ ℕ.gcd m n) {n/g≢0} (ℕ.≢-nonZero m/g≢0)
+normalize-pos : ∀ m n .{{_ : ℕ.NonZero n}} .{{_ : ℕ.NonZero m}} → Positive (normalize m n)
+normalize-pos m n {{n≢0}} {{m≢0}} = mkℚ+-pos (m ℕ./ ℕ.gcd m n) (n ℕ./ ℕ.gcd m n)
   where
-  n≢0′ = toWitnessFalse n≢0
-  instance g≢0 = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ n≢0′))
-  n/g≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 m n {{ℕ.≢-nonZero n≢0′}})
-  m/g≢0 = ℕ.m/gcd[m,n]≢0 m n
+  g = ℕ.gcd m n
+  instance
+    g≢0   = ℕ.≢-nonZero (ℕ.gcd[m,n]≢0 m n (inj₂ (ℕ.≢-nonZero⁻¹ n≢0)))
+    n/g≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m n {{n≢0}} {{g≢0}})
+    m/g≢0 = ℕ.≢-nonZero (ℕ.m/gcd[m,n]≢0 m n {{m≢0}} {{g≢0}})
 
-normalize-injective-≃ : ∀ m n c d {c≢0 d≢0} →
-                        normalize m c {c≢0} ≡ normalize n d {d≢0} →
+normalize-injective-≃ : ∀ m n c d {{_ : ℕ.NonZero c}} {{_ : ℕ.NonZero d}} →
+                        normalize m c ≡ normalize n d →
                         m ℕ.* d ≡ n ℕ.* c
-normalize-injective-≃ m n c d {c≢0} {d≢0} eq = ℕ./-cancelʳ-≡
+normalize-injective-≃ m n c d {{c≢0}} {{d≢0}} eq = ℕ./-cancelʳ-≡
   md∣gcd[m,c]gcd[n,d]
   nc∣gcd[m,c]gcd[n,d]
   (begin
@@ -317,19 +314,18 @@ normalize-injective-≃ m n c d {c≢0} {d≢0} eq = ℕ./-cancelʳ-≡
   nc∣gcd[n,d]gcd[m,c] = *-pres-∣ gcd[n,d]∣n gcd[m,c]∣c
   nc∣gcd[m,c]gcd[n,d] = subst (_∣ n ℕ.* c) (ℕ.*-comm gcd[n,d] gcd[m,c]) nc∣gcd[n,d]gcd[m,c]
 
-  c≢0′ = toWitnessFalse c≢0
-  d≢0′ = toWitnessFalse d≢0
-  gcd[m,c]≢0′  = ℕ.gcd[m,n]≢0 m c (inj₂ c≢0′)
-  gcd[n,d]≢0′  = ℕ.gcd[m,n]≢0 n d (inj₂ d≢0′)
-  instance gcd[m,c]≢0 = ℕ.≢-nonZero gcd[m,c]≢0′
-  instance gcd[n,d]≢0 = ℕ.≢-nonZero gcd[n,d]≢0′
-  c/gcd[m,c]≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 m c {{ℕ.≢-nonZero c≢0′}})
-  d/gcd[n,d]≢0 = fromWitnessFalse (ℕ.n/gcd[m,n]≢0 n d {{ℕ.≢-nonZero d≢0′}})
+  gcd[m,c]≢0′          = ℕ.gcd[m,n]≢0 m c (inj₂ (ℕ.≢-nonZero⁻¹ c≢0))
+  gcd[n,d]≢0′          = ℕ.gcd[m,n]≢0 n d (inj₂ (ℕ.≢-nonZero⁻¹ d≢0))
   gcd[m,c]*gcd[n,d]≢0′ = Sum.[ gcd[m,c]≢0′ , gcd[n,d]≢0′ ] ∘ ℕ.m*n≡0⇒m≡0∨n≡0 _
-  instance gcd[m,c]*gcd[n,d]≢0 = ℕ.≢-nonZero gcd[m,c]*gcd[n,d]≢0′
-  instance gcd[n,d]*gcd[m,c]≢0 = ℕ.≢-nonZero (subst (_≢ 0) (ℕ.*-comm gcd[m,c] gcd[n,d]) gcd[m,c]*gcd[n,d]≢0′)
+  instance
+    gcd[m,c]≢0   = ℕ.≢-nonZero gcd[m,c]≢0′
+    gcd[n,d]≢0   = ℕ.≢-nonZero gcd[n,d]≢0′
+    c/gcd[m,c]≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 m c {{c≢0}} {{gcd[m,c]≢0}})
+    d/gcd[n,d]≢0 = ℕ.≢-nonZero (ℕ.n/gcd[m,n]≢0 n d {{d≢0}} {{gcd[n,d]≢0}})
+    gcd[m,c]*gcd[n,d]≢0 = ℕ.≢-nonZero gcd[m,c]*gcd[n,d]≢0′
+    gcd[n,d]*gcd[m,c]≢0 = ℕ.≢-nonZero (subst (_≢ 0) (ℕ.*-comm gcd[m,c] gcd[n,d]) gcd[m,c]*gcd[n,d]≢0′)
 
-  div = mkℚ+-injective c/gcd[m,c]≢0 d/gcd[n,d]≢0 eq
+  div = mkℚ+-injective eq
   m/gcd[m,c]≡n/gcd[n,d] = proj₁ div
   c/gcd[m,c]≡d/gcd[n,d] = proj₂ div
 
@@ -337,53 +333,51 @@ normalize-injective-≃ m n c d {c≢0} {d≢0} eq = ℕ./-cancelʳ-≡
 -- Properties of _/_
 ------------------------------------------------------------------------
 
-↥-/ : ∀ i n {n≢0} → ↥ (i / n) {n≢0} ℤ.* gcd i (+ n) ≡ i
-↥-/ (+ m)    (suc n) = ↥-normalize m (suc n)
-↥-/ -[1+ m ] (suc n) = begin-equality
+↥-/ : ∀ i n .{{_ : ℕ.NonZero n}} → ↥ (i / n) ℤ.* gcd i (+ n) ≡ i
+↥-/ (+ m)    n = ↥-normalize m n
+↥-/ -[1+ m ] n = begin-equality
   ↥ (- norm)   ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↥-neg norm) ⟩
   ℤ.- (↥ norm) ℤ.* + g  ≡⟨ sym (ℤ.neg-distribˡ-* (↥ norm) (+ g)) ⟩
-  ℤ.- (↥ norm  ℤ.* + g) ≡⟨ cong (ℤ.-_) (↥-normalize (suc m) (suc n)) ⟩
+  ℤ.- (↥ norm  ℤ.* + g) ≡⟨ cong (ℤ.-_) (↥-normalize (suc m) n) ⟩
   S.- ◃ suc m           ≡⟨⟩
   -[1+ m ]              ∎
   where
   open ℤ.≤-Reasoning
-  g = ℕ.gcd (suc m) (suc n)
-  norm = normalize (suc m) (suc n)
+  g    = ℕ.gcd (suc m) n
+  norm = normalize (suc m) n
 
-↧-/ : ∀ i n {n≢0} → ↧ (i / n) {n≢0} ℤ.* gcd i (+ n) ≡ + n
-↧-/ (+ m)    (suc n) = ↧-normalize m (suc n)
-↧-/ -[1+ m ] (suc n) = begin-equality
+↧-/ : ∀ i n .{{_ : ℕ.NonZero n}} → ↧ (i / n) ℤ.* gcd i (+ n) ≡ + n
+↧-/ (+ m)    n = ↧-normalize m n
+↧-/ -[1+ m ] n = begin-equality
   ↧ (- norm) ℤ.* + g  ≡⟨ cong (ℤ._* + g) (↧-neg norm) ⟩
-  ↧ norm     ℤ.* + g  ≡⟨ ↧-normalize (suc m) (suc n) ⟩
-  + (suc n)           ∎
+  ↧ norm     ℤ.* + g  ≡⟨ ↧-normalize (suc m) n ⟩
+  + n                 ∎
   where
   open ℤ.≤-Reasoning
-  g = ℕ.gcd (suc m) (suc n)
-  norm = normalize (suc m) (suc n)
+  g    = ℕ.gcd (suc m) n
+  norm = normalize (suc m) n
 
 ↥p/↧p≡p : ∀ p → ↥ p / ↧ₙ p ≡ p
 ↥p/↧p≡p (mkℚ (+ n)    d-1 prf) = normalize-coprime prf
 ↥p/↧p≡p (mkℚ -[1+ n ] d-1 prf) = cong (-_) (normalize-coprime prf)
 
-0/n≡0 : ∀ n {n≢0} → (0ℤ / n) {n≢0} ≡ 0ℚ
-0/n≡0 n@(suc n-1) {n≢0} = mkℚ+-cong n/n≢0 _ {c₂ = 0-cop-1} (ℕ.0/n≡0 (ℕ.gcd 0 n)) (ℕ.n/n≡1 n)
+0/n≡0 : ∀ n .{{_ : ℕ.NonZero n}} → 0ℤ / n ≡ 0ℚ
+0/n≡0 n@(suc n-1) {{n≢0}} = mkℚ+-cong {{n/n≢0}} {c₂ = 0-cop-1} (ℕ.0/n≡0 (ℕ.gcd 0 n)) (ℕ.n/n≡1 n)
   where
-  n/n≢0 = subst _≢0 (sym (ℕ.n/n≡1 n)) _
   0-cop-1 = C.sym (C.1-coprimeTo 0)
+  n/n≢0   = ℕ.>-nonZero (subst (ℕ._> 0) (sym (ℕ.n/n≡1 n)) (ℕ.s≤s ℕ.z≤n))
 
-/-cong : ∀ {p₁ q₁ p₂ q₂ q₁≢0 q₂≢0} → p₁ ≡ p₂ → q₁ ≡ q₂ →
-         (p₁ / q₁) {q₁≢0} ≡ (p₂ / q₂) {q₂≢0}
-/-cong {+ n}       {q} {q₁≢0 = q≢0₁} {q≢0₂} refl refl =
-  normalize-cong {n} {q} {n} {q} {n₁≢0 = q≢0₁} {q≢0₂} refl refl
-/-cong { -[1+ n ]} {q} {q₁≢0 = q≢0₁} {q≢0₂} refl refl =
-  cong -_ (normalize-cong {suc n} {q} {suc n} {q} {q≢0₁} {q≢0₂} refl refl)
+/-cong : ∀ {p₁ q₁ p₂ q₂} .{{_ : ℕ.NonZero q₁}} .{{_ : ℕ.NonZero q₂}} →
+         p₁ ≡ p₂ → q₁ ≡ q₂ → p₁ / q₁ ≡ p₂ / q₂
+/-cong {+ n}       refl = normalize-cong {n} refl
+/-cong { -[1+ n ]} refl = cong -_ ∘′ normalize-cong {suc n} refl
 
 private
   /-injective-≃-helper : ∀ {m n c-1 d-1} →
                          - normalize (suc m) (suc c-1) ≡ normalize n (suc d-1) →
                           mkℚᵘ -[1+ m ] c-1 ≃ᵘ mkℚᵘ (+ n) d-1
   /-injective-≃-helper {m} {n} {c-1} {d-1} eq
-    with normalize-pos (suc m) (suc c-1) _ | normalize-nonNeg n (suc d-1)
+    with normalize-pos (suc m) (suc c-1) | normalize-nonNeg n (suc d-1)
   ... | norm[m,c]-pos | norm[n,d]-nonNeg =
     contradiction (sym eq) (nonNeg≢neg _ _ norm[n,d]-nonNeg (neg-pos norm[m,c]-pos))
 
@@ -1069,7 +1063,7 @@ toℚᵘ-homo-* p q with *-nf p q ℤ.≟ 0ℤ
   (↥ p ℤ.* ↥ q) ℤ.* ↧ (p * q)  ℤ.* *-nf p q    ∎))
   where open ≡-Reasoning; open CommSemigroupProperties ℤ.*-commutativeSemigroup
 
-toℚᵘ-homo-1/ : ∀ p {p≢0} → toℚᵘ ((1/ p) {p≢0}) ℚᵘ.≃ (ℚᵘ.1/ toℚᵘ p) {p≢0}
+toℚᵘ-homo-1/ : ∀ p .{{_ : NonZero p}} → toℚᵘ (1/ p) ℚᵘ.≃ (ℚᵘ.1/ toℚᵘ p)
 toℚᵘ-homo-1/ (mkℚ +[1+ _ ] _ _) = ℚᵘ.≃-refl
 toℚᵘ-homo-1/ (mkℚ -[1+ _ ] _ _) = ℚᵘ.≃-refl
 
@@ -1166,16 +1160,16 @@ private
 *-distrib-+ : _*_ DistributesOver _+_
 *-distrib-+ = *-distribˡ-+ , *-distribʳ-+
 
-*-inverseˡ : ∀ p {p≢0 : ℤ.∣ ↥ p ∣ ≢0} → (1/ p) {p≢0} * p ≡ 1ℚ
-*-inverseˡ p {p≢0} = toℚᵘ-injective (begin-equality
+*-inverseˡ : ∀ p .{{_ : NonZero p}} → (1/ p) * p ≡ 1ℚ
+*-inverseˡ p = toℚᵘ-injective (begin-equality
   toℚᵘ (1/ p * p)             ≈⟨ toℚᵘ-homo-* (1/ p) p ⟩
-  toℚᵘ (1/ p) ℚᵘ.* toℚᵘ p     ≈⟨ ℚᵘ.*-congʳ (toℚᵘ-homo-1/ p {p≢0}) ⟩
-  ℚᵘ.1/ (toℚᵘ p) ℚᵘ.* toℚᵘ p  ≈⟨ ℚᵘ.*-inverseˡ (toℚᵘ p) {p≢0} ⟩
+  toℚᵘ (1/ p) ℚᵘ.* toℚᵘ p     ≈⟨ ℚᵘ.*-congʳ (toℚᵘ-homo-1/ p) ⟩
+  ℚᵘ.1/ (toℚᵘ p) ℚᵘ.* toℚᵘ p  ≈⟨ ℚᵘ.*-inverseˡ (toℚᵘ p) ⟩
   ℚᵘ.1ℚᵘ                      ∎)
   where open ℚᵘ.≤-Reasoning
 
-*-inverseʳ : ∀ p {p≢0 : ℤ.∣ ↥ p ∣ ≢0} → p * (1/ p) {p≢0} ≡ 1ℚ
-*-inverseʳ p {p≢0} = trans (*-comm p (1/ p)) (*-inverseˡ p {p≢0})
+*-inverseʳ : ∀ p .{{_ : NonZero p}} → p * (1/ p) ≡ 1ℚ
+*-inverseʳ p = trans (*-comm p (1/ p)) (*-inverseˡ p)
 
 neg-distribˡ-* : ∀ p q → - (p * q) ≡ - p * q
 neg-distribˡ-* = +-*-Monomorphism.neg-distribˡ-* ℚᵘ.+-0-isGroup ℚᵘ.*-isMagma ℚᵘ.neg-distribˡ-*
@@ -1625,31 +1619,31 @@ antimono-≤-distrib-⊔ {f} = ⊓-⊔-properties.antimono-≤-distrib-⊔ (cong
 ------------------------------------------------------------------------
 
 private
-  pos⇒≢0 : ∀ p → Positive p → ℤ.∣ ↥ p ∣ ≢0
-  pos⇒≢0 p p>0 = Dec.fromWitnessFalse (contraposition ℤ.∣n∣≡0⇒n≡0 (≢-sym (ℤ.<⇒≢ (ℤ.positive⁻¹ p>0))))
+  pos⇒≢0 : ∀ p → Positive p → NonZero p
+  pos⇒≢0 (mkℚ +[1+ _ ] _ _) p>0 = _
 
-  neg⇒≢0 : ∀ p → Negative p → ℤ.∣ ↥ p ∣ ≢0
-  neg⇒≢0 p p<0 = Dec.fromWitnessFalse (contraposition ℤ.∣n∣≡0⇒n≡0 (ℤ.<⇒≢ (ℤ.negative⁻¹ p<0)))
+  neg⇒≢0 : ∀ p → Negative p → NonZero p
+  neg⇒≢0 (mkℚ -[1+ _ ] _ _) p<0 = _
 
-  1/p≢0 : ∀ p {p≢0} → ℤ.∣ ↥ ((1/ p) {p≢0}) ∣ ≢0
+  1/p≢0 : ∀ p .{{_ : NonZero p}} → NonZero (1/ p)
   1/p≢0 (mkℚ +[1+ _ ] _ _) = _
   1/p≢0 (mkℚ -[1+ _ ] _ _) = _
 
-1/-involutive : ∀ p {p≢0} → (1/ (1/ p) {p≢0}) {1/p≢0 p {p≢0}} ≡ p
+1/-involutive : ∀ p .{{p≢0 : NonZero p}} → (1/ (1/ p)) {{1/p≢0 p}} ≡ p
 1/-involutive (mkℚ +[1+ n ] d-1 _) = refl
 1/-involutive (mkℚ -[1+ n ] d-1 _) = refl
 
-pos⇒1/pos : ∀ p (p>0 : Positive p) → Positive ((1/ p) {pos⇒≢0 p p>0})
+pos⇒1/pos : ∀ p (p>0 : Positive p) → Positive ((1/ p) {{pos⇒≢0 p p>0}})
 pos⇒1/pos (mkℚ +[1+ n ] d-1 _) _ = tt
 
-neg⇒1/neg : ∀ p (p<0 : Negative p) → Negative ((1/ p) {neg⇒≢0 p p<0})
+neg⇒1/neg : ∀ p (p<0 : Negative p) → Negative ((1/ p) {{neg⇒≢0 p p<0}})
 neg⇒1/neg (mkℚ -[1+ n ] d-1 _) _ = _
 
-1/pos⇒pos : ∀ p {p≢0} → (1/p : Positive ((1/ p) {p≢0})) → Positive p
-1/pos⇒pos p {p≢0} 1/p>0 = subst Positive (1/-involutive p {p≢0}) (pos⇒1/pos (1/ p) 1/p>0)
+1/pos⇒pos : ∀ p .{{_ : NonZero p}} → (1/p : Positive (1/ p)) → Positive p
+1/pos⇒pos p 1/p>0 = subst Positive (1/-involutive p) (pos⇒1/pos (1/ p) 1/p>0)
 
-1/neg⇒neg : ∀ p {p≢0} → (1/p : Negative ((1/ p) {p≢0})) → Negative p
-1/neg⇒neg p {p≢0} 1/p>0 = subst Negative (1/-involutive p {p≢0}) (neg⇒1/neg (1/ p) 1/p>0)
+1/neg⇒neg : ∀ p .{{_ : NonZero p}} → (1/p : Negative (1/ p)) → Negative p
+1/neg⇒neg p 1/p>0 = subst Negative (1/-involutive p) (neg⇒1/neg (1/ p) 1/p>0)
 
 ------------------------------------------------------------------------
 -- Properties of ∣_∣
@@ -1730,6 +1724,7 @@ toℚᵘ-homo-∣-∣ (mkℚ -[1+ _ ] _ _) = *≡* refl
 
 ∣∣p∣∣≡∣p∣ : ∀ p → ∣ ∣ p ∣ ∣ ≡ ∣ p ∣
 ∣∣p∣∣≡∣p∣ p = 0≤p⇒∣p∣≡p (0≤∣p∣ p)
+
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/Rational/Unnormalised/Base.agda
+++ b/src/Data/Rational/Unnormalised/Base.agda
@@ -15,7 +15,6 @@ open import Data.Nat as ℕ using (ℕ; zero; suc)
 open import Level using (0ℓ)
 open import Relation.Nullary using (¬_)
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable using (False)
 open import Relation.Unary using (Pred)
 open import Relation.Binary using (Rel)
 open import Relation.Binary.PropositionalEquality.Core
@@ -103,67 +102,13 @@ p ≤ᵇ q = (↥ p ℤ.* ↧ q) ℤ.≤ᵇ (↥ q ℤ.* ↧ p)
 ------------------------------------------------------------------------
 -- Constructing rationals
 
-infix 4 _≢0
-_≢0 : ℕ → Set
-n ≢0 = False (n ℕ.≟ 0)
-
 -- An alternative constructor for ℚᵘ. See the constants section below
 -- for examples of how to use this operator.
 
 infixl 7 _/_
 
-_/_ : (n : ℤ) (d : ℕ) .{d≢0 : d ≢0} → ℚᵘ
+_/_ : (n : ℤ) (d : ℕ) .{{_ : ℕ.NonZero d}} → ℚᵘ
 n / suc d = mkℚᵘ n d
-
-------------------------------------------------------------------------------
--- Operations on rationals
-
-infix  8 -_ 1/_
-infixl 7 _*_ _÷_ _⊓_
-infixl 6 _-_ _+_ _⊔_
-
--- negation
-
--_ : ℚᵘ → ℚᵘ
-- mkℚᵘ n d = mkℚᵘ (ℤ.- n) d
-
--- addition
-
-_+_ : ℚᵘ → ℚᵘ → ℚᵘ
-p + q = (↥ p ℤ.* ↧ q ℤ.+ ↥ q ℤ.* ↧ p) / (↧ₙ p ℕ.* ↧ₙ q)
-
--- multiplication
-
-_*_ : ℚᵘ → ℚᵘ → ℚᵘ
-p * q = (↥ p ℤ.* ↥ q) / (↧ₙ p ℕ.* ↧ₙ q)
-
--- subtraction
-
-_-_ : ℚᵘ → ℚᵘ → ℚᵘ
-p - q = p + (- q)
-
--- reciprocal: requires a proof that the numerator is not zero
-
-1/_ : (p : ℚᵘ) → .{n≢0 : ℤ.∣ ↥ p ∣ ≢0} → ℚᵘ
-1/ mkℚᵘ +[1+ n ] d = mkℚᵘ +[1+ d ] n
-1/ mkℚᵘ -[1+ n ] d = mkℚᵘ -[1+ d ] n
-
--- division: requires a proof that the denominator is not zero
-
-_÷_ : (p q : ℚᵘ) → .{n≢0 : ℤ.∣ ↥ q ∣ ≢0} → ℚᵘ
-(p ÷ q) {n≢0} = p * (1/_ q {n≢0})
-
--- max
-_⊔_ : (p q : ℚᵘ) → ℚᵘ
-p ⊔ q = if p ≤ᵇ q then q else p
-
--- min
-_⊓_ : (p q : ℚᵘ) → ℚᵘ
-p ⊓ q = if p ≤ᵇ q then p else q
-
--- absolute value
-∣_∣ : ℚᵘ → ℚᵘ
-∣ mkℚᵘ p q ∣ = mkℚᵘ (+ ℤ.∣ p ∣) q
 
 ------------------------------------------------------------------------------
 -- Some constants
@@ -178,7 +123,7 @@ p ⊓ q = if p ≤ᵇ q then p else q
 ½ = + 1 / 2
 
 -½ : ℚᵘ
--½ = - ½
+-½ = ℤ.- (+ 1) / 2
 
 ------------------------------------------------------------------------
 -- Simple predicates
@@ -198,7 +143,7 @@ NonPositive p = ℤ.NonPositive (↥ p)
 NonNegative : Pred ℚᵘ 0ℓ
 NonNegative p = ℤ.NonNegative (↥ p)
 
--- Constructors
+-- Constructors and destructors
 
 -- Note: these could be proved more elegantly using the constructors
 -- from ℤ but it requires importing `Data.Integer.Properties` which
@@ -237,3 +182,53 @@ nonPositive {mkℚᵘ -[1+ n ] _} (*≤* _) = _
 nonNegative : ∀ {p} → p ≥ 0ℚᵘ → NonNegative p
 nonNegative {mkℚᵘ +0       _} (*≤* _) = _
 nonNegative {mkℚᵘ +[1+ n ] _} (*≤* _) = _
+
+------------------------------------------------------------------------------
+-- Operations on rationals
+
+infix  8 -_ 1/_
+infixl 7 _*_ _÷_ _⊓_
+infixl 6 _-_ _+_ _⊔_
+
+-- negation
+
+-_ : ℚᵘ → ℚᵘ
+- mkℚᵘ n d = mkℚᵘ (ℤ.- n) d
+
+-- addition
+
+_+_ : ℚᵘ → ℚᵘ → ℚᵘ
+p + q = (↥ p ℤ.* ↧ q ℤ.+ ↥ q ℤ.* ↧ p) / (↧ₙ p ℕ.* ↧ₙ q)
+
+-- multiplication
+
+_*_ : ℚᵘ → ℚᵘ → ℚᵘ
+p * q = (↥ p ℤ.* ↥ q) / (↧ₙ p ℕ.* ↧ₙ q)
+
+-- subtraction
+
+_-_ : ℚᵘ → ℚᵘ → ℚᵘ
+p - q = p + (- q)
+
+-- reciprocal: requires a proof that the numerator is not zero
+
+1/_ : (p : ℚᵘ) → .{{_ : NonZero p}} → ℚᵘ
+1/ mkℚᵘ +[1+ n ] d = mkℚᵘ +[1+ d ] n
+1/ mkℚᵘ -[1+ n ] d = mkℚᵘ -[1+ d ] n
+
+-- division: requires a proof that the denominator is not zero
+
+_÷_ : (p q : ℚᵘ) → .{{_ : NonZero q}} → ℚᵘ
+p ÷ q = p * (1/ q)
+
+-- max
+_⊔_ : (p q : ℚᵘ) → ℚᵘ
+p ⊔ q = if p ≤ᵇ q then q else p
+
+-- min
+_⊓_ : (p q : ℚᵘ) → ℚᵘ
+p ⊓ q = if p ≤ᵇ q then p else q
+
+-- absolute value
+∣_∣ : ℚᵘ → ℚᵘ
+∣ mkℚᵘ p q ∣ = mkℚᵘ (+ ℤ.∣ p ∣) q

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -47,24 +47,25 @@ open import Algebra.Properties.CommutativeSemigroup ℤ.*-commutativeSemigroup
 -- Properties of _/_
 ------------------------------------------------------------------------
 
-/-cong : ∀ {p₁ q₁ p₂ q₂} → p₁ ≡ p₂ → q₁ ≡ q₂ → ∀ q₁≢0 q₂≢0 → (p₁ / q₁) {q₁≢0} ≡ (p₂ / q₂) {q₂≢0}
-/-cong {p} {suc q} {.p} {.(suc q)} refl refl q₁≢0 q₂≢0 = refl
+/-cong : ∀ {n₁ d₁ n₂ d₂} .{{_ : ℕ.NonZero d₁}} .{{_ : ℕ.NonZero d₂}} →
+         n₁ ≡ n₂ → d₁ ≡ d₂ → n₁ / d₁ ≡ n₂ / d₂
+/-cong refl refl = refl
 
-↥[p/q]≡p : ∀ p q {q≢0} → ↥ (p / q) {q≢0} ≡ p
-↥[p/q]≡p p (suc q) {q≢0} = refl
+↥[n/d]≡n : ∀ n d .{{_ : ℕ.NonZero d}} → ↥ (n / d) ≡ n
+↥[n/d]≡n n (suc d) = refl
 
-↧[p/q]≡q : ∀ p q {q≢0} → ↧ (p / q) {q≢0} ≡ ℤ.+ q
-↧[p/q]≡q p (suc q) {q≢0} = refl
+↧[n/d]≡d : ∀ n d .{{_ : ℕ.NonZero d}} → ↧ (n / d) ≡ ℤ.+ d
+↧[n/d]≡d n (suc d) = refl
 
 ------------------------------------------------------------------------
 -- Properties of Positive/Negative/NonPositive/NonNegative predicates
 ------------------------------------------------------------------------
 
-positive⇒nonNegative : ∀ {q} → Positive q → NonNegative q
+positive⇒nonNegative : ∀ {p} → Positive p → NonNegative p
 positive⇒nonNegative {mkℚᵘ +0       _} _ = _
 positive⇒nonNegative {mkℚᵘ +[1+ n ] _} _ = _
 
-negative⇒nonPositive : ∀ {q} → Negative q → NonPositive q
+negative⇒nonPositive : ∀ {p} → Negative p → NonPositive p
 negative⇒nonPositive {mkℚᵘ +0       _} _ = _
 negative⇒nonPositive {mkℚᵘ -[1+ n ] _} _ = _
 
@@ -356,20 +357,6 @@ drop-*<* (*<* pq<qp) = pq<qp
 
 ≮⇒≥ : _≮_ ⇒ _≥_
 ≮⇒≥ p≮q = *≤* (ℤ.≮⇒≥ (p≮q ∘ *<*))
-
-p≄0⇒∣↥p∣≢0 : ∀ p → p ≠ 0ℚᵘ → ℤ.∣ (↥ p) ∣ ≢0
-p≄0⇒∣↥p∣≢0 p = Dec.fromWitnessFalse ∘ contraposition (lemma₁ p)
-  where
-    open ≡-Reasoning
-    lemma₁ : ∀ p → ℤ.∣ (↥ p) ∣ ≡ 0 → p ≃ 0ℚᵘ
-    lemma₁ (mkℚᵘ (ℤ.+ ℕ.zero) d-1) ∣↥p∣≡0 = *≡* refl
-
-∣↥p∣≢0⇒p≄0 : ∀ p → ℤ.∣ (↥ p) ∣ ≢0 → p ≠ 0ℚᵘ
-∣↥p∣≢0⇒p≄0 p = contraposition (lemma₁ p) ∘ Dec.toWitnessFalse
-  where
-    open ≡-Reasoning
-    lemma₁ : ∀ p → p ≃ 0ℚᵘ → ℤ.∣ (↥ p) ∣ ≡ 0
-    lemma₁ (mkℚᵘ (ℤ.+ ℕ.zero) d-1) (*≡* ↥p1≡0↧p) = refl
 
 ------------------------------------------------------------------------
 -- Relational properties
@@ -1059,7 +1046,7 @@ p≤q⇒0≤q-p {p} {q} p≤q = begin
 *-identity : Identity _≃_ 1ℚᵘ _*_
 *-identity = *-identityˡ , *-identityʳ
 
-*-inverseˡ : ∀ p {p≢0 : ℤ.∣ ↥ p ∣ ≢0} → 1/_ p {p≢0} * p ≃ 1ℚᵘ
+*-inverseˡ : ∀ p .{{_ : NonZero p}} → (1/ p) * p ≃ 1ℚᵘ
 *-inverseˡ p@(mkℚᵘ -[1+ n ] d) = *-inverseˡ (mkℚᵘ +[1+ n ] d)
 *-inverseˡ p@(mkℚᵘ +[1+ n ] d) = *≡* $ cong +[1+_] $ begin
   (n ℕ.+ d ℕ.* suc n) ℕ.* 1 ≡⟨ ℕ.*-identityʳ _ ⟩
@@ -1070,8 +1057,8 @@ p≤q⇒0≤q-p {p} {q} p≤q = begin
   d ℕ.+ n ℕ.* suc d ℕ.+ 0   ∎
   where open ≡-Reasoning; open ℕ-solver
 
-*-inverseʳ : ∀ p {p≢0 : ℤ.∣ ↥ p ∣ ≢0} → p * 1/_ p {p≢0} ≃ 1ℚᵘ
-*-inverseʳ p {p≢0} = ≃-trans (*-comm p (1/ p)) (*-inverseˡ p {p≢0})
+*-inverseʳ : ∀ p .{{_ : NonZero p}} → p * 1/ p ≃ 1ℚᵘ
+*-inverseʳ p = ≃-trans (*-comm p (1/ p)) (*-inverseˡ p)
 
 *-zeroˡ : LeftZero _≃_ 0ℚᵘ _*_
 *-zeroˡ p = *≡* refl
@@ -1115,26 +1102,21 @@ neg-distribʳ-* p q = *≡* $ cong (ℤ._* (↧ p ℤ.* ↧ q))
 ------------------------------------------------------------------------
 -- Properties of _*_ and _/_
 
-*-cancelˡ-/ : ∀ p {q r} pr≢0 r≢0 → ((ℤ.+ p ℤ.* q) / (p ℕ.* r)) {pr≢0} ≃ (q / r) {r≢0}
-*-cancelˡ-/ p {q} {r} pr≢0 r≢0 = *≡* (begin-equality
-  (↥ ((ℤ.+ p ℤ.* q) / (p ℕ.* r))) ℤ.* (↧ (q / r)) ≡⟨ cong (ℤ._* (↧ (q / r) {r≢0})) (↥[p/q]≡p (ℤ.+ p ℤ.* q) (p ℕ.* r) {pr≢0}) ⟩
-  (ℤ.+ p ℤ.* q) ℤ.* (↧ (q / r))                   ≡⟨ cong ((ℤ.+ p ℤ.* q) ℤ.*_) (↧[p/q]≡q q r {r≢0}) ⟩
-  (ℤ.+ p ℤ.* q) ℤ.* ℤ.+ r                         ≡⟨ solve 3 (λ a b c → ((a :* b) :* c) := (b :* (a :* c))) refl (ℤ.+ p) q (ℤ.+ r) ⟩
-  (q ℤ.* (ℤ.+ p ℤ.* ℤ.+ r))                       ≡˘⟨ cong (ℤ._* (ℤ.+ p ℤ.* ℤ.+ r)) (↥[p/q]≡p q r {r≢0}) ⟩
-  (↥ (q / r)) ℤ.* (ℤ.+ p ℤ.* ℤ.+ r)               ≡⟨  cong ((↥ (q / r) {r≢0}) ℤ.*_) (ℤ.pos-distrib-* p r) ⟩
-  (↥ (q / r)) ℤ.* (ℤ.+ (p ℕ.* r))                 ≡˘⟨ cong ((↥ (q / r) {r≢0}) ℤ.*_) (↧[p/q]≡q (ℤ.+ p ℤ.* q) (p ℕ.* r) {pr≢0}) ⟩
+*-cancelˡ-/ : ∀ p {q r} .{{_ : ℕ.NonZero r}} .{{_ : ℕ.NonZero (p ℕ.* r)}} →
+              ((ℤ.+ p ℤ.* q) / (p ℕ.* r)) ≃ (q / r)
+*-cancelˡ-/ p {q} {r} = *≡* (begin-equality
+  (↥ ((ℤ.+ p ℤ.* q) / (p ℕ.* r))) ℤ.* (↧ (q / r)) ≡⟨  cong (ℤ._* ↧ (q / r)) (↥[n/d]≡n (ℤ.+ p ℤ.* q) (p ℕ.* r)) ⟩
+  (ℤ.+ p ℤ.* q) ℤ.* (↧ (q / r))                   ≡⟨  cong ((ℤ.+ p ℤ.* q) ℤ.*_) (↧[n/d]≡d q r) ⟩
+  (ℤ.+ p ℤ.* q) ℤ.* ℤ.+ r                         ≡⟨  xy∙z≈y∙xz (ℤ.+ p) q (ℤ.+ r) ⟩
+  (q ℤ.* (ℤ.+ p ℤ.* ℤ.+ r))                       ≡˘⟨ cong (ℤ._* (ℤ.+ p ℤ.* ℤ.+ r)) (↥[n/d]≡n q r) ⟩
+  (↥ (q / r)) ℤ.* (ℤ.+ p ℤ.* ℤ.+ r)               ≡⟨  cong (↥ (q / r) ℤ.*_) (ℤ.pos-distrib-* p r) ⟩
+  (↥ (q / r)) ℤ.* (ℤ.+ (p ℕ.* r))                 ≡˘⟨ cong (↥ (q / r) ℤ.*_) (↧[n/d]≡d (ℤ.+ p ℤ.* q) (p ℕ.* r)) ⟩
   (↥ (q / r)) ℤ.* (↧ ((ℤ.+ p ℤ.* q) / (p ℕ.* r))) ∎)
-  where open ℤ.≤-Reasoning; open ℤ-solver
+  where open ℤ.≤-Reasoning
 
-*-cancelʳ-/ : ∀ p {q r} rp≢0 r≢0 → ((q ℤ.* ℤ.+ p) / (r ℕ.* p)) {rp≢0} ≃ (q / r) {r≢0}
-*-cancelʳ-/ p {q} {r} rp≢0 r≢0 = begin-equality
-  ((q ℤ.* ℤ.+ p) / (r ℕ.* p)) {rp≢0}              ≡⟨ /-cong (ℤ.*-comm q (ℤ.+ p)) (ℕ.*-comm r p) rp≢0 pr≢0 ⟩
-  ((ℤ.+ p ℤ.* q) / (p ℕ.* r)) {pr≢0}              ≈⟨ *-cancelˡ-/ p pr≢0 r≢0 ⟩
-  (q / r) {r≢0}                                   ∎
-  where
-  open ≤-Reasoning
-  pr≢0 : p ℕ.* r ≢0
-  pr≢0 = Dec.fromWitnessFalse (subst (_≢ 0) (ℕ.*-comm r p) (Dec.toWitnessFalse rp≢0))
+*-cancelʳ-/ : ∀ p {q r} .{{_ : ℕ.NonZero r}} .{{_ : ℕ.NonZero (r ℕ.* p)}} →
+              ((q ℤ.* ℤ.+ p) / (r ℕ.* p)) ≃ (q / r)
+*-cancelʳ-/ p {q} {r} rewrite ℕ.*-comm r p | ℤ.*-comm q (ℤ.+ p) = *-cancelˡ-/ p
 
 ------------------------------------------------------------------------
 -- Properties of _*_ and _≤_
@@ -1393,42 +1375,36 @@ private
 ------------------------------------------------------------------------
 
 private
-  pos⇒≢0 : ∀ p → Positive p → ℤ.∣ ↥ p ∣ ≢0
-  pos⇒≢0 p p>0 = Dec.fromWitnessFalse (contraposition ℤ.∣n∣≡0⇒n≡0 (≢-sym (ℤ.<⇒≢ (ℤ.positive⁻¹ p>0))))
+  pos⇒≢0 : ∀ p → Positive p → NonZero p
+  pos⇒≢0 (mkℚᵘ (+[1+ _ ]) _) _ = _
 
-  neg⇒≢0 : ∀ p → Negative p → ℤ.∣ ↥ p ∣ ≢0
-  neg⇒≢0 p p<0 = Dec.fromWitnessFalse (contraposition ℤ.∣n∣≡0⇒n≡0 (ℤ.<⇒≢ (ℤ.negative⁻¹ p<0)))
+  neg⇒≢0 : ∀ p → Negative p → NonZero p
+  neg⇒≢0 (mkℚᵘ (-[1+ _ ]) _) _ = _
 
-  1/p≢0 : ∀ p {p≢0} → ℤ.∣ (↥ ((1/ p) {p≢0})) ∣ ≢0
-  1/p≢0 (mkℚᵘ (+[1+ n ]) d-1) = tt
-  1/p≢0 (mkℚᵘ (-[1+ n ]) d-1) = tt
+  1/p≢0 : ∀ p .{{_ : NonZero p}} → NonZero (1/ p)
+  1/p≢0 (mkℚᵘ (+[1+ _ ]) _) = _
+  1/p≢0 (mkℚᵘ (-[1+ _ ]) _) = _
 
-  p>1⇒p≢0 : ∀ {p} → p > 1ℚᵘ → ℤ.∣ ↥ p ∣ ≢0
-  p>1⇒p≢0 {p} (*<* 1↧p<↥p1) = Dec.fromWitnessFalse (contraposition ℤ.∣n∣≡0⇒n≡0 (≢-sym (ℤ.<⇒≢ (begin-strict
-    +0           ≤⟨ ℤ.+≤+ ℕ.z≤n ⟩
-    ↧ p          ≡˘⟨ ℤ.*-identityˡ _ ⟩
-    1ℤ ℤ.* ↧ p   <⟨ 1↧p<↥p1 ⟩
-    ↥ p ℤ.* 1ℤ   ≡⟨ ℤ.*-identityʳ _ ⟩
-    ↥ p          ∎))))
-    where open ℤ.≤-Reasoning
+  p>1⇒p≢0 : ∀ {p} → p > 1ℚᵘ → NonZero p
+  p>1⇒p≢0 {p} p>1 = pos⇒≢0 p (positive (<-trans (*<* (ℤ.+<+ ℕ.≤-refl)) p>1))
 
-1/-involutive-≡ : ∀ p {p≢0} → (1/ (1/ p) {p≢0}) {1/p≢0 p {p≢0}} ≡ p
+1/-involutive-≡ : ∀ p .{{_ : NonZero p}} → (1/ (1/ p)) {{1/p≢0 p}} ≡ p
 1/-involutive-≡ (mkℚᵘ +[1+ n ] d-1) = refl
 1/-involutive-≡ (mkℚᵘ -[1+ n ] d-1) = refl
 
-1/-involutive : ∀ p {p≢0} → (1/ (1/ p) {p≢0}) {1/p≢0 p {p≢0}} ≃ p
-1/-involutive p {p≢0} = ≃-reflexive (1/-involutive-≡ p {p≢0})
+1/-involutive : ∀ p .{{_ : NonZero p}} → (1/ (1/ p)) {{1/p≢0 p}} ≃ p
+1/-involutive p = ≃-reflexive (1/-involutive-≡ p)
 
-pos⇒1/pos : ∀ p (p>0 : Positive p) → Positive ((1/ p) {pos⇒≢0 p p>0})
+pos⇒1/pos : ∀ p (p>0 : Positive p) → Positive ((1/ p) {{pos⇒≢0 p p>0}})
 pos⇒1/pos (mkℚᵘ +[1+ n ] d-1) _ = tt
 
-neg⇒1/neg : ∀ p (p<0 : Negative p) → Negative ((1/ p) {neg⇒≢0 p p<0})
+neg⇒1/neg : ∀ p (p<0 : Negative p) → Negative ((1/ p) {{neg⇒≢0 p p<0}})
 neg⇒1/neg (mkℚᵘ -[1+ n ] d-1) _ = tt
 
-p>1⇒1/p<1 : ∀ {p} → (p>1 : p > 1ℚᵘ) → (1/ p) {p>1⇒p≢0 p>1} < 1ℚᵘ
-p>1⇒1/p<1 {p} p>1 = lemma′ p (p>1⇒p≢0 p>1) p>1 where
-  open ℤ.≤-Reasoning
-  lemma′ : ∀ p p≢0 → p > 1ℚᵘ → (1/ p) {p≢0} < 1ℚᵘ
+p>1⇒1/p<1 : ∀ {p} → (p>1 : p > 1ℚᵘ) → (1/ p) {{p>1⇒p≢0 p>1}} < 1ℚᵘ
+p>1⇒1/p<1 {p} p>1 = lemma′ p (p>1⇒p≢0 p>1) p>1
+  where
+  lemma′ : ∀ p p≢0 → p > 1ℚᵘ → (1/ p) {{p≢0}} < 1ℚᵘ
   lemma′ (mkℚᵘ n@(+[1+ _ ]) d-1) _ (*<* ↥p1>1↧p) = *<* (begin-strict
     ↥ (1/ mkℚᵘ n d-1) ℤ.* 1ℤ         ≡⟨⟩
     +[1+ d-1 ] ℤ.* 1ℤ                ≡⟨ ℤ.*-comm +[1+ d-1 ] 1ℤ ⟩
@@ -1436,6 +1412,7 @@ p>1⇒1/p<1 {p} p>1 = lemma′ p (p>1⇒p≢0 p>1) p>1 where
     n  ℤ.* 1ℤ                        ≡⟨ ℤ.*-comm n 1ℤ ⟩
     1ℤ ℤ.* n                         ≡⟨⟩
     (↥ 1ℚᵘ) ℤ.* (↧ (1/ mkℚᵘ n d-1))  ∎)
+    where open ℤ.≤-Reasoning
 
 ------------------------------------------------------------------------
 -- Properties of _⊓_ and _⊔_
@@ -1717,11 +1694,11 @@ neg-distrib-⊓-⊔ = antimono-≤-distrib-⊓ neg-mono-≤
 ∣p+q∣≤∣p∣+∣q∣ p q = *≤* (begin
   ↥ ∣ p + q ∣ ℤ.* ↧ (∣ p ∣ + ∣ q ∣)                ≡⟨⟩
   ↥ ∣ (↥p↧q ℤ.+ ↥q↧p) / ↧p↧q ∣ ℤ.* ℤ.+ ↧p↧q        ≡⟨⟩
-  ↥ (ℤ.+ ℤ.∣ ↥p↧q ℤ.+ ↥q↧p ∣ / ↧p↧q) ℤ.* ℤ.+ ↧p↧q  ≡⟨ cong (λ h → h ℤ.* ℤ.+ ↧p↧q) (↥[p/q]≡p (ℤ.+ ℤ.∣ ↥p↧q ℤ.+ ↥q↧p ∣) ↧p↧q) ⟩
+  ↥ (ℤ.+ ℤ.∣ ↥p↧q ℤ.+ ↥q↧p ∣ / ↧p↧q) ℤ.* ℤ.+ ↧p↧q  ≡⟨ cong (λ h → h ℤ.* ℤ.+ ↧p↧q) (↥[n/d]≡n (ℤ.+ ℤ.∣ ↥p↧q ℤ.+ ↥q↧p ∣) ↧p↧q) ⟩
   ℤ.+ ℤ.∣ ↥p↧q ℤ.+ ↥q↧p ∣ ℤ.* ℤ.+ ↧p↧q             ≤⟨ ℤ.*-monoʳ-≤-pos ↧p↧q-1 (ℤ.+≤+ (ℤ.∣m+n∣≤∣m∣+∣n∣ ↥p↧q ↥q↧p)) ⟩
   (ℤ.+ ℤ.∣ ↥p↧q ∣ ℤ.+ ℤ.+ ℤ.∣ ↥q↧p ∣) ℤ.* ℤ.+ ↧p↧q ≡˘⟨ cong₂ (λ h₁ h₂ → (h₁ ℤ.+ h₂) ℤ.* ℤ.+ ↧p↧q) ∣↥p∣↧q≡∣↥p↧q∣ ∣↥q∣↧p≡∣↥q↧p∣ ⟩
   (∣↥p∣↧q ℤ.+ ∣↥q∣↧p) ℤ.* ℤ.+ ↧p↧q                 ≡⟨⟩
-  (↥∣p∣↧q ℤ.+ ↥∣q∣↧p) ℤ.* ℤ.+ ↧p↧q                 ≡⟨ cong (ℤ._* ℤ.+ ↧p↧q) (↥[p/q]≡p (↥∣p∣↧q ℤ.+ ↥∣q∣↧p) ↧p↧q) ⟩
+  (↥∣p∣↧q ℤ.+ ↥∣q∣↧p) ℤ.* ℤ.+ ↧p↧q                 ≡⟨ cong (ℤ._* ℤ.+ ↧p↧q) (↥[n/d]≡n (↥∣p∣↧q ℤ.+ ↥∣q∣↧p) ↧p↧q) ⟩
   ↥ ((↥∣p∣↧q ℤ.+ ↥∣q∣↧p) / ↧p↧q) ℤ.* ℤ.+ ↧p↧q      ≡⟨⟩
   ↥ (∣ p ∣ + ∣ q ∣) ℤ.* ↧ ∣ p + q ∣ ∎)
   where
@@ -1794,4 +1771,18 @@ neg-mono-<-> = neg-mono-<
 {-# WARNING_ON_USAGE neg-mono-<->
 "Warning: neg-mono-<-> was deprecated in v1.5.
 Please use neg-mono-< instead."
+#-}
+
+-- Version 2.0
+
+↥[p/q]≡p = ↥[n/d]≡n
+{-# WARNING_ON_USAGE ↥[p/q]≡p
+"Warning: ↥[p/q]≡p was deprecated in v2.0.
+Please use ↥[n/d]≡n instead."
+#-}
+
+↧[p/q]≡q = ↧[n/d]≡d
+{-# WARNING_ON_USAGE ↧[p/q]≡q
+"Warning: ↧[p/q]≡q was deprecated in v2.0.
+Please use ↧[n/d]≡d instead."
 #-}


### PR DESCRIPTION
Finishes off the first pass through of using instance arguments for `NonZero` proofs started in #1538. No major design issues reared their head, although a couple of the `gcd` related proofs are not quite as slick as they could be due to what I think is probably a bug in Agda which I've reported via https://github.com/agda/agda/issues/5494.