### PR TITLE
Add a difference operator for predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1115,6 +1115,7 @@ Other minor changes
   ```
   _≐_  : Pred A ℓ₁ → Pred A ℓ₂ → Set _
   _≐′_ : Pred A ℓ₁ → Pred A ℓ₂ → Set _
+  _∖_  : Pred A ℓ₁ → Pred A ℓ₂ → Pred A _
   ```
 
 * Added new operations in `Relation.Binary.PropositionalEquality.Properties`:

--- a/src/Relation/Unary.agda
+++ b/src/Relation/Unary.agda
@@ -194,6 +194,7 @@ infixr 9 _⊢_
 infixr 8 _⇒_
 infixr 7 _∩_
 infixr 6 _∪_
+infixr 6 _∖_
 infix 4 _≬_
 
 -- Complement.
@@ -215,6 +216,11 @@ P ∪ Q = λ x → x ∈ P ⊎ x ∈ Q
 
 _∩_ : Pred A ℓ₁ → Pred A ℓ₂ → Pred A _
 P ∩ Q = λ x → x ∈ P × x ∈ Q
+
+-- Difference.
+
+_∖_ : Pred A ℓ₁ → Pred A ℓ₂ → Pred A _
+P ∖ Q = λ x → x ∈ P × x ∉ Q
 
 -- Infinitary union.
 


### PR DESCRIPTION
Adds `_∖_  : Pred A ℓ₁ → Pred A ℓ₂ → Pred A _` in
`Relation.Unary`. The operator is implemented directly as a function on
elements rather than in terms of `∁` and `_∩_` in order to

*  be consistent with how the other operators on predicates in
   `Relation.Unary` are implemented; and
*  express the meaning of the operator as clearly as possible.