### PR TITLE
Add a proof of `subst Q eq (f x p) ≡ f y (subst P eq p)` in `Relation.Binary.PropositionalEquality.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,6 +588,11 @@ Other minor changes
   untilJust : IO (Maybe A) → IO A
   ```
 
+* Added new proofs in `Relation.Binary.PropositionalEquality.Properties`:
+  ```
+  subst-application′ : subst Q eq (f x p) ≡ f y (subst P eq p)
+  ```
+
 * Equality of predicates
   ```
   _≐_ : Pred A ℓ₁ → Pred A ℓ₂ → Set _

--- a/src/Relation/Binary/PropositionalEquality/Properties.agda
+++ b/src/Relation/Binary/PropositionalEquality/Properties.agda
@@ -120,6 +120,15 @@ subst-∘ : ∀ {x y : A} {P : Pred B p} {f : A → B}
           subst (P ∘ f) x≡y p ≡ subst P (cong f x≡y) p
 subst-∘ refl = refl
 
+-- Lemma 2.3.11 in the HoTT book, and `transport_map` in the UniMath
+-- library
+subst-application′ : ∀ {a b₁ b₂} {A : Set a}
+                     (B₁ : A → Set b₁) {B₂ : A → Set b₂}
+                     {x₁ x₂ : A} {y : B₁ x₁}
+                     (g : ∀ x → B₁ x → B₂ x) (eq : x₁ ≡ x₂) →
+                     subst B₂ eq (g x₁ y) ≡ g x₂ (subst B₁ eq y)
+subst-application′ _ _ refl = refl
+
 subst-application : ∀ {a₁ a₂ b₁ b₂} {A₁ : Set a₁} {A₂ : Set a₂}
                     (B₁ : A₁ → Set b₁) {B₂ : A₂ → Set b₂}
                     {f : A₂ → A₁} {x₁ x₂ : A₂} {y : B₁ (f x₁)}


### PR DESCRIPTION
Note that this is interderivable with `subst-application`, using `cong-id` and `subst-∘`, but perhaps the more common one? The arguments are as in `subst-application`.