### PR TITLE
Codata streams by coinductive records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -629,6 +629,14 @@ New modules
   Algebra.Properties.Semiring.Exp.TailRecursiveOptimised
   ```
 
+* A definition of infinite streams using coinductive records:
+  ```
+  Codata.Guarded.Stream
+  Codata.Guarded.Stream.Relation.Binary.Pointwise
+  Codata.Guarded.Stream.Relation.Unary.All
+  Codata.Guarded.Stream.Relation.Unary.Any
+  ```
+
 * A small library for function arguments with default values:
   ```
   Data.Default

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -110,10 +110,16 @@ _⁺++_ : List⁺ A → Stream A → Stream A
 head (xs ⁺++ ys) = List⁺.head xs
 tail (xs ⁺++ ys) = List⁺.tail xs ++ ys
 
-{-
 interleave⁺ : List⁺ (Stream A) → Stream A
-interleave⁺ xss = {!!}
--}
+interleave⁺ {A = A} (xs ∷ xss) = go [] xs xss
+  where
+    --    ,- tails of the streams we have already dealt with
+    --   |                 ,-- current focus
+    --   v                 v          v-- future work
+    go : List (Stream A) → Stream A → List (Stream A) → Stream A
+    head (go rev xs yss)        = head xs
+    tail (go rev xs [])         = interleave⁺ (List⁺.reverse (tail xs ∷ rev))
+    tail (go rev xs (ys ∷ yss)) = go (tail xs ∷ rev) ys yss
 
 cycle : List⁺ A → Stream A
 cycle {A = A} (x ∷ xs) = cycleAux List.[]

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -8,11 +8,11 @@
 
 module Codata.Guarded.Stream where
 
-open import Data.List.Base using (List)
-open import Data.List.NonEmpty.Base as List⁺ using (List⁺)
+open import Data.List.Base using (List; []; _∷_)
+open import Data.List.NonEmpty.Base as List⁺ using (List⁺; _∷_; _∷⁺_)
 open import Data.Nat.Base hiding (_⊔_)
 open import Data.Product as P using (Σ; proj₁; proj₂; _×_; _,_)
-open import Data.Vec.Base using (Vec)
+open import Data.Vec.Base using (Vec; []; _∷_)
 open import Function.Base using (_∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary
@@ -39,8 +39,8 @@ head (repeat x) = x
 tail (repeat x) = repeat x
 
 _++_ : List A → Stream A → Stream A
-List.[] ++ ys = ys
-(x List.∷ xs) ++ ys = record
+[] ++ ys = ys
+(x ∷ xs) ++ ys = record
   { head = x
   ; tail = xs ++ ys
   }
@@ -81,8 +81,8 @@ head (scanl f b xs) = b
 tail (scanl f b xs) = scanl f (f b (head xs)) (tail xs)
 
 splitAt : (n : ℕ) → Stream A → Vec A n × Stream A
-splitAt 0 xs = Vec.[] , xs
-splitAt (suc n) xs = P.map₁ (head xs Vec.∷_) (splitAt n (tail xs))
+splitAt 0 xs = [] , xs
+splitAt (suc n) xs = P.map₁ (head xs ∷_) (splitAt n (tail xs))
 
 take : (n : ℕ) → Stream A → Vec A n
 take n xs = P.proj₁ (splitAt n xs)
@@ -116,27 +116,27 @@ interleave⁺ xss = {!!}
 -}
 
 cycle : List⁺ A → Stream A
-cycle {A = A} (x List⁺.∷ xs) = cycleAux List.[]
+cycle {A = A} (x ∷ xs) = cycleAux List.[]
   where
     cycleAux : List A → Stream A
-    head (cycleAux List.[]) = x
-    tail (cycleAux List.[]) = cycleAux xs
-    head (cycleAux (x List.∷ xs)) = x
-    tail (cycleAux (x List.∷ xs)) = cycleAux xs
+    head (cycleAux []) = x
+    tail (cycleAux []) = cycleAux xs
+    head (cycleAux (x ∷ xs)) = x
+    tail (cycleAux (x ∷ xs)) = cycleAux xs
   
 
 cantor : Stream (Stream A) → Stream A
-cantor ls = zig (head ls List⁺.∷ List.[]) (tail ls)
+cantor ls = zig (head ls ∷ []) (tail ls)
   where
     zig : List⁺ (Stream A) → Stream (Stream A) → Stream A
     zag : List⁺ A → List⁺ (Stream A) → Stream (Stream A) → Stream A
 
     zig xss = zag (List⁺.map head xss) (List⁺.map tail xss)
 
-    head (zag (x List⁺.∷ List.[]) zs ls) = x
-    tail (zag (x List⁺.∷ List.[]) zs ls) = zig (head ls List⁺.∷⁺ zs) (tail ls)
-    head (zag (x List⁺.∷ y List.∷ xs) zs ls) = x
-    tail (zag (x List⁺.∷ y List.∷ xs) zs ls) = zag (y List⁺.∷ xs) zs ls
+    head (zag (x ∷ []) zs ls) = x
+    tail (zag (x ∷ []) zs ls) = zig (head ls ∷⁺ zs) (tail ls)
+    head (zag (x ∷ y ∷ xs) zs ls) = x
+    tail (zag (x ∷ y ∷ xs) zs ls) = zag (y ∷ xs) zs ls
 
 plane : {B : A → Set b} → Stream A → ((a : A) → Stream (B a)) → Stream (Σ A B)
 plane as bs = cantor (map (λ a → map (a ,_) (bs a)) as)

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -1,0 +1,138 @@
+{-# OPTIONS --safe --without-K --guardedness #-}
+------------------------------------------------------------------------
+-- Infinite streams defined as coinductive records
+------------------------------------------------------------------------
+module Codata.Guarded.Stream where
+
+open import Data.List.Base using (List)
+open import Data.List.NonEmpty.Base as List⁺ using (List⁺)
+open import Data.Nat.Base hiding (_⊔_)
+open import Data.Product as P using (Σ; proj₁; proj₂; _×_; _,_)
+open import Data.Vec.Base using (Vec)
+open import Function.Base using (_∘_)
+open import Level using (Level; _⊔_)
+open import Relation.Nullary
+open import Relation.Unary
+
+private
+  variable
+    a b c ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+record Stream (A : Set a) : Set a where
+  coinductive
+  constructor _∷_
+  field
+    head : A
+    tail : Stream A
+
+open Stream public
+
+repeat : A → Stream A
+head (repeat x) = x
+tail (repeat x) = repeat x
+
+_++_ : List A → Stream A → Stream A
+List.[] ++ ys = ys
+(x List.∷ xs) ++ ys = record
+  { head = x
+  ; tail = xs ++ ys
+  }
+
+lookup : ℕ → Stream A → A
+lookup zero xs = head xs
+lookup (suc n) xs = lookup n (tail xs)
+
+iterate : (A → A) → A → Stream A
+head (iterate f x) = x
+tail (iterate f x) = iterate f (f x)
+
+unfold : (A → A × B) → A → Stream B
+head (unfold next seed) = P.proj₂ (next seed)
+tail (unfold next seed) = unfold next (P.proj₁ (next seed))
+
+nats : Stream ℕ
+nats = iterate suc zero
+
+tabulate : (ℕ → A) → Stream A
+head (tabulate f) = f zero
+tail (tabulate f) = tabulate (f ∘ suc)
+
+map : (A → B) → Stream A → Stream B
+head (map f xs) = f (head xs)
+tail (map f xs) = map f (tail xs)
+
+ap : Stream (A → B) → Stream A → Stream B
+head (ap fs xs) = head fs (head xs)
+tail (ap fs xs) = ap (tail fs) (tail xs)
+
+zipWith : (A → B → C) → Stream A → Stream B → Stream C
+head (zipWith f xs ys) = f (head xs) (head ys)
+tail (zipWith f xs ys) = zipWith f (tail xs) (tail ys)
+
+scanl : (B → A → B) → B → Stream A → Stream B
+head (scanl f b xs) = b
+tail (scanl f b xs) = scanl f (f b (head xs)) (tail xs)
+
+splitAt : (n : ℕ) → Stream A → Vec A n × Stream A
+splitAt 0 xs = Vec.[] , xs
+splitAt (suc n) xs = P.map₁ (head xs Vec.∷_) (splitAt n (tail xs))
+
+take : (n : ℕ) → Stream A → Vec A n
+take n xs = P.proj₁ (splitAt n xs)
+
+drop : (n : ℕ) → Stream A → Stream A
+drop n xs = P.proj₂ (splitAt n xs)
+
+chunksOf : (n : ℕ) → Stream A → Stream (Vec A n)
+head (chunksOf n xs) = take n xs
+tail (chunksOf n xs) = chunksOf n (drop n xs)
+
+interleave : Stream A → Stream A → Stream A
+head (interleave xs ys) = head xs
+tail (interleave xs ys) = interleave ys (tail xs)
+
+evens : Stream A → Stream A
+head (evens xs) = head xs
+tail (evens xs) = evens (tail (tail xs))
+
+odds : Stream A → Stream A
+head (odds xs) = head (tail xs)
+tail (odds xs) = odds (tail (tail xs))
+
+_⁺++_ : List⁺ A → Stream A → Stream A
+head (xs ⁺++ ys) = List⁺.head xs
+tail (xs ⁺++ ys) = List⁺.tail xs ++ ys
+
+{-
+interleave⁺ : List⁺ (Stream A) → Stream A
+interleave⁺ xss = {!!}
+-}
+
+cycle : List⁺ A → Stream A
+cycle {A = A} (x List⁺.∷ xs) = cycleAux List.[]
+  where
+    cycleAux : List A → Stream A
+    head (cycleAux List.[]) = x
+    tail (cycleAux List.[]) = cycleAux xs
+    head (cycleAux (x List.∷ xs)) = x
+    tail (cycleAux (x List.∷ xs)) = cycleAux xs
+  
+
+cantor : Stream (Stream A) → Stream A
+cantor ls = zig (head ls List⁺.∷ List.[]) (tail ls)
+  where
+    zig : List⁺ (Stream A) → Stream (Stream A) → Stream A
+    zag : List⁺ A → List⁺ (Stream A) → Stream (Stream A) → Stream A
+
+    zig xss = zag (List⁺.map head xss) (List⁺.map tail xss)
+
+    head (zag (x List⁺.∷ List.[]) zs ls) = x
+    tail (zag (x List⁺.∷ List.[]) zs ls) = zig (head ls List⁺.∷⁺ zs) (tail ls)
+    head (zag (x List⁺.∷ y List.∷ xs) zs ls) = x
+    tail (zag (x List⁺.∷ y List.∷ xs) zs ls) = zag (y List⁺.∷ xs) zs ls
+
+plane : {B : A → Set b} → Stream A → ((a : A) → Stream (B a)) → Stream (Σ A B)
+plane as bs = cantor (map (λ a → map (a ,_) (bs a)) as)

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -80,6 +80,10 @@ scanl : (B → A → B) → B → Stream A → Stream B
 head (scanl f b xs) = b
 tail (scanl f b xs) = scanl f (f b (head xs)) (tail xs)
 
+tails : Stream A → Stream (Stream A)
+head (tails xs) = xs
+tail (tails xs) = tails (tail xs)
+
 splitAt : (n : ℕ) → Stream A → Vec A n × Stream A
 splitAt 0 xs = [] , xs
 splitAt (suc n) xs = P.map₁ (head xs ∷_) (splitAt n (tail xs))

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -1,7 +1,11 @@
-{-# OPTIONS --safe --without-K --guardedness #-}
 ------------------------------------------------------------------------
+-- The Agda standard library
+--
 -- Infinite streams defined as coinductive records
 ------------------------------------------------------------------------
+
+{-# OPTIONS --safe --without-K --guardedness #-}
+
 module Codata.Guarded.Stream where
 
 open import Data.List.Base using (List)

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -1,0 +1,70 @@
+{-# OPTIONS --safe --without-K --guardedness #-}
+
+module Codata.Guarded.Stream.Relation.Binary.Pointwise where
+
+open import Codata.Guarded.Stream as Stream using (Stream; head; tail)
+open import Data.Nat.Base using (ℕ)
+open import Function.Base using (_∘_)
+open import Level
+open import Relation.Binary
+
+private
+  variable
+    a b c d ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
+    D : Set d
+    R S T : REL A B ℓ
+    xs ys : Stream A
+
+record Pointwise (_∼_ : REL A B ℓ) (as : Stream A) (bs : Stream B) : Set ℓ where
+  coinductive
+  constructor _∷_
+  field
+    head : head as ∼ head bs
+    tail : Pointwise _∼_ (tail as) (tail bs)
+
+open Pointwise public
+
+map : R ⇒ S → Pointwise R ⇒ Pointwise S
+head (map R⇒S xs) = R⇒S (head xs)
+tail (map R⇒S xs) = map R⇒S (tail xs)
+
+refl : Reflexive R → Reflexive (Pointwise R)
+head (refl R-refl) = R-refl
+tail (refl R-refl) = refl R-refl
+
+sym : Sym R S → Sym (Pointwise R) (Pointwise S)
+head (sym R-sym-S xsRys) = R-sym-S (head xsRys)
+tail (sym R-sym-S xsRys) = sym R-sym-S (tail xsRys)
+
+trans : Trans R S T → Trans (Pointwise R) (Pointwise S) (Pointwise T)
+head (trans RST-trans xsRys ysSzs) = RST-trans (head xsRys) (head ysSzs)
+tail (trans RST-trans xsRys ysSzs) = trans RST-trans (tail xsRys) (tail ysSzs)
+
+antisym : Antisym R S T → Antisym (Pointwise R) (Pointwise S) (Pointwise T)
+head (antisym RST-antisym xsRys ysSxs) = RST-antisym (head xsRys) (head ysSxs)
+tail (antisym RST-antisym xsRys ysSxs) = antisym RST-antisym (tail xsRys) (tail ysSxs)
+
+tabulate⁺ : ∀ {f : ℕ → A} {g : ℕ → B} →
+            (∀ i → R (f i) (g i)) → Pointwise R (Stream.tabulate f) (Stream.tabulate g)
+head (tabulate⁺ f∼g) = f∼g 0
+tail (tabulate⁺ f∼g) = tabulate⁺ (f∼g ∘ ℕ.suc)
+
+tabulate⁻ : ∀ {f : ℕ → A} {g : ℕ → B} →
+            Pointwise R (Stream.tabulate f) (Stream.tabulate g) → (∀ i → R (f i) (g i))
+tabulate⁻ xsRys ℕ.zero = head xsRys
+tabulate⁻ xsRys (ℕ.suc i) = tabulate⁻ (tail xsRys) i
+
+map⁺ : ∀ (f : A → C) (g : B → D) →
+       Pointwise (λ a b → R (f a) (g b)) xs ys →
+       Pointwise R (Stream.map f xs) (Stream.map g ys)
+head (map⁺ f g faRgb) = head faRgb
+tail (map⁺ f g faRgb) = map⁺ f g (tail faRgb)
+
+map⁻ : ∀ (f : A → C) (g : B → D) →
+       Pointwise R (Stream.map f xs) (Stream.map g ys) →
+       Pointwise (λ a b → R (f a) (g b)) xs ys
+head (map⁻ f g faRgb) = head faRgb
+tail (map⁻ f g faRgb) = map⁻ f g (tail faRgb)

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -1,5 +1,5 @@
 ------------------------------------------------------------------------
--- The Agda standard libary
+-- The Agda standard library
 --
 -- Coinductive pointwise lifting of relations to streams
 ------------------------------------------------------------------------

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -16,11 +16,8 @@ open import Relation.Binary
 
 private
   variable
-    a b c d ℓ : Level
-    A : Set a
-    B : Set b
-    C : Set c
-    D : Set d
+    a ℓ : Level
+    A B C D : Set a
     R S T : REL A B ℓ
     xs ys : Stream A
 

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -1,3 +1,9 @@
+------------------------------------------------------------------------
+-- The Agda standard libary
+--
+-- Coinductive pointwise lifting of relations to streams
+------------------------------------------------------------------------
+
 {-# OPTIONS --safe --without-K --guardedness #-}
 
 module Codata.Guarded.Stream.Relation.Binary.Pointwise where

--- a/src/Codata/Guarded/Stream/Relation/Unary/All.agda
+++ b/src/Codata/Guarded/Stream/Relation/Unary/All.agda
@@ -1,4 +1,11 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Streams where all elements satisfy a given property
+------------------------------------------------------------------------
+
 {-# OPTIONS --safe --without-K --guardedness #-}
+
 module Codata.Guarded.Stream.Relation.Unary.All where
 
 open import Codata.Guarded.Stream using (Stream; head; tail)

--- a/src/Codata/Guarded/Stream/Relation/Unary/All.agda
+++ b/src/Codata/Guarded/Stream/Relation/Unary/All.agda
@@ -1,0 +1,37 @@
+{-# OPTIONS --safe --without-K --guardedness #-}
+module Codata.Guarded.Stream.Relation.Unary.All where
+
+open import Codata.Guarded.Stream using (Stream; head; tail)
+open import Data.Product using (_,_; proj₁; proj₂)
+open import Level
+open import Relation.Unary
+
+private
+  variable
+    a p ℓ : Level
+    A : Set a
+    P Q R : Pred A p
+    xs : Stream A
+
+record All (P : Pred A ℓ) (as : Stream A) : Set ℓ where
+  coinductive
+  constructor _∷_
+  field
+    head :     P (head as)
+    tail : All P (tail as)
+
+open All public
+
+map : P ⊆ Q → All P ⊆ All Q
+head (map f xs) = f (head xs)
+tail (map f xs) = map f (tail xs)
+
+zipWith : P ∩ Q ⊆ R → All P ∩ All Q ⊆ All R
+head (zipWith f (ps , qs)) = f (head ps , head qs)
+tail (zipWith f (ps , qs)) = zipWith f (tail ps , tail qs)
+
+unzipWith : R ⊆ P ∩ Q → All R ⊆ All P ∩ All Q
+head (proj₁ (unzipWith f rs)) = proj₁ (f (head rs))
+tail (proj₁ (unzipWith f rs)) = proj₁ (unzipWith f (tail rs))
+head (proj₂ (unzipWith f rs)) = proj₂ (f (head rs))
+tail (proj₂ (unzipWith f rs)) = proj₂ (unzipWith f (tail rs))

--- a/src/Codata/Guarded/Stream/Relation/Unary/Any.agda
+++ b/src/Codata/Guarded/Stream/Relation/Unary/Any.agda
@@ -1,0 +1,40 @@
+{-# OPTIONS --safe --without-K --guardedness #-}
+module Codata.Guarded.Stream.Relation.Unary.Any where
+
+open import Codata.Guarded.Stream as Stream using (Stream)
+open import Data.Empty
+open import Data.Nat.Base hiding (_⊔_)
+open import Level hiding (zero; suc)
+open import Relation.Nullary
+open import Relation.Unary
+
+private
+  variable
+    a p q : Level
+    A : Set a
+    P Q : Pred A p
+    xs : Stream A
+
+data Any {A : Set a} (P : Pred A p) : Stream A → Set (a ⊔ p) where
+  here  : ∀ {xs} →     P (Stream.head xs) → Any P xs
+  there : ∀ {xs} → Any P (Stream.tail xs) → Any P xs
+
+head : ¬ Any P (Stream.tail xs) → Any P xs → P (Stream.head xs)
+head ¬t (here h) = h
+head ¬t (there t) = ⊥-elim (¬t t)
+
+tail : ¬ P (Stream.head xs) → Any P xs → Any P (Stream.tail xs)
+tail ¬h (here h) = ⊥-elim (¬h h)
+tail ¬h (there t) = t
+
+map : P ⊆ Q → Any P ⊆ Any Q
+map g (here  px ) = here (g px)
+map g (there pxs) = there (map g pxs)
+
+index : Any P xs → ℕ
+index (here  px ) = zero
+index (there pxs) = suc (index pxs)
+
+lookup : {P : Pred A p} → Any P xs → A
+lookup {xs = xs} p = Stream.lookup (index p) xs
+

--- a/src/Codata/Guarded/Stream/Relation/Unary/Any.agda
+++ b/src/Codata/Guarded/Stream/Relation/Unary/Any.agda
@@ -1,4 +1,11 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Streams where at least one element satisfies a given property
+------------------------------------------------------------------------
+
 {-# OPTIONS --safe --without-K --guardedness #-}
+
 module Codata.Guarded.Stream.Relation.Unary.Any where
 
 open import Codata.Guarded.Stream as Stream using (Stream)


### PR DESCRIPTION
I'm using this for a bunch of personal projects so I'd like to get it in stdlib. However, it's nowhere near ready, really.

I'm only defining Streams for now because they have a regular structure, I don't need to worry about Maybes like I would with Colists or Conats defined this way.

I don't know how far I want to take various relations and properties. "All the way" might be the right answer for this.

I tried to be at least as complete as the other two definitions of streams, but I couldn't figure out how to implement some things, such as `interleave⁺ : List⁺ (Stream A) → Stream A`