### PR TITLE
Move definitions from Algebra.Core to Algebra.Module.Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -350,6 +350,7 @@ Non-backwards compatible changes
   pos⇒1/pos : ∀ p .{{_ : Positive p}} → Positive (1/ p)
   1/pos⇒pos : ∀ p .{{_ : NonZero p}} .{{Positive (1/ p)}} → Positive p
   ```
+* `Opₗ` and `Opᵣ` have moved from `Algebra.Core` to `Algebra.Module.Core`.
 
 Major improvements
 ------------------
@@ -574,6 +575,11 @@ Deprecated names
 
 New modules
 -----------
+
+* Operations for module-like algebraic structures:
+  ```
+  Algebra.Module.Core
+  ```
 
 * Morphisms between module-like algebraic structures:
   ```

--- a/src/Algebra/Core.agda
+++ b/src/Algebra/Core.agda
@@ -20,12 +20,3 @@ Op₁ A = A → A
 
 Op₂ : ∀ {ℓ} → Set ℓ → Set ℓ
 Op₂ A = A → A → A
-
-------------------------------------------------------------------------
--- Left and right actions
-
-Opₗ : ∀ {a b} → Set a → Set b → Set (a ⊔ b)
-Opₗ A B = A → B → B
-
-Opᵣ : ∀ {a b} → Set a → Set b → Set (a ⊔ b)
-Opᵣ A B = B → A → B

--- a/src/Algebra/Module.agda
+++ b/src/Algebra/Module.agda
@@ -9,6 +9,7 @@
 
 module Algebra.Module where
 
+open import Algebra.Module.Core public
 open import Algebra.Module.Structures public
 open import Algebra.Module.Structures.Biased public
 open import Algebra.Module.Bundles public

--- a/src/Algebra/Module/Bundles.agda
+++ b/src/Algebra/Module/Bundles.agda
@@ -27,6 +27,7 @@ module Algebra.Module.Bundles where
 
 open import Algebra.Bundles
 open import Algebra.Core
+open import Algebra.Module.Core
 open import Algebra.Module.Structures
 open import Algebra.Module.Definitions
 open import Function.Base

--- a/src/Algebra/Module/Consequences.agda
+++ b/src/Algebra/Module/Consequences.agda
@@ -8,8 +8,9 @@
 
 module Algebra.Module.Consequences where
 
-open import Algebra.Core using (Op₂; Opₗ; Opᵣ)
+open import Algebra.Core using (Op₂)
 import Algebra.Definitions as Defs
+open import Algebra.Module.Core using (Opₗ; Opᵣ)
 open import Algebra.Module.Definitions
 open import Function.Base using (flip)
 open import Level using (Level)

--- a/src/Algebra/Module/Core.agda
+++ b/src/Algebra/Module/Core.agda
@@ -1,0 +1,22 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Core algebraic definitions for module-like structures
+------------------------------------------------------------------------
+
+-- The contents of this module should be accessed via `Algebra.Module`
+
+{-# OPTIONS --without-K --safe #-}
+
+module Algebra.Module.Core where
+
+open import Level using (_⊔_)
+
+------------------------------------------------------------------------
+-- Left and right actions
+
+Opₗ : ∀ {a b} → Set a → Set b → Set (a ⊔ b)
+Opₗ A B = A → B → B
+
+Opᵣ : ∀ {a b} → Set a → Set b → Set (a ⊔ b)
+Opᵣ A B = B → A → B

--- a/src/Algebra/Module/Definitions.agda
+++ b/src/Algebra/Module/Definitions.agda
@@ -11,8 +11,6 @@ open import Relation.Binary
 
 module Algebra.Module.Definitions where
 
-  open import Algebra.Core
-
   import Algebra.Module.Definitions.Left as L
   import Algebra.Module.Definitions.Right as R
   import Algebra.Module.Definitions.Bi as B

--- a/src/Algebra/Module/Definitions/Bi.agda
+++ b/src/Algebra/Module/Definitions/Bi.agda
@@ -15,7 +15,7 @@ module Algebra.Module.Definitions.Bi
   {a a′ b ℓb} (A : Set a) (A′ : Set a′) {B : Set b} (_≈_ : Rel B ℓb)
   where
 
-  open import Algebra.Core
+  open import Algebra.Module.Core
 
   Associative : Opₗ A B → Opᵣ A′ B → Set _
   Associative _∙ₗ_ _∙ᵣ_ = ∀ x m y → ((x ∙ₗ m) ∙ᵣ y) ≈ (x ∙ₗ (m ∙ᵣ y))

--- a/src/Algebra/Module/Definitions/Left.agda
+++ b/src/Algebra/Module/Definitions/Left.agda
@@ -22,6 +22,7 @@ open import Data.Product
 -- Binary operations
 
 open import Algebra.Core
+open import Algebra.Module.Core
 
 ------------------------------------------------------------------------
 -- Properties of operations

--- a/src/Algebra/Module/Definitions/Right.agda
+++ b/src/Algebra/Module/Definitions/Right.agda
@@ -22,6 +22,7 @@ open import Data.Sum
 -- Binary operations
 
 open import Algebra.Core
+open import Algebra.Module.Core
 
 ------------------------------------------------------------------------
 -- Properties of operations

--- a/src/Algebra/Module/Morphism/Definitions.agda
+++ b/src/Algebra/Module/Morphism/Definitions.agda
@@ -15,7 +15,7 @@ module Algebra.Module.Morphism.Definitions
   {ℓ} (_≈_ : Rel B ℓ) -- The equality relation over the codomain
   where
 
-open import Algebra.Core
+open import Algebra.Module.Core
 open import Algebra.Morphism.Definitions A B _≈_ public
 
 Homomorphicₗ : (A → B) → Opₗ R A → Opₗ R B → Set _

--- a/src/Algebra/Module/Structures.agda
+++ b/src/Algebra/Module/Structures.agda
@@ -12,6 +12,7 @@ module Algebra.Module.Structures where
 
 open import Algebra.Bundles
 open import Algebra.Core
+open import Algebra.Module.Core
 import Algebra.Definitions as Defs
 open import Algebra.Module.Definitions
 open import Algebra.Structures

--- a/src/Algebra/Module/Structures/Biased.agda
+++ b/src/Algebra/Module/Structures/Biased.agda
@@ -13,6 +13,7 @@ module Algebra.Module.Structures.Biased where
 
 open import Algebra.Bundles
 open import Algebra.Core
+open import Algebra.Module.Core
 open import Algebra.Module.Consequences
 open import Algebra.Module.Structures
 open import Function.Base using (flip)


### PR DESCRIPTION
Based on discussion in #1676.

I don't know how to represent this in the changelog.