### PR TITLE
Moved `_/_` and `_%_` to `Base` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -479,6 +479,15 @@ Deprecated names
   reverse-suc        ↦ Data.Fin.Properties.opposite-suc
   ```
 
+* In `Data.Integer.DivMod` the operator names have been renamed to
+  be consistent with those in `Data.Nat.DivMod`:
+  ```
+  _divℕ_  ↦ _/ℕ_
+  _div_   ↦ _/_
+  _modℕ_  ↦ _%ℕ_
+  _mod_   ↦ _%_
+  ```
+
 * In `Data.Integer.Properties` references to variables in names have
   been made consistent so that `m`, `n` always refer to naturals and
   `i` and `j` always refer to integers:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -404,6 +404,19 @@ Major improvements
      it is defined immediately in terms of `_+_` and `-_`. This is the case for
 	 `Data.Integer` and `Data.Rational`.
 
+### Moved `_%_` and `_/_` operators to `Data.Nat.Base`
+
+* Previously the division and modulus operators were defined in `Data.Nat.DivMod`
+  which in turn meant that using them required importing `Data.Nat.Properties`
+  which is a very heavy dependency.
+  
+* To fix this, these operators have been moved to `Data.Nat.Base`. The properties
+  for them still live in `Data.Nat.DivMod` (which also publicly re-exports them
+  to provide backwards compatability).
+
+* Beneficieries of this change include `Data.Rational.Unnormalised.Base` whose
+  dependencies are now significantly smaller.
+
 Deprecated modules
 ------------------
 

--- a/src/Data/Fin/Substitution.agda
+++ b/src/Data/Fin/Substitution.agda
@@ -15,14 +15,13 @@
 
 module Data.Fin.Substitution where
 
-open import Data.Nat hiding (_⊔_)
+open import Data.Nat.Base hiding (_⊔_; _/_)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Vec.Base
-open import Function as Fun using (flip)
+open import Function.Base as Fun using (flip)
 open import Relation.Binary.Construct.Closure.ReflexiveTransitive
   as Star using (Star; ε; _◅_)
-open import Level using (Level; _⊔_)
-import Level as L
+open import Level using (Level; _⊔_; 0ℓ)
 open import Relation.Unary using (Pred)
 
 ------------------------------------------------------------------------
@@ -146,12 +145,12 @@ module VarSubst where
 
 -- "Term" substitutions.
 
-record TermSubst (T : Pred ℕ L.zero) : Set₁ where
+record TermSubst (T : Pred ℕ 0ℓ) : Set₁ where
   field
     var : ∀ {n} → Fin n → T n
-    app : ∀ {T′ : Pred ℕ L.zero} → Lift T′ T → ∀ {m n} → T m → Sub T′ m n → T n
+    app : ∀ {T′ : Pred ℕ 0ℓ} → Lift T′ T → ∀ {m n} → T m → Sub T′ m n → T n
 
-  module Lifted {T′ : Pred ℕ L.zero} (lift : Lift T′ T) where
+  module Lifted {T′ : Pred ℕ 0ℓ} (lift : Lift T′ T) where
     application : Application T T′
     application = record { _/_ = app lift }
 

--- a/src/Data/Fin/Substitution/Example.agda
+++ b/src/Data/Fin/Substitution/Example.agda
@@ -11,7 +11,7 @@ module Data.Fin.Substitution.Example where
 
 open import Data.Fin.Substitution
 open import Data.Fin.Substitution.Lemmas
-open import Data.Nat.Base
+open import Data.Nat.Base hiding (_/_)
 open import Data.Fin.Base using (Fin)
 open import Data.Vec.Base
 open import Relation.Binary.PropositionalEquality as PropEq

--- a/src/Data/Fin/Substitution/Lemmas.agda
+++ b/src/Data/Fin/Substitution/Lemmas.agda
@@ -10,7 +10,7 @@ module Data.Fin.Substitution.Lemmas where
 
 import Category.Applicative.Indexed as Applicative
 open import Data.Fin.Substitution
-open import Data.Nat hiding (_⊔_)
+open import Data.Nat hiding (_⊔_; _/_)
 open import Data.Fin.Base using (Fin; zero; suc; lift)
 open import Data.Vec.Base
 import Data.Vec.Properties as VecProp

--- a/src/Data/Integer/Base.agda
+++ b/src/Data/Integer/Base.agda
@@ -31,7 +31,7 @@ open import Relation.Unary using (Pred)
 
 infix  8 -_
 infixr 8 _^_
-infixl 7 _*_ _⊓_
+infixl 7 _*_ _⊓_ _/ℕ_ _/_ _%ℕ_ _%_
 infixl 6 _+_ _-_ _⊖_ _⊔_
 infix  4 _≤_ _≥_ _<_ _>_ _≰_ _≱_ _≮_ _≯_
 infix  4 _≤ᵇ_
@@ -274,6 +274,33 @@ _⊓_ : ℤ → ℤ → ℤ
 -[1+ m ] ⊓ +    n   = -[1+ m ]
 +    m   ⊓ -[1+ n ] = -[1+ n ]
 +    m   ⊓ +    n   = + (ℕ._⊓_ m n)
+
+-- Division by a natural
+
+_/ℕ_ : (dividend : ℤ) (divisor : ℕ) .{{_ : ℕ.NonZero divisor}} → ℤ
+(+ n      /ℕ d) = + (n ℕ./ d)
+(-[1+ n ] /ℕ d) with ℕ.suc n ℕ.% d
+... | ℕ.zero  = - (+ (ℕ.suc n ℕ./ d))
+... | ℕ.suc r = -[1+ (ℕ.suc n ℕ./ d) ]
+
+-- Division
+
+_/_ : (dividend divisor : ℤ) .{{_ : NonZero divisor}} → ℤ
+n / d = (sign d ◃ 1) * (n /ℕ ∣ d ∣)
+
+-- Modulus by a natural
+
+_%ℕ_ : (dividend : ℤ) (divisor : ℕ) .{{_ : ℕ.NonZero divisor}} → ℕ
+(+ n      %ℕ d) = n ℕ.% d
+(-[1+ n ] %ℕ d) with ℕ.suc n ℕ.% d
+... | ℕ.zero      = 0
+... | r@(ℕ.suc _) = d ℕ.∸ r
+
+-- Modulus
+
+_%_ : (dividend divisor : ℤ) .{{_ : NonZero divisor}} → ℕ
+n % d = n %ℕ ∣ d ∣
+
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/Integer/Base.agda
+++ b/src/Data/Integer/Base.agda
@@ -15,14 +15,10 @@
 module Data.Integer.Base where
 
 open import Data.Bool.Base using (Bool; T; true; false)
-open import Data.Empty using (⊥)
-open import Data.Unit.Base using (⊤)
-open import Data.Nat.Base as ℕ
-  using (ℕ; z≤n; s≤s) renaming (_+_ to _ℕ+_; _*_ to _ℕ*_)
-open import Data.Sign as Sign using (Sign) renaming (_*_ to _S*_)
-open import Function
+open import Data.Nat.Base as ℕ using (ℕ; z≤n; s≤s)
+open import Data.Sign.Base as Sign using (Sign)
 open import Level using (0ℓ)
-open import Relation.Binary using (Rel)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl)
 open import Relation.Nullary using (¬_)
@@ -228,10 +224,10 @@ m ⊖ n with m ℕ.<ᵇ n
 -- Addition.
 
 _+_ : ℤ → ℤ → ℤ
--[1+ m ] + -[1+ n ] = -[1+ ℕ.suc (m ℕ+ n) ]
+-[1+ m ] + -[1+ n ] = -[1+ ℕ.suc (m ℕ.+ n) ]
 -[1+ m ] + +    n   = n ⊖ ℕ.suc m
 +    m   + -[1+ n ] = m ⊖ ℕ.suc n
-+    m   + +    n   = + (m ℕ+ n)
++    m   + +    n   = + (m ℕ.+ n)
 
 -- Subtraction.
 
@@ -251,7 +247,7 @@ pred i = -1ℤ + i
 -- Multiplication.
 
 _*_ : ℤ → ℤ → ℤ
-i * j = sign i S* sign j ◃ ∣ i ∣ ℕ* ∣ j ∣
+i * j = sign i Sign.* sign j ◃ ∣ i ∣ ℕ.* ∣ j ∣
 
 -- Naïve exponentiation.
 

--- a/src/Data/Integer/DivMod.agda
+++ b/src/Data/Integer/DivMod.agda
@@ -23,39 +23,23 @@ open ≤-Reasoning
 ------------------------------------------------------------------------
 -- Definition
 
-infixl 7 _divℕ_ _div_ _modℕ_ _mod_
-_divℕ_ : (dividend : ℤ) (divisor : ℕ) .{{_ : ℕ.NonZero divisor}} → ℤ
-(+ n      divℕ d) = + (n ℕ./ d)
-(-[1+ n ] divℕ d) with ℕ.suc n ℕ.% d
-... | ℕ.zero  = - (+ (ℕ.suc n ℕ./ d))
-... | ℕ.suc r = -[1+ (ℕ.suc n ℕ./ d) ]
-
-_div_ : (dividend divisor : ℤ) .{{_ : NonZero divisor}} → ℤ
-n div d = (sign d ◃ 1) * (n divℕ ∣ d ∣)
-
-_modℕ_ : (dividend : ℤ) (divisor : ℕ) .{{_ : ℕ.NonZero divisor}} → ℕ
-(+ n      modℕ d) = n ℕ.% d
-(-[1+ n ] modℕ d) with ℕ.suc n ℕ.% d
-... | ℕ.zero      = 0
-... | r@(ℕ.suc _) = d ℕ.∸ r
-
-_mod_ : (dividend divisor : ℤ) .{{_ : NonZero divisor}} → ℕ
-n mod d = n modℕ ∣ d ∣
+open import Data.Integer.Base public
+  using (_/ℕ_; _/_; _%ℕ_; _%_)
 
 ------------------------------------------------------------------------
 -- Properties
 
-n%ℕd<d : ∀ n d .{{_ : ℕ.NonZero d}} → n modℕ d ℕ.< d
+n%ℕd<d : ∀ n d .{{_ : ℕ.NonZero d}} → n %ℕ d ℕ.< d
 n%ℕd<d (+ n)    d           = ℕ.m%n<n n d
 n%ℕd<d -[1+ n ] d@(ℕ.suc _) with ℕ.suc n ℕ.% d
-... | ℕ.zero  = ℕ.s≤s ℕ.z≤n
-... | ℕ.suc r = ℕ.s≤s (ℕ.m∸n≤m _ r)
+... | ℕ.zero  = s≤s z≤n
+... | ℕ.suc r = s≤s (ℕ.m∸n≤m _ r)
 
-n%d<d : ∀ n d .{{_ : NonZero d}} → n mod d ℕ.< ∣ d ∣
+n%d<d : ∀ n d .{{_ : NonZero d}} → n % d ℕ.< ∣ d ∣
 n%d<d n (+ d)    = n%ℕd<d n d
 n%d<d n -[1+ d ] = n%ℕd<d n (ℕ.suc d)
 
-a≡a%ℕn+[a/ℕn]*n : ∀ n d .{{_ : ℕ.NonZero d}} → n ≡ + (n modℕ d) + (n divℕ d) * + d
+a≡a%ℕn+[a/ℕn]*n : ∀ n d .{{_ : ℕ.NonZero d}} → n ≡ + (n %ℕ d) + (n /ℕ d) * + d
 a≡a%ℕn+[a/ℕn]*n (+ n) d = let q = n ℕ./ d; r = n ℕ.% d in begin-equality
   + n                ≡⟨ cong +_ (ℕ.m≡m%n+[m/n]*n n d) ⟩
   + (r ℕ.+ q ℕ.* d)  ≡⟨ pos-+-commute r (q ℕ.* d) ⟩
@@ -88,59 +72,89 @@ a≡a%ℕn+[a/ℕn]*n n@(-[1+ _ ]) d with ∣ n ∣ ℕ.% d in eq
   d ⊖ r            +   (-[1+ q ] * + d)  ≡⟨ cong (_+ -[1+ q ] * + d) (⊖-≥ (subst (ℕ._≤ d) eq (ℕ.m%n≤n ∣n∣ d))) ⟩
   + (d ℕ.∸ r)      +   (-[1+ q ] * + d)  ∎
 
-[n/ℕd]*d≤n : ∀ n d .{{_ : ℕ.NonZero d}} → (n divℕ d) * + d ≤ n
-[n/ℕd]*d≤n n d = let q = n divℕ d; r = n modℕ d in begin
+[n/ℕd]*d≤n : ∀ n d .{{_ : ℕ.NonZero d}} → (n /ℕ d) * + d ≤ n
+[n/ℕd]*d≤n n d = let q = n /ℕ d; r = n %ℕ d in begin
   q * + d        ≤⟨  i≤j+i _ (+ r) ⟩
   + r + q * + d  ≡˘⟨ a≡a%ℕn+[a/ℕn]*n n d ⟩
   n              ∎
 
-div-pos-is-divℕ : ∀ n d .{{_ : ℕ.NonZero d}} →
-                  n div (+ d) ≡ n divℕ d
-div-pos-is-divℕ n (ℕ.suc d) = *-identityˡ (n divℕ ℕ.suc d)
+div-pos-is-/ℕ : ∀ n d .{{_ : ℕ.NonZero d}} →
+                  n / (+ d) ≡ n /ℕ d
+div-pos-is-/ℕ n (ℕ.suc d) = *-identityˡ (n /ℕ ℕ.suc d)
 
-div-neg-is-neg-divℕ : ∀ n d .{{_ : ℕ.NonZero d}} .{{_ : NonZero (- + d)}} →
-                      n div (- + d) ≡ - (n divℕ d)
-div-neg-is-neg-divℕ n (ℕ.suc d) = -1*i≡-i (n divℕ ℕ.suc d)
+div-neg-is-neg-/ℕ : ∀ n d .{{_ : ℕ.NonZero d}} .{{_ : NonZero (- + d)}} →
+                      n / (- + d) ≡ - (n /ℕ d)
+div-neg-is-neg-/ℕ n (ℕ.suc d) = -1*i≡-i (n /ℕ ℕ.suc d)
 
-0≤n⇒0≤n/ℕd : ∀ n d .{{_ : ℕ.NonZero d}} → 0ℤ ≤ n → 0ℤ ≤ (n divℕ d)
-0≤n⇒0≤n/ℕd (+ n) d (+≤+ m≤n) = +≤+ ℕ.z≤n
+0≤n⇒0≤n/ℕd : ∀ n d .{{_ : ℕ.NonZero d}} → 0ℤ ≤ n → 0ℤ ≤ (n /ℕ d)
+0≤n⇒0≤n/ℕd (+ n) d (+≤+ m≤n) = +≤+ z≤n
 
-0≤n⇒0≤n/d : ∀ n d .{{_ : NonZero d}} → 0ℤ ≤ n → 0ℤ ≤ d → 0ℤ ≤ (n div d)
+0≤n⇒0≤n/d : ∀ n d .{{_ : NonZero d}} → 0ℤ ≤ n → 0ℤ ≤ d → 0ℤ ≤ (n / d)
 0≤n⇒0≤n/d n (+ d) {{d≢0}} 0≤n (+≤+ 0≤d)
-  rewrite div-pos-is-divℕ n d {{d≢0}}
+  rewrite div-pos-is-/ℕ n d {{d≢0}}
         = 0≤n⇒0≤n/ℕd n d 0≤n
 
-[n/d]*d≤n : ∀ n d .{{_ : NonZero d}} → (n div d) * d ≤ n
+[n/d]*d≤n : ∀ n d .{{_ : NonZero d}} → (n / d) * d ≤ n
 [n/d]*d≤n n (+ d) = begin
-  n div + d * + d        ≡⟨ cong (_* (+ d)) (div-pos-is-divℕ n d) ⟩
-  n divℕ d  * + d        ≤⟨ [n/ℕd]*d≤n n d ⟩
-  n                      ∎
+  n / + d * + d        ≡⟨ cong (_* (+ d)) (div-pos-is-/ℕ n d) ⟩
+  n /ℕ d  * + d        ≤⟨ [n/ℕd]*d≤n n d ⟩
+  n                    ∎
 [n/d]*d≤n n d@(-[1+ _ ]) = begin let ∣d∣ = ∣ d ∣ in
-  n div d        * d     ≡⟨ cong (_* d) (div-neg-is-neg-divℕ n ∣d∣) ⟩
-  - (n divℕ ∣d∣) * d     ≡⟨ sym (neg-distribˡ-* (n divℕ ∣d∣) d) ⟩
-  - (n divℕ ∣d∣  * d)    ≡⟨ neg-distribʳ-* (n divℕ ∣d∣) d ⟩
-  n divℕ ∣d∣     * + ∣d∣ ≤⟨ [n/ℕd]*d≤n n ∣d∣ ⟩
-  n                      ∎
+  n / d        * d     ≡⟨ cong (_* d) (div-neg-is-neg-/ℕ n ∣d∣) ⟩
+  - (n /ℕ ∣d∣) * d     ≡⟨ sym (neg-distribˡ-* (n /ℕ ∣d∣) d) ⟩
+  - (n /ℕ ∣d∣  * d)    ≡⟨ neg-distribʳ-* (n /ℕ ∣d∣) d ⟩
+  n /ℕ ∣d∣     * + ∣d∣ ≤⟨ [n/ℕd]*d≤n n ∣d∣ ⟩
+  n                    ∎
 
-n<s[n/ℕd]*d : ∀ n d .{{_ : ℕ.NonZero d}} → n < suc (n divℕ d) * + d
+n<s[n/ℕd]*d : ∀ n d .{{_ : ℕ.NonZero d}} → n < suc (n /ℕ d) * + d
 n<s[n/ℕd]*d n d = begin-strict
   n                    ≡⟨ a≡a%ℕn+[a/ℕn]*n n d ⟩
   + r + q * + d        <⟨ +-monoˡ-< (q * + d) (+<+ (n%ℕd<d n d)) ⟩
   + d + q * + d        ≡⟨ sym (suc-* q (+ d)) ⟩
-  suc (n divℕ d) * + d ∎
-  where q = n divℕ d; r = n modℕ d
+  suc (n /ℕ d) * + d   ∎
+  where q = n /ℕ d; r = n %ℕ d
 
-a≡a%n+[a/n]*n : ∀ a n .{{_ : NonZero n}} → a ≡ + (a mod n) + (a div n) * n
+a≡a%n+[a/n]*n : ∀ a n .{{_ : NonZero n}} → a ≡ + (a % n) + (a / n) * n
 a≡a%n+[a/n]*n n d@(+ _) = begin-equality
-  let ∣d∣ = ∣ d ∣; r = n mod d; q = n divℕ ∣d∣ in
+  let ∣d∣ = ∣ d ∣; r = n % d; q = n /ℕ ∣d∣ in
   n                  ≡⟨ a≡a%ℕn+[a/ℕn]*n n ∣d∣ ⟩
-  + r + (q * + ∣d∣)  ≡⟨ cong (λ p → + r + p * d) (sym (div-pos-is-divℕ n ∣d∣)) ⟩
-  + r + n div d * d  ∎
+  + r + (q * + ∣d∣)  ≡⟨ cong (λ p → + r + p * d) (sym (div-pos-is-/ℕ n ∣d∣)) ⟩
+  + r + n / d * d    ∎
 a≡a%n+[a/n]*n n d@(-[1+ _ ]) = begin-equality
-  let ∣d∣ = ∣ d ∣; r = n mod d; q = n divℕ ∣d∣ in
+  let ∣d∣ = ∣ d ∣; r = n % d; q = n /ℕ ∣d∣ in
   n                  ≡⟨ a≡a%ℕn+[a/ℕn]*n n ∣d∣ ⟩
   + r + q * + ∣d∣    ≡⟨⟩
   + r + q * - d      ≡⟨ cong (_+_ (+ r)) (sym (neg-distribʳ-* q d)) ⟩
   + r + - (q * d)    ≡⟨ cong (_+_ (+ r)) (neg-distribˡ-* q d) ⟩
   + r + - q * d      ≡⟨ cong (_+_ (+ r) ∘′ (_* d)) (sym (-1*i≡-i q)) ⟩
-  + r + n div d * d  ∎
+  + r + n / d * d    ∎
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.0
+
+infixl 7 _divℕ_ _div_ _modℕ_ _mod_
+_divℕ_ = _/ℕ_
+{-# WARNING_ON_USAGE _divℕ_
+"Warning: _divℕ_ was deprecated in v2.0.
+Please use _/ℕ_ instead."
+#-}
+_div_ = _/_
+{-# WARNING_ON_USAGE _div_
+"Warning: _div_ was deprecated in v2.0.
+Please use _/_ instead."
+#-}
+_modℕ_ = _%ℕ_
+{-# WARNING_ON_USAGE _modℕ_
+"Warning: _modℕ_ was deprecated in v2.0.
+Please use _%ℕ_ instead."
+#-}
+_mod_ = _%_
+{-# WARNING_ON_USAGE _mod_
+"Warning: _mod_ was deprecated in v2.0.
+Please use _%_ instead."
+#-}

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -172,11 +172,13 @@ x ^ suc n = x * x ^ n
 ∣ suc x - suc y ∣ = ∣ x - y ∣
 
 -- Division
+-- Note properties of these are in `Nat.DivMod` not `Nat.Properties`
 
 _/_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
 m / (suc n) = div-helper 0 n m n
 
 -- Remainder/modulus
+-- Note properties of these are in `Nat.DivMod` not `Nat.Properties`
 
 _%_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
 m % (suc n) = mod-helper 0 n m n

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -117,10 +117,13 @@ instance
 open import Agda.Builtin.Nat public
   using (_+_; _*_) renaming (_-_ to _∸_)
 
+open import Agda.Builtin.Nat
+  using (div-helper; mod-helper)
+
 pred : ℕ → ℕ
 pred n = n ∸ 1
 
-infixl 7 _⊓_
+infixl 7 _⊓_ _/_ _%_
 infixl 6 _+⋎_ _⊔_
 
 -- Argument-swapping addition. Used by Data.Vec._⋎_.
@@ -167,6 +170,16 @@ x ^ suc n = x * x ^ n
 ∣ zero  - y     ∣ = y
 ∣ x     - zero  ∣ = x
 ∣ suc x - suc y ∣ = ∣ x - y ∣
+
+-- Division
+
+_/_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
+m / (suc n) = div-helper 0 n m n
+
+-- Remainder/modulus
+
+_%_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
+m % (suc n) = mod-helper 0 n m n
 
 ------------------------------------------------------------------------
 -- Alternative definition of _≤_

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -28,25 +28,8 @@ open ≤-Reasoning
 ------------------------------------------------------------------------
 -- Definitions
 
--- The division and modulus operations are only defined when the divisor
--- is non-zero. The proof of non-zero-ness is provided as an irrelevant
--- instance argument which is defined in terms of `⊤` and `⊥`. This
--- allows it to be automatically inferred when the divisor is of the
--- form `suc n`, and hence minimises the number of these proofs that
--- need be passed around. You can therefore write `m / suc n` without
--- further elaboration.
-
-infixl 7 _/_ _%_
-
--- Natural division
-
-_/_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
-m / (suc n) = div-helper 0 n m n
-
--- Natural remainder/modulus
-
-_%_ : (dividend divisor : ℕ) .{{_ : NonZero divisor}} → ℕ
-m % (suc n) = mod-helper 0 n m n
+open import Data.Nat.Base public
+  using (_%_; _/_)
 
 ------------------------------------------------------------------------
 -- Relationship between _%_ and _div_

--- a/src/Data/Rational/Base.agda
+++ b/src/Data/Rational/Base.agda
@@ -9,31 +9,21 @@
 module Data.Rational.Base where
 
 open import Data.Bool.Base using (Bool; true; false; if_then_else_)
-open import Function.Base using (id)
 open import Data.Integer.Base as ℤ using (ℤ; +_; +0; +[1+_]; -[1+_])
-import Data.Integer.GCD as ℤ
-import Data.Integer.DivMod as ℤ
 open import Data.Nat.GCD
-open import Data.Nat.Divisibility as ℕDiv using (divides; 0∣⇒≡0)
 open import Data.Nat.Coprimality as C
   using (Coprime; Bézout-coprime; coprime-/gcd; coprime?; ¬0-coprimeTo-2+)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc) hiding (module ℕ)
-import Data.Nat.DivMod as ℕ
 open import Data.Rational.Unnormalised.Base as ℚᵘ using (ℚᵘ; mkℚᵘ)
-open import Data.Product
-open import Data.Sign using (Sign)
 open import Data.Sum.Base using (inj₂)
+open import Function.Base using (id)
 open import Level using (0ℓ)
 open import Relation.Nullary using (¬_; recompute)
-open import Relation.Nullary.Decidable
-  using (False; fromWitness; fromWitnessFalse; toWitnessFalse)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Unary using (Pred)
-open import Relation.Binary using (Rel)
-open import Relation.Binary.PropositionalEquality
-  using (_≡_; _≢_; refl; subst; cong; cong₂; module ≡-Reasoning)
-
-open ≡-Reasoning
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.PropositionalEquality.Core
+  using (_≡_; _≢_; refl)
 
 ------------------------------------------------------------------------
 -- Rational numbers in reduced form. Note that there is exactly one
@@ -250,7 +240,7 @@ p ⊓ q = if p ≤ᵇ q then p else q
 
 -- Floor (round towards -∞)
 floor : ℚ → ℤ
-floor p = (↥ p) ℤ.div (↧ p)
+floor p = ↥ p ℤ./ ↧ p
 
 -- Ceiling (round towards +∞)
 ceiling : ℚ → ℤ

--- a/src/Data/Rational/Unnormalised/Base.agda
+++ b/src/Data/Rational/Unnormalised/Base.agda
@@ -16,7 +16,7 @@ open import Level using (0ℓ)
 open import Relation.Nullary using (¬_)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Unary using (Pred)
-open import Relation.Binary using (Rel)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl)
 

--- a/src/Data/Rational/Unnormalised/Base.agda
+++ b/src/Data/Rational/Unnormalised/Base.agda
@@ -11,8 +11,7 @@ module Data.Rational.Unnormalised.Base where
 open import Data.Bool.Base using (Bool; true; false; if_then_else_)
 open import Data.Integer.Base as ℤ
   using (ℤ; +_; +0; +[1+_]; -[1+_]; +<+; +≤+)
-import Data.Integer.DivMod as ℤ
-open import Data.Nat as ℕ using (ℕ; zero; suc)
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc)
 open import Level using (0ℓ)
 open import Relation.Nullary using (¬_)
 open import Relation.Nullary.Negation using (contradiction)
@@ -239,7 +238,7 @@ p ⊓ q = if p ≤ᵇ q then p else q
 
 -- Floor (round towards -∞)
 floor : ℚᵘ → ℤ
-floor p = (↥ p) ℤ.div (↧ p)
+floor p = ↥ p ℤ./ ↧ p
 
 -- Ceiling (round towards +∞)
 ceiling : ℚᵘ → ℤ
@@ -262,6 +261,6 @@ fracPart : ℚᵘ → ℚᵘ
 fracPart p = ∣ p - truncate p / 1 ∣
 
 -- Extra notations  ⌊ ⌋ floor,  ⌈ ⌉ ceiling,  [ ] truncate
-syntax floor p = ⌊ p ⌋
-syntax ceiling p = ⌈ p ⌉
+syntax floor    p = ⌊ p ⌋
+syntax ceiling  p = ⌈ p ⌉
 syntax truncate p = [ p ]

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -19,7 +19,6 @@ open import Data.Bool.Base using (T; true; false)
 open import Data.Nat.Base as ℕ using (suc; pred)
 import Data.Nat.Properties as ℕ
 open import Data.Nat.Solver renaming (module +-*-Solver to ℕ-solver)
-open import Data.Unit using (tt)
 open import Data.Integer.Base as ℤ using (ℤ; +0; +[1+_]; -[1+_]; 0ℤ; 1ℤ; -1ℤ)
 open import Data.Integer.Solver renaming (module +-*-Solver to ℤ-solver)
 import Data.Integer.Properties as ℤ


### PR DESCRIPTION
The dependency graph of `Data.Rational.Unnormalised.Base` was pretty huge, as it requires importing `Data.Nat.DivMod` which in turn imports `Data.Nat.Properties`.

This PR fixes the problem by moving the definitions of `_/_` and `_%_` to `Data.Nat.Base` (and similarly for `Data.Integer.Base` for the integer variants).

This is backwards compatible, and feels like absolutely the right thing to do, but opens up a whole thorny set of questions about library design such as should we move more definitions into `Data.Nat.Base`, e.g. `_|_` from `Data.Nat.Divisibility.Core` (a horrible module to exist)?, or `Prime` from `Data.Nat.Primality`?

But we unfortunately can't move _all_ function or predicate definitions in there, as e.g. the implementation of `gcd` or `!_` relies on well-foundedness and proofs about non-zeroness....