### PR TITLE
Add injectivity proof for Data.Fin.lower₁

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -923,6 +923,8 @@ Other minor changes
   combine-injectiveʳ : combine x y ≡ combine x z → y ≡ z
   combine-injective  : combine x y ≡ combine w z → x ≡ w × y ≡ z
   combine-surjective : ∀ x → ∃₂ λ y z → combine y z ≡ x
+  
+  lower₁-injective   : lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
   ```
 
 * Added new functions in `Data.Integer.Base`:

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -451,6 +451,14 @@ toℕ-lower₁ {ℕ.zero} zero p     = contradiction refl p
 toℕ-lower₁ {ℕ.suc m} zero p    = refl
 toℕ-lower₁ {ℕ.suc m} (suc x) p = cong ℕ.suc (toℕ-lower₁ x (p ∘ cong ℕ.suc))
 
+lower₁-injective : ∀ {n} {i j} {n≢i : n ≢ toℕ i} {n≢j : n ≢ toℕ j} →
+                   lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
+lower₁-injective {zero}  {zero}  {_}     {n≢i} {_}   _ = ⊥-elim (n≢i refl)
+lower₁-injective {zero}  {_}     {zero}  {_}   {n≢j} _ = ⊥-elim (n≢j refl)
+lower₁-injective {suc n} {0F}    {0F}    {_}   {_}   refl = refl
+lower₁-injective {suc n} {suc i} {suc j} {n≢i} {n≢j} eq =
+  cong suc (lower₁-injective (suc-injective eq))
+
 ------------------------------------------------------------------------
 -- inject₁ and lower₁
 


### PR DESCRIPTION
I needed a proof for the injectivity of lower₁ in Data.Fin, but the standard library did not contain such a proof. After writing it I realized that I might as well contribute it back upstream as it seems useful enough, so I cleaned it up to (hopefully) comply with the style guidelines.