### PR TITLE
Fix implicit arguments in +-distrib-/-∣ʳ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Bug-fixes
 * In `/-monoˡ-≤` in `Data.Nat.DivMod` the parameter `o` was implicit but not inferrable.
   It has been changed to be explicit.
 
+* In `+-distrib-/-∣ʳ` in `Data.Nat.DivMod` the parameter `m` was implicit but not inferrable,
+  while `n` is explicit but inferrable.  They have been changed.
+
 * In `Function.Definitions` the definitions of `Surjection`, `Inverseˡ`,
   `Inverseʳ` were not being re-exported correctly and therefore had an unsolved
   meta-variable whenever this module was explicitly parameterised. This has

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -239,9 +239,9 @@ m≥n⇒m/n>0 {m@(suc _)} {n@(suc _)} m≥n = begin
   n % d             <⟨ m%n<n n d ⟩
   d                 ∎)
 
-+-distrib-/-∣ʳ : ∀ {m} n {d} .{{_ : NonZero d}} →
++-distrib-/-∣ʳ : ∀ m {n} {d} .{{_ : NonZero d}} →
                  d ∣ n → (m + n) / d ≡ m / d + n / d
-+-distrib-/-∣ʳ {m} n {d} (divides p refl) = +-distrib-/ m n (begin-strict
++-distrib-/-∣ʳ m {n} {d} (divides p refl) = +-distrib-/ m n (begin-strict
   m % d + p * d % d ≡⟨ cong (m % d +_) (m*n%n≡0 p d) ⟩
   m % d + 0         ≡⟨ +-identityʳ _ ⟩
   m % d             <⟨ m%n<n m d ⟩


### PR DESCRIPTION
In `+-distrib-/-∣ʳ`,  `m` should be explicit and `n` should be implicit.