### PR TITLE
Switch to new function hiearchy in several places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,8 @@ Non-backwards compatible changes
     * `∪⇔⊎`
     * `∃-Subset-[]-⇔`
     * `∃-Subset-∷-⇔`
+  * `Data.List.Countdown`
+    * `empty`
   * `Data.List.Fresh.Relation.Unary.Any`
     * `⊎⇔Any`
   * `Data.List.Relation.Binary.Lex`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,62 @@ Non-backwards compatible changes
   1/pos⇒pos : ∀ p .{{_ : NonZero p}} .{{Positive (1/ p)}} → Positive p
   ```
 
+* Various modules have changed the types of some definitions to use the new
+  function hierachy:
+  * `Data.Fin.Properties`
+    * `∀-cons-⇔`
+    * `⊎⇔∃`
+  * `Data.Fin.Subset.Properties`
+    * `out⊆-⇔`
+    * `in⊆in-⇔`
+    * `out⊂in-⇔`
+    * `out⊂out-⇔`
+    * `in⊂in-⇔`
+    * `x∈⁅y⁆⇔x≡y`
+    * `∩⇔×`
+    * `∪⇔⊎`
+    * `∃-Subset-[]-⇔`
+    * `∃-Subset-∷-⇔`
+  * `Data.List.Fresh.Relation.Unary.Any`
+    * `⊎⇔Any`
+  * `Data.List.Relation.Binary.Lex`
+    * `[]<[]-⇔`
+    * `∷<∷-⇔`
+  * `Data.List.Relation.Binary.Sublist.Heterogeneous.Properties`
+    * `∷⁻¹`
+    * `∷ʳ⁻¹`
+    * `Sublist-[x]-bijection`
+  * `Data.List.Relation.Binary.Sublist.Setoid.Properties`
+    * `∷⁻¹`
+    * `∷ʳ⁻¹`
+    * `[x]⊆xs⤖x∈xs`
+  * `Data.Maybe.Relation.Binary.Connected`
+    * `just-equivalence`
+  * `Data.Maybe.Relation.Binary.Pointwise`
+    * `just-equivalence`
+  * `Data.Maybe.Relation.Unary.All`
+    * `just-equivalence`
+  * `Data.Maybe.Relation.Unary.Any`
+    * `just-equivalence`
+  * `Data.Nat.Divisibility`
+    * `m%n≡0⇔n∣m`
+  * `Data.Nat.Properties`
+    * `eq?`
+  * `Data.Vec.Relation.Binary.Lex.Core`
+    * `P⇔[]<[]`
+    * `∷<∷-⇔`
+  * `Data.Vec.Relation.Binary.Pointwise.Extensional`
+    * `equivalent`
+    * `Pointwise-≡↔≡`
+  * `Data.Vec.Relation.Binary.Pointwise.Inductive`
+    * `Pointwise-≡↔≡`
+  * `Relation.Binary.Construct.Closure.Reflexive.Properties`
+    * `⊎⇔Refl`
+  * `Relation.Binary.Construct.Closure.Transitive`
+    * `equivalent`
+  * `Relation.Nullary.Decidable`
+    * `map`
+
 Major improvements
 ------------------
 

--- a/README/Tactic/Rewrite.agda
+++ b/README/Tactic/Rewrite.agda
@@ -13,7 +13,7 @@ open import Tactic.Rewrite using (cong!)
 -- Usage
 ----------------------------------------------------------------------
 
--- When performing large equational reasoning proofs, it's quite 
+-- When performing large equational reasoning proofs, it's quite
 -- common to have to construct sophisticated lambdas to pass
 -- into 'cong'. This can be extremely tedious, and can bog down
 -- large proofs in piles of boilerplate. The 'cong!' tactic
@@ -79,13 +79,13 @@ module LiteralTests
 
   test₁ : 40 + 2 ≡ 42
   test₁ = cong! refl
-  
+
   test₂ : 48 ≡ 42 → 42 ≡ 48
   test₂ eq = cong! (sym eq)
-  
-  test₃ : (f : ℕ → ℕ) → f 48 ≡ f 42 
+
+  test₃ : (f : ℕ → ℕ) → f 48 ≡ f 42
   test₃ f = cong! assumption
-  
+
   test₄ : (f : ℕ → ℕ → ℕ) → f 48 48 ≡ f 42 42
   test₄ f = cong! assumption
 
@@ -111,7 +111,7 @@ module HigherOrderTests
 
   test₂ : f ≡ g → ∀ n → f (f (f n)) ≡ g (g (g n))
   test₂ eq n = cong! eq
- 
+
 module EquationalReasoningTests where
 
   test₁ : ∀ m n → m ≡ n → suc (suc (m + 0)) + m ≡ suc (suc n) + (n + 0)

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -23,10 +23,8 @@ open import Data.Product using (Σ-syntax; ∃; ∃₂; ∄; _×_; _,_; map; pro
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_; flip)
-open import Function.Bundles using (_↔_; mk↔′)
+open import Function.Bundles using (_↣_; _⇔_; _↔_; mk⇔; mk↔′)
 open import Function.Definitions.Core2 using (Surjective)
-open import Function.Equivalence using (_⇔_; equivalence)
-open import Function.Injection using (_↣_)
 open import Relation.Binary as B hiding (Decidable; _⇔_)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; trans; cong; subst; _≗_; module ≡-Reasoning)
@@ -773,7 +771,7 @@ module _ {n p} {P : Pred (Fin (suc n)) p} where
   ∀-cons z s (suc i) = s i
 
   ∀-cons-⇔ : (P zero × Π[ P ∘ suc ]) ⇔ Π[ P ]
-  ∀-cons-⇔ = equivalence (uncurry ∀-cons) < _$ zero , _∘ suc >
+  ∀-cons-⇔ = mk⇔ (uncurry ∀-cons) < _$ zero , _∘ suc >
 
   ∃-here : P zero → ∃⟨ P ⟩
   ∃-here = zero ,_
@@ -786,7 +784,7 @@ module _ {n p} {P : Pred (Fin (suc n)) p} where
   ∃-toSum (suc f , P₁₊) = inj₂ (f , P₁₊)
 
   ⊎⇔∃ : (P zero ⊎ ∃⟨ P ∘ suc ⟩) ⇔ ∃⟨ P ⟩
-  ⊎⇔∃ = equivalence [ ∃-here , ∃-there ] ∃-toSum
+  ⊎⇔∃ = mk⇔ [ ∃-here , ∃-there ] ∃-toSum
 
 decFinSubset : ∀ {n p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
                Decidable Q → (∀ {f} → Q f → Dec (P f)) → Dec (Q ⊆ P)

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -28,7 +28,7 @@ open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Vec.Base
 open import Data.Vec.Properties
 open import Function.Base using (_∘_; const; id; case_of_)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Level using (Level)
 open import Relation.Binary as B hiding (Decidable; _⇔_)
 open import Relation.Binary.PropositionalEquality
@@ -66,14 +66,14 @@ out⊆ : p ⊆ q → outside ∷ p ⊆ s ∷ q
 out⊆ p⊆q (there ∈p) = there (p⊆q ∈p)
 
 out⊆-⇔ : p ⊆ q ⇔ outside ∷ p ⊆ s ∷ q
-out⊆-⇔ = equivalence out⊆ drop-∷-⊆
+out⊆-⇔ = mk⇔ out⊆ drop-∷-⊆
 
 in⊆in : p ⊆ q → inside ∷ p ⊆ inside ∷ q
 in⊆in p⊆q here = here
 in⊆in p⊆q (there ∈p) = there (p⊆q ∈p)
 
 in⊆in-⇔ : p ⊆ q ⇔ inside ∷ p ⊆ inside ∷ q
-in⊆in-⇔ = equivalence in⊆in drop-∷-⊆
+in⊆in-⇔ = mk⇔ in⊆in drop-∷-⊆
 
 s⊆s : p ⊆ q → s ∷ p ⊆ s ∷ q
 s⊆s p⊆q here = here
@@ -92,13 +92,13 @@ out⊂in : p ⊆ q → outside ∷ p ⊂ inside ∷ q
 out⊂in p⊆q = out⊆ p⊆q , zero , here , λ ()
 
 out⊂in-⇔ : p ⊆ q ⇔ outside ∷ p ⊂ inside ∷ q
-out⊂in-⇔ = equivalence out⊂in (drop-∷-⊆ ∘ proj₁)
+out⊂in-⇔ = mk⇔ out⊂in (drop-∷-⊆ ∘ proj₁)
 
 out⊂out-⇔ : p ⊂ q ⇔ outside ∷ p ⊂ outside ∷ q
-out⊂out-⇔ = equivalence out⊂ drop-∷-⊂
+out⊂out-⇔ = mk⇔ out⊂ drop-∷-⊂
 
 in⊂in-⇔ : p ⊂ q ⇔ inside ∷ p ⊂ inside ∷ q
-in⊂in-⇔ = equivalence in⊂in drop-∷-⊂
+in⊂in-⇔ = mk⇔ in⊂in drop-∷-⊂
 
 ------------------------------------------------------------------------
 -- _∈_
@@ -179,7 +179,7 @@ x∈⁅y⁆⇒x≡y zero    (there p) = contradiction p ∉⊥
 x∈⁅y⁆⇒x≡y (suc y) (there p) = cong suc (x∈⁅y⁆⇒x≡y y p)
 
 x∈⁅y⁆⇔x≡y : x ∈ ⁅ y ⁆ ⇔ x ≡ y
-x∈⁅y⁆⇔x≡y {x = x} {y = y} = equivalence
+x∈⁅y⁆⇔x≡y {x = x} {y = y} = mk⇔
   (x∈⁅y⁆⇒x≡y y)
   (λ x≡y → subst (λ y → x ∈ ⁅ y ⁆) x≡y (x∈⁅x⁆ x))
 
@@ -503,7 +503,7 @@ x∈p∩q⁻ (s      ∷ p) (t      ∷ q) (there x∈p∩q) =
   Product.map there there (x∈p∩q⁻ p q x∈p∩q)
 
 ∩⇔× : x ∈ p ∩ q ⇔ (x ∈ p × x ∈ q)
-∩⇔× = equivalence (x∈p∩q⁻ _ _) x∈p∩q⁺
+∩⇔× = mk⇔ (x∈p∩q⁻ _ _) x∈p∩q⁺
 
 ∣p∩q∣≤∣p∣ : ∀ (p q : Subset n) → ∣ p ∩ q ∣ ≤ ∣ p ∣
 ∣p∩q∣≤∣p∣ p q = p⊆q⇒∣p∣≤∣q∣ (p∩q⊆p p q)
@@ -741,7 +741,7 @@ x∈p∪q⁺ (inj₁ x∈p) = p⊆p∪q _   x∈p
 x∈p∪q⁺ (inj₂ x∈q) = q⊆p∪q _ _ x∈q
 
 ∪⇔⊎ : x ∈ p ∪ q ⇔ (x ∈ p ⊎ x ∈ q)
-∪⇔⊎ = equivalence (x∈p∪q⁻ _ _) x∈p∪q⁺
+∪⇔⊎ = mk⇔ (x∈p∪q⁻ _ _) x∈p∪q⁺
 
 ∣p∣≤∣p∪q∣ : ∀ (p q : Subset n) → ∣ p ∣ ≤ ∣ p ∪ q ∣
 ∣p∣≤∣p∪q∣ p q = p⊆q⇒∣p∣≤∣q∣ (p⊆p∪q {p = p} q)
@@ -839,7 +839,7 @@ module _ {P : Pred (Subset 0) ℓ} where
   ∃-Subset-zero ([] , P[]) = P[]
 
   ∃-Subset-[]-⇔ : P [] ⇔ ∃⟨ P ⟩
-  ∃-Subset-[]-⇔ = equivalence ([] ,_) ∃-Subset-zero
+  ∃-Subset-[]-⇔ = mk⇔ ([] ,_) ∃-Subset-zero
 
 module _ {P : Pred (Subset (suc n)) ℓ} where
 
@@ -848,7 +848,7 @@ module _ {P : Pred (Subset (suc n)) ℓ} where
   ∃-Subset-suc ( inside ∷ p , Pip) = inj₁ (p , Pip)
 
   ∃-Subset-∷-⇔ : (∃⟨ P ∘ (inside ∷_) ⟩ ⊎ ∃⟨ P ∘ (outside ∷_) ⟩) ⇔ ∃⟨ P ⟩
-  ∃-Subset-∷-⇔ = equivalence
+  ∃-Subset-∷-⇔ = mk⇔
     [ Product.map _ id , Product.map _ id ]′
     ∃-Subset-suc
 

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -17,8 +17,7 @@ open import Data.Fin.Base using (Fin; zero; suc; punchOut)
 open import Data.Fin.Properties
   using (suc-injective; punchOut-injective)
 open import Function.Base
-open import Function.Equality using (_⟨$⟩_)
-open import Function.Injection
+open import Function.Bundles
   using (Injection; module Injection)
 open import Data.Bool.Base using (true; false)
 open import Data.List hiding (lookup)
@@ -126,11 +125,11 @@ record _⊕_ (counted : List Elem) (n : ℕ) : Set where
 
 empty : ∀ {n} → Injection D.setoid (PropEq.setoid (Fin n)) → [] ⊕ n
 empty inj =
-  record { kind      = inj₂ ∘ _⟨$⟩_ to
+  record { kind      = inj₂ ∘ f
          ; injective = λ {x} {y} {i} eq₁ eq₂ → injective (begin
-             to ⟨$⟩ x  ≡⟨ inj₂-injective eq₁ ⟩
-             i         ≡⟨ PropEq.sym $ inj₂-injective eq₂ ⟩
-             to ⟨$⟩ y  ∎)
+             f x ≡⟨ inj₂-injective eq₁ ⟩
+             i   ≡⟨ PropEq.sym $ inj₂-injective eq₂ ⟩
+             f y ∎)
          }
   where open Injection inj
 
@@ -139,10 +138,8 @@ empty inj =
 emptyFromList : (counted : List Elem) → (∀ x → x ∈ counted) →
                 [] ⊕ length counted
 emptyFromList counted complete = empty record
-  { to = record
-    { _⟨$⟩_ = λ x → first-index x (complete x)
-    ; cong  = first-index-cong (complete _) (complete _)
-    }
+  { f = λ x → first-index x (complete x)
+  ; cong = first-index-cong (complete _) (complete _)
   ; injective = first-index-injective (complete _) (complete _)
   }
 

--- a/src/Data/List/Fresh/Relation/Unary/Any.agda
+++ b/src/Data/List/Fresh/Relation/Unary/Any.agda
@@ -12,7 +12,7 @@ open import Level using (Level; _⊔_; Lift)
 open import Data.Empty
 open import Data.Product using (∃; _,_; -,_)
 open import Data.Sum.Base using (_⊎_; [_,_]′; inj₁; inj₂)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Sum using (_⊎-dec_)
@@ -50,7 +50,7 @@ module _ {R : Rel A r} {P : Pred A p} {x} {xs : List# A R} {pr} where
   fromSum = [ here , there ]′
 
   ⊎⇔Any : (P x ⊎ Any P xs) ⇔ Any P (cons x xs pr)
-  ⊎⇔Any = equivalence fromSum toSum
+  ⊎⇔Any = mk⇔ fromSum toSum
 
 module _ {R : Rel A r} {P : Pred A p} {Q : Pred A q} where
 

--- a/src/Data/List/Relation/Binary/Lex.agda
+++ b/src/Data/List/Relation/Binary/Lex.agda
@@ -14,7 +14,7 @@ open import Data.Product using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Data.List.Base using (List; []; _∷_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_])
 open import Function.Base using (_∘_; flip; id)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Level using (_⊔_)
 open import Relation.Nullary using (Dec; yes; no; ¬_)
 import Relation.Nullary.Decidable as Dec
@@ -99,11 +99,11 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} {P : Set}
 
 
   []<[]-⇔ : P ⇔ [] < []
-  []<[]-⇔ = equivalence base (λ { (base p) → p })
+  []<[]-⇔ = mk⇔ base (λ { (base p) → p })
 
 
   ∷<∷-⇔ : ∀ {x y xs ys} → (x ≺ y ⊎ (x ≈ y × xs < ys)) ⇔ (x ∷ xs) < (y ∷ ys)
-  ∷<∷-⇔ = equivalence [ this , uncurry next ] toSum
+  ∷<∷-⇔ = mk⇔ [ this , uncurry next ] toSum
 
   module _ (dec-P : Dec P) (dec-≈ : Decidable _≈_) (dec-≺ : Decidable _≺_)
     where

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -346,7 +346,6 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   toAny∘fromAny≗id (there p) = P.cong there (toAny∘fromAny≗id p)
 
   Sublist-[x]-bijection : ∀ {x xs} → (Sublist R [ x ] xs) ⤖ (Any (R x) xs)
-  -- Sublist-[x]-bijection = mk⤖ toAny fromAny toAny-injective toAny∘fromAny≗id
   Sublist-[x]-bijection = mk⤖ (toAny-injective , < fromAny , toAny∘fromAny≗id >)
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -24,11 +24,10 @@ open import Data.List.Relation.Binary.Sublist.Heterogeneous
 open import Data.Maybe.Relation.Unary.All as MAll using (nothing; just)
 open import Data.Nat.Base using (ℕ; _≤_; _≥_); open ℕ; open _≤_
 import Data.Nat.Properties as ℕₚ
-open import Data.Product using (∃₂; _×_; _,_; proj₂; uncurry)
+open import Data.Product using (∃₂; _×_; _,_; <_,_>; proj₂; uncurry)
 
 open import Function.Base
-open import Function.Bijection   using (_⤖_; bijection)
-open import Function.Equivalence using (_⇔_ ; equivalence)
+open import Function.Bundles using (_⤖_; _⇔_ ; mk⤖; mk⇔)
 
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary using (Dec; does; _because_; yes; no; ¬_)
@@ -313,10 +312,10 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} {a as b bs} where
 
   ∷⁻¹ : R a b → Sublist R as bs ⇔ Sublist R (a ∷ as) (b ∷ bs)
-  ∷⁻¹ r = equivalence (r ∷_) ∷⁻
+  ∷⁻¹ r = mk⇔ (r ∷_) ∷⁻
 
   ∷ʳ⁻¹ : ¬ R a b → Sublist R (a ∷ as) bs ⇔ Sublist R (a ∷ as) (b ∷ bs)
-  ∷ʳ⁻¹ ¬r = equivalence (_ ∷ʳ_) (∷ʳ⁻ ¬r)
+  ∷ʳ⁻¹ ¬r = mk⇔ (_ ∷ʳ_) (∷ʳ⁻ ¬r)
 
 ------------------------------------------------------------------------
 -- Irrelevant special case
@@ -347,7 +346,8 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   toAny∘fromAny≗id (there p) = P.cong there (toAny∘fromAny≗id p)
 
   Sublist-[x]-bijection : ∀ {x xs} → (Sublist R [ x ] xs) ⤖ (Any (R x) xs)
-  Sublist-[x]-bijection = bijection toAny fromAny toAny-injective toAny∘fromAny≗id
+  -- Sublist-[x]-bijection = mk⤖ toAny fromAny toAny-injective toAny∘fromAny≗id
+  Sublist-[x]-bijection = mk⤖ (toAny-injective , < fromAny , toAny∘fromAny≗id >)
 
 ------------------------------------------------------------------------
 -- Relational properties

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -27,8 +27,7 @@ import Data.Nat.Properties as ℕₚ
 open import Data.Product using (∃; _,_; proj₂)
 
 open import Function.Base
-open import Function.Bijection   using (_⤖_)
-open import Function.Equivalence using (_⇔_)
+open import Function.Bundles using (_⇔_; _⤖_)
 
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; cong)
 open import Relation.Unary using (Pred; Decidable; Irrelevant)

--- a/src/Data/Maybe/Relation/Binary/Connected.agda
+++ b/src/Data/Maybe/Relation/Binary/Connected.agda
@@ -11,7 +11,7 @@ module Data.Maybe.Relation.Binary.Connected where
 open import Level
 open import Data.Product
 open import Data.Maybe.Base using (Maybe; just; nothing)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
@@ -42,7 +42,7 @@ drop-just : Connected R (just x) (just y) → R x y
 drop-just (just p) = p
 
 just-equivalence : R x y ⇔ Connected R (just x) (just y)
-just-equivalence = equivalence just drop-just
+just-equivalence = mk⇔ just drop-just
 
 ------------------------------------------------------------------------
 -- Relational properties

--- a/src/Data/Maybe/Relation/Binary/Pointwise.agda
+++ b/src/Data/Maybe/Relation/Binary/Pointwise.agda
@@ -11,7 +11,7 @@ module Data.Maybe.Relation.Binary.Pointwise where
 open import Level
 open import Data.Product
 open import Data.Maybe.Base using (Maybe; just; nothing)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
@@ -35,7 +35,7 @@ module _ {a b ℓ} {A : Set a} {B : Set b} {R : REL A B ℓ} where
   drop-just (just p) = p
 
   just-equivalence : ∀ {x y} → R x y ⇔ Pointwise R (just x) (just y)
-  just-equivalence = equivalence just drop-just
+  just-equivalence = mk⇔ just drop-just
 
   nothing-inv : ∀ {x} → Pointwise R nothing x → x ≡ nothing
   nothing-inv nothing = P.refl

--- a/src/Data/Maybe/Relation/Unary/All.agda
+++ b/src/Data/Maybe/Relation/Unary/All.agda
@@ -14,7 +14,7 @@ open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Maybe.Relation.Unary.Any using (Any; just)
 open import Data.Product as Prod using (_,_)
 open import Function.Base using (id; _∘′_)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Level
 open import Relation.Binary.PropositionalEquality as P using (_≡_; cong)
 open import Relation.Unary
@@ -37,7 +37,7 @@ module _ {a p} {A : Set a} {P : Pred A p} where
   drop-just (just px) = px
 
   just-equivalence : ∀ {x} → P x ⇔ All P (just x)
-  just-equivalence = equivalence just drop-just
+  just-equivalence = mk⇔ just drop-just
 
   map : ∀ {q} {Q : Pred A q} → P ⊆ Q → All P ⊆ All Q
   map f (just px) = just (f px)

--- a/src/Data/Maybe/Relation/Unary/Any.agda
+++ b/src/Data/Maybe/Relation/Unary/Any.agda
@@ -11,7 +11,7 @@ module Data.Maybe.Relation.Unary.Any where
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Product as Prod using (∃; _,_; -,_)
 open import Function.Base using (id)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Level
 open import Relation.Binary.PropositionalEquality as P using (_≡_; cong)
 open import Relation.Unary
@@ -33,7 +33,7 @@ module _ {a p} {A : Set a} {P : Pred A p} where
   drop-just (just px) = px
 
   just-equivalence : ∀ {x} → P x ⇔ Any P (just x)
-  just-equivalence = equivalence just drop-just
+  just-equivalence = mk⇔ just drop-just
 
   map : ∀ {q} {Q : Pred A q} → P ⊆ Q → Any P ⊆ Any Q
   map f (just px) = just (f px)

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -15,7 +15,7 @@ open import Data.Nat.Properties
 open import Data.Product
 open import Data.Unit using (tt)
 open import Function.Base
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Level using (0ℓ)
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable as Dec using (False)
@@ -48,7 +48,7 @@ n∣m⇒m%n≡0 m n (divides v eq) = begin-equality
   where open ≤-Reasoning
 
 m%n≡0⇔n∣m : ∀ m n .{{_ : NonZero n}} → m % n ≡ 0 ⇔ n ∣ m
-m%n≡0⇔n∣m m n = equivalence (m%n≡0⇒n∣m m n) (n∣m⇒m%n≡0 m n)
+m%n≡0⇔n∣m m n = mk⇔ (m%n≡0⇒n∣m m n) (n∣m⇒m%n≡0 m n)
 
 ------------------------------------------------------------------------
 -- Properties of _∣_ and _≤_

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -27,7 +27,7 @@ open import Data.Product using (_×_; _,_)
 open import Data.Sum.Base as Sum
 open import Data.Unit using (tt)
 open import Function.Base
-open import Function.Injection using (_↣_)
+open import Function.Bundles using (_↣_)
 open import Function.Metric.Nat
 open import Level using (0ℓ)
 open import Relation.Binary

--- a/src/Data/Vec/Relation/Binary/Lex/Core.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Core.agda
@@ -16,7 +16,7 @@ open import Data.Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec using (Vec; []; _∷_)
 open import Data.Vec.Relation.Binary.Pointwise.Inductive using (Pointwise; []; _∷_)
 open import Function.Base using (flip)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; refl; cong)
@@ -83,14 +83,14 @@ module _ {P : Set} {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
   ≰-next x≮y xs≮ys (next x≈y xs<ys) = contradiction xs<ys xs≮ys
 
   P⇔[]<[] : P ⇔ [] <ₗₑₓ []
-  P⇔[]<[] = equivalence base (λ { (base p) → p })
+  P⇔[]<[] = mk⇔ base (λ { (base p) → p })
 
   toSum : ∀ {x y n} {xs ys : Vec A n} → (x ∷ xs) <ₗₑₓ (y ∷ ys) → (x ≺ y ⊎ (x ≈ y × xs <ₗₑₓ ys))
   toSum (this x≺y m≡n)   = inj₁ x≺y
   toSum (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
 
   ∷<∷-⇔ : ∀ {x y n} {xs ys : Vec A n} → (x ≺ y ⊎ (x ≈ y × xs <ₗₑₓ ys)) ⇔ (x ∷ xs) <ₗₑₓ (y ∷ ys)
-  ∷<∷-⇔ = equivalence [ flip this refl , uncurry next ] toSum
+  ∷<∷-⇔ = mk⇔ [ flip this refl , uncurry next ] toSum
 
   module _ (≈-equiv : IsPartialEquivalence _≈_)
            ((≺-respʳ-≈ , ≺-respˡ-≈) : _≺_ Respects₂ _≈_)

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -140,8 +140,7 @@ Pointwise-≡⇒≡ {xs = x ∷ xs} {y ∷ ys} xs∼ys     =
 ≡⇒Pointwise-≡ P.refl = refl P.refl
 
 Pointwise-≡↔≡ : ∀ {n} {xs ys : Vec A n} → Pointwise _≡_ xs ys ⇔ xs ≡ ys
-Pointwise-≡↔≡ {ℓ} {A} =
-  mk⇔ Pointwise-≡⇒≡ ≡⇒Pointwise-≡
+Pointwise-≡↔≡ {ℓ} {A} = mk⇔ Pointwise-≡⇒≡ ≡⇒Pointwise-≡
 
 ------------------------------------------------------------------------
 -- Pointwise and Plus commute when the underlying relation is

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -16,9 +16,8 @@ open import Data.Vec.Relation.Binary.Pointwise.Inductive as Inductive
   renaming (Pointwise to IPointwise)
 open import Level using (_⊔_)
 open import Function.Base using (_∘_)
-open import Function.Equality using (_⟨$⟩_)
-open import Function.Equivalence as Equiv
-  using (_⇔_; ⇔-setoid; equivalence; module Equivalence)
+open import Function.Bundles using (module Equivalence; _⇔_; mk⇔)
+open import Function.Properties.Equivalence using (⇔-setoid)
 open import Level using (Level; _⊔_; 0ℓ)
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
@@ -88,7 +87,7 @@ module _ {_∼_ : REL A B ℓ} where
 
   equivalent : ∀ {n} {xs : Vec A n} {ys : Vec B n} →
                Pointwise _∼_ xs ys ⇔ IPointwise _∼_ xs ys
-  equivalent = equivalence extensional⇒inductive inductive⇒extensional
+  equivalent = mk⇔ extensional⇒inductive inductive⇒extensional
 
 ------------------------------------------------------------------------
 -- Relational properties
@@ -142,7 +141,7 @@ Pointwise-≡⇒≡ {xs = x ∷ xs} {y ∷ ys} xs∼ys     =
 
 Pointwise-≡↔≡ : ∀ {n} {xs ys : Vec A n} → Pointwise _≡_ xs ys ⇔ xs ≡ ys
 Pointwise-≡↔≡ {ℓ} {A} =
-  Equiv.equivalence Pointwise-≡⇒≡ ≡⇒Pointwise-≡
+  mk⇔ Pointwise-≡⇒≡ ≡⇒Pointwise-≡
 
 ------------------------------------------------------------------------
 -- Pointwise and Plus commute when the underlying relation is
@@ -160,9 +159,9 @@ module _ {_∼_ : Rel A ℓ} where
   ∙⁺⇒⁺∙ : ∀ {n} {xs ys : Vec A n} → Reflexive _∼_ →
           Pointwise (Plus _∼_) xs ys → Plus (Pointwise _∼_) xs ys
   ∙⁺⇒⁺∙ rfl =
-    Plus.map (_⟨$⟩_ (Equivalence.from equivalent)) ∘
+    Plus.map (Equivalence.g equivalent) ∘
     helper ∘
-    _⟨$⟩_ (Equivalence.to equivalent)
+    Equivalence.f equivalent
     where
     helper : ∀ {n} {xs ys : Vec A n} →
              IPointwise (Plus _∼_) xs ys → Plus (IPointwise _∼_) xs ys
@@ -211,6 +210,6 @@ private
          Pointwise (Plus _R_) xs ys →
          Plus (Pointwise _R_) xs ys)
   counterexample ∙⁺⇒⁺∙ =
-    ¬ix⁺∙jz (Equivalence.to Plus.equivalent ⟨$⟩
-               Plus.map (_⟨$⟩_ (Equivalence.to equivalent))
-                 (∙⁺⇒⁺∙ (Equivalence.from equivalent ⟨$⟩ ix∙⁺jz)))
+    ¬ix⁺∙jz (Equivalence.f Plus.equivalent
+              (Plus.map (Equivalence.f equivalent)
+                (∙⁺⇒⁺∙ (Equivalence.g equivalent ix∙⁺jz))))

--- a/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Inductive.agda
@@ -15,7 +15,7 @@ open import Data.Vec.Base as Vec hiding ([_]; head; tail; map; lookup; uncons)
 open import Data.Vec.Relation.Unary.All using (All; []; _∷_)
 open import Level using (Level; _⊔_)
 open import Function.Base using (_∘_)
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Relation.Nullary
@@ -255,4 +255,4 @@ Pointwise-≡⇒≡ (P.refl ∷ xs∼ys) = P.cong (_ ∷_) (Pointwise-≡⇒≡ 
 ≡⇒Pointwise-≡ P.refl = refl P.refl
 
 Pointwise-≡↔≡ : ∀ {n} {xs ys : Vec A n} → Pointwise _≡_ xs ys ⇔ xs ≡ ys
-Pointwise-≡↔≡ = equivalence Pointwise-≡⇒≡ ≡⇒Pointwise-≡
+Pointwise-≡↔≡ = mk⇔ Pointwise-≡⇒≡ ≡⇒Pointwise-≡

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -10,7 +10,7 @@ module Relation.Binary.Construct.Closure.Reflexive.Properties where
 
 open import Data.Product as Prod
 open import Data.Sum.Base as Sum
-open import Function.Equivalence using (_⇔_; equivalence)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Function.Base using (id)
 open import Level
 open import Relation.Binary hiding (_⇔_)
@@ -51,7 +51,7 @@ module _ {_~_ : Rel A ℓ} where
   toSum refl = inj₁ refl
 
   ⊎⇔Refl : ∀ {a b} → (a ≡ b ⊎ a ~ b) ⇔ a ~ᵒ b
-  ⊎⇔Refl = equivalence fromSum toSum
+  ⊎⇔Refl = mk⇔ fromSum toSum
 
   sym : Symmetric _~_ → Symmetric _~ᵒ_
   sym ~-sym [ x∼y ] = [ ~-sym x∼y ]

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -9,7 +9,7 @@
 module Relation.Binary.Construct.Closure.Transitive where
 
 open import Function.Base
-open import Function.Equivalence as Equiv using (_⇔_)
+open import Function.Bundles using (_⇔_; mk⇔)
 open import Induction.WellFounded
 open import Level
 open import Relation.Binary hiding (_⇔_)
@@ -124,7 +124,7 @@ map R₁⇒R₂ (x ∼⁺⟨ xR⁺z ⟩ zR⁺y) =
 -- Plus and TransClosure are equivalent.
 equivalent : ∀ {_∼_ : Rel A ℓ} {x y} →
              Plus _∼_ x y ⇔ TransClosure _∼_ x y
-equivalent {_∼_ = _∼_} = Equiv.equivalence complete sound
+equivalent {_∼_ = _∼_} = mk⇔ complete sound
   where
   complete : Plus _∼_ ⇒ TransClosure _∼_
   complete [ x∼y ]             = [ x∼y ]

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -13,9 +13,7 @@ open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
 open import Function.Base
 open import Function.Equality    using (_⟨$⟩_; module Π)
-open import Function using (_↔_; mk↔′)
-open import Function.Equivalence using (_⇔_; equivalence; module Equivalence)
-open import Function.Injection   using (Injection; module Injection)
+open import Function using (Injection; module Injection; module Equivalence; _⇔_; _↔_; mk↔′)
 open import Relation.Binary      using (Setoid; module Setoid; Decidable)
 open import Relation.Nullary
 open import Relation.Nullary.Reflects using (invert)
@@ -36,7 +34,7 @@ open import Relation.Nullary.Decidable.Core public
 -- Maps
 
 map : P ⇔ Q → Dec P → Dec Q
-map P⇔Q = map′ (to ⟨$⟩_) (from ⟨$⟩_)
+map P⇔Q = map′ f g
   where open Equivalence P⇔Q
 
 module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
@@ -53,7 +51,7 @@ module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
 
   via-injection : Decidable _≈B_ → Decidable _≈A_
   via-injection dec x y =
-    map′ injective (Π.cong to) (dec (to ⟨$⟩ x) (to ⟨$⟩ y))
+    map′ injective cong (dec (f x) (f y))
 
 ------------------------------------------------------------------------
 -- A lemma relating True and Dec

--- a/src/Tactic/Rewrite.agda
+++ b/src/Tactic/Rewrite.agda
@@ -135,7 +135,7 @@ private
   antiUnifyArgs : ℕ → Args Term → Args Term → Maybe (Args Term)
   antiUnifyClauses : ℕ → Clauses → Clauses → Maybe Clauses
   antiUnifyClause : ℕ → Clause → Clause → Maybe Clause
-  
+
   antiUnify ϕ (var x args) (var y args') with x Nat.≡ᵇ y | antiUnifyArgs ϕ args args'
   ... | _     | nothing    = var ϕ []
   ... | false | just uargs = var ϕ uargs


### PR DESCRIPTION
I was annoyed that `Data.Fin.Properties` depended on both the old and the new hierarchy, and pulled the thread.

Part of #759 