### PR TITLE
Resolve Issue #602:new lemma added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -664,6 +664,11 @@ Other minor changes
   sign-cong′ : s₁ ◃ n₁ ≡ s₂ ◃ n₂ → s₁ ≡ s₂ ⊎ (n₁ ≡ 0 × n₂ ≡ 0)
   ```
 
+* Added new proofs in `Data.List.Relation.Binary.Lex.Strict`:
+  ```agda
+  xs≮[] : ∀ xs → ¬ xs < []
+  ```
+
 * Added new proofs in `Data.Nat.Properties`:
   ```agda
   n+1+m≢m   : n + suc m ≢ m

--- a/src/Data/List/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/List/Relation/Binary/Lex/Strict.agda
@@ -45,8 +45,11 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
       _≋_ = Pointwise _≈_
       _<_ = Lex-< _≈_ _≺_
 
+    xs≮[] : ∀ xs → ¬ xs < []
+    xs≮[] _ (base ())
+
     ¬[]<[] : ¬ [] < []
-    ¬[]<[] (base ())
+    ¬[]<[] = xs≮[] []
 
     <-irreflexive : Irreflexive _≈_ _≺_ → Irreflexive _≋_ _<_
     <-irreflexive irr (x≈y ∷ xs≋ys) (this x<y)     = irr x≈y x<y


### PR DESCRIPTION
Proof `xs≮[] : ∀ xs → ¬ xs < []` added as per discussion. 
CHANGELOG.md suitably updated. 
Old proof of `¬[]<[] : ¬ [] < []` now defined to be`xs≮[] []` (and definitionally equal to previous definition)