### PR TITLE
[ new ] GenerateEverything --include-deprecated flag

### DIFF
--- a/GenerateEverything.hs
+++ b/GenerateEverything.hs
@@ -297,8 +297,9 @@ checkFilePaths cat fps = forM_ fps $ \ fp -> do
 
 main = do
   args <- getArgs
-  case args of
-    [] -> return ()
+  includeDeprecated <- case args of
+    [] -> return False
+    ["--include-deprecated"] -> return True
     _  -> hPutStr stderr usage >> exitFailure
 
   checkFilePaths "unsafe" unsafeModules
@@ -309,7 +310,8 @@ main = do
                find always
                     (extension ==? ".agda" ||? extension ==? ".lagda")
                     srcDir
-  libraryfiles <- filter ((Deprecated /=) . status) <$> mapM analyse modules
+  libraryfiles <- (if includeDeprecated then id
+    else (filter ((Deprecated /=) . status) <$>)) (mapM analyse modules)
 
   let mkModule str = "module " ++ str ++ " where"
 


### PR DESCRIPTION
When `Everything.agda` is used to build the entire contents of the library, we want to include the deprecated modules too, as they are still a usable part of the library. In particular, currently the nixpkgs version of agda-stdlib leaves deprecated modules unusable.