### PR TITLE
committed changes as per Issue #1589

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -528,6 +528,8 @@ Other minor changes
   map-⊛ : ∀ {n} (f : A → B → C) (g : A → B) (xs : Vec A n) → (map f xs ⊛ map g xs) ≡ map (f ˢ g) xs
   ⊛-is->>= : ∀ {n} (fs : Vec (A → B) n) (xs : Vec A n) → (fs ⊛ xs) ≡ (fs DiagonalBind.>>= flip map xs)
   transpose-replicate : ∀ {m n} (xs : Vec A m) → transpose (replicate {n = n} xs) ≡ map replicate xs
+  []≔-++-↑ʳ : ∀ {m n y} (xs : Vec A m) (ys : Vec A n) i →
+                 (xs ++ ys) [ m ↑ʳ i ]≔ y ≡ xs ++ (ys [ i ]≔ y)
   ```
 
 * Added new proofs in `Function.Construct.Symmetry`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,11 +335,27 @@ Deprecated names
   sym-↔   ↦   ↔-sym
   ```
 
-* In `Data.Fin.Base`: two new, hopefully more memorable, names `↑ˡ` `↑ʳ` for the 'left', resp. 'right' injection of a Fin m into a larger Fin (n + m), with argument order to reflect the position of the Fin m argument. Knock-on changes in `Data.Fin.Properties`, `Data.Vec.Properties`, `Data.Vec.Functional`, `Data.Vec.Functional.Properties`, `Data.Vec.Functional.Relation.Binary.Pointwise.Properties`, `Data.Vec.Functional.Relation.Unary.All.Properties`. 
+* In `Data.Fin.Base`: 
+two new, hopefully more memorable, names `↑ˡ` `↑ʳ` for the 'left', resp. 'right' injection of a Fin m into a 'larger' type, `Fin (m + n)`, resp. `Fin (n + m)`, with argument order to reflect the position of the Fin m argument. 
   ```
   inject+   ↦   flip _↑ˡ_
   raise     ↦   _↑ʳ_
   ```
+
+* In `Data.Fin.Properties`: 
+  ```
+  toℕ-raise       ↦ toℕ-↑ʳ
+  toℕ-inject+ n i ↦ sym (toℕ-↑ˡ i n)
+  splitAt-inject+ m n i ↦ splitAt-↑ˡ m i n
+  splitAt-raise ↦ splitAt-↑ʳ
+  ```
+
+* In `Data.Vec.Properties`: 
+  ```
+  []≔-++-inject+       ↦ []≔-++-↑ˡ
+  ```
+  Additionally, `[]≔-++-↑ʳ`, by analogy. 
+
 
 New modules
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -335,6 +335,12 @@ Deprecated names
   sym-↔   ↦   ↔-sym
   ```
 
+* In `Data.Fin.Base`: two new, hopefully more memorable, names `↑ˡ` `↑ʳ` for the 'left', resp. 'right' injection of a Fin m into a larger Fin (n + m), with argument order to reflect the position of the Fin m argument. Knock-on changes in `Data.Fin.Properties`, `Data.Vec.Properties`, `Data.Vec.Functional`, `Data.Vec.Functional.Properties`, `Data.Vec.Functional.Relation.Binary.Pointwise.Properties`, `Data.Vec.Functional.Relation.Unary.All.Properties`. 
+  ```
+  inject+   ↦   flip _↑ˡ_
+  raise     ↦   _↑ʳ_
+  ```
+
 New modules
 -----------
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -46,21 +46,6 @@ How to make changes
    in the library. See `agda-stdlib-fork/notes/style-guide.md` for a
    selection of the most important ones.
 
-6. Document your changes in `agda-stdlib-fork/CHANGELOG.md`.
-
-7. Ensure your changes are compatible with the rest of the library by
-   running the commands
-   ```
-   make clean
-   make test
-   ```
-   inside the `agda-stdlib-fork` folder. Continue to correct any bugs
-   thrown up until the tests are passed.
-
-   Your proposed changes MUST pass these tests. Note that the tests
-   require the use of a tool called `fix-whitespace`. See the
-   instructions at the end of this file for how to install this.
-
    If you are creating new modules, please make sure you are having a
    proper header, and a brief description of what the module is for, e.g.
    ```
@@ -84,6 +69,24 @@ How to make changes
    * Either be called `SOME/PATH/Unsafe.agda` or `SOME/PATH/WithK.agda`
    * Or explicitly declared as either unsafe or needing K in `GenerateEverything.hs`
 
+6. Document your changes in `agda-stdlib-fork/CHANGELOG.md`.
+
+7. [ Optional ] Ensure your changes are compatible with the rest of the library
+   by running the commands
+   ```
+   make clean
+   make test
+   ```
+   inside the `agda-stdlib-fork` folder. Continue to correct any bugs
+   thrown up until the tests are passed. Note that the tests
+   require the use of a tool called `fix-whitespace`. See the
+   instructions at the end of this file for how to install this.
+   
+   Note this step is optional as these tests will also be run automatically
+   by our CI infrastructure when you open a pull request on Github, but it
+   can be useful to run it locally to get a faster turn around time when finding
+   problems.
+
 ### Upload your changes
 
 8. Use the `git add X` command to add changes to file `X` to the commit,
@@ -101,11 +104,11 @@ How to make changes
    ```
 
 11. Go to your fork on Github at `https://github.com/USER_NAME/agda-stdlib`
-        and follow the [official Git instructions](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork)
-        to open a pull request to the main standard library repository.
+    and follow the [official Git instructions](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork)
+    to open a pull request to the main standard library repository.
 
 12. The library maintainers will then be made aware of your requested
-        changes and should be in touch soon.
+    changes and should be in touch soon.
 
 How to enforce whitespace policies
 ----------------------------------

--- a/HACKING.md
+++ b/HACKING.md
@@ -81,7 +81,7 @@ How to make changes
    thrown up until the tests are passed. Note that the tests
    require the use of a tool called `fix-whitespace`. See the
    instructions at the end of this file for how to install this.
-   
+
    Note this step is optional as these tests will also be run automatically
    by our CI infrastructure when you open a pull request on Github, but it
    can be useful to run it locally to get a faster turn around time when finding

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -80,11 +80,13 @@ fromℕ<″ (suc m) (ℕ.less-than-or-equal refl) =
 -- canonical liftings of i:Fin m to larger index
 
 -- injection on the left: "i" ↑ˡ n = "i" in Fin (m + n)
+infixl 5 _↑ˡ_
 _↑ˡ_ : ∀ {m} → Fin m → ∀ n → Fin (m ℕ.+ n)
 zero    ↑ˡ n = zero
 (suc i) ↑ˡ n = suc (i ↑ˡ n)
 
 -- injection on the right: n ↑ʳ "i" = "n + i" in Fin (n + m)
+infixr 5 _↑ʳ_
 _↑ʳ_ : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
 zero    ↑ʳ i = i
 (suc n) ↑ʳ i = suc (n ↑ʳ i)

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -17,7 +17,7 @@ open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s)
 open import Data.Nat.Properties.Core using (≤-pred)
 open import Data.Product as Product using (_×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
-open import Function.Base using (id; _∘_; _on_)
+open import Function.Base using (id; _∘_; _on_; flip)
 open import Level using (0ℓ)
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable.Core using (True; toWitness)
@@ -77,11 +77,24 @@ fromℕ<″ zero    (ℕ.less-than-or-equal refl) = zero
 fromℕ<″ (suc m) (ℕ.less-than-or-equal refl) =
   suc (fromℕ<″ m (ℕ.less-than-or-equal refl))
 
--- raise m "i" = "m + i".
+-- canonical liftings of smaller i:Fin m to larger index Fin (n + m)
 
+-- injection on the left: "i" ↑ˡ n = "i"
+_↑ˡ_ : ∀ {m} → Fin m → ∀ n → Fin (m ℕ.+ n)
+zero    ↑ˡ n = zero
+(suc i) ↑ˡ n = suc (i ↑ˡ n)
+
+-- injection on the right: n ↑ʳ "i" = "n + i".
+_↑ʳ_ : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
+zero    ↑ʳ i = i
+(suc n) ↑ʳ i = suc (n ↑ʳ i)
+
+-- raise n "i" = "n + i".
 raise : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
+{-
 raise zero    i = i
 raise (suc n) i = suc (raise n i)
+-}
 
 -- reduce≥ "m + i" _ = "i".
 
@@ -100,8 +113,10 @@ inject! {n = suc _} {i = suc _}  zero    = zero
 inject! {n = suc _} {i = suc _}  (suc j) = suc (inject! j)
 
 inject+ : ∀ {m} n → Fin m → Fin (m ℕ.+ n)
+{-
 inject+ n zero    = zero
 inject+ n (suc i) = suc (inject+ n i)
+-}
 
 inject₁ : ∀ {m} → Fin m → Fin (suc m)
 inject₁ zero    = zero
@@ -134,7 +149,7 @@ splitAt (suc m) (suc i) = Sum.map suc id (splitAt m i)
 
 -- inverse of above function
 join : ∀ m n → Fin m ⊎ Fin n → Fin (m ℕ.+ n)
-join m n = [ inject+ n , raise {n} m ]′
+join m n = [ _↑ˡ n , m ↑ʳ_ ]′
 
 -- quotRem k "i" = "i % k" , "i / k"
 -- This is dual to group from Data.Vec.
@@ -150,8 +165,8 @@ remQuot k = Product.swap ∘ quotRem k
 
 -- inverse of remQuot
 combine : ∀ {n k} → Fin n → Fin k → Fin (n ℕ.* k)
-combine {suc n} {k} zero y = inject+ (n ℕ.* k) y
-combine {suc n} {k} (suc x) y = raise k (combine x y)
+combine {suc n} {k} zero y = y ↑ˡ (n ℕ.* k)
+combine {suc n} {k} (suc x) y = k ↑ʳ (combine x y)
 
 ------------------------------------------------------------------------
 -- Operations
@@ -306,4 +321,17 @@ fromℕ≤″ = fromℕ<″
 {-# WARNING_ON_USAGE fromℕ≤″
 "Warning: fromℕ≤″ was deprecated in v1.2.
 Please use fromℕ<″ instead."
+#-}
+
+-- Version 2.0
+
+raise = _↑ʳ_
+{-# WARNING_ON_USAGE raise
+"Warning: raise was deprecated in v2.0.
+Please use _↑_ʳ instead."
+#-}
+inject+ = flip _↑ˡ_
+{-# WARNING_ON_USAGE inject+
+"Warning: inject+ was deprecated in v2.0.
+Please use _↑ˡ_ instead."
 #-}

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -77,7 +77,7 @@ fromℕ<″ zero    (ℕ.less-than-or-equal refl) = zero
 fromℕ<″ (suc m) (ℕ.less-than-or-equal refl) =
   suc (fromℕ<″ m (ℕ.less-than-or-equal refl))
 
--- canonical liftings of i:Fin m to larger index 
+-- canonical liftings of i:Fin m to larger index
 
 -- injection on the left: "i" ↑ˡ n = "i" in Fin (m + n)
 _↑ˡ_ : ∀ {m} → Fin m → ∀ n → Fin (m ℕ.+ n)

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -105,12 +105,6 @@ inject! : ∀ {n} {i : Fin (suc n)} → Fin′ i → Fin n
 inject! {n = suc _} {i = suc _}  zero    = zero
 inject! {n = suc _} {i = suc _}  (suc j) = suc (inject! j)
 
-inject+ : ∀ {m} n → Fin m → Fin (m ℕ.+ n)
-{-
-inject+ n zero    = zero
-inject+ n (suc i) = suc (inject+ n i)
--}
-
 inject₁ : ∀ {m} → Fin m → Fin (suc m)
 inject₁ zero    = zero
 inject₁ (suc i) = suc (inject₁ i)
@@ -323,7 +317,8 @@ raise = _↑ʳ_
 "Warning: raise was deprecated in v2.0.
 Please use _↑_ʳ instead."
 #-}
-inject+ = flip _↑ˡ_
+inject+ : ∀ {m} n → Fin m → Fin (m ℕ.+ n)
+inject+ n i = i ↑ˡ n
 {-# WARNING_ON_USAGE inject+
 "Warning: inject+ was deprecated in v2.0.
 Please use _↑ˡ_ instead.

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -77,24 +77,17 @@ fromℕ<″ zero    (ℕ.less-than-or-equal refl) = zero
 fromℕ<″ (suc m) (ℕ.less-than-or-equal refl) =
   suc (fromℕ<″ m (ℕ.less-than-or-equal refl))
 
--- canonical liftings of smaller i:Fin m to larger index Fin (n + m)
+-- canonical liftings of i:Fin m to larger index 
 
--- injection on the left: "i" ↑ˡ n = "i"
+-- injection on the left: "i" ↑ˡ n = "i" in Fin (m + n)
 _↑ˡ_ : ∀ {m} → Fin m → ∀ n → Fin (m ℕ.+ n)
 zero    ↑ˡ n = zero
 (suc i) ↑ˡ n = suc (i ↑ˡ n)
 
--- injection on the right: n ↑ʳ "i" = "n + i".
+-- injection on the right: n ↑ʳ "i" = "n + i" in Fin (n + m)
 _↑ʳ_ : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
 zero    ↑ʳ i = i
 (suc n) ↑ʳ i = suc (n ↑ʳ i)
-
--- raise n "i" = "n + i".
-raise : ∀ {m} n → Fin m → Fin (n ℕ.+ m)
-{-
-raise zero    i = i
-raise (suc n) i = suc (raise n i)
--}
 
 -- reduce≥ "m + i" _ = "i".
 
@@ -333,5 +326,8 @@ Please use _↑_ʳ instead."
 inject+ = flip _↑ˡ_
 {-# WARNING_ON_USAGE inject+
 "Warning: inject+ was deprecated in v2.0.
-Please use _↑ˡ_ instead."
+Please use _↑ˡ_ instead.
+NB argument order has been flipped:
+the left-hand argument is the Fin m
+the right-hand is the Nat index increment."
 #-}

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -106,26 +106,20 @@ toℕ-strengthen zero    = refl
 toℕ-strengthen (suc i) = cong suc (toℕ-strengthen i)
 
 ------------------------------------------------------------------------
--- ↑ˡ
+-- ↑ˡ: "i" ↑ˡ n = "i" in Fin (m + n)
 ------------------------------------------------------------------------
 
-_toℕ-↑ˡ_ : ∀ {m} (i : Fin m) n → toℕ (i ↑ˡ n) ≡ toℕ i
-zero    toℕ-↑ˡ n = refl
-(suc i) toℕ-↑ˡ n = cong suc (i toℕ-↑ˡ n)
+toℕ-↑ˡ : ∀ {m} (i : Fin m) n → toℕ (i ↑ˡ n) ≡ toℕ i
+toℕ-↑ˡ zero    n = refl
+toℕ-↑ˡ (suc i) n = cong suc (toℕ-↑ˡ i n)
 
 ------------------------------------------------------------------------
--- ↑ʳ
+-- ↑ʳ: n ↑ʳ "i" = "n + i" in Fin (n + m)
 ------------------------------------------------------------------------
 
-_toℕ-↑ʳ_ : ∀ {m} n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
-zero    toℕ-↑ʳ i = refl
-(suc n) toℕ-↑ʳ i = cong suc (n toℕ-↑ʳ i)
-
-toℕ-raise : ∀ {m} n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
-{-
-toℕ-raise zero    i = refl
-toℕ-raise (suc n) i = cong suc (toℕ-raise n i)
--}
+toℕ-↑ʳ : ∀ {m} n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
+toℕ-↑ʳ zero    i = refl
+toℕ-↑ʳ (suc n) i = cong suc (toℕ-↑ʳ n i)
 
 toℕ<n : ∀ {n} (i : Fin n) → toℕ i ℕ.< n
 toℕ<n zero    = s≤s z≤n
@@ -925,20 +919,24 @@ Please use join-splitAt instead."
 
 -- Version 2.0
 
-toℕ-raise = _toℕ-↑ʳ_
+toℕ-raise = toℕ-↑ʳ
 {-# WARNING_ON_USAGE toℕ-raise
 "Warning: toℕ-raise was deprecated in v2.0.
-Please use _toℕ-↑_ʳ instead."
+Please use toℕ-↑ʳ instead."
 #-}
-toℕ-inject+ n i = sym (i toℕ-↑ˡ n)
+toℕ-inject+ n i = sym (toℕ-↑ˡ i n)
 {-# WARNING_ON_USAGE toℕ-inject+
 "Warning: toℕ-inject+ was deprecated in v2.0.
-Please use _toℕ-↑ˡ_ instead."
+Please use toℕ-↑ˡ instead.
+NB argument order has been flipped:
+the left-hand argument is the Fin m
+the right-hand is the Nat index increment."
 #-}
 splitAt-inject+ m n i = splitAt-↑ˡ m i n
 {-# WARNING_ON_USAGE splitAt-inject+
 "Warning: splitAt-inject+ was deprecated in v2.0.
-Please use splitAt-↑ˡ instead."
+Please use splitAt-↑ˡ instead.
+NB argument order has been flipped."
 #-}
 splitAt-raise = splitAt-↑ʳ
 {-# WARNING_ON_USAGE splitAt-raise

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -106,7 +106,7 @@ toℕ-strengthen zero    = refl
 toℕ-strengthen (suc i) = cong suc (toℕ-strengthen i)
 
 ------------------------------------------------------------------------
--- ↑ˡ: "i" ↑ˡ n = "i" in Fin (m + n)
+-- toℕ-↑ˡ: "i" ↑ˡ n = "i" in Fin (m + n)
 ------------------------------------------------------------------------
 
 toℕ-↑ˡ : ∀ {m} (i : Fin m) n → toℕ (i ↑ˡ n) ≡ toℕ i
@@ -114,7 +114,7 @@ toℕ-↑ˡ zero    n = refl
 toℕ-↑ˡ (suc i) n = cong suc (toℕ-↑ˡ i n)
 
 ------------------------------------------------------------------------
--- ↑ʳ: n ↑ʳ "i" = "n + i" in Fin (n + m)
+-- toℕ-↑ʳ: n ↑ʳ "i" = "n + i" in Fin (n + m)
 ------------------------------------------------------------------------
 
 toℕ-↑ʳ : ∀ {m} n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
@@ -384,15 +384,6 @@ toℕ-inject {i = suc i} zero    = refl
 toℕ-inject {i = suc i} (suc j) = cong suc (toℕ-inject j)
 
 ------------------------------------------------------------------------
--- inject+
-------------------------------------------------------------------------
-
-toℕ-inject+ : ∀ {m} n (i : Fin m) → toℕ i ≡ toℕ (i ↑ˡ n)
-{-
-toℕ-inject+ n zero    = refl
-toℕ-inject+ n (suc i) = cong suc (toℕ-inject+ n i)
--}
-------------------------------------------------------------------------
 -- inject₁
 ------------------------------------------------------------------------
 
@@ -507,22 +498,9 @@ splitAt-↑ˡ : ∀ m i n → splitAt m (i ↑ˡ n) ≡ inj₁ i
 splitAt-↑ˡ (suc m) zero    n = refl
 splitAt-↑ˡ (suc m) (suc i) n rewrite splitAt-↑ˡ m i n = refl
 
-splitAt-inject+ : ∀ m n i → splitAt m (i ↑ˡ n) ≡ inj₁ i
-{-
-splitAt-inject+ (suc m) n zero = refl
-splitAt-inject+ (suc m) n (suc i) rewrite splitAt-inject+ m n i = refl
--}
-
 splitAt-↑ʳ : ∀ m n i → splitAt m (m ↑ʳ i) ≡ inj₂ {B = Fin n} i
 splitAt-↑ʳ zero    n i = refl
 splitAt-↑ʳ (suc m) n i rewrite splitAt-↑ʳ m n i = refl
-
-splitAt-raise : ∀ m n i → splitAt m (m ↑ʳ i) ≡ inj₂ {B = Fin n} i
-{-
-splitAt-raise : ∀ m n i → splitAt m (raise {n} m i) ≡ inj₂ i
-splitAt-raise zero    n i = refl
-splitAt-raise (suc m) n i rewrite splitAt-raise m n i = refl
--}
 
 splitAt-join : ∀ m n i → splitAt m (join m n i) ≡ i
 splitAt-join m n (inj₁ x) = splitAt-↑ˡ m x n
@@ -924,6 +902,7 @@ toℕ-raise = toℕ-↑ʳ
 "Warning: toℕ-raise was deprecated in v2.0.
 Please use toℕ-↑ʳ instead."
 #-}
+toℕ-inject+ : ∀ {m} n (i : Fin m) → toℕ i ≡ toℕ (i ↑ˡ n)
 toℕ-inject+ n i = sym (toℕ-↑ˡ i n)
 {-# WARNING_ON_USAGE toℕ-inject+
 "Warning: toℕ-inject+ was deprecated in v2.0.
@@ -932,12 +911,14 @@ NB argument order has been flipped:
 the left-hand argument is the Fin m
 the right-hand is the Nat index increment."
 #-}
+splitAt-inject+ : ∀ m n i → splitAt m (i ↑ˡ n) ≡ inj₁ i
 splitAt-inject+ m n i = splitAt-↑ˡ m i n
 {-# WARNING_ON_USAGE splitAt-inject+
 "Warning: splitAt-inject+ was deprecated in v2.0.
 Please use splitAt-↑ˡ instead.
 NB argument order has been flipped."
 #-}
+splitAt-raise : ∀ m n i → splitAt m (m ↑ʳ i) ≡ inj₂ {B = Fin n} i
 splitAt-raise = splitAt-↑ʳ
 {-# WARNING_ON_USAGE splitAt-raise
 "Warning: splitAt-raise was deprecated in v2.0.

--- a/src/Data/Vec/Functional.agda
+++ b/src/Data/Vec/Functional.agda
@@ -138,10 +138,10 @@ unzip : ∀ {n} → Vector (A × B) n → Vector A n × Vector B n
 unzip = unzipWith id
 
 take : ∀ m {n} → Vector A (m ℕ.+ n) → Vector A m
-take _ {n = n} xs = xs ∘ inject+ n
+take _ {n = n} xs = xs ∘ (_↑ˡ n)
 
 drop : ∀ m {n} → Vector A (m ℕ.+ n) → Vector A n
-drop m xs = xs ∘ raise m
+drop m xs = xs ∘ (m ↑ʳ_)
 
 reverse : ∀ {n} → Vector A n → Vector A n
 reverse xs = xs ∘ opposite

--- a/src/Data/Vec/Functional/Properties.agda
+++ b/src/Data/Vec/Functional/Properties.agda
@@ -166,12 +166,12 @@ lookup-++-≥ : ∀ {m n} (xs : Vector A m) (ys : Vector A n) →
 lookup-++-≥ {m = m} xs ys i i≥m = cong Sum.[ xs , ys ] (Finₚ.splitAt-≥ m i i≥m)
 
 lookup-++ˡ : ∀ {m n} (xs : Vector A m) (ys : Vector A n) i →
-             (xs ++ ys) (inject+ n i) ≡ xs i
-lookup-++ˡ {m = m} {n = n} xs ys i = cong Sum.[ xs , ys ] (Finₚ.splitAt-inject+ m n i)
+             (xs ++ ys) (i ↑ˡ n) ≡ xs i
+lookup-++ˡ {m = m} {n = n} xs ys i = cong Sum.[ xs , ys ] (Finₚ.splitAt-↑ˡ m i n)
 
 lookup-++ʳ : ∀ {m n} (xs : Vector A m) (ys : Vector A n) i →
-             (xs ++ ys) (raise m i) ≡ ys i
-lookup-++ʳ {m = m} {n = n} xs ys i = cong Sum.[ xs , ys ] (Finₚ.splitAt-raise m n i)
+             (xs ++ ys) (m ↑ʳ i) ≡ ys i
+lookup-++ʳ {m = m} {n = n} xs ys i = cong Sum.[ xs , ys ] (Finₚ.splitAt-↑ʳ m n i)
 
 module _ {m} {ys ys′ : Vector A m} where
 
@@ -194,19 +194,19 @@ module _ {m} {ys ys′ : Vector A m} where
   ++-injectiveˡ : ∀ {n} (xs xs′ : Vector A n) →
                   xs ++ ys ≗ xs′ ++ ys′ → xs ≗ xs′
   ++-injectiveˡ xs xs′ eq i = begin
-    xs i                        ≡˘⟨ lookup-++ˡ xs ys i ⟩
-    (xs ++ ys) (inject+ m i)    ≡⟨ eq (inject+ m i) ⟩
-    (xs′ ++ ys′) (inject+ m i)  ≡⟨ lookup-++ˡ xs′ ys′ i ⟩
-    xs′ i                       ∎
+    xs i                   ≡˘⟨ lookup-++ˡ xs ys i ⟩
+    (xs ++ ys) (i ↑ˡ m)    ≡⟨ eq (i ↑ˡ m) ⟩
+    (xs′ ++ ys′) (i ↑ˡ m)  ≡⟨ lookup-++ˡ xs′ ys′ i ⟩
+    xs′ i                  ∎
     where open ≡-Reasoning
 
   ++-injectiveʳ : ∀ {n} (xs xs′ : Vector A n) →
                   xs ++ ys ≗ xs′ ++ ys′ → ys ≗ ys′
   ++-injectiveʳ {n} xs xs′ eq i = begin
-    ys i                      ≡˘⟨ lookup-++ʳ xs ys i ⟩
-    (xs ++ ys) (raise n i)    ≡⟨ eq (raise n i)   ⟩
-    (xs′ ++ ys′) (raise n i)  ≡⟨ lookup-++ʳ xs′ ys′ i ⟩
-    ys′ i                     ∎
+    ys i                   ≡˘⟨ lookup-++ʳ xs ys i ⟩
+    (xs ++ ys) (n ↑ʳ i)    ≡⟨ eq (n ↑ʳ i)   ⟩
+    (xs′ ++ ys′) (n ↑ʳ i)  ≡⟨ lookup-++ʳ xs′ ys′ i ⟩
+    ys′ i                  ∎
     where open ≡-Reasoning
 
   ++-injective : ∀ {n} (xs xs′ : Vector A n) →

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -120,13 +120,13 @@ module _ (R : REL A B r) where
 
   ++⁻ˡ : ∀ {m n} (xs : Vector A m) (ys : Vector B m) {xs′ ys′} →
          Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs ys
-  ++⁻ˡ {m} {n} _ _ rs i with rs (inject+ n i)
-  ... | r rewrite splitAt-inject+ m n i = r
+  ++⁻ˡ {m} {n} _ _ rs i with rs (i ↑ˡ n)
+  ... | r rewrite splitAt-↑ˡ m i n = r
 
   ++⁻ʳ : ∀ {m n} (xs : Vector A m) (ys : Vector B m) {xs′ ys′} →
          Pointwise R (xs ++ xs′) (ys ++ ys′) → Pointwise R xs′ ys′
-  ++⁻ʳ {m} {n} _ _ rs i with rs (raise m i)
-  ... | r rewrite splitAt-raise m n i = r
+  ++⁻ʳ {m} {n} _ _ rs i with rs (m ↑ʳ i)
+  ... | r rewrite splitAt-↑ʳ m n i = r
 
   ++⁻ : ∀ {m n} xs ys {xs′ ys′} →
         Pointwise R (xs ++ xs′) (ys ++ ys′) →

--- a/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Unary/All/Properties.agda
@@ -97,12 +97,12 @@ module _ (P : Pred A p) {m n : ℕ} {xs : Vector A m} {ys : Vector A n} where
 module _ (P : Pred A p) {m n : ℕ} (xs : Vector A m) {ys : Vector A n} where
 
   ++⁻ˡ : All P (xs ++ ys) → All P xs
-  ++⁻ˡ ps i with ps (inject+ n i)
-  ... | p rewrite splitAt-inject+ m n i = p
+  ++⁻ˡ ps i with ps (i ↑ˡ n)
+  ... | p rewrite splitAt-↑ˡ m i n = p
 
   ++⁻ʳ : All P (xs ++ ys) → All P ys
-  ++⁻ʳ ps i with ps (raise m i)
-  ... | p rewrite splitAt-raise m n i = p
+  ++⁻ʳ ps i with ps (m ↑ʳ i)
+  ... | p rewrite splitAt-↑ʳ m n i = p
 
   ++⁻ : All P (xs ++ ys) → All P xs × All P ys
   ++⁻ ps = ++⁻ˡ ps , ++⁻ʳ ps

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -352,7 +352,7 @@ lookup∘updateAt′ i j xs i≢j =
 []≔-++-↑ʳ : ∀ {m n y} (xs : Vec A m) (ys : Vec A n) i →
                  (xs ++ ys) [ m ↑ʳ i ]≔ y ≡ xs ++ (ys [ i ]≔ y)
 []≔-++-↑ʳ {m = zero}     []    (y ∷ ys) i = refl
-[]≔-++-↑ʳ {m = suc n} (x ∷ xs) (y ∷ ys) i = P.cong (x ∷_) $ []≔-++-↑ʳ xs (y ∷ ys) i 
+[]≔-++-↑ʳ {m = suc n} (x ∷ xs) (y ∷ ys) i = P.cong (x ∷_) $ []≔-++-↑ʳ xs (y ∷ ys) i
 
 lookup∘update : ∀ {n} (i : Fin n) (xs : Vec A n) x →
                 lookup (xs [ i ]≔ x) i ≡ x

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -11,7 +11,7 @@ module Data.Vec.Properties where
 open import Algebra.Definitions
 open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
-open import Data.Fin.Base as Fin using (Fin; zero; suc; toℕ; fromℕ)
+open import Data.Fin.Base as Fin using (Fin; zero; suc; toℕ; fromℕ; _↑ˡ_; _↑ʳ_)
 open import Data.List.Base as List using (List)
 open import Data.Nat.Base
 open import Data.Nat.Properties using (+-assoc; ≤-step)
@@ -343,11 +343,19 @@ lookup∘updateAt′ i j xs i≢j =
              xs [ i ]≔ lookup xs i ≡ xs
 []≔-lookup xs i = updateAt-id-relative i xs refl
 
+[]≔-++-↑ˡ : ∀ {m n x} (xs : Vec A m) (ys : Vec A n) i →
+                 (xs ++ ys) [ i ↑ˡ n ]≔ x ≡ (xs [ i ]≔ x) ++ ys
+[]≔-++-↑ˡ (x ∷ xs) ys zero    = refl
+[]≔-++-↑ˡ (x ∷ xs) ys (suc i) =
+  P.cong (x ∷_) $ []≔-++-↑ˡ xs ys i
+
 []≔-++-inject+ : ∀ {m n x} (xs : Vec A m) (ys : Vec A n) i →
-                 (xs ++ ys) [ Fin.inject+ n i ]≔ x ≡ (xs [ i ]≔ x) ++ ys
+                 (xs ++ ys) [ i ↑ˡ n ]≔ x ≡ (xs [ i ]≔ x) ++ ys
+{-
 []≔-++-inject+ (x ∷ xs) ys zero    = refl
 []≔-++-inject+ (x ∷ xs) ys (suc i) =
   P.cong (x ∷_) $ []≔-++-inject+ xs ys i
+-}
 
 lookup∘update : ∀ {n} (i : Fin n) (xs : Vec A n) x →
                 lookup (xs [ i ]≔ x) i ≡ x
@@ -436,12 +444,12 @@ lookup-++-≥ []       ys i       i≥m       = refl
 lookup-++-≥ (x ∷ xs) ys (suc i) (s≤s i≥m) = lookup-++-≥ xs ys i i≥m
 
 lookup-++ˡ : ∀ {m n} (xs : Vec A m) (ys : Vec A n) i →
-             lookup (xs ++ ys) (Fin.inject+ n i) ≡ lookup xs i
+             lookup (xs ++ ys) (i ↑ˡ n) ≡ lookup xs i
 lookup-++ˡ (x ∷ xs) ys zero    = refl
 lookup-++ˡ (x ∷ xs) ys (suc i) = lookup-++ˡ xs ys i
 
 lookup-++ʳ : ∀ {m n} (xs : Vec A m) (ys : Vec A n) i →
-             lookup (xs ++ ys) (Fin.raise m i) ≡ lookup ys i
+             lookup (xs ++ ys) (m ↑ʳ i) ≡ lookup ys i
 lookup-++ʳ []       ys       zero    = refl
 lookup-++ʳ []       (y ∷ xs) (suc i) = lookup-++ʳ [] xs i
 lookup-++ʳ (x ∷ xs) ys       i       = lookup-++ʳ xs ys i
@@ -860,4 +868,12 @@ lookup-++-+′ = lookup-++ʳ
 {-# WARNING_ON_USAGE lookup-++-+′
 "Warning: lookup-++-+′ was deprecated in v1.1.
 Please use lookup-++ʳ instead."
+#-}
+
+-- Version 2.0
+
+[]≔-++-inject+ = []≔-++-↑ˡ
+{-# WARNING_ON_USAGE []≔-++-inject+
+"Warning: []≔-++-inject+ was deprecated in v2.0.
+Please use []≔-++-↑ˡ instead."
 #-}

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -349,13 +349,10 @@ lookup∘updateAt′ i j xs i≢j =
 []≔-++-↑ˡ (x ∷ xs) ys (suc i) =
   P.cong (x ∷_) $ []≔-++-↑ˡ xs ys i
 
-[]≔-++-inject+ : ∀ {m n x} (xs : Vec A m) (ys : Vec A n) i →
-                 (xs ++ ys) [ i ↑ˡ n ]≔ x ≡ (xs [ i ]≔ x) ++ ys
-{-
-[]≔-++-inject+ (x ∷ xs) ys zero    = refl
-[]≔-++-inject+ (x ∷ xs) ys (suc i) =
-  P.cong (x ∷_) $ []≔-++-inject+ xs ys i
--}
+[]≔-++-↑ʳ : ∀ {m n y} (xs : Vec A m) (ys : Vec A n) i →
+                 (xs ++ ys) [ m ↑ʳ i ]≔ y ≡ xs ++ (ys [ i ]≔ y)
+[]≔-++-↑ʳ {m = zero}     []    (y ∷ ys) i = refl
+[]≔-++-↑ʳ {m = suc n} (x ∷ xs) (y ∷ ys) i = P.cong (x ∷_) $ []≔-++-↑ʳ xs (y ∷ ys) i 
 
 lookup∘update : ∀ {n} (i : Fin n) (xs : Vec A n) x →
                 lookup (xs [ i ]≔ x) i ≡ x
@@ -872,6 +869,8 @@ Please use lookup-++ʳ instead."
 
 -- Version 2.0
 
+[]≔-++-inject+ : ∀ {m n x} (xs : Vec A m) (ys : Vec A n) i →
+                 (xs ++ ys) [ i ↑ˡ n ]≔ x ≡ (xs [ i ]≔ x) ++ ys
 []≔-++-inject+ = []≔-++-↑ˡ
 {-# WARNING_ON_USAGE []≔-++-inject+
 "Warning: []≔-++-inject+ was deprecated in v2.0.


### PR DESCRIPTION
New names in `Data.Fin.Base` , as discussed.
Knock-on consequences for `Data.Fin.*` `Data.Vec.*`, as discussed. 
Passes fix-whitespace and GenerateEverything tests. 
Old definitions *not* deleted, only deprecated. 
Deprecate warning notices added. 
CHANGELOG.md updated. 
