### PR TITLE
Add missing instance to quasigroup and loop.

### DIFF
--- a/src/Algebra/Bundles.agda
+++ b/src/Algebra/Bundles.agda
@@ -945,12 +945,6 @@ record Quasigroup c ℓ : Set (suc (c ⊔ ℓ)) where
   open RawQuasigroup rawQuasigroup public
     using (_≈_; //-rawMagma; \\-rawMagma; ∙-rawMagma)
 
-  setoid : Setoid _ _
-  setoid = record { isEquivalence = isEquivalence }
-
-  open Setoid setoid public
-    using (_≉_)
-
 record RawLoop  c ℓ : Set (suc (c ⊔ ℓ)) where
   infixl 7 _∙_
   infixl 7 _\\_
@@ -1004,7 +998,8 @@ record Loop  c ℓ : Set (suc (c ⊔ ℓ)) where
   quasigroup = record { isQuasigroup = isQuasigroup }
 
   open Quasigroup quasigroup public
-    using (_≉_; ∙-rawMagma; \\-rawMagma; //-rawMagma)
+    using (∙-rawMagma; \\-rawMagma; //-rawMagma)
+    
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
 ------------------------------------------------------------------------

--- a/src/Algebra/Bundles.agda
+++ b/src/Algebra/Bundles.agda
@@ -999,7 +999,7 @@ record Loop  c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open Quasigroup quasigroup public
     using (∙-rawMagma; \\-rawMagma; //-rawMagma)
-    
+
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
 ------------------------------------------------------------------------

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -575,7 +575,7 @@ record IsQuasigroup (∙ \\ // : Op₂ A) : Set (a ⊔ ℓ) where
   rightDividesˡ = proj₁ rightDivides
 
   rightDividesʳ : RightDividesʳ ∙ //
-  rightDividesʳ = proj₂ rightDivides  
+  rightDividesʳ = proj₂ rightDivides
 
 
 record IsLoop (∙ \\ // : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -562,9 +562,31 @@ record IsQuasigroup (∙ \\ // : Op₂ A) : Set (a ⊔ ℓ) where
 
   open IsEquivalence isEquivalence public
 
+  setoid : Setoid a ℓ
+  setoid = record { isEquivalence = isEquivalence }
+
+  leftDividesˡ : LeftDividesˡ ∙ \\
+  leftDividesˡ = proj₁ leftDivides
+
+  leftDividesʳ : LeftDividesʳ ∙ \\
+  leftDividesʳ = proj₂ leftDivides
+
+  rightDividesˡ : RightDividesˡ ∙ //
+  rightDividesˡ = proj₁ rightDivides
+
+  rightDividesʳ : RightDividesʳ ∙ //
+  rightDividesʳ = proj₂ rightDivides  
+
+
 record IsLoop (∙ \\ // : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
   field
     isQuasigroup : IsQuasigroup ∙ \\ //
     identity     : Identity ε ∙
 
   open IsQuasigroup isQuasigroup public
+
+  identityˡ : LeftIdentity ε ∙
+  identityˡ = proj₁ identity
+
+  identityʳ : RightIdentity ε ∙
+  identityʳ = proj₂ identity

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -556,14 +556,35 @@ record IsCommutativeRing
 
 record IsQuasigroup (∙ \\ // : Op₂ A) : Set (a ⊔ ℓ) where
   field
-    isEquivalence :  IsEquivalence _≈_
-    leftDivides  :  LeftDivides ∙ \\
-    rightDivides :  RightDivides ∙ //
+    isEquivalence : IsEquivalence _≈_
+    ∙-cong        : Congruent₂ ∙
+    \\-cong       : Congruent₂ \\
+    //-cong       : Congruent₂ //
+    leftDivides   : LeftDivides ∙ \\
+    rightDivides  : RightDivides ∙ //
 
   open IsEquivalence isEquivalence public
 
   setoid : Setoid a ℓ
   setoid = record { isEquivalence = isEquivalence }
+
+  ∙-congˡ : LeftCongruent ∙
+  ∙-congˡ y≈z = ∙-cong refl y≈z
+
+  ∙-congʳ : RightCongruent ∙
+  ∙-congʳ y≈z = ∙-cong y≈z refl
+
+  \\-congˡ : LeftCongruent \\
+  \\-congˡ y≈z = \\-cong refl y≈z
+
+  \\-congʳ : RightCongruent \\
+  \\-congʳ y≈z = \\-cong y≈z refl
+
+  //-congˡ : LeftCongruent //
+  //-congˡ y≈z = //-cong refl y≈z
+
+  //-congʳ : RightCongruent //
+  //-congʳ y≈z = //-cong y≈z refl
 
   leftDividesˡ : LeftDividesˡ ∙ \\
   leftDividesˡ = proj₁ leftDivides


### PR DESCRIPTION
Should the binary operations be congruent? Like: 

> record IsQuasigroup (∙ \\ // : Op₂ A) : Set (a ⊔ ℓ) where
  field
    isEquivalence :  IsEquivalence _≈_
    ∙-cong        : Congruent₂ ∙
    \\\\-cong        : Congruent₂ \\\\
    //-cong        : Congruent₂ //
    leftDivides  :  LeftDivides ∙ \\\\
    rightDivides :  RightDivides ∙ //