### PR TITLE
Adapted proofs in `Data.Nat` and `Data.Integer` that used the old `suc` trick to use `NonZero`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,16 @@ Non-backwards compatible changes
   ```
   This does however mean that if you passed in the value `x` to these proofs before, then you
   will now have to pass in `suc x`. The full list of such proofs is below:
+  - In `Data.Nat.Properties`:
+	```agda
+	*-cancelʳ-≡ : ∀ m n {o} → m * suc o ≡ n * suc o → m ≡ n
+	*-cancelˡ-≡ : ∀ {m n} o → suc o * m ≡ suc o * n → m ≡ n
+	*-cancelʳ-≤ : ∀ m n o → m * suc o ≤ n * suc o → m ≤ n
+	*-cancelˡ-≤ : ∀ {m n} o → suc o * m ≤ suc o * n → m ≤ n
+	*-monoˡ-<   : ∀ n → (_* suc n) Preserves _<_ ⟶ _<_
+	*-monoʳ-<   : ∀ n → (suc n *_) Preserves _<_ ⟶ _<_
+	```
+
   - In `Data.Nat.DivMod`:
 	```agda
     m≡m%n+[m/n]*n : ∀ m n → m ≡ m % suc n + (m / suc n) * suc n
@@ -144,16 +154,66 @@ Non-backwards compatible changes
     m%n≤m         : ∀ m n → m % suc n ≤ m
     m≤n⇒m%n≡m     : ∀ {m n} → m ≤ n → m % suc n ≡ m
     ```
+
   - In `Data.Nat.Divisibility`
     ```agda
     m%n≡0⇒n∣m : ∀ m n → m % suc n ≡ 0 → suc n ∣ m
     n∣m⇒m%n≡0 : ∀ m n → suc n ∣ m → m % suc n ≡ 0
     m%n≡0⇔n∣m : ∀ m n → m % suc n ≡ 0 ⇔ suc n ∣ m
-    ```
+	∣⇒≤       : ∀ {m n} → m ∣ suc n → m ≤ suc n
+	>⇒∤        : ∀ {m n} → m > suc n → m ∤ suc n
+	*-cancelˡ-∣ : ∀ {i j} k → suc k * i ∣ suc k * j → i ∣ j
+	```
+
   - In `Data.Nat.GCD`
     ```
     GCD-* : ∀ {m n d c} → GCD (m * suc c) (n * suc c) (d * suc c) → GCD m n d
+	gcd[m,n]≤n : ∀ m n → gcd m (suc n) ≤ suc n
     ```
+
+  - In `Data.Nat.Coprimality`:
+	```
+	Bézout-coprime : ∀ {i j d} → Bézout.Identity (suc d) (i * suc d) (j * suc d) → Coprime i j
+	```
+	
+  - In `Data.Integer.Properties`:
+	```
+	sign-◃    : ∀ s n → sign (s ◃ suc n) ≡ s
+	sign-cong : ∀ {s₁ s₂ n₁ n₂} → s₁ ◃ suc n₁ ≡ s₂ ◃ suc n₂ → s₁ ≡ s₂
+	-◃<+◃     : ∀ m n → Sign.- ◃ (suc m) < Sign.+ ◃ n
+	m⊖1+n<m   : ∀ m n → m ⊖ suc n < + m
+    ```
+
+  - In `Data.Integer.Divisibility`:
+	```
+	*-cancelˡ-∣ : ∀ k {i j} → k ≢ + 0 → k * i ∣ k * j → i ∣ j
+	*-cancelʳ-∣ : ∀ k {i j} → k ≢ + 0 → i * k ∣ j * k → i ∣ j
+	```
+
+  - In `Data.Integer.Divisibility.Signed`:
+	```
+    *-cancelˡ-∣ : ∀ k {i j} → k ≢ + 0 → k * i ∣ k * j → i ∣ j
+	*-cancelʳ-∣ : ∀ k {i j} → k ≢ + 0 → i * k ∣ j * k → i ∣ j
+	```
+
+* A couple of other proofs in have also changed form:
+  - In `Data.Nat.Properties`:
+  ```
+  m≤m*n          : ∀ m {n} → 0 < n → m ≤ m * n 
+  m≤n*m          : ∀ m {n} → 0 < n → m ≤ n * m
+  m<m*n          : ∀ {m n} → 0 < m → 1 < n → m < m * n
+  suc[pred[n]]≡n : ∀ {n} → n ≢ 0 → suc (pred n) ≡ n
+  ```
+  - In `Data.Nat.DivMod`:
+  ```
+  m/n<m         : ∀ m n {≢0} → m ≥ 1 → n ≥ 2 → (m / n) {≢0} < m
+  ```
+  - In `Data.Integer.Properties`:
+  ```
+  *-cancelʳ-≡ : ∀ i j k → k ≢ + 0 → i * k ≡ j * k → i ≡ j
+  *-cancelˡ-≡ : ∀ i j k → i ≢ + 0 → i * j ≡ i * k → j ≡ k
+  *-cancelʳ-≤-pos : ∀ m n o → m * + suc o ≤ n * + suc o → m ≤ n
+  ```
 
 ### Strict functions
 
@@ -199,6 +259,11 @@ Deprecated modules
 
 Deprecated names
 ----------------
+
+* In `Data.Nat.Properties`:
+  ```
+  suc[pred[n]]≡n ↦ suc-pred
+  ```
 
 New modules
 -----------
@@ -298,6 +363,16 @@ Other minor additions
   ∧-isCommutativeSemigroup : IsCommutativeSemigroup ∧
   ```
   and their corresponding algebraic substructures.
+
+* Added new proofs in `Data.Integer.Properties`:
+  ```agda
+  sign-cong′ : s₁ ◃ n₁ ≡ s₂ ◃ n₂ → s₁ ≡ s₂ ⊎ (n₁ ≡ 0 × n₂ ≡ 0)
+  ```
+
+* Added new proofs in `Data.Nat.Properties`:
+  ```agda
+  m*n≡0⇒m≡0 : .{{_ : NonZero n}} → m * n ≡ 0 → m ≡ 0
+  ```
 
 * Added new definitions and proofs in `Data.Rational.Properties`:
   ```agda

--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -54,13 +54,13 @@ toNatDigits base@(suc zero)    n = replicate n 1
 toNatDigits base@(suc (suc b)) n = aux (<-wellFounded-fast n) []
   where
   aux : {n : ℕ} → Acc _<_ n → List ℕ → List ℕ
-  aux {zero}        _        xs =  (0 ∷ xs)
-  aux {n@(suc n-1)} (acc wf) xs with does (0 <? n / base)
-  ... | false =  (n % base) ∷ xs
-  ... | true  =  aux (wf (n / base) q<n) ((n % base) ∷ xs)
+  aux {zero}        _      xs =  (0 ∷ xs)
+  aux {n@(suc _)} (acc wf) xs with does (0 <? n / base)
+  ... | false = (n % base) ∷ xs
+  ... | true  = aux (wf (n / base) q<n) ((n % base) ∷ xs)
     where
     q<n : n / base < n
-    q<n = m/n<m n base (s≤s z≤n) (s≤s (s≤s z≤n))
+    q<n = m/n<m n base (s≤s (s≤s z≤n))
 
 ------------------------------------------------------------------------
 -- Converting between `ℕ` and expansions of `Digit base`

--- a/src/Data/Integer/Base.agda
+++ b/src/Data/Integer/Base.agda
@@ -178,7 +178,7 @@ nonNegative {+[1+ n ]} _ = _
 infix 5 _◂_ _◃_
 
 _◃_ : Sign → ℕ → ℤ
-_      ◃ ℕ.zero  = + ℕ.zero
+_      ◃ ℕ.zero  = +0
 Sign.+ ◃ n       = + n
 Sign.- ◃ ℕ.suc n = -[1+ n ]
 

--- a/src/Data/Integer/Divisibility.agda
+++ b/src/Data/Integer/Divisibility.agda
@@ -43,22 +43,15 @@ open ℕᵈ public using (divides)
   where open ℕᵈ.∣-Reasoning
 
 *-monoˡ-∣ : ∀ k → (_* k) Preserves _∣_ ⟶ _∣_
-*-monoˡ-∣ k {i} {j}
-  rewrite *-comm i k
-        | *-comm j k
-        = *-monoʳ-∣ k
+*-monoˡ-∣ k {i} {j} rewrite *-comm i k | *-comm j k = *-monoʳ-∣ k
 
-*-cancelˡ-∣ : ∀ k {i j} → k ≢ + 0 → k * i ∣ k * j → i ∣ j
-*-cancelˡ-∣ k {i} {j} k≢0 k*i∣k*j = ℕᵈ.*-cancelˡ-∣ (ℕ.pred ∣ k ∣) $ begin
-  let ∣k∣-is-suc = ℕᵖ.suc[pred[n]]≡n (k≢0 ∘ ∣n∣≡0⇒n≡0) in
-  ℕ.suc (ℕ.pred ∣ k ∣) ℕ.* ∣ i ∣ ≡⟨ cong (ℕ._* ∣ i ∣) (∣k∣-is-suc) ⟩
-  ∣ k ∣ ℕ.* ∣ i ∣                ≡⟨ sym (abs-*-commute k i) ⟩
-  ∣ k * i ∣                      ∣⟨ k*i∣k*j ⟩
-  ∣ k * j ∣                      ≡⟨ abs-*-commute k j ⟩
-  ∣ k ∣ ℕ.* ∣ j ∣                ≡⟨ cong (ℕ._* ∣ j ∣) (sym ∣k∣-is-suc) ⟩
-  ℕ.suc (ℕ.pred ∣ k ∣) ℕ.* ∣ j ∣ ∎
+*-cancelˡ-∣ : ∀ k {i j} .{{_ : NonZero k}} → k * i ∣ k * j → i ∣ j
+*-cancelˡ-∣ k {i} {j} k*i∣k*j = ℕᵈ.*-cancelˡ-∣ ∣ k ∣ $ begin
+  ∣ k ∣ ℕ.* ∣ i ∣  ≡⟨ sym (abs-*-commute k i) ⟩
+  ∣ k * i ∣        ∣⟨ k*i∣k*j ⟩
+  ∣ k * j ∣        ≡⟨ abs-*-commute k j ⟩
+  ∣ k ∣ ℕ.* ∣ j ∣  ∎
   where open ℕᵈ.∣-Reasoning
 
-*-cancelʳ-∣ : ∀ k {i j} → k ≢ + 0 → i * k ∣ j * k → i ∣ j
-*-cancelʳ-∣ k {i} {j} ≢0 = *-cancelˡ-∣ k ≢0 ∘
-  subst₂ _∣_ (*-comm i k) (*-comm j k)
+*-cancelʳ-∣ : ∀ k {i j} .{{_ : NonZero k}} → i * k ∣ j * k → i ∣ j
+*-cancelʳ-∣ k {i} {j} rewrite *-comm i k | *-comm j k = *-cancelˡ-∣ k

--- a/src/Data/Integer/Divisibility/Signed.agda
+++ b/src/Data/Integer/Divisibility/Signed.agda
@@ -42,51 +42,51 @@ open _∣_ using (quotient) public
 -- Conversion between signed and unsigned divisibility
 
 ∣ᵤ⇒∣ : ∀ {k i} → k ∣ᵤ i → k ∣ i
-∣ᵤ⇒∣ {k} {i} (divides 0 eq) = divides (+ 0) (∣n∣≡0⇒n≡0 eq)
-∣ᵤ⇒∣ {k} {i} (divides q@(ℕ.suc q′) eq) with k ≟ + 0
-... | yes refl = divides (+ 0) (∣n∣≡0⇒n≡0 (trans eq (ℕ.*-zeroʳ q)))
-... | no ¬k≠0  = divides ((S._*_ on sign) i k ◃ q) (◃-≡ sign-eq abs-eq) where
+∣ᵤ⇒∣ {k} {i} (divides 0           eq) = divides (+ 0) (∣n∣≡0⇒n≡0 eq)
+∣ᵤ⇒∣ {k} {i} (divides q@(ℕ.suc _) eq) with k ≟ +0
+... | yes refl = divides +0 (∣n∣≡0⇒n≡0 (trans eq (ℕ.*-zeroʳ q)))
+... | no  neq  = divides (sign i S.* sign k ◃ q) (◃-≡ sign-eq abs-eq)
+  where
+  ikq = sign i S.* sign k ◃ q
 
-  k′   = ℕ.suc (ℕ.pred ∣ k ∣)
-  ikq′ = sign i S.* sign k ◃ ℕ.suc q′
+  *-nonZero : ∀ m n .{{_ : ℕ.NonZero m}} .{{_ : ℕ.NonZero n}} → ℕ.NonZero (m ℕ.* n)
+  *-nonZero (ℕ.suc _) (ℕ.suc _) = _
 
-  sign-eq : sign i ≡ sign (((S._*_ on sign) i k ◃ q) * k)
+  ◃-nonZero : ∀ s n .{{_ : ℕ.NonZero n}} → NonZero (s ◃ n)
+  ◃-nonZero S.- (ℕ.suc _) = _
+  ◃-nonZero S.+ (ℕ.suc _) = _
+
+  ikq≢0 : NonZero ikq
+  ikq≢0 = ◃-nonZero (sign i S.* sign k) q
+
+  instance
+    ikq*∣k∣≢0 : ℕ.NonZero (∣ ikq ∣ ℕ.* ∣ k ∣)
+    ikq*∣k∣≢0 = *-nonZero ∣ ikq ∣ ∣ k ∣ {{ikq≢0}} {{≢-nonZero neq}}
+
+  sign-eq : sign i ≡ sign (ikq * k)
   sign-eq = sym $ begin
-    sign (((S._*_ on sign) i k ◃ ℕ.suc q′) * k)
-      ≡⟨ cong (λ m → sign (sign ikq′ S.* sign k ◃ ∣ ikq′ ∣ ℕ.* m))
-              (sym (ℕ.suc[pred[n]]≡n (¬k≠0 ∘ ∣n∣≡0⇒n≡0))) ⟩
-    sign (sign ikq′ S.* sign k ◃ ∣ ikq′ ∣ ℕ.* k′)
-      ≡⟨ cong (λ m → sign (sign ikq′ S.* sign k ◃ m ℕ.* k′))
-              (abs-◃ (sign i S.* sign k) (ℕ.suc q′)) ⟩
-    sign (sign ikq′ S.* sign k ◃ _)
-      ≡⟨ sign-◃ (sign ikq′ S.* sign k) (ℕ.pred ∣ k ∣ ℕ.+ q′ ℕ.* k′) ⟩
-    sign ikq′ S.* sign k
-      ≡⟨ cong (S._* sign k) (sign-◃ (sign i S.* sign k) q′) ⟩
-    sign i S.* sign k S.* sign k
-        ≡⟨ SProp.*-assoc (sign i) (sign k) (sign k) ⟩
-    sign i S.* (sign k S.* sign k)
-      ≡⟨ cong (sign i S.*_) (SProp.s*s≡+ (sign k)) ⟩
-    sign i S.* S.+
-      ≡⟨ SProp.*-identityʳ (sign i) ⟩
-    sign i
-      ∎ where open ≡-Reasoning
+    sign (ikq * k)                  ≡⟨ sign-◃ (sign ikq S.* sign k) (∣ ikq ∣ ℕ.* ∣ k ∣) ⟩
+    sign ikq S.* sign k             ≡⟨ cong (S._* sign k) (sign-◃ (sign i S.* sign k) q) ⟩
+    (sign i S.* sign k) S.* sign k  ≡⟨ SProp.*-assoc (sign i) (sign k) (sign k) ⟩
+    sign i S.* (sign k S.* sign k)  ≡⟨ cong (sign i S.*_) (SProp.s*s≡+ (sign k)) ⟩
+    sign i S.* S.+                  ≡⟨ SProp.*-identityʳ (sign i) ⟩
+    sign i                          ∎
+    where open ≡-Reasoning
 
-  abs-eq : ∣ i ∣ ≡ ∣ ((S._*_ on sign) i k ◃ q) * k ∣
+  abs-eq : ∣ i ∣ ≡ ∣ ikq * k ∣
   abs-eq = sym $ begin
-    ∣ ((S._*_ on sign) i k ◃ ℕ.suc q′) * k ∣
-      ≡⟨ abs-◃ (sign ikq′ S.* sign k) (∣ ikq′ ∣ ℕ.* ∣ k ∣) ⟩
-    ∣ ikq′ ∣ ℕ.* ∣ k ∣
-      ≡⟨ cong (ℕ._* ∣ k ∣) (abs-◃ (sign i S.* sign k) (ℕ.suc q′)) ⟩
-    ℕ.suc q′ ℕ.* ∣ k ∣
-      ≡⟨ sym eq ⟩
-    ∣ i ∣
-      ∎ where open ≡-Reasoning
+    ∣ ikq * k ∣        ≡⟨ ∣m*n∣≡∣m∣*∣n∣ ikq k ⟩
+    ∣ ikq ∣ ℕ.* ∣ k ∣  ≡⟨ cong (ℕ._* ∣ k ∣) (abs-◃ (sign i S.* sign k) q) ⟩
+    q ℕ.* ∣ k ∣        ≡⟨ sym eq ⟩
+    ∣ i ∣              ∎
+    where open ≡-Reasoning
 
 ∣⇒∣ᵤ : ∀ {k i} → k ∣ i → k ∣ᵤ i
 ∣⇒∣ᵤ {k} {i} (divides q eq) = divides ∣ q ∣ $′ begin
   ∣ i ∣           ≡⟨ cong ∣_∣ eq ⟩
   ∣ q * k ∣       ≡⟨ abs-*-commute q k ⟩
-  ∣ q ∣ ℕ.* ∣ k ∣ ∎ where open ≡-Reasoning
+  ∣ q ∣ ℕ.* ∣ k ∣ ∎
+  where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- _∣_ is a preorder
@@ -132,7 +132,7 @@ infix 4 _∣?_
 _∣?_ : Decidable _∣_
 k ∣? m = DEC.map′ ∣ᵤ⇒∣ ∣⇒∣ᵤ (∣ k ∣ ℕ.∣? ∣ m ∣)
 
-0∣⇒≡0 : ∀ {m} → + 0 ∣ m → m ≡ + 0
+0∣⇒≡0 : ∀ {m} → 0ℤ ∣ m → m ≡ 0ℤ
 0∣⇒≡0 0|m = ∣n∣≡0⇒n≡0 (ℕ.0∣⇒≡0 (∣⇒∣ᵤ 0|m))
 
 m∣∣m∣ : ∀ {m} → m ∣ (+ ∣ m ∣)
@@ -166,9 +166,7 @@ m∣∣m∣ = ∣ᵤ⇒∣ ℕ.∣-refl
   where open ∣-Reasoning
 
 ∣m+n∣n⇒∣m : ∀ {i m n} → i ∣ m + n → i ∣ n → i ∣ m
-∣m+n∣n⇒∣m {i} {m} {n} i|m+n i|n
-  rewrite +-comm m n
-        = ∣m+n∣m⇒∣n i|m+n i|n
+∣m+n∣n⇒∣m {m = m} {n} i|m+n i|n rewrite +-comm m n = ∣m+n∣m⇒∣n i|m+n i|n
 
 ∣n⇒∣m*n : ∀ {i} m {n} → i ∣ n → i ∣ m * n
 ∣n⇒∣m*n {i} m {n} (divides q eq) = divides (m * q) $′ begin
@@ -178,18 +176,17 @@ m∣∣m∣ = ∣ᵤ⇒∣ ℕ.∣-refl
   where open ≡-Reasoning
 
 ∣m⇒∣m*n : ∀ {i m} n → i ∣ m → i ∣ m * n
-∣m⇒∣m*n {i} {m} n i|m
-  rewrite *-comm m n
-        = ∣n⇒∣m*n {i} n {m} i|m
+∣m⇒∣m*n {m = m} n i|m rewrite *-comm m n = ∣n⇒∣m*n n i|m
 
 *-monoʳ-∣ : ∀ k → (k *_) Preserves _∣_ ⟶ _∣_
-*-monoʳ-∣ k i∣j = ∣ᵤ⇒∣ (Unsigned.*-monoʳ-∣ k (∣⇒∣ᵤ i∣j))
+*-monoʳ-∣ k = ∣ᵤ⇒∣ ∘ Unsigned.*-monoʳ-∣ k ∘ ∣⇒∣ᵤ
 
 *-monoˡ-∣ : ∀ k → (_* k) Preserves _∣_ ⟶ _∣_
-*-monoˡ-∣ k {i} {j} i∣j = ∣ᵤ⇒∣ (Unsigned.*-monoˡ-∣ k {i} {j} (∣⇒∣ᵤ i∣j))
+*-monoˡ-∣ k {i} {j} = ∣ᵤ⇒∣ ∘ Unsigned.*-monoˡ-∣ k {i} {j} ∘ ∣⇒∣ᵤ
 
-*-cancelˡ-∣ : ∀ k {i j} → k ≢ + 0 → k * i ∣ k * j → i ∣ j
-*-cancelˡ-∣ k k≢0 = ∣ᵤ⇒∣ ∘ Unsigned.*-cancelˡ-∣ k k≢0 ∘ ∣⇒∣ᵤ
+*-cancelˡ-∣ : ∀ k {i j} .{{_ : NonZero k}} → k * i ∣ k * j → i ∣ j
+*-cancelˡ-∣ k = ∣ᵤ⇒∣ ∘ Unsigned.*-cancelˡ-∣ k ∘ ∣⇒∣ᵤ
 
-*-cancelʳ-∣ : ∀ k {i j} → k ≢ + 0 → i * k ∣ j * k → i ∣ j
-*-cancelʳ-∣ k {i} {j} k≢0 = ∣ᵤ⇒∣ ∘′ Unsigned.*-cancelʳ-∣ k {i} {j} k≢0 ∘′ ∣⇒∣ᵤ
+*-cancelʳ-∣ : ∀ k {i j} .{{_ : NonZero k}} → i * k ∣ j * k → i ∣ j
+*-cancelʳ-∣ k {i} {j} = ∣ᵤ⇒∣ ∘′ Unsigned.*-cancelʳ-∣ k {i} {j} ∘′ ∣⇒∣ᵤ
+

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -28,6 +28,7 @@ open import Data.Product using (proj₁; proj₂; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Data.Sign as Sign using () renaming (_*_ to _𝕊*_)
 import Data.Sign.Properties as 𝕊ₚ
+open import Data.Product using (_×_)
 open import Data.Unit using (tt)
 open import Function.Base using (_∘_; _$_; id)
 open import Level using (0ℓ)
@@ -465,12 +466,12 @@ neg-cancel-< { -[1+ m ]} { -[1+ n ]} (+<+ (s≤s m<n)) = -<- m<n
   suc m ℕ.⊔ suc n          ≤⟨ ℕₚ.m⊔n≤m+n (suc m) (suc n) ⟩
   suc m ℕ.+ suc n          ∎
   where open ℕₚ.≤-Reasoning
-∣m+n∣≤∣m∣+∣n∣ (+ zero) (+ n) = ℕₚ.≤-refl
-∣m+n∣≤∣m∣+∣n∣ (+ zero) -[1+ n ] = ℕₚ.≤-refl
-∣m+n∣≤∣m∣+∣n∣ (-[1+ m ]) (+ n) = begin
-  ∣ n ⊖ suc m ∣            ≤⟨ ∣m⊝n∣≤m⊔n n (suc m) ⟩
+∣m+n∣≤∣m∣+∣n∣ +0       (+ n)    = ℕₚ.≤-refl
+∣m+n∣≤∣m∣+∣n∣ +0       -[1+ n ] = ℕₚ.≤-refl
+∣m+n∣≤∣m∣+∣n∣ -[1+ m ] (+ n)    = begin
+  ∣ n ⊖ suc m ∣            ≤⟨ ∣m⊝n∣≤m⊔n  n (suc m) ⟩
   n ℕ.⊔ suc m              ≤⟨ ℕₚ.m⊔n≤m+n n (suc m) ⟩
-  n ℕ.+ suc m              ≡⟨ ℕₚ.+-comm n (suc m) ⟩
+  n ℕ.+ suc m              ≡⟨ ℕₚ.+-comm  n (suc m) ⟩
   suc m ℕ.+ n              ∎
   where open ℕₚ.≤-Reasoning
 ∣m+n∣≤∣m∣+∣n∣ (-[1+ m ]) (-[1+ n ]) rewrite ℕₚ.+-suc (suc m) n = ℕₚ.≤-refl
@@ -505,9 +506,9 @@ neg-cancel-< { -[1+ m ]} { -[1+ n ]} (+<+ (s≤s m<n)) = -<- m<n
 -◃n≡-n zero    = refl
 -◃n≡-n (suc _) = refl
 
-sign-◃ : ∀ s n → sign (s ◃ suc n) ≡ s
-sign-◃ Sign.- _ = refl
-sign-◃ Sign.+ _ = refl
+sign-◃ : ∀ s n .{{_ : ℕ.NonZero n}} → sign (s ◃ n) ≡ s
+sign-◃ Sign.- (suc _) = refl
+sign-◃ Sign.+ (suc _) = refl
 
 abs-◃ : ∀ s n → ∣ s ◃ n ∣ ≡ n
 abs-◃ _      zero    = refl
@@ -518,13 +519,21 @@ signₙ◃∣n∣≡n : ∀ n → sign n ◃ ∣ n ∣ ≡ n
 signₙ◃∣n∣≡n (+ n)    = +◃n≡+n n
 signₙ◃∣n∣≡n -[1+ n ] = refl
 
-sign-cong : ∀ {s₁ s₂ n₁ n₂} →
-            s₁ ◃ suc n₁ ≡ s₂ ◃ suc n₂ → s₁ ≡ s₂
-sign-cong {s₁} {s₂} {n₁} {n₂} eq = begin
-  s₁                  ≡⟨ sym $ sign-◃ s₁ n₁ ⟩
-  sign (s₁ ◃ suc n₁)  ≡⟨ cong sign eq ⟩
-  sign (s₂ ◃ suc n₂)  ≡⟨ sign-◃ s₂ n₂ ⟩
-  s₂                  ∎ where open ≡-Reasoning
+sign-cong : ∀ {s₁ s₂ n₁ n₂} .{{_ : ℕ.NonZero n₁}} .{{_ : ℕ.NonZero n₂}} →
+            s₁ ◃ n₁ ≡ s₂ ◃ n₂ → s₁ ≡ s₂
+sign-cong {s₁} {s₂} {n₁@(suc _)} {n₂@(suc _)} eq = begin
+  s₁              ≡⟨ sym $ sign-◃ s₁ n₁ ⟩
+  sign (s₁ ◃ n₁)  ≡⟨ cong sign eq ⟩
+  sign (s₂ ◃ n₂)  ≡⟨ sign-◃ s₂ n₂ ⟩
+  s₂              ∎ where open ≡-Reasoning
+
+sign-cong′ : ∀ {s₁ s₂ n₁ n₂} → s₁ ◃ n₁ ≡ s₂ ◃ n₂ → s₁ ≡ s₂ ⊎ (n₁ ≡ 0 × n₂ ≡ 0)
+sign-cong′ {s₁} {s₂} {zero}   {zero}   eq = inj₂ (refl , refl)
+sign-cong′ {s₁} {Sign.- } {zero} {suc n₂} ()
+sign-cong′ {s₁} {Sign.+ } {zero} {suc n₂} ()
+sign-cong′ {Sign.- } {s₂} {suc n₁} {zero} ()
+sign-cong′ {Sign.+ } {s₂} {suc n₁} {zero} ()
+sign-cong′ {s₁} {s₂} {suc n₁} {suc n₂} eq = inj₁ (sign-cong eq)
 
 abs-cong : ∀ {s₁ s₂ n₁ n₂} → s₁ ◃ n₁ ≡ s₂ ◃ n₂ → n₁ ≡ n₂
 abs-cong {s₁} {s₂} {n₁} {n₂} eq = begin
@@ -556,9 +565,9 @@ neg◃-cancel-< {zero}  {zero}  (+<+ ())
 neg◃-cancel-< {suc m} {zero}  -<+       = s≤s z≤n
 neg◃-cancel-< {suc m} {suc n} (-<- n<m) = s≤s n<m
 
--◃<+◃ : ∀ m n → Sign.- ◃ (suc m) < Sign.+ ◃ n
--◃<+◃ m zero    = -<+
--◃<+◃ m (suc n) = -<+
+-◃<+◃ : ∀ m n .{{_ : ℕ.NonZero m}} → Sign.- ◃ m < Sign.+ ◃ n
+-◃<+◃ (suc _) zero    = -<+
+-◃<+◃ (suc _) (suc _) = -<+
 
 +◃≮-◃ : ∀ {m n} → Sign.+ ◃ m ≮ Sign.- ◃ n
 +◃≮-◃ {zero}  {zero} (+<+ ())
@@ -661,9 +670,9 @@ m⊖n≤m (suc m) (suc n) = begin
 m⊖n<1+m : ∀ m n → m ⊖ n < +[1+ m ]
 m⊖n<1+m m n = ≤-<-trans (m⊖n≤m m n) (+<+ (ℕₚ.m<n+m m (s≤s z≤n)))
 
-m⊖1+n<m : ∀ m n → m ⊖ suc n < + m
-m⊖1+n<m zero    n = -<+
-m⊖1+n<m (suc m) n = begin-strict
+m⊖1+n<m : ∀ m n .{{_ : ℕ.NonZero n}} → m ⊖ n < + m
+m⊖1+n<m zero    (suc n) = -<+
+m⊖1+n<m (suc m) (suc n) = begin-strict
   suc m ⊖ suc n ≡⟨ [1+m]⊖[1+n]≡m⊖n m n ⟩
   m ⊖ n         <⟨ m⊖n<1+m m n ⟩
   +[1+ m ]      ∎ where open ≤-Reasoning
@@ -1254,7 +1263,7 @@ minus-suc m n = begin
   pred (m - + n)     ∎ where open ≡-Reasoning
 
 m≤pred[n]⇒m<n : ∀ {m n} → m ≤ pred n → m < n
-m≤pred[n]⇒m<n {m} { + n}      m≤predn = ≤-<-trans m≤predn (m⊖1+n<m n 0)
+m≤pred[n]⇒m<n {m} { + n}      m≤predn = ≤-<-trans m≤predn (m⊖1+n<m n 1)
 m≤pred[n]⇒m<n {m} { -[1+ n ]} m≤predn = ≤-<-trans m≤predn (-<- ℕₚ.≤-refl)
 
 m<n⇒m≤pred[n] : ∀ {m n} → m < n → m ≤ pred n
@@ -1337,8 +1346,7 @@ private
 private
 
   -- lemma used to prove distributivity.
-  distrib-lemma :
-    ∀ a b c → (c ⊖ b) * -[1+ a ] ≡ a ℕ.+ b ℕ.* suc a ⊖ (a ℕ.+ c ℕ.* suc a)
+  distrib-lemma : ∀ a b c → (c ⊖ b) * -[1+ a ] ≡ a ℕ.+ b ℕ.* suc a ⊖ (a ℕ.+ c ℕ.* suc a)
   distrib-lemma a b c
     rewrite +-cancelˡ-⊖ a (b ℕ.* suc a) (c ℕ.* suc a)
           | ⊖-swap (b ℕ.* suc a) (c ℕ.* suc a)
@@ -1353,7 +1361,7 @@ private
     rewrite sign-⊖-≰ b≰c
           | ∣⊖∣-≰ b≰c
           | +◃n≡+n ((b ∸ c) ℕ.* suc a)
-          | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c a)
+          | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c (suc a))
           | neg-involutive (+ (b ℕ.* suc a ∸ c ℕ.* suc a))
           | ℕₚ.*-distribʳ-∸ (suc a) b c
           = refl
@@ -1420,7 +1428,7 @@ private
         | sign-⊖-≰ b≰c
         | ∣⊖∣-≰ b≰c
         | -◃n≡-n ((b ∸ c) ℕ.* suc a)
-        | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c a)
+        | ⊖-≰ (b≰c ∘ ℕₚ.*-cancelʳ-≤ b c (suc a))
         | ℕₚ.*-distribʳ-∸ (suc a) b c
         = refl
 *-distribʳ-+ (+ suc c) (+ suc a) -[1+ b ] with b ℕ.≤? a
@@ -1439,7 +1447,7 @@ private
         | +-cancelˡ-⊖ c (a ℕ.* suc c) (b ℕ.* suc c)
         | sign-⊖-≰ b≰a
         | ∣⊖∣-≰ b≰a
-        | ⊖-≰ (b≰a ∘ ℕₚ.*-cancelʳ-≤ b a c)
+        | ⊖-≰ (b≰a ∘ ℕₚ.*-cancelʳ-≤ b a (suc c))
         | -◃n≡-n ((b ∸ a) ℕ.* suc c)
         | ℕₚ.*-distribʳ-∸ (suc c) b a
         = refl
@@ -1567,44 +1575,17 @@ private
 abs-*-commute : ℤtoℕ.Homomorphic₂ ∣_∣ _*_ ℕ._*_
 abs-*-commute i j = abs-◃ _ _
 
-*-cancelʳ-≡ : ∀ i j k → k ≢ + 0 → i * k ≡ j * k → i ≡ j
-*-cancelʳ-≡ i j k            ≢0 eq with signAbs k
-*-cancelʳ-≡ i j .+0       ≢0 eq | s ◂ zero  = contradiction refl ≢0
-*-cancelʳ-≡ i j .(s ◃ suc n) ≢0 eq | s ◂ suc n
-  with ∣ s ◃ suc n ∣ | abs-◃ s (suc n) | sign (s ◃ suc n) | sign-◃ s n
-...  | .(suc n)      | refl            | .s               | refl =
-  ◃-cong (sign-i≡sign-j i j eq) $
-         ℕₚ.*-cancelʳ-≡ ∣ i ∣ ∣ j ∣ $ abs-cong eq
-  where
-  sign-i≡sign-j : ∀ i j →
-                  (sign i 𝕊* s) ◃ (∣ i ∣ ℕ.* suc n) ≡
-                  (sign j 𝕊* s) ◃ (∣ j ∣ ℕ.* suc n) →
-                  sign i ≡ sign j
-  sign-i≡sign-j i              j              eq with signAbs i | signAbs j
-  sign-i≡sign-j .+0         .+0         eq | s₁ ◂ zero   | s₂ ◂ zero   = refl
-  sign-i≡sign-j .+0         .(s₂ ◃ suc n₂) eq | s₁ ◂ zero   | s₂ ◂ suc n₂
-    with ∣ s₂ ◃ suc n₂ ∣ | abs-◃ s₂ (suc n₂)
-  ... | .(suc n₂) | refl
-    with abs-cong {s₁} {sign (s₂ ◃ suc n₂) 𝕊* s} {0} {suc n₂ ℕ.* suc n} eq
-  ...   | ()
-  sign-i≡sign-j .(s₁ ◃ suc n₁) .+0         eq | s₁ ◂ suc n₁ | s₂ ◂ zero
-    with ∣ s₁ ◃ suc n₁ ∣ | abs-◃ s₁ (suc n₁)
-  ... | .(suc n₁) | refl
-    with abs-cong {sign (s₁ ◃ suc n₁) 𝕊* s} {s₁} {suc n₁ ℕ.* suc n} {0} eq
-  ...   | ()
-  sign-i≡sign-j .(s₁ ◃ suc n₁) .(s₂ ◃ suc n₂) eq | s₁ ◂ suc n₁ | s₂ ◂ suc n₂
-    with ∣ s₁ ◃ suc n₁ ∣ | abs-◃ s₁ (suc n₁)
-       | sign (s₁ ◃ suc n₁) | sign-◃ s₁ n₁
-       | ∣ s₂ ◃ suc n₂ ∣ | abs-◃ s₂ (suc n₂)
-       | sign (s₂ ◃ suc n₂) | sign-◃ s₂ n₂
-  ... | .(suc n₁) | refl | .s₁ | refl | .(suc n₂) | refl | .s₂ | refl =
-    𝕊ₚ.*-cancelʳ-≡ s₁ s₂ (sign-cong eq)
+*-cancelʳ-≡ : ∀ i j k .{{_ : NonZero k}} → i * k ≡ j * k → i ≡ j
+*-cancelʳ-≡ i j k eq with sign-cong′ eq
+... | inj₁ s[ik]≡s[jk] = ◃-cong
+  (𝕊ₚ.*-cancelʳ-≡ {sign k} (sign i) (sign j) s[ik]≡s[jk])
+  (ℕₚ.*-cancelʳ-≡ ∣ i ∣ ∣ j ∣ (abs-cong eq))
+... | inj₂ (∣ik∣≡0 , ∣jk∣≡0) = trans
+  (∣n∣≡0⇒n≡0 (ℕₚ.m*n≡0⇒m≡0 _ _ ∣ik∣≡0))
+  (sym (∣n∣≡0⇒n≡0 (ℕₚ.m*n≡0⇒m≡0 _ _ ∣jk∣≡0)))
 
-*-cancelˡ-≡ : ∀ i j k → i ≢ + 0 → i * j ≡ i * k → j ≡ k
-*-cancelˡ-≡ i j k
-  rewrite *-comm i j
-        | *-comm i k
-        = *-cancelʳ-≡ j k i
+*-cancelˡ-≡ : ∀ i j k .{{_ : NonZero i}} → i * j ≡ i * k → j ≡ k
+*-cancelˡ-≡ i j k rewrite *-comm i j | *-comm i k = *-cancelʳ-≡ j k i
 
 suc-* : ∀ m n → sucℤ m * n ≡ n + m * n
 suc-* m n = begin
@@ -1621,8 +1602,8 @@ suc-* m n = begin
   m + m * n  ∎
   where open ≡-Reasoning
 
--1*n≡-n : ∀ n → -[1+ 0 ] * n ≡ - n
--1*n≡-n -[1+ n ] = cong (λ v → + suc v) (ℕₚ.+-identityʳ n)
+-1*n≡-n : ∀ n → -1ℤ * n ≡ - n
+-1*n≡-n -[1+ n ] = cong +[1+_] (ℕₚ.+-identityʳ n)
 -1*n≡-n +0       = refl
 -1*n≡-n +[1+ n ] = cong -[1+_] (ℕₚ.+-identityʳ n)
 
@@ -1665,7 +1646,7 @@ neg-distribʳ-* x y = begin
     (*-comm (t ◃ zero) (s ◃ suc m))
 ◃-distrib-* s t (suc m) (suc n) =
   sym (cong₂ _◃_
-    (cong₂ _𝕊*_ (sign-◃ s m) (sign-◃ t n))
+    (cong₂ _𝕊*_ (sign-◃ s (suc m)) (sign-◃ t (suc n)))
     (∣s◃m∣*∣t◃n∣≡m*n s t (suc m) (suc n)))
 
 ------------------------------------------------------------------------
@@ -1673,13 +1654,13 @@ neg-distribʳ-* x y = begin
 
 *-cancelʳ-≤-pos : ∀ m n o → m * + suc o ≤ n * + suc o → m ≤ n
 *-cancelʳ-≤-pos (-[1+ m ]) (-[1+ n ]) o (-≤- n≤m) =
-  -≤- (ℕₚ.≤-pred (ℕₚ.*-cancelʳ-≤ (suc n) (suc m) o (s≤s n≤m)))
+  -≤- (ℕₚ.≤-pred (ℕₚ.*-cancelʳ-≤ (suc n) (suc m) (suc o) (s≤s n≤m)))
 *-cancelʳ-≤-pos -[1+ _ ]   (+ _)      _ _         = -≤+
 *-cancelʳ-≤-pos +0      +0      _ _         = +≤+ z≤n
 *-cancelʳ-≤-pos +0      (+ suc _)  _ _         = +≤+ z≤n
 *-cancelʳ-≤-pos (+ suc _)  +0      _ (+≤+ ())
 *-cancelʳ-≤-pos (+ suc m)  (+ suc n)  o (+≤+ m≤n) =
-  +≤+ (ℕₚ.*-cancelʳ-≤ (suc m) (suc n) o m≤n)
+  +≤+ (ℕₚ.*-cancelʳ-≤ (suc m) (suc n) (suc o) m≤n)
 
 *-cancelˡ-≤-pos : ∀ m n o → + suc m * n ≤ + suc m * o → n ≤ o
 *-cancelˡ-≤-pos m n o
@@ -1835,23 +1816,7 @@ neg-distribʳ-* x y = begin
 -- Properties of _*_ and ∣_∣
 
 ∣m*n∣≡∣m∣*∣n∣ : ∀ m n → ∣ m * n ∣ ≡ ∣ m ∣ ℕ.* ∣ n ∣
-∣m*n∣≡∣m∣*∣n∣ +[1+ m ] +[1+ n ] = refl
-∣m*n∣≡∣m∣*∣n∣ +[1+ m ] (+ zero) = begin
-  ∣ +[1+ m ] * + zero ∣             ≡⟨ cong ∣_∣ (*-zeroʳ +[1+ m ]) ⟩
-  ∣ + zero ∣                        ≡˘⟨ ℕₚ.*-zeroʳ m ⟩
-  ∣ +[1+ m ] ∣ ℕ.* ∣ + zero ∣       ∎
-  where open ≡-Reasoning
-∣m*n∣≡∣m∣*∣n∣ +[1+ m ] -[1+ n ] = refl
-∣m*n∣≡∣m∣*∣n∣ (+ zero) +[1+ n ] = refl
-∣m*n∣≡∣m∣*∣n∣ (+ zero) (+ zero) = refl
-∣m*n∣≡∣m∣*∣n∣ (+ zero) -[1+ n ] = refl
-∣m*n∣≡∣m∣*∣n∣ -[1+ m ] +[1+ n ] = refl
-∣m*n∣≡∣m∣*∣n∣ -[1+ m ] (+ zero) = begin
-  ∣ -[1+ m ] * + zero ∣             ≡⟨ cong ∣_∣ (*-zeroʳ -[1+ m ]) ⟩
-  ∣ + zero ∣                        ≡˘⟨ ℕₚ.*-zeroʳ m ⟩
-  ∣ -[1+ m ] ∣ ℕ.* ∣ + zero ∣       ∎
-  where open ≡-Reasoning
-∣m*n∣≡∣m∣*∣n∣ -[1+ m ] -[1+ n ] = refl
+∣m*n∣≡∣m∣*∣n∣ m n = abs-◃ (sign m 𝕊* sign n) (∣ m ∣ ℕ.* ∣ n ∣)
 
 ------------------------------------------------------------------------
 -- Properties of _⊓_ and _⊔_

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -175,7 +175,7 @@ toℕ-injective : Injective _≡_ _≡_ toℕ
 toℕ-injective {zero}     {zero}     _               =  refl
 toℕ-injective {2[1+ x ]} {2[1+ y ]} 2[1+xN]≡2[1+yN] =  cong 2[1+_] x≡y
   where
-  1+xN≡1+yN = ℕₚ.*-cancelˡ-≡ {ℕ.suc _} {ℕ.suc _} 1 2[1+xN]≡2[1+yN]
+  1+xN≡1+yN = ℕₚ.*-cancelˡ-≡ {ℕ.suc _} {ℕ.suc _} 2 2[1+xN]≡2[1+yN]
   xN≡yN     = cong ℕ.pred 1+xN≡1+yN
   x≡y       = toℕ-injective xN≡yN
 
@@ -188,7 +188,7 @@ toℕ-injective {1+[2 x ]} {2[1+ y ]} 1+2xN≡2[1+yN] =
 toℕ-injective {1+[2 x ]} {1+[2 y ]} 1+2xN≡1+2yN =  cong 1+[2_] x≡y
   where
   2xN≡2yN = cong ℕ.pred 1+2xN≡1+2yN
-  xN≡yN   = ℕₚ.*-cancelˡ-≡ 1 2xN≡2yN
+  xN≡yN   = ℕₚ.*-cancelˡ-≡ 2 2xN≡2yN
   x≡y     = toℕ-injective xN≡yN
 
 toℕ-surjective : Surjective _≡_ toℕ
@@ -291,7 +291,7 @@ toℕ-mono-< {1+[2 x ]} {2[1+ y ]} (odd<even (inj₁ x<y)) =   begin
   where open ℕₚ.≤-Reasoning;  xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
 toℕ-mono-< {1+[2 x ]} {2[1+ .x ]} (odd<even (inj₂ refl)) =
   ℕₚ.≤-reflexive (sym (ℕₚ.*-distribˡ-+ 2 1 (toℕ x)))
-toℕ-mono-< {1+[2 x ]} {1+[2 y ]} (odd<odd x<y) =  ℕₚ.+-monoʳ-< 1 (ℕₚ.*-monoʳ-< 1 xN<yN)
+toℕ-mono-< {1+[2 x ]} {1+[2 y ]} (odd<odd x<y) =  ℕₚ.+-monoʳ-< 1 (ℕₚ.*-monoʳ-< 2 xN<yN)
   where xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
 
 toℕ-cancel-< : ∀ {x y} → toℕ x ℕ.< toℕ y → x < y
@@ -306,7 +306,7 @@ toℕ-cancel-< {1+[2 x ]} {2[1+ y ]} x<y with toℕ x ℕₚ.≟ toℕ y
 ... | yes x≡y = odd<even (inj₂ (toℕ-injective x≡y))
 ... | no  x≢y
   rewrite ℕₚ.+-suc (toℕ y) (toℕ y ℕ.+ 0) =
-  odd<even (inj₁ (toℕ-cancel-< (ℕₚ.≤∧≢⇒< (ℕₚ.*-cancelˡ-≤ 1 (ℕₚ.+-cancelˡ-≤ 2 x<y)) x≢y)))
+  odd<even (inj₁ (toℕ-cancel-< (ℕₚ.≤∧≢⇒< (ℕₚ.*-cancelˡ-≤ 2 (ℕₚ.+-cancelˡ-≤ 2 x<y)) x≢y)))
 toℕ-cancel-< {1+[2 x ]} {1+[2 y ]} x<y =
   odd<odd (toℕ-cancel-< (ℕₚ.*-cancelˡ-< 2 (ℕ.≤-pred x<y)))
 

--- a/src/Data/Nat/Coprimality.agda
+++ b/src/Data/Nat/Coprimality.agda
@@ -112,12 +112,11 @@ recompute {n} {d} c = Nullary.recompute (coprime? n d) c
 -- If the "gcd" in Bézout's identity is non-zero, then the "other"
 -- divisors are coprime.
 
-Bézout-coprime : ∀ {i j d} →
-                 Bézout.Identity (suc d) (i * suc d) (j * suc d) →
-                 Coprime i j
-Bézout-coprime (Bézout.+- x y eq) (divides q₁ refl , divides q₂ refl) =
+Bézout-coprime : ∀ {i j d} .{{_ : NonZero d}} →
+                 Bézout.Identity d (i * d) (j * d) → Coprime i j
+Bézout-coprime {d = suc _} (Bézout.+- x y eq) (divides q₁ refl , divides q₂ refl) =
   lem₁₀ y q₂ x q₁ eq
-Bézout-coprime (Bézout.-+ x y eq) (divides q₁ refl , divides q₂ refl) =
+Bézout-coprime {d = suc _} (Bézout.-+ x y eq) (divides q₁ refl , divides q₂ refl) =
   lem₁₀ x q₁ y q₂ eq
 
 -- Coprime numbers satisfy Bézout's identity.

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -186,15 +186,15 @@ m/n*n≤m m n@(suc n-1) = begin
   m                    ∎
 
 m/n≤m : ∀ m n .{{_ : NonZero n}} → (m / n) ≤ m
-m/n≤m m n@(suc n-1) = *-cancelʳ-≤ (m / n) m n-1 (begin
+m/n≤m m n = *-cancelʳ-≤ (m / n) m n (begin
   (m / n) * n ≤⟨ m/n*n≤m m n ⟩
-  m           ≤⟨ m≤m*n m (s≤s z≤n) ⟩
+  m           ≤⟨ m≤m*n m n ⟩
   m * n       ∎)
 
-m/n<m : ∀ m n .{{_ : NonZero n}} → m ≥ 1 → n ≥ 2 → m / n < m
-m/n<m m n@(suc n-1) m≥1 n≥2 = *-cancelʳ-< {n} (m / n) m (begin-strict
+m/n<m : ∀ m n .{{_ : NonZero m}} .{{_ : NonZero n}} → n ≥ 2 → m / n < m
+m/n<m m n n≥2 = *-cancelʳ-< (m / n) m (begin-strict
   (m / n) * n ≤⟨ m/n*n≤m m n ⟩
-  m           <⟨ m<m*n m≥1 n≥2 ⟩
+  m           <⟨ m<m*n m n n≥2 ⟩
   m * n       ∎)
 
 /-mono-≤ : ∀ {m n o p} .{{_ : NonZero o}} .{{_ : NonZero p}} →
@@ -258,7 +258,7 @@ m*n/m*o≡n/o m@(suc m-1) n o {{o≢0}} = helper (<-wellFounded n)
   where
   helper : ∀ {n} → Acc _<_ n → (m * n) / (m * o) ≡ n / o
   helper {n} (acc rec) with n <? o
-  ... | yes n<o = trans (m<n⇒m/n≡0 (*-monoʳ-< m-1 n<o)) (sym (m<n⇒m/n≡0 n<o))
+  ... | yes n<o = trans (m<n⇒m/n≡0 (*-monoʳ-< m n<o)) (sym (m<n⇒m/n≡0 n<o))
   ... | no  n≮o = begin-equality
     (m * n) / (m * o)             ≡⟨  m/n≡1+[m∸n]/n (*-monoʳ-≤ m (≮⇒≥ n≮o)) ⟩
     1 + (m * n ∸ m * o) / (m * o) ≡˘⟨ cong (λ v → 1 + v / (m * o)) (*-distribˡ-∸ m n o) ⟩
@@ -278,7 +278,7 @@ m*n/m*o≡n/o m@(suc m-1) n o {{o≢0}} = helper (<-wellFounded n)
 
 /-*-interchange : ∀ {m n o p} .{{_ : NonZero o}} .{{_ : NonZero p}} .{{_ : NonZero (o * p)}} →
                   o ∣ m → p ∣ n → (m * n) / (o * p) ≡ (m / o) * (n / p)
-/-*-interchange {m} {n} {o@(suc _)} {p@(suc _)} o∣m p∣n = *-cancelˡ-≡ (pred (o * p)) (begin-equality
+/-*-interchange {m} {n} {o@(suc _)} {p@(suc _)} o∣m p∣n = *-cancelˡ-≡ (o * p) (begin-equality
   (o * p) * ((m * n) / (o * p)) ≡⟨  m*[n/m]≡n (*-pres-∣ o∣m p∣n) ⟩
   m * n                         ≡˘⟨ cong₂ _*_ (m*[n/m]≡n o∣m) (m*[n/m]≡n p∣n) ⟩
   (o * (m / o)) * (p * (n / p)) ≡⟨ [m*n]*[o*p]≡[m*o]*[n*p] o (m / o) p (n / p) ⟩

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -53,14 +53,14 @@ m%n≡0⇔n∣m m n = equivalence (m%n≡0⇒n∣m m n) (n∣m⇒m%n≡0 m n)
 ------------------------------------------------------------------------
 -- Properties of _∣_ and _≤_
 
-∣⇒≤ : ∀ {m n} → m ∣ suc n → m ≤ suc n
-∣⇒≤ {m} {n} (divides (suc q) eq) = begin
+∣⇒≤ : ∀ {m n} .{{_ : NonZero n}} → m ∣ n → m ≤ n
+∣⇒≤ {m} {n@(suc _)} (divides (suc q) eq) = begin
   m          ≤⟨ m≤m+n m (q * m) ⟩
   suc q * m  ≡⟨ sym eq ⟩
-  suc n      ∎
+  n          ∎
   where open ≤-Reasoning
 
->⇒∤ : ∀ {m n} → m > suc n → m ∤ suc n
+>⇒∤ : ∀ {m n} .{{_ : NonZero n}} → m > n → m ∤ n
 >⇒∤ (s≤s m>n) m∣n = contradiction (∣⇒≤ m∣n) (≤⇒≯ m>n)
 
 ------------------------------------------------------------------------
@@ -188,18 +188,18 @@ m∣m*n n = divides n (*-comm _ n)
 *-monoˡ-∣ : ∀ {i j} k → i ∣ j → i * k ∣ j * k
 *-monoˡ-∣ {i} {j} k rewrite *-comm i k | *-comm j k = *-monoʳ-∣ k
 
-*-cancelˡ-∣ : ∀ {i j} k → suc k * i ∣ suc k * j → i ∣ j
-*-cancelˡ-∣ {i} {j} k (divides q eq) =
+*-cancelˡ-∣ : ∀ {i j} k .{{_ : NonZero k}} → k * i ∣ k * j → i ∣ j
+*-cancelˡ-∣ {i} {j} k@(suc _) (divides q eq) =
   divides q $ *-cancelʳ-≡ j (q * i) $ begin-equality
-    j * (suc k)      ≡⟨ *-comm j (suc k) ⟩
-    suc k * j        ≡⟨ eq ⟩
-    q * (suc k * i)  ≡⟨ cong (q *_) (*-comm (suc k) i) ⟩
-    q * (i * suc k)  ≡⟨ sym (*-assoc q i (suc k)) ⟩
-    (q * i) * suc k  ∎
+    j * k        ≡⟨ *-comm j k ⟩
+    k * j        ≡⟨ eq ⟩
+    q * (k * i)  ≡⟨ cong (q *_) (*-comm k i) ⟩
+    q * (i * k)  ≡⟨ sym (*-assoc q i k) ⟩
+    (q * i) * k  ∎
     where open ≤-Reasoning
 
-*-cancelʳ-∣ : ∀ {i j} k {k≢0 : False (k ≟ 0)} → i * k ∣ j * k → i ∣ j
-*-cancelʳ-∣ {i} {j} k@(suc k-1) rewrite *-comm i k | *-comm j k = *-cancelˡ-∣ k-1
+*-cancelʳ-∣ : ∀ {i j} k .{{_ : NonZero k}} → i * k ∣ j * k → i ∣ j
+*-cancelʳ-∣ {i} {j} k rewrite *-comm i k | *-comm j k = *-cancelˡ-∣ k
 
 ------------------------------------------------------------------------
 -- Properties of _∣_ and _∸_

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -120,7 +120,7 @@ gcd-universality {m} {n} forwards backwards with backwards ∣-refl
 -- This could be simplified with some nice backwards/forwards reasoning
 -- after the new function hierarchy is up and running.
 gcd[cm,cn]/c≡gcd[m,n] : ∀ c m n .{{_ : NonZero c}} → gcd (c * m) (c * n) / c ≡ gcd m n
-gcd[cm,cn]/c≡gcd[m,n] c@(suc c-1) m n = gcd-universality forwards backwards
+gcd[cm,cn]/c≡gcd[m,n] c m n = gcd-universality forwards backwards
   where
   forwards : ∀ {d : ℕ} → d ∣ m × d ∣ n → d ∣ gcd (c * m) (c * n) / c
   forwards {d} (d∣m , d∣n) = m*n∣o⇒n∣o/m c d (gcd-greatest (*-monoʳ-∣ c d∣m) (*-monoʳ-∣ c d∣n))
@@ -128,25 +128,25 @@ gcd[cm,cn]/c≡gcd[m,n] c@(suc c-1) m n = gcd-universality forwards backwards
   backwards : ∀ {d : ℕ} → d ∣ gcd (c * m) (c * n) / c → d ∣ m × d ∣ n
   backwards {d} d∣gcd[cm,cn]/c with m∣n/o⇒o*m∣n (gcd-greatest (m∣m*n m) (m∣m*n n)) d∣gcd[cm,cn]/c
   ... | cd∣gcd[cm,n] =
-    *-cancelˡ-∣ c-1 (∣-trans cd∣gcd[cm,n] (gcd[m,n]∣m (c * m) _)) ,
-    *-cancelˡ-∣ c-1 (∣-trans cd∣gcd[cm,n] (gcd[m,n]∣n (c * m) _))
+    *-cancelˡ-∣ c (∣-trans cd∣gcd[cm,n] (gcd[m,n]∣m (c * m) _)) ,
+    *-cancelˡ-∣ c (∣-trans cd∣gcd[cm,n] (gcd[m,n]∣n (c * m) _))
 
 c*gcd[m,n]≡gcd[cm,cn] : ∀ c m n → c * gcd m n ≡ gcd (c * m) (c * n)
-c*gcd[m,n]≡gcd[cm,cn] zero        m n = P.sym gcd[0,0]≡0
-c*gcd[m,n]≡gcd[cm,cn] c@(suc c-1) m n = begin
+c*gcd[m,n]≡gcd[cm,cn] zero      m n = P.sym gcd[0,0]≡0
+c*gcd[m,n]≡gcd[cm,cn] c@(suc _) m n = begin
   c * gcd m n                   ≡⟨ cong (c *_) (P.sym (gcd[cm,cn]/c≡gcd[m,n] c m n)) ⟩
   c * (gcd (c * m) (c * n) / c) ≡⟨ m*[n/m]≡n (gcd-greatest (m∣m*n m) (m∣m*n n)) ⟩
   gcd (c * m) (c * n)           ∎
   where open P.≡-Reasoning
 
-gcd[m,n]≤n : ∀ m n → gcd m (suc n) ≤ suc n
-gcd[m,n]≤n m n = ∣⇒≤ (gcd[m,n]∣n m (suc n))
+gcd[m,n]≤n : ∀ m n .{{_ : NonZero n}} → gcd m n ≤ n
+gcd[m,n]≤n m n = ∣⇒≤ (gcd[m,n]∣n m n)
 
 n/gcd[m,n]≢0 : ∀ m n .{{_ : NonZero n}} .{{_ : NonZero (gcd m n)}} → n / gcd m n ≢ 0
-n/gcd[m,n]≢0 m n@(suc n-1) = m<n⇒n≢0 (m≥n⇒m/n>0 {n} {gcd m n} (gcd[m,n]≤n m n-1))
+n/gcd[m,n]≢0 m n = m<n⇒n≢0 (m≥n⇒m/n>0 {n} {gcd m n} (gcd[m,n]≤n m n))
 
 m/gcd[m,n]≢0 : ∀ m n .{{_ : NonZero m}} .{{_ : NonZero (gcd m n)}} → m / gcd m n ≢ 0
-m/gcd[m,n]≢0 m@(suc _) n rewrite gcd-comm m n = n/gcd[m,n]≢0 n m
+m/gcd[m,n]≢0 m n rewrite gcd-comm m n = n/gcd[m,n]≢0 n m
 
 ------------------------------------------------------------------------
 -- A formal specification of GCD

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -869,18 +869,20 @@ m+n≮m m n = subst (_≮ m) (+-comm n m) (m+n≮n n m)
 ------------------------------------------------------------------------
 -- Other properties of _*_ and _≡_
 
-*-cancelʳ-≡ : ∀ m n {o} → m * suc o ≡ n * suc o → m ≡ n
-*-cancelʳ-≡ zero    zero        eq = refl
-*-cancelʳ-≡ (suc m) (suc n) {o} eq =
+*-cancelʳ-≡ : ∀ m n {o} .{{_ : NonZero o}} → m * o ≡ n * o → m ≡ n
+*-cancelʳ-≡ zero    zero    {suc o} eq = refl
+*-cancelʳ-≡ (suc m) (suc n) {suc o} eq =
   cong suc (*-cancelʳ-≡ m n (+-cancelˡ-≡ (suc o) eq))
 
-*-cancelˡ-≡ : ∀ {m n} o → suc o * m ≡ suc o * n → m ≡ n
-*-cancelˡ-≡ {m} {n} o eq = *-cancelʳ-≡ m n
-  (subst₂ _≡_ (*-comm (suc o) m) (*-comm (suc o) n) eq)
+*-cancelˡ-≡ : ∀ {m n} o .{{_ : NonZero o}} → o * m ≡ o * n → m ≡ n
+*-cancelˡ-≡ {m} {n} o rewrite *-comm o m | *-comm o n = *-cancelʳ-≡ m n
 
 m*n≡0⇒m≡0∨n≡0 : ∀ m {n} → m * n ≡ 0 → m ≡ 0 ⊎ n ≡ 0
 m*n≡0⇒m≡0∨n≡0 zero    {n}     eq = inj₁ refl
 m*n≡0⇒m≡0∨n≡0 (suc m) {zero}  eq = inj₂ refl
+
+m*n≡0⇒m≡0 : ∀ m n .{{_ : NonZero n}} → m * n ≡ 0 → m ≡ 0
+m*n≡0⇒m≡0 zero (suc _) eq = refl
 
 m*n≡1⇒m≡1 : ∀ m n → m * n ≡ 1 → m ≡ 1
 m*n≡1⇒m≡1 (suc zero)    n             _  = refl
@@ -902,13 +904,13 @@ m*n≡1⇒n≡1 m n eq = m*n≡1⇒m≡1 n m (trans (*-comm n m) eq)
 ------------------------------------------------------------------------
 -- Other properties of _*_ and _≤_/_<_
 
-*-cancelʳ-≤ : ∀ m n o → m * suc o ≤ n * suc o → m ≤ n
-*-cancelʳ-≤ zero    _       _ _  = z≤n
-*-cancelʳ-≤ (suc m) (suc n) o le =
-  s≤s (*-cancelʳ-≤ m n o (+-cancelˡ-≤ (suc o) le))
+*-cancelʳ-≤ : ∀ m n o .{{_ : NonZero o}} → m * o ≤ n * o → m ≤ n
+*-cancelʳ-≤ zero    _       (suc o) _  = z≤n
+*-cancelʳ-≤ (suc m) (suc n) (suc o) le =
+  s≤s (*-cancelʳ-≤ m n (suc o) (+-cancelˡ-≤ (suc o) le))
 
-*-cancelˡ-≤ : ∀ {m n} o → suc o * m ≤ suc o * n → m ≤ n
-*-cancelˡ-≤ {m} {n} o rewrite *-comm (suc o) m | *-comm (suc o) n = *-cancelʳ-≤ m n o
+*-cancelˡ-≤ : ∀ {m n} o .{{_ : NonZero o}} → o * m ≤ o * n → m ≤ n
+*-cancelˡ-≤ {m} {n} o rewrite *-comm o m | *-comm o n = *-cancelʳ-≤ m n o
 
 *-mono-≤ : _*_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
 *-mono-≤ z≤n       _   = z≤n
@@ -925,32 +927,32 @@ m*n≡1⇒n≡1 m n eq = m*n≡1⇒m≡1 n m (trans (*-comm n m) eq)
 *-mono-< (s≤s (s≤s m≤n)) (s≤s u≤v) =
   +-mono-< (s≤s u≤v) (*-mono-< (s≤s m≤n) (s≤s u≤v))
 
-*-monoˡ-< : ∀ n → (_* suc n) Preserves _<_ ⟶ _<_
-*-monoˡ-< n (s≤s z≤n)       = s≤s z≤n
-*-monoˡ-< n (s≤s (s≤s m≤o)) =
-  +-mono-≤-< (≤-refl {suc n}) (*-monoˡ-< n (s≤s m≤o))
+*-monoˡ-< : ∀ n .{{_ : NonZero n}} → (_* n) Preserves _<_ ⟶ _<_
+*-monoˡ-< (suc n) (s≤s z≤n)       = s≤s z≤n
+*-monoˡ-< (suc n) (s≤s (s≤s m≤o)) =
+  +-mono-≤-< (≤-refl {suc n}) (*-monoˡ-< (suc n) (s≤s m≤o))
 
-*-monoʳ-< : ∀ n → (suc n *_) Preserves _<_ ⟶ _<_
-*-monoʳ-< zero    (s≤s m≤o) = +-mono-≤ (s≤s m≤o) z≤n
-*-monoʳ-< (suc n) (s≤s m≤o) =
-  +-mono-≤ (s≤s m≤o) (<⇒≤ (*-monoʳ-< n (s≤s m≤o)))
+*-monoʳ-< : ∀ n .{{_ : NonZero n}} → (n *_) Preserves _<_ ⟶ _<_
+*-monoʳ-< (suc zero)    (s≤s m≤o) = +-mono-≤ (s≤s m≤o) z≤n
+*-monoʳ-< (suc (suc n)) (s≤s m≤o) =
+  +-mono-≤ (s≤s m≤o) (<⇒≤ (*-monoʳ-< (suc n) (s≤s m≤o)))
 
-m≤m*n : ∀ m {n} → 0 < n → m ≤ m * n
-m≤m*n m {n} 0<n = begin
+m≤m*n : ∀ m n .{{_ : NonZero n}} → m ≤ m * n
+m≤m*n m n@(suc _) = begin
   m     ≡⟨ sym (*-identityʳ m) ⟩
-  m * 1 ≤⟨ *-monoʳ-≤ m 0<n ⟩
+  m * 1 ≤⟨ *-monoʳ-≤ m (s≤s z≤n) ⟩
   m * n ∎
 
-m≤n*m : ∀ m {n} → 0 < n → m ≤ n * m
-m≤n*m m {n} 0<n = begin
-  m     ≤⟨ m≤m*n m 0<n ⟩
+m≤n*m : ∀ m n .{{_ : NonZero n}} → m ≤ n * m
+m≤n*m m n@(suc _) = begin
+  m     ≤⟨ m≤m*n m n ⟩
   m * n ≡⟨ *-comm m n ⟩
   n * m ∎
 
-m<m*n :  ∀ {m n} → 0 < m → 1 < n → m < m * n
-m<m*n {m@(suc m-1)} {n@(suc (suc n-2))} (s≤s _) (s≤s (s≤s _)) = begin-strict
+m<m*n : ∀ m n .{{_ : NonZero m}} → 1 < n → m < m * n
+m<m*n m@(suc m-1) n@(suc (suc n-2)) (s≤s (s≤s _)) = begin-strict
   m           <⟨ s≤s (s≤s (m≤n+m m-1 n-2)) ⟩
-  n + m-1     ≤⟨ +-monoʳ-≤ n (m≤m*n m-1 0<1+n) ⟩
+  n + m-1     ≤⟨ +-monoʳ-≤ n (m≤m*n m-1 n) ⟩
   n + m-1 * n ≡⟨⟩
   m * n       ∎
 
@@ -960,7 +962,6 @@ m<m*n {m@(suc m-1)} {n@(suc (suc n-2))} (s≤s _) (s≤s (s≤s _)) = begin-stri
 *-cancelʳ-< {m}     (suc n) (suc o) nm<om =
   s≤s (*-cancelʳ-< n o (+-cancelˡ-< m nm<om))
 
--- Redo in terms of `comm+cancelʳ⇒cancelˡ` when generalised
 *-cancelˡ-< : LeftCancellative _<_ _*_
 *-cancelˡ-< x {y} {z} rewrite *-comm x y | *-comm x z = *-cancelʳ-< y z
 
@@ -1613,9 +1614,8 @@ pred[n]≤n {suc n} = n≤1+n n
 <⇒≤pred : ∀ {m n} → m < n → m ≤ pred n
 <⇒≤pred (s≤s le) = le
 
-suc[pred[n]]≡n : ∀ {n} → n ≢ 0 → suc (pred n) ≡ n
-suc[pred[n]]≡n {zero}  n≢0 = contradiction refl n≢0
-suc[pred[n]]≡n {suc n} n≢0 = refl
+suc-pred : ∀ n .{{_ : NonZero n}} → suc (pred n) ≡ n
+suc-pred (suc n) = refl
 
 ------------------------------------------------------------------------
 -- Properties of ∣_-_∣
@@ -2223,7 +2223,7 @@ Please use m^n≡1⇒n≡0∨m≡1 instead."
 "Warning: [i+j]∸[i+k]≡j∸k was deprecated in v1.1.
 Please use [m+n]∸[m+o]≡n∸o instead."
 #-}
-m≢0⇒suc[pred[m]]≡m = suc[pred[n]]≡n
+m≢0⇒suc[pred[m]]≡m = suc-pred
 {-# WARNING_ON_USAGE m≢0⇒suc[pred[m]]≡m
 "Warning: m≢0⇒suc[pred[m]]≡m was deprecated in v1.1.
 Please use suc[pred[n]]≡n instead."
@@ -2392,4 +2392,13 @@ n≤m⊔n = m≤n⊔m
 ⊓-abs-⊔ = ⊓-absorbs-⊔
 {-# WARNING_ON_USAGE ⊓-abs-⊔
 "Warning: ⊓-abs-⊔ was deprecated in v1.6. Please use ⊓-absorbs-⊔ instead."
+#-}
+
+-- Version 2.0
+
+suc[pred[n]]≡n : ∀ {n} → n ≢ 0 → suc (pred n) ≡ n
+suc[pred[n]]≡n {zero}  0≢0 = contradiction refl 0≢0
+suc[pred[n]]≡n {suc n} _   = refl
+{-# WARNING_ON_USAGE suc[pred[n]]≡n
+"Warning: suc[pred[n]]≡n was deprecated in v2.0. Please use suc-pred instead. Note that the proof now uses instance arguments"
 #-}

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -159,7 +159,7 @@ mkℚ+-pos (suc n) (suc d) nz = _
 
   helper : mkℚ n₁ d₁ c₁ ≡ mkℚ n₂ d₂ c₂
   helper with ∣-antisym 1+d₁∣1+d₂ 1+d₂∣1+d₁
-  ... | refl with ℤ.*-cancelʳ-≡ n₁ n₂ (+ suc d₁) (λ ()) eq
+  ... | refl with ℤ.*-cancelʳ-≡ n₁ n₂ (+ suc d₁) eq
   ...   | refl = refl
 
 ------------------------------------------------------------------------
@@ -838,7 +838,7 @@ toℚᵘ-homo-+ p q with +-nf p q ℤ.≟ 0ℤ
   eq : ↥ (p + q) ≡ 0ℤ
   eq rewrite eq2 = cong ↥_ (0/n≡0 (↧ₙ p ℕ.* ↧ₙ q))
 
-... | no  nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (+-nf p q) nf[p,q]≢0 (begin
+... | no  nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (+-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} (begin
   ↥ (p + q) ℤ.* ↧+ᵘ p q    ℤ.* +-nf p q   ≡⟨ xy∙z≈xz∙y (↥ (p + q)) _ _ ⟩
   ↥ (p + q) ℤ.* +-nf p q   ℤ.* ↧+ᵘ p q    ≡⟨ cong (ℤ._* ↧+ᵘ p q) (↥-+ p q) ⟩
   ↥+ᵘ p q   ℤ.* ↧+ᵘ p q                   ≡⟨ cong (↥+ᵘ p q ℤ.*_) (sym (↧-+ p q)) ⟩
@@ -1061,7 +1061,7 @@ toℚᵘ-homo-* p q with *-nf p q ℤ.≟ 0ℤ
 
   eq : ↥ (p * q) ≡ 0ℤ
   eq rewrite eq2 = cong ↥_ (0/n≡0 (↧ₙ p ℕ.* ↧ₙ q))
-... | no  nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (*-nf p q) nf[p,q]≢0 (begin
+... | no  nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (*-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} (begin
   ↥ (p * q)     ℤ.* (↧ p ℤ.* ↧ q) ℤ.* *-nf p q ≡⟨ xy∙z≈xz∙y (↥ (p * q)) _ _ ⟩
   ↥ (p * q)     ℤ.* *-nf p q ℤ.* (↧ p ℤ.* ↧ q) ≡⟨ cong (ℤ._* (↧ p ℤ.* ↧ q)) (↥-* p q) ⟩
   (↥ p ℤ.* ↥ q) ℤ.* (↧ p ℤ.* ↧ q)              ≡⟨ cong ((↥ p ℤ.* ↥ q) ℤ.*_) (sym (↧-* p q)) ⟩

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -86,7 +86,7 @@ drop-*≡* (*≡* eq) = eq
 
 ≃-trans : Transitive _≃_
 ≃-trans {x} {y} {z} (*≡* ad≡cb) (*≡* cf≡ed) =
-  *≡* (ℤ.*-cancelʳ-≡ (↥ x ℤ.* ↧ z) (↥ z ℤ.* ↧ x) (↧ y) (λ()) (begin
+  *≡* (ℤ.*-cancelʳ-≡ (↥ x ℤ.* ↧ z) (↥ z ℤ.* ↧ x) (↧ y) (begin
      ↥ x ℤ.* ↧ z ℤ.* ↧ y ≡⟨ xy∙z≈xz∙y (↥ x) _ _ ⟩
      ↥ x ℤ.* ↧ y ℤ.* ↧ z ≡⟨ cong (ℤ._* ↧ z) ad≡cb ⟩
      ↥ y ℤ.* ↧ x ℤ.* ↧ z ≡⟨ xy∙z≈xz∙y (↥ y) _ _ ⟩


### PR DESCRIPTION
I've gone through all of `Data.Nat` and `Data.Integer` folders looking for proofs which use the old way of ensuring something was `NonZero` (by taking an argument `n` and only using it in the form `suc n`),  and adapted them to use the new `NonZero` instance argument approach.

This has eliminated a lot of places where we were using these proofs and having to use `suc (pred x)` instead of `x` merely to manipulate into the form `suc _`.