### PR TITLE
Add convenience definitions for equality between pairs from pair of equalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -517,6 +517,13 @@ Other minor changes
   map-cong : f ≗ g → h ≗ i → map f h ≗ map g i
   ```
 
+* Added new definitions to `Data.Product.Properties` and
+  `Function.Related.TypeIsomorphisms` for convenience:
+  ```
+  Σ-≡,≡→≡ : (∃ λ (p : proj₁ p₁ ≡ proj₁ p₂) → subst B p (proj₂ p₁) ≡ proj₂ p₂) → p₁ ≡ p₂
+  ×-≡,≡→≡ : (proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂) → p₁ ≡ p₂
+  ```
+
 * Added new proofs in `Data.String.Properties`:
   ```
   ≤-isDecTotalOrder-≈ : IsDecTotalOrder _≈_ _≤_

--- a/src/Data/Container/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Container/Relation/Unary/Any/Properties.agda
@@ -221,7 +221,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
           , P.subst (P ∘′ proj₂ xs) (P.sym (right-inverse-of position⊸m _)) p
 
     f∘t : f ∘ t ≗ id
-    f∘t (any (p₂ , p)) = P.cong any $ Inverse.to Σ-≡,≡↔≡ ⟨$⟩
+    f∘t (any (p₂ , p)) = P.cong any $ Σ-≡,≡→≡
       ( left-inverse-of position⊸m p₂
       , (P.subst (P ∘ proj₂ xs ∘ to position⊸m)
            (left-inverse-of position⊸m p₂)
@@ -263,7 +263,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
       )
 
     t∘f : t ∘ f ≗ id
-    t∘f (any (p₁ , p)) = P.cong any $ Inverse.to Σ-≡,≡↔≡ ⟨$⟩
+    t∘f (any (p₁ , p)) = P.cong any $ Σ-≡,≡→≡
       ( right-inverse-of position⊸m p₁
       , (P.subst (P ∘ proj₂ xs)
            (right-inverse-of position⊸m p₁)

--- a/src/Data/Product/Function/Dependent/Propositional.agda
+++ b/src/Data/Product/Function/Dependent/Propositional.agda
@@ -195,7 +195,7 @@ module _ {a₁ a₂} {A₁ : Set a₁} {A₂ : Set a₂}
            P.subst B₁ (P.sym (LeftInverse.left-inverse-of A₁↞A₂ x)) y)
 
     left-inverse-of : ∀ p → from (to p) ≡ p
-    left-inverse-of (x , y) = Inverse.to Σ-≡,≡↔≡ ⟨$⟩
+    left-inverse-of (x , y) = Σ-≡,≡→≡
       ( LeftInverse.left-inverse-of A₁↞A₂ x
       , (P.subst B₁ (LeftInverse.left-inverse-of A₁↞A₂ x)
            (LeftInverse.from B₁↞B₂ ⟨$⟩ (LeftInverse.to B₁↞B₂ ⟨$⟩
@@ -231,7 +231,7 @@ module _ {a₁ a₂} {A₁ : Set a₁} {A₂ : Set a₂}
            P.subst B₂ (P.sym (Surjection.right-inverse-of A₁↠A₂ x)) y)
 
     right-inverse-of : ∀ p → to (from p) ≡ p
-    right-inverse-of (x , y) = Inverse.to Σ-≡,≡↔≡ ⟨$⟩
+    right-inverse-of (x , y) = Σ-≡,≡→≡
       ( Surjection.right-inverse-of A₁↠A₂ x
       , (P.subst B₂ (Surjection.right-inverse-of A₁↠A₂ x)
            (Surjection.to B₁↠B₂ ⟨$⟩ (Surjection.from B₁↠B₂ ⟨$⟩
@@ -266,7 +266,7 @@ module _ {a₁ a₂} {A₁ : Set a₁} {A₂ : Set a₂}
     left-inverse-of :
       ∀ p → Surjection.from surjection′ ⟨$⟩
               (Surjection.to surjection′ ⟨$⟩ p) ≡ p
-    left-inverse-of (x , y) = Inverse.to Σ-≡,≡↔≡ ⟨$⟩
+    left-inverse-of (x , y) = Σ-≡,≡→≡
       ( _≃_.left-inverse-of A₁≃A₂ x
       , (P.subst B₁ (_≃_.left-inverse-of A₁≃A₂ x)
            (Inverse.from B₁↔B₂ ⟨$⟩

--- a/src/Data/Product/Properties.agda
+++ b/src/Data/Product/Properties.agda
@@ -67,25 +67,29 @@ swap-involutive _ = refl
 ------------------------------------------------------------------------
 -- Equality between pairs can be expressed as a pair of equalities
 
-Σ-≡,≡↔≡ : {A : Set a} {B : A → Set b} {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
-          (∃ λ (p : a₁ ≡ a₂) → subst B p b₁ ≡ b₂) ↔ (p₁ ≡ p₂)
-Σ-≡,≡↔≡ {A = A} {B = B} = mk↔ {f = to} (right-inverse-of , left-inverse-of)
-  where
-  to : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
-       Σ (a₁ ≡ a₂) (λ p → subst B p b₁ ≡ b₂) → p₁ ≡ p₂
-  to (refl , refl) = refl
+module _ {A : Set a} {B : A → Set b} {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} where
+  private
+    to : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
+         Σ (a₁ ≡ a₂) (λ p → subst B p b₁ ≡ b₂) → p₁ ≡ p₂
+    to (refl , refl) = refl
 
-  from : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
-         p₁ ≡ p₂ → Σ (a₁ ≡ a₂) (λ p → subst B p b₁ ≡ b₂)
-  from refl = refl , refl
+    from : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
+           p₁ ≡ p₂ → Σ (a₁ ≡ a₂) (λ p → subst B p b₁ ≡ b₂)
+    from refl = refl , refl
 
-  left-inverse-of : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
-                    (p : Σ (a₁ ≡ a₂) (λ x → subst B x b₁ ≡ b₂)) →
-                    from (to p) ≡ p
-  left-inverse-of (refl , refl) = refl
+    left-inverse-of : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : Σ A B} →
+                      (p : Σ (a₁ ≡ a₂) (λ x → subst B x b₁ ≡ b₂)) →
+                      from (to p) ≡ p
+    left-inverse-of (refl , refl) = refl
 
-  right-inverse-of : {p₁ p₂ : Σ A B} (p : p₁ ≡ p₂) → to (from p) ≡ p
-  right-inverse-of refl = refl
+    right-inverse-of : {p₁ p₂ : Σ A B} (p : p₁ ≡ p₂) → to (from p) ≡ p
+    right-inverse-of refl = refl
+
+  Σ-≡,≡↔≡ : (∃ λ (p : a₁ ≡ a₂) → subst B p b₁ ≡ b₂) ↔ p₁ ≡ p₂
+  Σ-≡,≡↔≡ = mk↔ {f = to} (right-inverse-of , left-inverse-of)
+
+  Σ-≡,≡→≡ : (∃ λ (p : a₁ ≡ a₂) → subst B p b₁ ≡ b₂) → p₁ ≡ p₂
+  Σ-≡,≡→≡ = to
 
 -- the non-dependent case. Proofs are exactly as above, and straightforward.
 ×-≡,≡↔≡ : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : A × B} → (a₁ ≡ a₂ × b₁ ≡ b₂) ↔ p₁ ≡ p₂
@@ -94,6 +98,9 @@ swap-involutive _ = refl
   (λ { refl         → refl , refl})
   (λ {refl → refl})
   (λ {(refl , refl) → refl})
+
+×-≡,≡→≡ : {p₁@(a₁ , b₁) p₂@(a₂ , b₂) : A × B} → (a₁ ≡ a₂ × b₁ ≡ b₂) → p₁ ≡ p₂
+×-≡,≡→≡ = Inverse.f ×-≡,≡↔≡
 
 ------------------------------------------------------------------------
 -- The order of ∃₂ can be swapped

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -339,65 +339,63 @@ True↔ (false because ofⁿ ¬p) _ =
 ------------------------------------------------------------------------
 -- Equality between pairs can be expressed as a pair of equalities
 
-Σ-≡,≡↔≡ : ∀ {a b} {A : Set a} {B : A → Set b} {p₁ p₂ : Σ A B} →
-          (∃ λ (p : proj₁ p₁ ≡ proj₁ p₂) →
-             P.subst B p (proj₂ p₁) ≡ proj₂ p₂) ↔
-          (p₁ ≡ p₂)
-Σ-≡,≡↔≡ {A = A} {B} = inverse to from left-inverse-of right-inverse-of
-  where
-  to : {p₁ p₂ : Σ A B} →
-       Σ (proj₁ p₁ ≡ proj₁ p₂)
-         (λ p → P.subst B p (proj₂ p₁) ≡ proj₂ p₂) →
-       p₁ ≡ p₂
-  to (P.refl , P.refl) = P.refl
-
-  from : {p₁ p₂ : Σ A B} →
-         p₁ ≡ p₂ →
+module _ {a b} {A : Set a} {B : A → Set b} {p₁ p₂ : Σ A B} where
+  private
+    to : {p₁ p₂ : Σ A B} →
          Σ (proj₁ p₁ ≡ proj₁ p₂)
-           (λ p → P.subst B p (proj₂ p₁) ≡ proj₂ p₂)
-  from P.refl = P.refl , P.refl
+           (λ p → P.subst B p (proj₂ p₁) ≡ proj₂ p₂) →
+         p₁ ≡ p₂
+    to (P.refl , P.refl) = P.refl
 
-  left-inverse-of : {p₁ p₂ : Σ A B}
-                    (p : Σ (proj₁ p₁ ≡ proj₁ p₂)
-                           (λ x → P.subst B x (proj₂ p₁) ≡ proj₂ p₂)) →
-                    from (to p) ≡ p
-  left-inverse-of (P.refl , P.refl) = P.refl
+    from : {p₁ p₂ : Σ A B} →
+           p₁ ≡ p₂ →
+           Σ (proj₁ p₁ ≡ proj₁ p₂)
+             (λ p → P.subst B p (proj₂ p₁) ≡ proj₂ p₂)
+    from P.refl = P.refl , P.refl
 
-  right-inverse-of : {p₁ p₂ : Σ A B} (p : p₁ ≡ p₂) → to (from p) ≡ p
-  right-inverse-of P.refl = P.refl
+    left-inverse-of : {p₁ p₂ : Σ A B}
+                      (p : Σ (proj₁ p₁ ≡ proj₁ p₂)
+                             (λ x → P.subst B x (proj₂ p₁) ≡ proj₂ p₂)) →
+                      from (to p) ≡ p
+    left-inverse-of (P.refl , P.refl) = P.refl
 
-×-≡,≡↔≡ : ∀ {a b} {A : Set a} {B : Set b} {p₁ p₂ : A × B} →
-          (proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂) ↔ p₁ ≡ p₂
-×-≡,≡↔≡ {A = A} {B} = inverse to from left-inverse-of right-inverse-of
-  where
-  to : {p₁ p₂ : A × B} →
-       (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂) → p₁ ≡ p₂
-  to (P.refl , P.refl) = P.refl
+    right-inverse-of : {p₁ p₂ : Σ A B} (p : p₁ ≡ p₂) → to (from p) ≡ p
+    right-inverse-of P.refl = P.refl
 
-  from : {p₁ p₂ : A × B} → p₁ ≡ p₂ →
-         (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂)
-  from P.refl = P.refl , P.refl
+  Σ-≡,≡↔≡ : (∃ λ (p : proj₁ p₁ ≡ proj₁ p₂) →
+               P.subst B p (proj₂ p₁) ≡ proj₂ p₂) ↔
+            p₁ ≡ p₂
+  Σ-≡,≡↔≡ = inverse to from left-inverse-of right-inverse-of
 
-  left-inverse-of : {p₁ p₂ : A × B} →
-                    (p : (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂)) →
-                    from (to p) ≡ p
-  left-inverse-of (P.refl , P.refl) = P.refl
+  Σ-≡,≡→≡ : (∃ λ (p : proj₁ p₁ ≡ proj₁ p₂) →
+               P.subst B p (proj₂ p₁) ≡ proj₂ p₂) →
+            p₁ ≡ p₂
+  Σ-≡,≡→≡ = to
 
-  right-inverse-of : {p₁ p₂ : A × B} (p : p₁ ≡ p₂) → to (from p) ≡ p
-  right-inverse-of P.refl = P.refl
+module _ {a b} {A : Set a} {B : Set b} {p₁ p₂ : A × B} where
+  private
+    to : {p₁ p₂ : A × B} →
+         (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂) → p₁ ≡ p₂
+    to (P.refl , P.refl) = P.refl
+
+    from : {p₁ p₂ : A × B} → p₁ ≡ p₂ →
+           (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂)
+    from P.refl = P.refl , P.refl
+
+    left-inverse-of : {p₁ p₂ : A × B} →
+                      (p : (proj₁ p₁ ≡ proj₁ p₂) × (proj₂ p₁ ≡ proj₂ p₂)) →
+                      from (to p) ≡ p
+    left-inverse-of (P.refl , P.refl) = P.refl
+
+    right-inverse-of : {p₁ p₂ : A × B} (p : p₁ ≡ p₂) → to (from p) ≡ p
+    right-inverse-of P.refl = P.refl
+
+  ×-≡,≡↔≡ : (proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂) ↔ p₁ ≡ p₂
+  ×-≡,≡↔≡ = inverse to from left-inverse-of right-inverse-of
+
+  ×-≡,≡→≡ : (proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂) → p₁ ≡ p₂
+  ×-≡,≡→≡ = to
 
 ×-≡×≡↔≡,≡ : ∀ {a b} {A : Set a} {B : Set b} {x y} (p : A × B) →
             (x ≡ proj₁ p × y ≡ proj₂ p) ↔ (x , y) ≡ p
-×-≡×≡↔≡,≡ {x = x} {y} p = inverse to from from∘to to∘from
-   where
-   to : (x ≡ proj₁ p × y ≡ proj₂ p) → (x , y) ≡ p
-   to = uncurry $ P.cong₂ _,_
-
-   from : (x , y) ≡ p → (x ≡ proj₁ p × y ≡ proj₂ p)
-   from = < P.cong proj₁ , P.cong proj₂ >
-
-   from∘to : ∀ v → from (to v) ≡ v
-   from∘to (P.refl , P.refl) = P.refl
-
-   to∘from : ∀ v → to (from v) ≡ v
-   to∘from P.refl = P.refl
+×-≡×≡↔≡,≡ _ = ×-≡,≡↔≡


### PR DESCRIPTION
Also reprove `(x ≡ proj₁ p × y ≡ proj₂ p) ↔ (x , y) ≡ p` as an immediate consequence of `(proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂) ↔ p₁ ≡ p₂`, using eta. The where blocks are moved around to into private blocks in order to bind the arguments only once using an anonymous module, but maybe that's too much noise for too little gain.