### PR TITLE
Improve definition of `Prime` and add Euclid's lemma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,27 @@ Non-backwards compatible changes
   ∣↥p∣≢0⇒p≄0 : ∀ p → ℤ.∣ (↥ p) ∣ ≢0 → p ≠ 0ℚᵘ
   ```
 
+### Change in the definition of `Prime`
+
+* The definition of `Prime` in `Data.Nat.Primality` was:
+  ```agda
+  Prime 0             = ⊥
+  Prime 1             = ⊥
+  Prime (suc (suc n)) = (i : Fin n) → 2 + toℕ i ∤ 2 + n
+  ```
+  which was very hard to reason about as not only did it involve conversion
+  to and from the `Fin` type, it also required that the divisor was of the form
+  `2 + toℕ i`, which has exactly the same problem as the `suc n` hack described
+  above used for non-zeroness.
+  
+* To make it easier to use, reason about and read, the definition has been
+  changed to:
+  ```agda
+  Prime 0 = ⊥
+  Prime 1 = ⊥
+  Prime n = ∀ {d} → 2 ≤ d → d < n → d ∤ n
+  ```
+
 ### Implementation of division and modulus for `ℤ`
 
 * The previous implementations of `_divℕ_`, `_div_`, `_modℕ_`, `_mod_`
@@ -855,7 +876,7 @@ Other minor changes
   ¬composite⇒prime : 2 ≤ n → ¬ Composite n → Prime n
   prime⇒¬composite : Prime n → ¬ Composite n
   ¬prime⇒composite : 2 ≤ n → ¬ Prime n → Composite n
-  euclid'sLemma    : Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
+  euclidsLemma     : Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
   ```
 
 * Added new proofs in `Data.Nat.Properties`:
@@ -863,11 +884,19 @@ Other minor changes
   n≮0       : n ≮ 0
   n+1+m≢m   : n + suc m ≢ m
   m*n≡0⇒m≡0 : .{{_ : NonZero n}} → m * n ≡ 0 → m ≡ 0
+  
+  anyUpTo? : ∀ (P? : U.Decidable P) (v : ℕ) → Dec (∃ λ n → n < v × P n)
+  allUpTo? : ∀ (P? : U.Decidable P) (v : ℕ) → Dec (∀ {n} → n < v → P n)
   ```
 
 * Added new proofs in `Data.Nat.DivMod`:
   ```agda
   m%n≤n : .{{_ : NonZero n}} → m % n ≤ n
+  ```
+
+* Added new proofs in `Data.Nat.Divisibility`:
+  ```agda
+  n∣m*n*o : n ∣ m * n * o
   ```
 
 * Added new patterns in `Data.Nat.Reflection`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -855,6 +855,7 @@ Other minor changes
   ¬composite⇒prime : 2 ≤ n → ¬ Composite n → Prime n
   prime⇒¬composite : Prime n → ¬ Composite n
   ¬prime⇒composite : 2 ≤ n → ¬ Prime n → Composite n
+  euclid'sLemma    : Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
   ```
 
 * Added new proofs in `Data.Nat.Properties`:

--- a/src/Data/Nat/Coprimality.agda
+++ b/src/Data/Nat/Coprimality.agda
@@ -25,7 +25,7 @@ open import Data.Product as Prod
 open import Function
 open import Level using (0ℓ)
 open import Relation.Binary.PropositionalEquality as P
-  using (_≡_; _≢_; refl; cong; subst; module ≡-Reasoning)
+  using (_≡_; _≢_; refl; trans; cong; subst; module ≡-Reasoning)
 open import Relation.Nullary as Nullary hiding (recompute)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary
@@ -145,21 +145,12 @@ coprime-factors c (divides q₁ eq₁ , divides q₂ eq₂) with coprime-Bézout
 
 prime⇒coprime : ∀ m → Prime m →
                 ∀ n → 0 < n → n < m → Coprime m n
-prime⇒coprime (suc (suc m)) _  _ _  _ {1} _                       = refl
-prime⇒coprime (suc (suc m)) p  _ _  _ {0} (divides q 2+m≡q*0 , _) =
-  ⊥-elim $ m+1+n≢m 0 (begin-equality
-    2 + m  ≡⟨ 2+m≡q*0 ⟩
-    q * 0  ≡⟨ *-zeroʳ q ⟩
-    0      ∎)
-prime⇒coprime (suc (suc m)) p (suc n) _ 1+n<2+m {suc (suc i)}
-              (2+i∣2+m , 2+i∣1+n) =
-  ⊥-elim (p (s≤s (s≤s z≤n)) (s≤s (s≤s i<m)) 2+i∣2+m)
-  where
-  i<m : i < m
-  i<m = +-cancelˡ-< 2 (begin-strict
-    2 + i ≤⟨ ∣⇒≤ 2+i∣1+n ⟩
-    1 + n <⟨ 1+n<2+m ⟩
-    2 + m ∎)
+prime⇒coprime (suc (suc _)) p _ _ _ {0} (0∣m , _) =
+  contradiction (0∣⇒≡0 0∣m) λ()
+prime⇒coprime (suc (suc _)) _ _ _ _ {1} _         = refl
+prime⇒coprime (suc (suc _)) p (suc _) _ n<m {(suc (suc _))} (d∣m , d∣n) =
+  contradiction d∣m (p 2≤d d<m)
+  where 2≤d = s≤s (s≤s z≤n); d<m = <-transˡ (s≤s (∣⇒≤ d∣n)) n<m
 
 
 ------------------------------------------------------------------------

--- a/src/Data/Nat/Coprimality.agda
+++ b/src/Data/Nat/Coprimality.agda
@@ -153,18 +153,13 @@ prime⇒coprime (suc (suc m)) p  _ _  _ {0} (divides q 2+m≡q*0 , _) =
     0      ∎)
 prime⇒coprime (suc (suc m)) p (suc n) _ 1+n<2+m {suc (suc i)}
               (2+i∣2+m , 2+i∣1+n) =
-  ⊥-elim (p _ 2+i′∣2+m)
+  ⊥-elim (p (s≤s (s≤s z≤n)) (s≤s (s≤s i<m)) 2+i∣2+m)
   where
   i<m : i < m
   i<m = +-cancelˡ-< 2 (begin-strict
     2 + i ≤⟨ ∣⇒≤ 2+i∣1+n ⟩
     1 + n <⟨ 1+n<2+m ⟩
     2 + m ∎)
-
-  2+i′∣2+m : 2 + toℕ (fromℕ< i<m) ∣ 2 + m
-  2+i′∣2+m = subst (_∣ 2 + m)
-    (P.sym (cong (2 +_) (toℕ-fromℕ< i<m)))
-    2+i∣2+m
 
 
 ------------------------------------------------------------------------

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -171,6 +171,9 @@ n∣m*n m = divides m refl
 m∣m*n : ∀ {m} n → m ∣ m * n
 m∣m*n n = divides n (*-comm _ n)
 
+n∣m*n*o : ∀ m {n} o → n ∣ m * n * o
+n∣m*n*o m o = ∣-trans (n∣m*n m) (m∣m*n o)
+
 ∣m⇒∣m*n : ∀ {i m} n → i ∣ m → i ∣ m * n
 ∣m⇒∣m*n {i} {m} n (divides q refl) = ∣-trans (n∣m*n q) (m∣m*n n)
 

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -166,7 +166,14 @@ module GCD where
       -- greatest common divisor according to the partial order _∣_.
       greatest : ∀ {d} → d ∣ m × d ∣ n → d ∣ gcd
 
+    gcd∣m : gcd ∣ m
+    gcd∣m = proj₁ commonDivisor
+
+    gcd∣n : gcd ∣ n
+    gcd∣n = proj₂ commonDivisor
+
   open GCD public
+
 
   -- The gcd is unique.
 

--- a/src/Data/Nat/Primality.agda
+++ b/src/Data/Nat/Primality.agda
@@ -9,124 +9,137 @@
 module Data.Nat.Primality where
 
 open import Data.Empty using (⊥)
-open import Data.Fin.Base using (Fin; toℕ; fromℕ<)
-open import Data.Fin.Properties using (all?; any?; toℕ-fromℕ<)
-open import Data.Nat.Base using (ℕ; suc; _+_; _*_; _≤_; z≤n; s≤s)
-open import Data.Nat.Divisibility using (_∣_; _∤_; _∣?_; ∣⇒≤; 0∣⇒≡0; ∣m+n∣m⇒∣n; m∣m*n; n∣m*n; module ∣-Reasoning)
+open import Data.Nat.Base
+open import Data.Nat.Divisibility
 open import Data.Nat.GCD using (module GCD; module Bézout)
-open import Data.Nat.Properties using (_≟_; ≤∧≢⇒<; +-comm; *-assoc; +-cancelˡ-≤)
-open import Data.Product using (Σ-syntax; _,_; proj₁; proj₂)
+open import Data.Nat.Properties
+open import Data.Product
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+open import Function.Base using (flip; _∘_; _∘′_)
 open import Relation.Nullary using (yes; no; ¬_)
-open import Relation.Nullary.Decidable using (from-yes)
+open import Relation.Nullary.Decidable as Dec using (from-yes)
+open import Relation.Nullary.Product using (_×-dec_)
+open import Relation.Nullary.Implication using (_→-dec_)
 open import Relation.Nullary.Negation using (¬?; contradiction; decidable-stable)
 open import Relation.Unary using (Decidable)
-open import Relation.Binary.PropositionalEquality using (sym; cong; subst)
+open import Relation.Binary.PropositionalEquality using (refl; sym; cong; subst)
+
+private
+  variable
+    n : ℕ
+
+------------------------------------------------------------------------
+-- Definitions
 
 -- Definition of compositeness
 
 Composite : ℕ → Set
 Composite 0 = ⊥
 Composite 1 = ⊥
-Composite (suc (suc n)) = Σ[ i ∈ Fin n ] 2 + toℕ i ∣ 2 + n
-
--- Decision procedure for compositeness
-
-composite? : Decidable Composite
-composite? 0 = no λ()
-composite? 1 = no λ()
-composite? (suc (suc n)) = any? (λ _ → _ ∣? _)
+Composite n = ∃ λ d → 2 ≤ d × d < n × d ∣ n
 
 -- Definition of primality.
 
 Prime : ℕ → Set
-Prime 0             = ⊥
-Prime 1             = ⊥
-Prime (suc (suc n)) = (i : Fin n) → 2 + toℕ i ∤ 2 + n
+Prime 0 = ⊥
+Prime 1 = ⊥
+Prime n = ∀ {d} → 2 ≤ d → d < n → d ∤ n
 
--- Decision procedure for primality.
+------------------------------------------------------------------------
+-- Decidability
+
+composite? : Decidable Composite
+composite? 0               = no λ()
+composite? 1               = no λ()
+composite? n@(suc (suc _)) = Dec.map′
+  (map₂ λ { (a , b , c) → (b , a , c)})
+  (map₂ λ { (a , b , c) → (b , a , c)})
+  (anyUpTo? (λ d → 2 ≤? d ×-dec d ∣? n) n)
 
 prime? : Decidable Prime
-prime? 0             = no λ()
-prime? 1             = no λ()
-prime? (suc (suc n)) = all? (λ _ → ¬? (_ ∣? _))
+prime? 0                 = no λ()
+prime? 1                 = no λ()
+prime? n@(suc (suc n-2)) = Dec.map′
+  (λ f {d} → flip (f {d}))
+  (λ f {d} → flip (f {d}))
+  (allUpTo? (λ d → 2 ≤? d →-dec ¬? (d ∣? n)) n)
 
--- Relation between compositeness and primality
+------------------------------------------------------------------------
+-- Relationships between compositeness and primality
 
-composite⇒¬prime : ∀ {n} → Composite n → ¬ Prime n
-composite⇒¬prime {suc (suc n)} (i , 2+i∣2+n) 2+n-prime = 2+n-prime i 2+i∣2+n
+composite⇒¬prime : Composite n → ¬ Prime n
+composite⇒¬prime {suc (suc _)} (d , 2≤d , d<n , d∣n) n-prime =
+  n-prime 2≤d d<n d∣n
 
-¬composite⇒prime : ∀ {n} → 2 ≤ n → ¬ Composite n → Prime n
-¬composite⇒prime {suc (suc n)} (s≤s (s≤s _)) ¬n-composite i 2+i∣2+n = ¬n-composite (i , 2+i∣2+n)
+¬composite⇒prime : 2 ≤ n → ¬ Composite n → Prime n
+¬composite⇒prime (s≤s (s≤s _)) ¬n-composite {d} 2≤d d<n d∣n =
+  ¬n-composite (d , 2≤d , d<n , d∣n)
 
-prime⇒¬composite : ∀ {n} → Prime n → ¬ Composite n
-prime⇒¬composite {suc (suc n)} 2+n-prime (i , 2+i∣2+n) = 2+n-prime i 2+i∣2+n
+prime⇒¬composite : Prime n → ¬ Composite n
+prime⇒¬composite {n@(suc (suc _))} n-prime (d , 2≤d , d<n , d∣n) =
+  n-prime 2≤d d<n d∣n
 
 -- note that this has to recompute the factor!
-¬prime⇒composite : ∀ {n} → 2 ≤ n → ¬ Prime n → Composite n
-¬prime⇒composite {n} 2≤n ¬n-prime = decidable-stable (composite? n) λ ¬n-composite → ¬n-prime (¬composite⇒prime 2≤n ¬n-composite)
+¬prime⇒composite : 2 ≤ n → ¬ Prime n → Composite n
+¬prime⇒composite {n} 2≤n ¬n-prime =
+  decidable-stable (composite? n) (¬n-prime ∘′ ¬composite⇒prime 2≤n)
+
+------------------------------------------------------------------------
+-- Euclid's lemma
 
 -- For p prime, if p ∣ m * n, then either p ∣ m or p ∣ n.
 -- This demonstrates that the usual definition of prime numbers matches the
 -- ring theoretic definition of a prime element of the semiring ℕ.
 -- This is useful for proving many other theorems involving prime numbers.
-euclid'sLemma : ∀ m n {p} → Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
-euclid'sLemma m n {p} p-prime p∣m*n with Bézout.lemma m p
--- if the GCD of m and p is zero then p must be zero, which is impossible as p
--- is a prime
-... | Bézout.result 0 g _ = contradiction p-prime (subst Prime (0∣⇒≡0 (proj₂ (GCD.commonDivisor g))))
--- if the GCD of m and p is one then m and p is coprime, and we know that for
--- some integers s and r, sm + rp = 1. We can use this fact to determine that p
--- divides n
-... | Bézout.result 1 _ (Bézout.+- r s 1+sp≡rm) = inj₂ (∣m+n∣m⇒∣n p∣spn+n p∣spn)
+euclidsLemma : ∀ m n {p} → Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
+euclidsLemma m n {p@(suc (suc _))} p-prime p∣m*n = result
   where
-    open ∣-Reasoning
-    p∣spn+n : p ∣ s * p * n + n
-    p∣spn+n = begin
-      p             ∣⟨ p∣m*n ⟩
-      m * n         ∣⟨ n∣m*n r ⟩
-      r * (m * n)   ≡˘⟨ *-assoc r m n ⟩
+  open ∣-Reasoning
+
+  p∣rmn : ∀ r → p ∣ r * m * n
+  p∣rmn r = begin
+    p           ∣⟨ p∣m*n ⟩
+    m * n       ∣⟨ n∣m*n r ⟩
+    r * (m * n) ≡˘⟨ *-assoc r m n ⟩
+    r * m * n   ∎
+
+  result : p ∣ m ⊎ p ∣ n
+  result with Bézout.lemma m p
+  -- if the GCD of m and p is zero then p must be zero, which is impossible as p
+  -- is a prime
+  ... | Bézout.result 0 g _ = contradiction (0∣⇒≡0 (GCD.gcd∣n g)) λ()
+
+  -- if the GCD of m and p is one then m and p is coprime, and we know that for
+  -- some integers s and r, sm + rp = 1. We can use this fact to determine that p
+  -- divides n
+  ... | Bézout.result 1 _ (Bézout.+- r s 1+sp≡rm) =
+    inj₂ (flip ∣m+n∣m⇒∣n (n∣m*n*o s n) (begin
+      p             ∣⟨ p∣rmn r ⟩
       r * m * n     ≡˘⟨ cong (_* n) 1+sp≡rm ⟩
       n + s * p * n ≡⟨ +-comm n (s * p * n) ⟩
-      s * p * n + n ∎
-    p∣spn : p ∣ s * p * n
-    p∣spn = begin
-      p         ∣⟨ n∣m*n s ⟩
-      s * p     ∣⟨ m∣m*n n ⟩
-      s * p * n ∎
-... | Bézout.result 1 _ (Bézout.-+ r s 1+rm≡sp) = inj₂ (∣m+n∣m⇒∣n p∣rmn+n p∣rmn)
-  where
-    open ∣-Reasoning
-    p∣rmn+n : p ∣ r * m * n + n
-    p∣rmn+n = begin
-      p             ∣⟨ n∣m*n s ⟩
-      s * p         ∣⟨ m∣m*n n ⟩
+      s * p * n + n ∎))
+
+  ... | Bézout.result 1 _ (Bézout.-+ r s 1+rm≡sp) =
+    inj₂ (flip ∣m+n∣m⇒∣n (p∣rmn r) (begin
+      p             ∣⟨ n∣m*n*o s n ⟩
       s * p * n     ≡˘⟨ cong (_* n) 1+rm≡sp ⟩
       n + r * m * n ≡⟨ +-comm n (r * m * n) ⟩
-      r * m * n + n ∎
-    p∣rmn : p ∣ r * m * n
-    p∣rmn = begin
-      p           ∣⟨ p∣m*n ⟩
-      m * n       ∣⟨ n∣m*n r ⟩
-      r * (m * n) ≡˘⟨ *-assoc r m n ⟩
-      r * m * n   ∎
--- if the GCD of m and p is greater than one, then it must be p and hence p ∣ m.
--- Proving this is a little messy, though!
-... | Bézout.result (suc (suc n)) g _ with suc (suc n) ≟ p
-... | yes 2+n=p = inj₁ (subst (_∣ m) 2+n=p (proj₁ (GCD.commonDivisor g)))
-... | no  2+n≠p with p
-... | suc (suc p′)
-  = contradiction
-    (subst (λ n′ → 2 + n′ ∣ 2 + p′) (sym (toℕ-fromℕ< _)) (proj₂ (GCD.commonDivisor g)))
-    (p-prime (fromℕ< (+-cancelˡ-≤ 2 (≤∧≢⇒< (∣⇒≤ (proj₂ (GCD.commonDivisor g))) 2+n≠p))))
+      r * m * n + n ∎))
+
+  -- if the GCD of m and p is greater than one, then it must be p and hence p ∣ m.
+  ... | Bézout.result d@(suc (suc _)) g _ with d ≟ p
+  ...   | yes refl = inj₁ (GCD.gcd∣m g)
+  ...   | no  d≢p  = contradiction (GCD.gcd∣n g) (p-prime (s≤s (s≤s z≤n)) d<p)
+    where d<p = flip ≤∧≢⇒< d≢p (∣⇒≤ (GCD.gcd∣n g))
 
 private
 
   -- Example: 2 is prime.
-
   2-is-prime : Prime 2
   2-is-prime = from-yes (prime? 2)
+
 
   -- Example: 6 is composite
   6-is-composite : Composite 6
   6-is-composite = from-yes (composite? 6)
+

--- a/src/Data/Nat/Primality.agda
+++ b/src/Data/Nat/Primality.agda
@@ -9,15 +9,19 @@
 module Data.Nat.Primality where
 
 open import Data.Empty using (⊥)
-open import Data.Fin.Base using (Fin; toℕ)
-open import Data.Fin.Properties using (all?; any?)
-open import Data.Nat.Base using (ℕ; suc; _+_; _≤_; z≤n; s≤s)
-open import Data.Nat.Divisibility using (_∣_; _∤_; _∣?_)
-open import Data.Product using (Σ-syntax; _,_)
+open import Data.Fin.Base using (Fin; toℕ; fromℕ<)
+open import Data.Fin.Properties using (all?; any?; toℕ-fromℕ<)
+open import Data.Nat.Base using (ℕ; suc; _+_; _*_; _≤_; z≤n; s≤s)
+open import Data.Nat.Divisibility using (_∣_; _∤_; _∣?_; ∣⇒≤; 0∣⇒≡0; ∣m+n∣m⇒∣n; m∣m*n; n∣m*n; module ∣-Reasoning)
+open import Data.Nat.GCD using (module GCD; module Bézout)
+open import Data.Nat.Properties using (_≟_; ≤∧≢⇒<; +-comm; *-assoc; +-cancelˡ-≤)
+open import Data.Product using (Σ-syntax; _,_; proj₁; proj₂)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Relation.Nullary using (yes; no; ¬_)
 open import Relation.Nullary.Decidable using (from-yes)
-open import Relation.Nullary.Negation using (¬?; decidable-stable)
+open import Relation.Nullary.Negation using (¬?; contradiction; decidable-stable)
 open import Relation.Unary using (Decidable)
+open import Relation.Binary.PropositionalEquality using (sym; cong; subst)
 
 -- Definition of compositeness
 
@@ -61,6 +65,60 @@ prime⇒¬composite {suc (suc n)} 2+n-prime (i , 2+i∣2+n) = 2+n-prime i 2+i∣
 -- note that this has to recompute the factor!
 ¬prime⇒composite : ∀ {n} → 2 ≤ n → ¬ Prime n → Composite n
 ¬prime⇒composite {n} 2≤n ¬n-prime = decidable-stable (composite? n) λ ¬n-composite → ¬n-prime (¬composite⇒prime 2≤n ¬n-composite)
+
+-- For p prime, if p ∣ m * n, then either p ∣ m or p ∣ n.
+-- This demonstrates that the usual definition of prime numbers matches the
+-- ring theoretic definition of a prime element of the semiring ℕ.
+-- This is useful for proving many other theorems involving prime numbers.
+euclid'sLemma : ∀ m n {p} → Prime p → p ∣ m * n → p ∣ m ⊎ p ∣ n
+euclid'sLemma m n {p} p-prime p∣m*n with Bézout.lemma m p
+-- if the GCD of m and p is zero then p must be zero, which is impossible as p
+-- is a prime
+... | Bézout.result 0 g _ = contradiction p-prime (subst Prime (0∣⇒≡0 (proj₂ (GCD.commonDivisor g))))
+-- if the GCD of m and p is one then m and p is coprime, and we know that for
+-- some integers s and r, sm + rp = 1. We can use this fact to determine that p
+-- divides n
+... | Bézout.result 1 _ (Bézout.+- r s 1+sp≡rm) = inj₂ (∣m+n∣m⇒∣n p∣spn+n p∣spn)
+  where
+    open ∣-Reasoning
+    p∣spn+n : p ∣ s * p * n + n
+    p∣spn+n = begin
+      p             ∣⟨ p∣m*n ⟩
+      m * n         ∣⟨ n∣m*n r ⟩
+      r * (m * n)   ≡˘⟨ *-assoc r m n ⟩
+      r * m * n     ≡˘⟨ cong (_* n) 1+sp≡rm ⟩
+      n + s * p * n ≡⟨ +-comm n (s * p * n) ⟩
+      s * p * n + n ∎
+    p∣spn : p ∣ s * p * n
+    p∣spn = begin
+      p         ∣⟨ n∣m*n s ⟩
+      s * p     ∣⟨ m∣m*n n ⟩
+      s * p * n ∎
+... | Bézout.result 1 _ (Bézout.-+ r s 1+rm≡sp) = inj₂ (∣m+n∣m⇒∣n p∣rmn+n p∣rmn)
+  where
+    open ∣-Reasoning
+    p∣rmn+n : p ∣ r * m * n + n
+    p∣rmn+n = begin
+      p             ∣⟨ n∣m*n s ⟩
+      s * p         ∣⟨ m∣m*n n ⟩
+      s * p * n     ≡˘⟨ cong (_* n) 1+rm≡sp ⟩
+      n + r * m * n ≡⟨ +-comm n (r * m * n) ⟩
+      r * m * n + n ∎
+    p∣rmn : p ∣ r * m * n
+    p∣rmn = begin
+      p           ∣⟨ p∣m*n ⟩
+      m * n       ∣⟨ n∣m*n r ⟩
+      r * (m * n) ≡˘⟨ *-assoc r m n ⟩
+      r * m * n   ∎
+-- if the GCD of m and p is greater than one, then it must be p and hence p ∣ m.
+-- Proving this is a little messy, though!
+... | Bézout.result (suc (suc n)) g _ with suc (suc n) ≟ p
+... | yes 2+n=p = inj₁ (subst (_∣ m) 2+n=p (proj₁ (GCD.commonDivisor g)))
+... | no  2+n≠p with p
+... | suc (suc p′)
+  = contradiction
+    (subst (λ n′ → 2 + n′ ∣ 2 + p′) (sym (toℕ-fromℕ< _)) (proj₂ (GCD.commonDivisor g)))
+    (p-prime (fromℕ< (+-cancelˡ-≤ 2 (≤∧≢⇒< (∣⇒≤ (proj₂ (GCD.commonDivisor g))) 2+n≠p))))
 
 private
 


### PR DESCRIPTION
This is something that'll be very useful for number theory proofs involving prime numbers.

There's two reasons I'm not quite happy with this addition:

* The proof is a little messy in parts
* The proof depends on Bézout's lemma, and `Data.Nat.GCD` is a heavy dependency to add to the `Data.Nat.Primality` module.

I'd like to discuss these a bit to see if they can be resolved or mitigated.