### PR TITLE
Add properties about unary predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1130,54 +1130,55 @@ Other minor changes
 
 * Added new proofs in `Relation.Unary.Properties`:
   ```
-  ⊆-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊆_
-  ⊆-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊆_
-  ⊆-min : Min {B = Pred A ℓ} _⊆_ ∅
-  ⊆-max : Max {A = Pred A ℓ} _⊆_ U
-  P⊂Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊆_
-  ⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊂_ _⊂_
-  ⊂-⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊆_ _⊂_
-  ⊆-⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊂_ _⊂_
-  ⊂-respʳ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐_
-  ⊂-respˡ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐_
-  ⊂-resp-≐ : (_⊂_ {A = A} {ℓ}) Respects₂ _≐_
-  ⊂-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊂_
-  ⊂-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊂_
-  ⊂-asym : Asymmetric {A = Pred A ℓ} _⊂_
+  ⊆-refl : Reflexive _⊆_
+  ⊆-reflexive : _≐_ ⇒ _⊆_
+  ⊆-antisym : Antisymmetric _≐_ _⊆_
+  ⊆-min : Min _⊆_ ∅
+  ⊆-max : Max _⊆_ U
+  ⊂⇒⊆ : _⊂_ ⇒ _⊆_
+  ⊂-trans : Trans _⊂_ _⊂_ _⊂_
+  ⊂-⊆-trans : Trans _⊂_ _⊆_ _⊂_
+  ⊆-⊂-trans : Trans _⊆_ _⊂_ _⊂_
+  ⊂-respʳ-≐ : _⊂_ Respectsʳ _≐_
+  ⊂-respˡ-≐ : _⊂_ Respectsˡ _≐_
+  ⊂-resp-≐ : _⊂_ Respects₂ _≐_
+  ⊂-irrefl : Irreflexive _≐_ _⊂_
+  ⊂-antisym : Antisymmetric _≐_ _⊂_
+  ⊂-asym : Asymmetric _⊂_
   ∅-⊆′ : (P : Pred A ℓ) → ∅ ⊆′ P
   ⊆′-U : (P : Pred A ℓ) → P ⊆′ U
-  ⊆′-refl : Reflexive (_⊆′_ {A = A} {ℓ})
-  ⊆′-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_  _⊆′_
-  ⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊆′_ _⊆′_
-  ⊆′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊆′_
-  ⊆′-min : Min {B = Pred A ℓ} _⊆′_ ∅
-  ⊆′-max : Max {A = Pred A ℓ} _⊆′_ U
-  P⊂′Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊆′_
-  ⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊂′_ _⊂′_
-  ⊂′-⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊆′_ _⊂′_
-  ⊆′-⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊂′_ _⊂′_
-  ⊂′-respʳ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐′_
-  ⊂′-respˡ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐′_
-  ⊂′-resp-≐′ : (_⊂′_ {A = A} {ℓ}) Respects₂ _≐′_
-  ⊂′-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _⊂′_
-  ⊂′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊂′_
-  P⊆Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ _⊆′_
-  P⊆′Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ _⊆_
-  P⊂Q⇒P⊂′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊂′_
-  P⊂′Q⇒P⊂Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊂_
-  ≐-refl : Reflexive {A = Pred A ℓ} _≐_
-  ≐-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐_
-  ≐-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐_ _≐_ _≐_
-  ≐′-refl : Reflexive {A = Pred A ℓ} _≐′_
-  ≐′-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐′_
-  ≐′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐′_ _≐′_ _≐′_
-  P≐Q⇒P≐′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐′_
-  P≐′Q⇒P≐Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐_
+  ⊆′-refl : Reflexive {A = Pred A ℓ} _⊆′_
+  ⊆′-reflexive : _≐′_ ⇒ _⊆′_
+  ⊆′-trans : Trans _⊆′_ _⊆′_ _⊆′_
+  ⊆′-antisym : Antisymmetric _≐′_ _⊆′_
+  ⊆′-min : Min _⊆′_ ∅
+  ⊆′-max : Max _⊆′_ U
+  ⊂′⇒⊆′ : _⊂′_ ⇒ _⊆′_
+  ⊂′-trans : Trans _⊂′_ _⊂′_ _⊂′_
+  ⊂′-⊆′-trans : Trans _⊂′_ _⊆′_ _⊂′_
+  ⊆′-⊂′-trans : Trans _⊆′_ _⊂′_ _⊂′_
+  ⊂′-respʳ-≐′ : _⊂′_ Respectsʳ _≐′_
+  ⊂′-respˡ-≐′ : _⊂′_ Respectsˡ _≐′_
+  ⊂′-resp-≐′ : _⊂′_ Respects₂ _≐′_
+  ⊂′-irrefl : Irreflexive _≐′_ _⊂′_
+  ⊂′-antisym : Antisymmetric _≐′_ _⊂′_
+  ⊆⇒⊆′ : _⊆_ ⇒ _⊆′_
+  ⊆′⇒⊆ : _⊆′_ ⇒ _⊆_
+  ⊂⇒⊂′ : _⊂_ ⇒ _⊂′_
+  ⊂′⇒⊂ : _⊂′_ ⇒ _⊂_
+  ≐-refl : Reflexive _≐_
+  ≐-sym : Sym _≐_ _≐_
+  ≐-trans : Trans _≐_ _≐_ _≐_
+  ≐′-refl : Reflexive _≐′_
+  ≐′-sym : Sym _≐′_ _≐′_
+  ≐′-trans : Trans _≐′_ _≐′_ _≐′_
+  ≐⇒≐′ : _≐_ ⇒ _≐′_
+  ≐′⇒≐ : _≐′_ ⇒ _≐_
   ```
 
 * Generalised proofs in `Relation.Unary.Properties`:
   ```
-  ⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊆_ _⊆_
+  ⊆-trans : Trans _⊆_ _⊆_ _⊆_
   ```
 
 * Added new operations in `Relation.Binary.PropositionalEquality.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -647,6 +647,11 @@ New modules
   Relation.Unary.Relation.Binary.Equality
   ```
 
+* The subset relations on predicates define an order
+  ```
+  Relation.Unary.Relation.Binary.Subset
+  ```
+
 * Polymorphic versions of some unary relations and their properties
   ```
   Relation.Unary.Polymorphic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1117,6 +1117,58 @@ Other minor changes
   _≐′_ : Pred A ℓ₁ → Pred A ℓ₂ → Set _
   ```
 
+* Added new proofs in `Relation.Unary.Properties`:
+  ```
+  ⊆-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊆_
+  ⊆-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊆_
+  ⊆-min : Min {B = Pred A ℓ} _⊆_ ∅
+  ⊆-max : Max {A = Pred A ℓ} _⊆_ U
+  P⊂Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊆_
+  ⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊂_ _⊂_
+  ⊂-⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊆_ _⊂_
+  ⊆-⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊂_ _⊂_
+  ⊂-respʳ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐_
+  ⊂-respˡ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐_
+  ⊂-resp-≐ : (_⊂_ {A = A} {ℓ}) Respects₂ _≐_
+  ⊂-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊂_
+  ⊂-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊂_
+  ⊂-asym : Asymmetric {A = Pred A ℓ} _⊂_
+  ∅-⊆′ : (P : Pred A ℓ) → ∅ ⊆′ P
+  ⊆′-U : (P : Pred A ℓ) → P ⊆′ U
+  ⊆′-refl : Reflexive (_⊆′_ {A = A} {ℓ})
+  ⊆′-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_  _⊆′_
+  ⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊆′_ _⊆′_
+  ⊆′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊆′_
+  ⊆′-min : Min {B = Pred A ℓ} _⊆′_ ∅
+  ⊆′-max : Max {A = Pred A ℓ} _⊆′_ U
+  P⊂′Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊆′_
+  ⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊂′_ _⊂′_
+  ⊂′-⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊆′_ _⊂′_
+  ⊆′-⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊂′_ _⊂′_
+  ⊂′-respʳ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐′_
+  ⊂′-respˡ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐′_
+  ⊂′-resp-≐′ : (_⊂′_ {A = A} {ℓ}) Respects₂ _≐′_
+  ⊂′-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _⊂′_
+  ⊂′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊂′_
+  P⊆Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ _⊆′_
+  P⊆′Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ _⊆_
+  P⊂Q⇒P⊂′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊂′_
+  P⊂′Q⇒P⊂Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊂_
+  ≐-refl : Reflexive {A = Pred A ℓ} _≐_
+  ≐-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐_
+  ≐-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐_ _≐_ _≐_
+  ≐′-refl : Reflexive {A = Pred A ℓ} _≐′_
+  ≐′-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐′_
+  ≐′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐′_ _≐′_ _≐′_
+  P≐Q⇒P≐′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐′_
+  P≐′Q⇒P≐Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐_
+  ```
+
+* Generalised proofs in `Relation.Unary.Properties`:
+  ```
+  ⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊆_ _⊆_
+  ```
+
 * Added new operations in `Relation.Binary.PropositionalEquality.Properties`:
   ```
   J       : (B : (y : A) → x ≡ y → Set b) (p : x ≡ y) → B x refl → B y p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -642,9 +642,10 @@ New modules
   Relation.Unary.Relation.Binary.Equality
   ```
 
-* Polymorphic verstions of some unary relations
+* Polymorphic versions of some unary relations and their properties
   ```
   Relation.Unary.Polymorphic
+  Relation.Unary.Polymorphic.Properties
   ```
 
 * Alpha equality over reflected terms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -637,6 +637,11 @@ New modules
   ```
   All contents is re-exported by `Relation.Binary.Lattice` as before.
 
+* Algebraic properties of `_∩_` and `_∪_` for predicates
+  ```
+  Relation.Unary.Algebra
+  ```
+
 * Both versions of equality on predications are equivalences
   ```
   Relation.Unary.Relation.Binary.Equality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1130,7 +1130,6 @@ Other minor changes
 
 * Added new proofs in `Relation.Unary.Properties`:
   ```
-  ⊆-refl : Reflexive _⊆_
   ⊆-reflexive : _≐_ ⇒ _⊆_
   ⊆-antisym : Antisymmetric _≐_ _⊆_
   ⊆-min : Min _⊆_ ∅
@@ -1144,7 +1143,6 @@ Other minor changes
   ⊂-resp-≐ : _⊂_ Respects₂ _≐_
   ⊂-irrefl : Irreflexive _≐_ _⊂_
   ⊂-antisym : Antisymmetric _≐_ _⊂_
-  ⊂-asym : Asymmetric _⊂_
   ∅-⊆′ : (P : Pred A ℓ) → ∅ ⊆′ P
   ⊆′-U : (P : Pred A ℓ) → P ⊆′ U
   ⊆′-refl : Reflexive {A = Pred A ℓ} _⊆′_

--- a/src/Relation/Unary/Algebra.agda
+++ b/src/Relation/Unary/Algebra.agda
@@ -1,0 +1,382 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Algebraic properties of constructions over unary relations
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Unary.Algebra where
+
+open import Algebra.Bundles
+import Algebra.Definitions as AlgebraicDefinitions
+open import Algebra.Lattice.Bundles
+import Algebra.Lattice.Structures as AlgebraicLatticeStructures
+import Algebra.Structures as AlgebraicStructures
+open import Data.Empty.Polymorphic using (⊥-elim)
+open import Data.Product as Product using (_,_; proj₁; proj₂; <_,_>; curry; uncurry)
+open import Data.Sum as Sum using (inj₁; inj₂; [_,_])
+open import Data.Unit.Polymorphic using (tt)
+open import Function using (id; const; _∘_)
+open import Level
+open import Relation.Unary hiding (∅; U)
+open import Relation.Unary.Polymorphic using (∅; U)
+open import Relation.Unary.Relation.Binary.Equality using (≐-isEquivalence)
+
+module _ {a ℓ : Level} {A : Set a} where
+
+  open AlgebraicDefinitions {A = Pred A ℓ} _≐_
+
+------------------------------------------------------------------------
+-- Properties of _∩_
+
+  ∩-cong : Congruent₂ _∩_
+  ∩-cong (P⊆Q , Q⊆P) (R⊆S , S⊆R) = Product.map P⊆Q R⊆S , Product.map Q⊆P S⊆R
+
+  ∩-comm : Commutative _∩_
+  ∩-comm _ _ = Product.swap , Product.swap
+
+  ∩-assoc : Associative _∩_
+  ∩-assoc _ _ _ = Product.assocʳ′ , Product.assocˡ′
+
+  ∩-idem : Idempotent _∩_
+  ∩-idem _ = proj₁ , < id , id >
+
+  ∩-identityˡ : LeftIdentity U _∩_
+  ∩-identityˡ _ = proj₂ , < const tt , id >
+
+  ∩-identityʳ : RightIdentity U _∩_
+  ∩-identityʳ _ = proj₁ , < id , const tt >
+
+  ∩-identity : Identity U _∩_
+  ∩-identity = ∩-identityˡ , ∩-identityʳ
+
+  ∩-zeroˡ : LeftZero ∅ _∩_
+  ∩-zeroˡ _ = proj₁ , ⊥-elim
+
+  ∩-zeroʳ : RightZero ∅ _∩_
+  ∩-zeroʳ _ = proj₂ , ⊥-elim
+
+  ∩-zero : Zero ∅ _∩_
+  ∩-zero = ∩-zeroˡ , ∩-zeroʳ
+
+------------------------------------------------------------------------
+-- Properties of _∪_
+
+  ∪-cong : Congruent₂ _∪_
+  ∪-cong (P⊆Q , Q⊆P) (R⊆S , S⊆R) = Sum.map P⊆Q R⊆S , Sum.map Q⊆P S⊆R
+
+  ∪-comm : Commutative _∪_
+  ∪-comm _ _ = Sum.swap , Sum.swap
+
+  ∪-assoc : Associative _∪_
+  ∪-assoc _ _ _ = Sum.assocʳ , Sum.assocˡ
+
+  ∪-idem : Idempotent _∪_
+  ∪-idem _ = [ id , id ] , inj₁
+
+  ∪-identityˡ : LeftIdentity ∅ _∪_
+  ∪-identityˡ _ = [ ⊥-elim , id ] , inj₂
+
+  ∪-identityʳ : RightIdentity ∅ _∪_
+  ∪-identityʳ _ = [ id , ⊥-elim ] , inj₁
+
+  ∪-identity : Identity ∅ _∪_
+  ∪-identity = ∪-identityˡ , ∪-identityʳ
+
+------------------------------------------------------------------------
+-- Properties of _∩_ and _∪_
+
+  ∩-distribˡ-∪ : _∩_ DistributesOverˡ _∪_
+  ∩-distribˡ-∪ _ _ _ =
+    ( uncurry (λ x∈P → [ inj₁ ∘ (x∈P ,_) , inj₂ ∘ (x∈P ,_) ])
+    , [ Product.map₂ inj₁ , Product.map₂ inj₂ ]
+    )
+
+  ∩-distribʳ-∪ : _∩_ DistributesOverʳ _∪_
+  ∩-distribʳ-∪ _ _ _ =
+    ( uncurry [ curry inj₁ , curry inj₂ ]
+    , [ Product.map₁ inj₁ , Product.map₁ inj₂ ]
+    )
+
+  ∩-distrib-∪ : _∩_ DistributesOver _∪_
+  ∩-distrib-∪ = ∩-distribˡ-∪ , ∩-distribʳ-∪
+
+  ∪-distribˡ-∩ : _∪_ DistributesOverˡ _∩_
+  ∪-distribˡ-∩ _ _ _ =
+    ( [ < inj₁ , inj₁ > , Product.map inj₂ inj₂ ]
+    , uncurry [ const ∘ inj₁ , (λ x∈Q → [ inj₁ , inj₂ ∘ (x∈Q ,_) ]) ]
+    )
+
+  ∪-distribʳ-∩ : _∪_ DistributesOverʳ _∩_
+  ∪-distribʳ-∩ _ _ _ =
+    ( [ Product.map inj₁ inj₁ , < inj₂ , inj₂ > ]
+    , uncurry [ (λ x∈Q → [ inj₁ ∘ (x∈Q ,_) , inj₂ ]) , const ∘ inj₂ ]
+    )
+
+  ∪-distrib-∩ : _∪_ DistributesOver _∩_
+  ∪-distrib-∩ = ∪-distribˡ-∩ , ∪-distribʳ-∩
+
+  ∩-abs-∪ : _∩_ Absorbs _∪_
+  ∩-abs-∪ _ _ = proj₁ , < id , inj₁ >
+
+  ∪-abs-∩ : _∪_ Absorbs _∩_
+  ∪-abs-∩ _ _ = [ id , proj₁ ] , inj₁
+
+  ∪-∩-absorptive : Absorptive _∪_ _∩_
+  ∪-∩-absorptive = ∪-abs-∩ , ∩-abs-∪
+
+  ∩-∪-absorptive : Absorptive _∩_ _∪_
+  ∩-∪-absorptive = ∩-abs-∪ , ∪-abs-∩
+
+module _ {a : Level} (A : Set a) (ℓ : Level) where
+
+  open AlgebraicStructures        {A = Pred A ℓ} _≐_
+  open AlgebraicLatticeStructures {A = Pred A ℓ} _≐_
+
+------------------------------------------------------------------------
+-- Algebraic structures of _∩_
+
+  ∩-isMagma : IsMagma _∩_
+  ∩-isMagma = record
+    { isEquivalence = ≐-isEquivalence
+    ; ∙-cong = ∩-cong
+    }
+
+  ∩-isSemigroup : IsSemigroup _∩_
+  ∩-isSemigroup = record
+    { isMagma = ∩-isMagma
+    ; assoc = ∩-assoc
+    }
+
+  ∩-isBand : IsBand _∩_
+  ∩-isBand = record
+    { isSemigroup = ∩-isSemigroup
+    ; idem = ∩-idem
+    }
+
+  ∩-isSemilattice : IsSemilattice _∩_
+  ∩-isSemilattice = record
+    { isBand = ∩-isBand
+    ; comm = ∩-comm
+    }
+
+  ∩-isMonoid : IsMonoid _∩_ U
+  ∩-isMonoid = record
+    { isSemigroup = ∩-isSemigroup
+    ; identity = ∩-identity
+    }
+
+  ∩-isCommutativeMonoid : IsCommutativeMonoid _∩_ U
+  ∩-isCommutativeMonoid = record
+    { isMonoid = ∩-isMonoid
+    ; comm = ∩-comm
+    }
+
+  ∩-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∩_ U
+  ∩-isIdempotentCommutativeMonoid = record
+    { isCommutativeMonoid = ∩-isCommutativeMonoid
+    ; idem = ∩-idem
+    }
+
+------------------------------------------------------------------------
+-- Algebraic structures of _∪_
+
+  ∪-isMagma : IsMagma _∪_
+  ∪-isMagma = record
+    { isEquivalence = ≐-isEquivalence
+    ; ∙-cong = ∪-cong
+    }
+
+  ∪-isSemigroup : IsSemigroup _∪_
+  ∪-isSemigroup = record
+    { isMagma = ∪-isMagma
+    ; assoc = ∪-assoc
+    }
+
+  ∪-isBand : IsBand _∪_
+  ∪-isBand = record
+    { isSemigroup = ∪-isSemigroup
+    ; idem = ∪-idem
+    }
+
+  ∪-isSemilattice : IsSemilattice _∪_
+  ∪-isSemilattice = record
+    { isBand = ∪-isBand
+    ; comm = ∪-comm
+    }
+
+  ∪-isMonoid : IsMonoid _∪_ ∅
+  ∪-isMonoid = record
+    { isSemigroup = ∪-isSemigroup
+    ; identity = ∪-identity
+    }
+
+  ∪-isCommutativeMonoid : IsCommutativeMonoid _∪_ ∅
+  ∪-isCommutativeMonoid = record
+    { isMonoid = ∪-isMonoid
+    ; comm = ∪-comm
+    }
+
+  ∪-isIdempotentCommutativeMonoid : IsIdempotentCommutativeMonoid _∪_ ∅
+  ∪-isIdempotentCommutativeMonoid = record
+    { isCommutativeMonoid = ∪-isCommutativeMonoid
+    ; idem = ∪-idem
+    }
+
+------------------------------------------------------------------------
+-- Algebraic structures of _∩_ and _∪_
+
+  ∪-∩-isSemiringWithoutAnnihilatingZero : IsSemiringWithoutAnnihilatingZero _∪_ _∩_ ∅ U
+  ∪-∩-isSemiringWithoutAnnihilatingZero = record
+    { +-isCommutativeMonoid = ∪-isCommutativeMonoid
+    ; *-isMonoid = ∩-isMonoid
+    ; distrib = ∩-distrib-∪
+    }
+
+  ∪-∩-isSemiring : IsSemiring _∪_ _∩_ ∅ U
+  ∪-∩-isSemiring = record
+    { isSemiringWithoutAnnihilatingZero = ∪-∩-isSemiringWithoutAnnihilatingZero
+    ; zero = ∩-zero
+    }
+
+  ∪-∩-isCommutativeSemiring : IsCommutativeSemiring _∪_ _∩_ ∅ U
+  ∪-∩-isCommutativeSemiring = record
+    { isSemiring = ∪-∩-isSemiring
+    ; *-comm = ∩-comm
+    }
+
+  ∪-∩-isLattice : IsLattice _∪_ _∩_
+  ∪-∩-isLattice = record
+    { isEquivalence = ≐-isEquivalence
+    ; ∨-comm = ∪-comm
+    ; ∨-assoc = ∪-assoc
+    ; ∨-cong = ∪-cong
+    ; ∧-comm = ∩-comm
+    ; ∧-assoc = ∩-assoc
+    ; ∧-cong = ∩-cong
+    ; absorptive = ∪-∩-absorptive
+    }
+
+  ∪-∩-isDistributiveLattice : IsDistributiveLattice _∪_ _∩_
+  ∪-∩-isDistributiveLattice = record
+    { isLattice = ∪-∩-isLattice
+    ; ∨-distrib-∧ = ∪-distrib-∩
+    ; ∧-distrib-∨ = ∩-distrib-∪
+    }
+
+  ∩-∪-isSemiringWithoutAnnihilatingZero : IsSemiringWithoutAnnihilatingZero _∩_ _∪_ U ∅
+  ∩-∪-isSemiringWithoutAnnihilatingZero = record
+    { +-isCommutativeMonoid = ∩-isCommutativeMonoid
+    ; *-isMonoid = ∪-isMonoid
+    ; distrib = ∪-distrib-∩
+    }
+
+------------------------------------------------------------------------
+-- Algebraic bundles of _∩_
+
+  ∩-magma : Magma _ _
+  ∩-magma = record
+    { isMagma = ∩-isMagma
+    }
+
+  ∩-semigroup : Semigroup _ _
+  ∩-semigroup = record
+    { isSemigroup = ∩-isSemigroup
+    }
+
+  ∩-band : Band _ _
+  ∩-band = record
+    { isBand = ∩-isBand
+    }
+
+  ∩-semilattice : Semilattice _ _
+  ∩-semilattice = record
+    { isSemilattice = ∩-isSemilattice
+    }
+
+  ∩-monoid : Monoid _ _
+  ∩-monoid = record
+    { isMonoid = ∩-isMonoid
+    }
+
+  ∩-commutativeMonoid : CommutativeMonoid _ _
+  ∩-commutativeMonoid = record
+    { isCommutativeMonoid = ∩-isCommutativeMonoid
+    }
+
+  ∩-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+  ∩-idempotentCommutativeMonoid = record
+    { isIdempotentCommutativeMonoid = ∩-isIdempotentCommutativeMonoid
+    }
+
+------------------------------------------------------------------------
+-- Algebraic bundles of _∪_
+
+  ∪-magma : Magma _ _
+  ∪-magma = record
+    { isMagma = ∪-isMagma
+    }
+
+  ∪-semigroup : Semigroup _ _
+  ∪-semigroup = record
+    { isSemigroup = ∪-isSemigroup
+    }
+
+  ∪-band : Band _ _
+  ∪-band = record
+    { isBand = ∪-isBand
+    }
+
+  ∪-semilattice : Semilattice _ _
+  ∪-semilattice = record
+    { isSemilattice = ∪-isSemilattice
+    }
+
+  ∪-monoid : Monoid _ _
+  ∪-monoid = record
+    { isMonoid = ∪-isMonoid
+    }
+
+  ∪-commutativeMonoid : CommutativeMonoid _ _
+  ∪-commutativeMonoid = record
+    { isCommutativeMonoid = ∪-isCommutativeMonoid
+    }
+
+  ∪-idempotentCommutativeMonoid : IdempotentCommutativeMonoid _ _
+  ∪-idempotentCommutativeMonoid = record
+    { isIdempotentCommutativeMonoid = ∪-isIdempotentCommutativeMonoid
+    }
+
+------------------------------------------------------------------------
+-- Algebraic bundles of _∩_ and _∪_
+
+  ∪-∩-semiringWithoutAnnihilatingZero : SemiringWithoutAnnihilatingZero _ _
+  ∪-∩-semiringWithoutAnnihilatingZero = record
+    { isSemiringWithoutAnnihilatingZero = ∪-∩-isSemiringWithoutAnnihilatingZero
+    }
+
+  ∪-∩-semiring : Semiring _ _
+  ∪-∩-semiring = record
+    { isSemiring = ∪-∩-isSemiring
+    }
+
+  ∪-∩-commutativeSemiring : CommutativeSemiring _ _
+  ∪-∩-commutativeSemiring = record
+    { isCommutativeSemiring = ∪-∩-isCommutativeSemiring
+    }
+
+  ∪-∩-lattice : Lattice _ _
+  ∪-∩-lattice = record
+    { isLattice = ∪-∩-isLattice
+    }
+
+  ∪-∩-distributiveLattice : DistributiveLattice _ _
+  ∪-∩-distributiveLattice = record
+    { isDistributiveLattice = ∪-∩-isDistributiveLattice
+    }
+
+  ∩-∪-semiringWithoutAnnihilatingZero : SemiringWithoutAnnihilatingZero _ _
+  ∩-∪-semiringWithoutAnnihilatingZero = record
+    { isSemiringWithoutAnnihilatingZero = ∩-∪-isSemiringWithoutAnnihilatingZero
+    }

--- a/src/Relation/Unary/Polymorphic/Properties.agda
+++ b/src/Relation/Unary/Polymorphic/Properties.agda
@@ -1,0 +1,73 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of polymorphic versions of standard definitions in
+-- Relation.Unary
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Unary.Polymorphic.Properties where
+
+open import Level using (Level)
+open import Relation.Binary.Definitions hiding (Decidable; Universal)
+open import Relation.Nullary using (yes; no)
+open import Relation.Unary hiding (∅; U)
+open import Relation.Unary.Polymorphic
+open import Data.Unit.Polymorphic.Base using (tt)
+
+private
+  variable
+    a ℓ ℓ₁ ℓ₂ : Level
+    A : Set a
+
+----------------------------------------------------------------------
+-- The empty set
+
+∅? : Decidable {A = A} {ℓ} ∅
+∅? _ = no λ()
+
+∅-Empty : Empty {A = A} {ℓ} ∅
+∅-Empty _ ()
+
+∁∅-Universal : Universal {A = A} {ℓ} (∁ ∅)
+∁∅-Universal _ ()
+
+----------------------------------------------------------------------
+-- The universe
+
+U? : Decidable {A = A} {ℓ} U
+U? _ = yes tt
+
+U-Universal : Universal {A = A} {ℓ} U
+U-Universal _ = _
+
+∁U-Empty : Empty {A = A} {ℓ} (∁ U)
+∁U-Empty _ x∈∁U = x∈∁U _
+
+----------------------------------------------------------------------
+-- Subset properties
+
+∅-⊆ : (P : Pred A ℓ₁) → ∅ {ℓ = ℓ₂} ⊆ P
+∅-⊆ _ ()
+
+⊆-U : (P : Pred A ℓ₁) → P ⊆ U {ℓ = ℓ₂}
+⊆-U _ _ = _
+
+⊆-min : Minimum (_⊆_ {A = A} {ℓ}) ∅
+⊆-min = ∅-⊆
+
+⊆-max : Maximum (_⊆_ {A = A} {ℓ}) U
+⊆-max = ⊆-U
+
+∅-⊆′ : (P : Pred A ℓ₁) → ∅ {ℓ = ℓ₂} ⊆′ P
+∅-⊆′ _ _ = λ ()
+
+⊆′-U : (P : Pred A ℓ₁) → P ⊆′ U {ℓ = ℓ₂}
+⊆′-U _ _ _ = _
+
+⊆′-min : Minimum (_⊆′_ {A = A} {ℓ}) ∅
+⊆′-min = ∅-⊆′
+
+⊆′-max : Maximum (_⊆′_ {A = A} {ℓ}) U
+⊆′-max = ⊆′-U

--- a/src/Relation/Unary/Polymorphic/Properties.agda
+++ b/src/Relation/Unary/Polymorphic/Properties.agda
@@ -54,10 +54,10 @@ U-Universal _ = _
 ⊆-U : (P : Pred A ℓ₁) → P ⊆ U {ℓ = ℓ₂}
 ⊆-U _ _ = _
 
-⊆-min : Minimum (_⊆_ {A = A} {ℓ}) ∅
+⊆-min : Min {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ ∅
 ⊆-min = ∅-⊆
 
-⊆-max : Maximum (_⊆_ {A = A} {ℓ}) U
+⊆-max : Max {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ U
 ⊆-max = ⊆-U
 
 ∅-⊆′ : (P : Pred A ℓ₁) → ∅ {ℓ = ℓ₂} ⊆′ P
@@ -66,8 +66,8 @@ U-Universal _ = _
 ⊆′-U : (P : Pred A ℓ₁) → P ⊆′ U {ℓ = ℓ₂}
 ⊆′-U _ _ _ = _
 
-⊆′-min : Minimum (_⊆′_ {A = A} {ℓ}) ∅
+⊆′-min : Min {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ ∅
 ⊆′-min = ∅-⊆′
 
-⊆′-max : Maximum (_⊆′_ {A = A} {ℓ}) U
+⊆′-max : Max {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ U
 ⊆′-max = ⊆′-U

--- a/src/Relation/Unary/Properties.agda
+++ b/src/Relation/Unary/Properties.agda
@@ -8,22 +8,22 @@
 
 module Relation.Unary.Properties where
 
-open import Data.Product using (_×_; _,_; swap; proj₁)
+open import Data.Product as Product using (_×_; _,_; swap; proj₁; zip′)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Data.Unit.Base using (tt)
 open import Level
-open import Relation.Binary.Core
+open import Relation.Binary.Core as Binary
 open import Relation.Binary.Definitions hiding (Decidable; Universal)
 open import Relation.Unary
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Product using (_×-dec_)
 open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Nullary.Negation.Core using (¬?)
-open import Function.Base using (_$_; _∘_)
+open import Function.Base using (id; _$_; _∘_)
 
 private
   variable
-    a b ℓ ℓ₁ ℓ₂ : Level
+    a b ℓ ℓ₁ ℓ₂ ℓ₃ : Level
     A : Set a
     B : Set b
 
@@ -60,14 +60,143 @@ U-Universal = λ _ → _
 ⊆-U : (P : Pred A ℓ) → P ⊆ U
 ⊆-U P _ = _
 
-⊆-refl : Reflexive (_⊆_ {A = A} {ℓ})
+⊆-refl : Reflexive {A = Pred A ℓ} _⊆_
 ⊆-refl x∈P = x∈P
 
-⊆-trans : Transitive (_⊆_ {A = A} {ℓ})
+⊆-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊆_
+⊆-reflexive (P⊆Q , Q⊆P) = P⊆Q
+
+⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊆_ _⊆_
 ⊆-trans P⊆Q Q⊆R x∈P = Q⊆R (P⊆Q x∈P)
 
-⊂-asym : Asymmetric (_⊂_ {A = A} {ℓ})
+⊆-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊆_
+⊆-antisym = _,_
+
+⊆-min : Min {B = Pred A ℓ} _⊆_ ∅
+⊆-min = ∅-⊆
+
+⊆-max : Max {A = Pred A ℓ} _⊆_ U
+⊆-max = ⊆-U
+
+P⊂Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊆_
+P⊂Q⇒P⊆Q = proj₁
+
+⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊂_ _⊂_
+⊂-trans (P⊆Q , Q⊈P) (Q⊆R , R⊈Q) = (λ x∈P → Q⊆R (P⊆Q x∈P)) , (λ R⊆P → R⊈Q (λ x∈R → P⊆Q (R⊆P x∈R)))
+
+⊂-⊆-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊆_ _⊂_
+⊂-⊆-trans (P⊆Q , Q⊈P) Q⊆R = (λ x∈P → Q⊆R (P⊆Q x∈P)) , (λ R⊆P → Q⊈P (λ x∈Q → R⊆P (Q⊆R x∈Q)))
+
+⊆-⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊂_ _⊂_
+⊆-⊂-trans P⊆Q (Q⊆R , R⊈Q) = (λ x∈P → Q⊆R (P⊆Q x∈P)) , (λ R⊆P → R⊈Q (λ R⊆Q → P⊆Q (R⊆P R⊆Q)))
+
+⊂-respʳ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐_
+⊂-respʳ-≐ (Q⊆R , _) P⊂Q = ⊂-⊆-trans P⊂Q Q⊆R
+
+⊂-respˡ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐_
+⊂-respˡ-≐ (_ , R⊆Q) P⊂Q = ⊆-⊂-trans R⊆Q P⊂Q
+
+⊂-resp-≐ : (_⊂_ {A = A} {ℓ}) Respects₂ _≐_
+⊂-resp-≐ = ⊂-respʳ-≐ , ⊂-respˡ-≐
+
+⊂-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊂_
+⊂-irrefl (_ , Q⊆P) (_ , Q⊈P) = Q⊈P Q⊆P
+
+⊂-antisym : Antisymmetric {A = Pred A ℓ} _≐_ _⊂_
+⊂-antisym (P⊆Q , _) (Q⊆P , _) = ⊆-antisym P⊆Q Q⊆P
+
+⊂-asym : Asymmetric {A = Pred A ℓ} _⊂_
 ⊂-asym (_ , Q⊈P) = Q⊈P ∘ proj₁
+
+∅-⊆′ : (P : Pred A ℓ) → ∅ ⊆′ P
+∅-⊆′ _ _ = λ ()
+
+⊆′-U : (P : Pred A ℓ) → P ⊆′ U
+⊆′-U _ _ _ = _
+
+⊆′-refl : Reflexive (_⊆′_ {A = A} {ℓ})
+⊆′-refl x x∈P = x∈P
+
+⊆′-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_  _⊆′_
+⊆′-reflexive (P⊆Q , Q⊆P) = P⊆Q
+
+⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊆′_ _⊆′_
+⊆′-trans P⊆Q Q⊆R x x∈P = Q⊆R x (P⊆Q x x∈P)
+
+⊆′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊆′_
+⊆′-antisym = _,_
+
+⊆′-min : Min {B = Pred A ℓ} _⊆′_ ∅
+⊆′-min = ∅-⊆′
+
+⊆′-max : Max {A = Pred A ℓ} _⊆′_ U
+⊆′-max = ⊆′-U
+
+P⊂′Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊆′_
+P⊂′Q⇒P⊆′Q = proj₁
+
+⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊂′_ _⊂′_
+⊂′-trans (P⊆Q , Q⊈P) (Q⊆R , R⊈Q) = ⊆′-trans P⊆Q Q⊆R , λ R⊆P → R⊈Q (⊆′-trans R⊆P P⊆Q)
+
+⊂′-⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊆′_ _⊂′_
+⊂′-⊆′-trans (P⊆Q , Q⊈P) Q⊆R = ⊆′-trans P⊆Q Q⊆R , λ R⊆P → Q⊈P (⊆′-trans Q⊆R R⊆P)
+
+⊆′-⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊂′_ _⊂′_
+⊆′-⊂′-trans P⊆Q (Q⊆R , R⊈Q) = ⊆′-trans P⊆Q Q⊆R , λ R⊆P → R⊈Q (⊆′-trans R⊆P P⊆Q)
+
+⊂′-respʳ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐′_
+⊂′-respʳ-≐′ (Q⊆R , _) P⊂Q = ⊂′-⊆′-trans P⊂Q Q⊆R
+
+⊂′-respˡ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐′_
+⊂′-respˡ-≐′ (_ , R⊆Q) P⊂Q = ⊆′-⊂′-trans R⊆Q P⊂Q
+
+⊂′-resp-≐′ : (_⊂′_ {A = A} {ℓ}) Respects₂ _≐′_
+⊂′-resp-≐′ = ⊂′-respʳ-≐′ , ⊂′-respˡ-≐′
+
+⊂′-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _⊂′_
+⊂′-irrefl (_ , Q⊆P) (_ , Q⊈P) = Q⊈P Q⊆P
+
+⊂′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊂′_
+⊂′-antisym (P⊆Q , _) (Q⊆P , _) = ⊆′-antisym P⊆Q Q⊆P
+
+P⊆Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ _⊆′_
+P⊆Q⇒P⊆′Q P⊆Q _ x∈P = P⊆Q x∈P
+
+P⊆′Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ _⊆_
+P⊆′Q⇒P⊆Q P⊆Q x∈P = P⊆Q _ x∈P
+
+P⊂Q⇒P⊂′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊂′_
+P⊂Q⇒P⊂′Q = Product.map P⊆Q⇒P⊆′Q (_∘ P⊆′Q⇒P⊆Q)
+
+P⊂′Q⇒P⊂Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊂_
+P⊂′Q⇒P⊂Q = Product.map P⊆′Q⇒P⊆Q (_∘ P⊆Q⇒P⊆′Q)
+
+----------------------------------------------------------------------
+-- Equality properties
+
+≐-refl : Reflexive {A = Pred A ℓ} _≐_
+≐-refl = id , id
+
+≐-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐_
+≐-sym = swap
+
+≐-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐_ _≐_ _≐_
+≐-trans = zip′ (λ P⊆Q Q⊆R x∈P → Q⊆R (P⊆Q x∈P)) (λ Q⊆P R⊆Q x∈R → Q⊆P (R⊆Q x∈R))
+
+≐′-refl : Reflexive {A = Pred A ℓ} _≐′_
+≐′-refl = (λ _ → id) , (λ _ → id)
+
+≐′-sym : Sym {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐′_
+≐′-sym = swap
+
+≐′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐′_ _≐′_ _≐′_
+≐′-trans = zip′ (λ P⊆Q Q⊆R x x∈P → Q⊆R x (P⊆Q x x∈P)) λ Q⊆P R⊆Q x x∈R → Q⊆P x (R⊆Q x x∈R)
+
+P≐Q⇒P≐′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐′_
+P≐Q⇒P≐′Q = Product.map P⊆Q⇒P⊆′Q P⊆Q⇒P⊆′Q
+
+P≐′Q⇒P≐Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐_
+P≐′Q⇒P≐Q = Product.map P⊆′Q⇒P⊆Q P⊆′Q⇒P⊆Q
 
 ----------------------------------------------------------------------
 -- Decidability properties

--- a/src/Relation/Unary/Properties.agda
+++ b/src/Relation/Unary/Properties.agda
@@ -78,8 +78,8 @@ U-Universal = λ _ → _
 ⊆-max : Max {A = Pred A ℓ} _⊆_ U
 ⊆-max = ⊆-U
 
-P⊂Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊆_
-P⊂Q⇒P⊆Q = proj₁
+⊂⇒⊆ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊆_
+⊂⇒⊆ = proj₁
 
 ⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂_ _⊂_ _⊂_
 ⊂-trans (P⊆Q , Q⊈P) (Q⊆R , R⊈Q) = (λ x∈P → Q⊆R (P⊆Q x∈P)) , (λ R⊆P → R⊈Q (λ x∈R → P⊆Q (R⊆P x∈R)))
@@ -90,13 +90,13 @@ P⊂Q⇒P⊆Q = proj₁
 ⊆-⊂-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆_ _⊂_ _⊂_
 ⊆-⊂-trans P⊆Q (Q⊆R , R⊈Q) = (λ x∈P → Q⊆R (P⊆Q x∈P)) , (λ R⊆P → R⊈Q (λ R⊆Q → P⊆Q (R⊆P R⊆Q)))
 
-⊂-respʳ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐_
+⊂-respʳ-≐ : _Respectsʳ_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _≐_
 ⊂-respʳ-≐ (Q⊆R , _) P⊂Q = ⊂-⊆-trans P⊂Q Q⊆R
 
-⊂-respˡ-≐ : (_⊂_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐_
+⊂-respˡ-≐ : _Respectsˡ_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _≐_
 ⊂-respˡ-≐ (_ , R⊆Q) P⊂Q = ⊆-⊂-trans R⊆Q P⊂Q
 
-⊂-resp-≐ : (_⊂_ {A = A} {ℓ}) Respects₂ _≐_
+⊂-resp-≐ : _Respects₂_ {A = Pred A ℓ} _⊂_ _≐_
 ⊂-resp-≐ = ⊂-respʳ-≐ , ⊂-respˡ-≐
 
 ⊂-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _⊂_
@@ -114,10 +114,10 @@ P⊂Q⇒P⊆Q = proj₁
 ⊆′-U : (P : Pred A ℓ) → P ⊆′ U
 ⊆′-U _ _ _ = _
 
-⊆′-refl : Reflexive (_⊆′_ {A = A} {ℓ})
+⊆′-refl : Reflexive {A = Pred A ℓ} _⊆′_
 ⊆′-refl x x∈P = x∈P
 
-⊆′-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_  _⊆′_
+⊆′-reflexive : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _⊆′_
 ⊆′-reflexive (P⊆Q , Q⊆P) = P⊆Q
 
 ⊆′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊆′_ _⊆′_
@@ -132,8 +132,8 @@ P⊂Q⇒P⊆Q = proj₁
 ⊆′-max : Max {A = Pred A ℓ} _⊆′_ U
 ⊆′-max = ⊆′-U
 
-P⊂′Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊆′_
-P⊂′Q⇒P⊆′Q = proj₁
+⊂′⇒⊆′ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊆′_
+⊂′⇒⊆′ = proj₁
 
 ⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊂′_ _⊂′_ _⊂′_
 ⊂′-trans (P⊆Q , Q⊈P) (Q⊆R , R⊈Q) = ⊆′-trans P⊆Q Q⊆R , λ R⊆P → R⊈Q (⊆′-trans R⊆P P⊆Q)
@@ -144,13 +144,13 @@ P⊂′Q⇒P⊆′Q = proj₁
 ⊆′-⊂′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _⊆′_ _⊂′_ _⊂′_
 ⊆′-⊂′-trans P⊆Q (Q⊆R , R⊈Q) = ⊆′-trans P⊆Q Q⊆R , λ R⊆P → R⊈Q (⊆′-trans R⊆P P⊆Q)
 
-⊂′-respʳ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsʳ _≐′_
+⊂′-respʳ-≐′ : _Respectsʳ_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _≐′_
 ⊂′-respʳ-≐′ (Q⊆R , _) P⊂Q = ⊂′-⊆′-trans P⊂Q Q⊆R
 
-⊂′-respˡ-≐′ : (_⊂′_ {A = A} {ℓ₁} {ℓ₂}) Respectsˡ _≐′_
+⊂′-respˡ-≐′ : _Respectsˡ_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _≐′_
 ⊂′-respˡ-≐′ (_ , R⊆Q) P⊂Q = ⊆′-⊂′-trans R⊆Q P⊂Q
 
-⊂′-resp-≐′ : (_⊂′_ {A = A} {ℓ}) Respects₂ _≐′_
+⊂′-resp-≐′ : _Respects₂_ {A = Pred A ℓ₁} _⊂′_ _≐′_
 ⊂′-resp-≐′ = ⊂′-respʳ-≐′ , ⊂′-respˡ-≐′
 
 ⊂′-irrefl : Irreflexive {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _⊂′_
@@ -159,17 +159,17 @@ P⊂′Q⇒P⊆′Q = proj₁
 ⊂′-antisym : Antisymmetric {A = Pred A ℓ} _≐′_ _⊂′_
 ⊂′-antisym (P⊆Q , _) (Q⊆P , _) = ⊆′-antisym P⊆Q Q⊆P
 
-P⊆Q⇒P⊆′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ _⊆′_
-P⊆Q⇒P⊆′Q P⊆Q _ x∈P = P⊆Q x∈P
+⊆⇒⊆′ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆_ _⊆′_
+⊆⇒⊆′ P⊆Q _ x∈P = P⊆Q x∈P
 
-P⊆′Q⇒P⊆Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ _⊆_
-P⊆′Q⇒P⊆Q P⊆Q x∈P = P⊆Q _ x∈P
+⊆′⇒⊆ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊆′_ _⊆_
+⊆′⇒⊆ P⊆Q x∈P = P⊆Q _ x∈P
 
-P⊂Q⇒P⊂′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊂′_
-P⊂Q⇒P⊂′Q = Product.map P⊆Q⇒P⊆′Q (_∘ P⊆′Q⇒P⊆Q)
+⊂⇒⊂′ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂_ _⊂′_
+⊂⇒⊂′ = Product.map ⊆⇒⊆′ (_∘ ⊆′⇒⊆)
 
-P⊂′Q⇒P⊂Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊂_
-P⊂′Q⇒P⊂Q = Product.map P⊆′Q⇒P⊆Q (_∘ P⊆Q⇒P⊆′Q)
+⊂′⇒⊂ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _⊂′_ _⊂_
+⊂′⇒⊂ = Product.map ⊆′⇒⊆ (_∘ ⊆⇒⊆′)
 
 ----------------------------------------------------------------------
 -- Equality properties
@@ -192,11 +192,11 @@ P⊂′Q⇒P⊂Q = Product.map P⊆′Q⇒P⊆Q (_∘ P⊆Q⇒P⊆′Q)
 ≐′-trans : Trans {A = Pred A ℓ₁} {B = Pred A ℓ₂} {C = Pred A ℓ₃} _≐′_ _≐′_ _≐′_
 ≐′-trans = zip′ (λ P⊆Q Q⊆R x x∈P → Q⊆R x (P⊆Q x x∈P)) λ Q⊆P R⊆Q x x∈R → Q⊆P x (R⊆Q x x∈R)
 
-P≐Q⇒P≐′Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐′_
-P≐Q⇒P≐′Q = Product.map P⊆Q⇒P⊆′Q P⊆Q⇒P⊆′Q
+≐⇒≐′ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐_ _≐′_
+≐⇒≐′ = Product.map ⊆⇒⊆′ ⊆⇒⊆′
 
-P≐′Q⇒P≐Q : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐_
-P≐′Q⇒P≐Q = Product.map P⊆′Q⇒P⊆Q P⊆′Q⇒P⊆Q
+≐′⇒≐ : Binary._⇒_ {A = Pred A ℓ₁} {B = Pred A ℓ₂} _≐′_ _≐_
+≐′⇒≐ = Product.map ⊆′⇒⊆ ⊆′⇒⊆
 
 ----------------------------------------------------------------------
 -- Decidability properties

--- a/src/Relation/Unary/Relation/Binary/Equality.agda
+++ b/src/Relation/Unary/Relation/Binary/Equality.agda
@@ -9,25 +9,36 @@
 module Relation.Unary.Relation.Binary.Equality where
 
 open import Level using (Level)
+open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Unary using (Pred; _≐_; _≐′_)
 open import Relation.Unary.Properties
 
 private
   variable
-    a ℓ₁ ℓ₂ : Level
+    a ℓ : Level
     A : Set a
 
-≐-isEquivalence : IsEquivalence {A = Pred A ℓ₁} _≐_
+≐-isEquivalence : IsEquivalence {A = Pred A ℓ} _≐_
 ≐-isEquivalence = record
   { refl = ≐-refl
   ; sym = ≐-sym
   ; trans = ≐-trans
   }
 
-≐′-isEquivalence : IsEquivalence {A = Pred A ℓ₁} _≐′_
+≐′-isEquivalence : IsEquivalence {A = Pred A ℓ} _≐′_
 ≐′-isEquivalence = record
   { refl = ≐′-refl
   ; sym = ≐′-sym
   ; trans = ≐′-trans
+  }
+
+≐-setoid : ∀ {a} (A : Set a) ℓ → Setoid _ _
+≐-setoid A ℓ = record
+  { isEquivalence = ≐-isEquivalence {A = A} {ℓ}
+  }
+
+≐′-setoid : ∀ {a} (A : Set a) ℓ → Setoid _ _
+≐′-setoid A ℓ = record
+  { isEquivalence = ≐′-isEquivalence {A = A} {ℓ}
   }

--- a/src/Relation/Unary/Relation/Binary/Equality.agda
+++ b/src/Relation/Unary/Relation/Binary/Equality.agda
@@ -8,11 +8,10 @@
 
 module Relation.Unary.Relation.Binary.Equality where
 
-open import Data.Product using (Σ; _,_; swap; zip′)
-open import Function.Base using (id)
 open import Level using (Level)
 open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Unary using (Pred; _≐_; _≐′_)
+open import Relation.Unary.Properties
 
 private
   variable
@@ -21,14 +20,14 @@ private
 
 ≐-isEquivalence : IsEquivalence {A = Pred A ℓ₁} _≐_
 ≐-isEquivalence = record
-  { refl = id , id
-  ; sym = swap
-  ; trans = zip′ (λ P⊆Q Q⊆R {_} Px → Q⊆R (P⊆Q Px)) (λ Q⊆P R⊆Q {_} Rx → Q⊆P (R⊆Q Rx))
+  { refl = ≐-refl
+  ; sym = ≐-sym
+  ; trans = ≐-trans
   }
 
 ≐′-isEquivalence : IsEquivalence {A = Pred A ℓ₁} _≐′_
 ≐′-isEquivalence = record
-  { refl = (λ _ → id) , λ _ → id
-  ; sym = swap
-  ; trans = zip′ (λ P⊆Q Q⊆R a a∈P → Q⊆R a (P⊆Q a a∈P)) λ Q⊆P R⊆Q a a∈R → Q⊆P a (R⊆Q a a∈R)
+  { refl = ≐′-refl
+  ; sym = ≐′-sym
+  ; trans = ≐′-trans
   }

--- a/src/Relation/Unary/Relation/Binary/Subset.agda
+++ b/src/Relation/Unary/Relation/Binary/Subset.agda
@@ -1,0 +1,104 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Order properties of the subset relations _⊆_ and _⊂_
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Relation.Unary.Relation.Binary.Subset where
+
+open import Level using (Level)
+import Relation.Binary.Structures as BinaryStructures
+open import Relation.Binary.Bundles
+open import Relation.Unary
+open import Relation.Unary.Properties
+open import Relation.Unary.Relation.Binary.Equality using (≐-isEquivalence; ≐′-isEquivalence)
+
+----------------------------------------------------------------------
+-- Structures
+
+module _ {a : Level} {A : Set a} {ℓ : Level} where
+
+  open BinaryStructures {A = Pred A ℓ} _≐_
+
+  ⊆-isPreorder : IsPreorder _⊆_
+  ⊆-isPreorder = record
+    { isEquivalence = ≐-isEquivalence
+    ; reflexive = ⊆-reflexive
+    ; trans = ⊆-trans
+    }
+
+  ⊆-isPartialOrder : IsPartialOrder _⊆_
+  ⊆-isPartialOrder = record
+    { isPreorder = ⊆-isPreorder
+    ; antisym = ⊆-antisym
+    }
+
+  ⊂-isStrictPartialOrder : IsStrictPartialOrder _⊂_
+  ⊂-isStrictPartialOrder = record
+    { isEquivalence = ≐-isEquivalence
+    ; irrefl = ⊂-irrefl
+    ; trans = ⊂-trans
+    ; <-resp-≈ = ⊂-resp-≐
+    }
+
+module _ {a : Level} {A : Set a} {ℓ : Level} where
+
+  open BinaryStructures {A = Pred A ℓ} _≐′_
+
+  ⊆′-isPreorder : IsPreorder _⊆′_
+  ⊆′-isPreorder = record
+    { isEquivalence = ≐′-isEquivalence
+    ; reflexive = ⊆′-reflexive
+    ; trans = ⊆′-trans
+    }
+
+  ⊆′-isPartialOrder : IsPartialOrder _⊆′_
+  ⊆′-isPartialOrder = record
+    { isPreorder = ⊆′-isPreorder
+    ; antisym = ⊆′-antisym
+    }
+
+  ⊂′-isStrictPartialOrder : IsStrictPartialOrder _⊂′_
+  ⊂′-isStrictPartialOrder = record
+    { isEquivalence = ≐′-isEquivalence
+    ; irrefl = ⊂′-irrefl
+    ; trans = ⊂′-trans
+    ; <-resp-≈ = ⊂′-resp-≐′
+    }
+
+----------------------------------------------------------------------
+-- Bundles
+
+module _ {a : Level} (A : Set a) (ℓ : Level) where
+
+  ⊆-preorder : Preorder _ _ _
+  ⊆-preorder = record
+    { isPreorder = ⊆-isPreorder {A = A} {ℓ}
+    }
+
+  ⊆-poset : Poset _ _ _
+  ⊆-poset = record
+    { isPartialOrder = ⊆-isPartialOrder {A = A} {ℓ}
+    }
+
+  ⊂-strictPartialOrder : StrictPartialOrder _ _ _
+  ⊂-strictPartialOrder = record
+    { isStrictPartialOrder = ⊂-isStrictPartialOrder {A = A} {ℓ}
+    }
+
+  ⊆′-preorder : Preorder _ _ _
+  ⊆′-preorder = record
+    { isPreorder = ⊆′-isPreorder {A = A} {ℓ}
+    }
+
+  ⊆′-poset : Poset _ _ _
+  ⊆′-poset = record
+    { isPartialOrder = ⊆′-isPartialOrder {A = A} {ℓ}
+    }
+
+  ⊂′-strictPartialOrder : StrictPartialOrder _ _ _
+  ⊂′-strictPartialOrder = record
+    { isStrictPartialOrder = ⊂′-isStrictPartialOrder {A = A} {ℓ}
+    }


### PR DESCRIPTION
These include:
- setoid bundles for `_≐_` and `_≐′_`;
- properties about the subset relations `_⊆_`, `_⊂_`, `_⊆′_`, `_⊂′_`;
- the analogues of the properties about the predicates `∅` and `U` of level `0ℓ` for the level-polymorphic predicates `∅` and `U` from `Relation.Unary.Polymorphic`;
- algebraic properties about `_∩_` and `_∪_`. Here I have used the level-polymorphic `∅` and `U`;
- order structures and bundles for the subset relations, e.g. `_⊆_` is a partial order and `_⊂_` a strict partial order.

I have made the following choices:
- I have only added proofs for the combinations `_⊆_`, `_⊂_` and `_≐_` and `_⊆′_`, `_⊂′_` and `_≐′_`;
- for the structures, I have used implicit arguments and for the bundles explicit arguments `A` and `ℓ`. I don’t know what is best practice here.