### PR TITLE
Added boolean versions of List/Vec functions that use predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -960,6 +960,20 @@ Other minor changes
   ^-monoid-morphism    : IsMonoidMorphism ℕ.+-0-monoid *-1-monoid (i ^_)
   ```
 
+* Added new functions in `Data.List`:
+  ```agda
+  takeWhileᵇ   : (A → Bool) → List A → List A
+  dropWhileᵇ   : (A → Bool) → List A → List A
+  filterᵇ      : (A → Bool) → List A → List A
+  partitionᵇ   : (A → Bool) → List A → List A × List A
+  spanᵇ        : (A → Bool) → List A → List A × List A
+  breakᵇ       : (A → Bool) → List A → List A × List A
+  linesByᵇ     : (A → Bool) → List A → List (List A)
+  wordsByᵇ     : (A → Bool) → List A → List (List A)
+  derunᵇ       : (A → A → Bool) → List A → List A
+  deduplicateᵇ : (A → A → Bool) → List A → List A
+  ```
+  
 * Added new proofs in `Data.List.Relation.Binary.Lex.Strict`:
   ```agda
   xs≮[] : ¬ xs < []
@@ -1098,6 +1112,12 @@ Other minor changes
   *-abelianGroup : AbelianGroup 0ℓ 0ℓ
   ```
 
+* Added new functions in `Data.String.Base`:
+  ```agda
+  wordsByᵇ : (Char → Bool) → String → List String
+  linesByᵇ : (Char → Bool) → String → List String 
+  ```
+  
 * Added new proofs in `Data.String.Properties`:
   ```
   ≤-isDecTotalOrder-≈ : IsDecTotalOrder _≈_ _≤_
@@ -1119,6 +1139,7 @@ Other minor changes
 
   foldr′ : (A → B → B) → B → Vec A n → B
   foldl′ : (B → A → B) → B → Vec A n → B
+  countᵇ : (A → Bool) → Vec A n → ℕ
 
   diagonal           : Vec (Vec A n) n → Vec A n
   DiagonalBind._>>=_ : Vec A n → (A → Vec B n) → Vec B n

--- a/src/Data/List/Relation/Unary/Unique/DecSetoid/Properties.agda
+++ b/src/Data/List/Relation/Unary/Unique/DecSetoid/Properties.agda
@@ -12,6 +12,7 @@ open import Data.List.Relation.Unary.All.Properties using (all-filter)
 open import Data.List.Relation.Unary.Unique.Setoid.Properties
 open import Level
 open import Relation.Binary using (DecSetoid)
+open import Relation.Nullary.Negation using (¬?)
 
 module Data.List.Relation.Unary.Unique.DecSetoid.Properties where
 
@@ -29,4 +30,5 @@ module _ (DS : DecSetoid a ℓ) where
 
   deduplicate-! : ∀ xs → Unique (deduplicate _≟_ xs)
   deduplicate-! []       = []
-  deduplicate-! (x ∷ xs) = all-filter _ (deduplicate _ xs) ∷ filter⁺ S _ (deduplicate-! xs)
+  deduplicate-! (x ∷ xs) = all-filter (λ y → ¬? (x ≟ y)) (deduplicate _≟_ xs)
+                         ∷ filter⁺ S  (λ y → ¬? (x ≟ y)) (deduplicate-! xs)

--- a/src/Data/Product.agda
+++ b/src/Data/Product.agda
@@ -177,6 +177,9 @@ curry′ = curry
 uncurry′ : (A → B → C) → (A × B → C)
 uncurry′ = uncurry
 
+map₂′ : (B → C) → A × B → A × C
+map₂′ f = map₂ f
+
 dmap′ : ∀ {x y} {X : A → Set x} {Y : B → Set y} →
         ((a : A) → X a) → ((b : B) → Y b) →
         ((a , b) : A × B) → X a × Y b

--- a/src/Data/String.agda
+++ b/src/Data/String.agda
@@ -53,28 +53,6 @@ parensIfSpace s with does (' ' ∈? toList s)
 ... | true  = parens s
 ... | false = s
 
-------------------------------------------------------------------------
--- Splitting strings
-
-wordsBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
-wordsBy P? = List.map fromList ∘ List.wordsBy P? ∘ toList
-
-words : String → List String
-words = wordsBy (T? ∘ Char.isSpace)
-
--- `words` ignores contiguous whitespace
-_ : words " abc  b   " ≡ "abc" ∷ "b" ∷ []
-_ = refl
-
-linesBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
-linesBy P? = List.map fromList ∘ List.linesBy P? ∘ toList
-
-lines : String → List String
-lines = linesBy ('\n' Char.≟_)
-
--- `lines` preserves empty lines
-_ : lines "\nabc\n\nb\n\n\n" ≡ "" ∷ "abc" ∷ "" ∷ "b" ∷ "" ∷ "" ∷ []
-_ = refl
 
 ------------------------------------------------------------------------
 -- Rectangle

--- a/src/Data/String/Base.agda
+++ b/src/Data/String/Base.agda
@@ -9,7 +9,7 @@
 module Data.String.Base where
 
 open import Level using (zero)
-open import Data.Bool.Base using (true; false)
+open import Data.Bool.Base using (Bool; true; false)
 open import Data.Char.Base as Char using (Char)
 open import Data.List.Base as List using (List; [_]; _∷_; [])
 open import Data.List.NonEmpty.Base as NE using (List⁺)
@@ -19,6 +19,7 @@ open import Data.Maybe.Base as Maybe using (Maybe)
 open import Data.Nat.Base using (ℕ; _∸_; ⌊_/2⌋; ⌈_/2⌉)
 open import Data.Product using (proj₁; proj₂)
 open import Function.Base using (_on_; _∘′_; _∘_)
+open import Level using (Level)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 open import Relation.Unary using (Pred; Decidable)
@@ -156,3 +157,32 @@ fromAlignment : Alignment → ℕ → String → String
 fromAlignment Left   = padRight ' '
 fromAlignment Center = padBoth ' ' ' '
 fromAlignment Right  = padLeft ' '
+
+------------------------------------------------------------------------
+-- Splitting strings
+
+wordsByᵇ : (Char → Bool) → String → List String
+wordsByᵇ p = List.map fromList ∘ List.wordsByᵇ p ∘ toList
+
+wordsBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
+wordsBy P? = wordsByᵇ (does ∘ P?)
+
+words : String → List String
+words = wordsByᵇ Char.isSpace
+
+-- `words` ignores contiguous whitespace
+_ : words " abc  b   " ≡ "abc" ∷ "b" ∷ []
+_ = refl
+
+linesByᵇ : (Char → Bool) → String → List String
+linesByᵇ p = List.map fromList ∘ List.linesByᵇ p ∘ toList
+
+linesBy : ∀ {p} {P : Pred Char p} → Decidable P → String → List String
+linesBy P? = linesByᵇ (does ∘ P?)
+
+lines : String → List String
+lines = linesByᵇ ('\n' Char.≈ᵇ_)
+
+-- `lines` preserves empty lines
+_ : lines "\nabc\n\nb\n\n\n" ≡ "" ∷ "abc" ∷ "" ∷ "b" ∷ "" ∷ "" ∷ []
+_ = refl

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -221,11 +221,12 @@ foldl₁ _⊕_ (x ∷ xs) = foldl _ _⊕_ x xs
 sum : Vec ℕ n → ℕ
 sum = foldr _ _+_ 0
 
+countᵇ : (A → Bool) → Vec A n → ℕ
+countᵇ p []       = zero
+countᵇ p (x ∷ xs) = if p x then suc (countᵇ p xs) else countᵇ p xs
+
 count : ∀ {P : Pred A p} → Decidable P → Vec A n → ℕ
-count P? []       = zero
-count P? (x ∷ xs) with does (P? x)
-... | true  = suc (count P? xs)
-... | false = count P? xs
+count P? = countᵇ (does ∘ P?)
 
 ------------------------------------------------------------------------
 -- Operations for building vectors


### PR DESCRIPTION
Fixes https://github.com/agda/agda-stdlib/issues/920. For each function that took a decidable predicate as an argument, adds a new boolean valued version of it, and redefines the existing predicate version in terms of it.

Bikeshedding about the naming convention welcome!