### PR TITLE
[ new ] Codata.Guarded.Stream.Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -457,7 +457,7 @@ Major improvements
 * Previously the division and modulus operators were defined in `Data.Nat.DivMod`
   which in turn meant that using them required importing `Data.Nat.Properties`
   which is a very heavy dependency.
-  
+
 * To fix this, these operators have been moved to `Data.Nat.Base`. The properties
   for them still live in `Data.Nat.DivMod` (which also publicly re-exports them
   to provide backwards compatability).
@@ -725,6 +725,7 @@ New modules
 * A definition of infinite streams using coinductive records:
   ```
   Codata.Guarded.Stream
+  Codata.Guarded.Stream.Properties
   Codata.Guarded.Stream.Relation.Binary.Pointwise
   Codata.Guarded.Stream.Relation.Unary.All
   Codata.Guarded.Stream.Relation.Unary.Any
@@ -831,7 +832,7 @@ New modules
   -‿distribˡ-* : ∀ x y → - (x * y) ≈ - x * y
   -‿distribʳ-* : ∀ x y → - (x * y) ≈ x * - y
   ```
-  
+
 
 Other minor changes
 -------------------
@@ -883,14 +884,14 @@ Other minor changes
   ring : Ring a ℓ₁ → Ring b ℓ₂ → Ring (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   commutativeRing : CommutativeRing a ℓ₁ → CommutativeRing b ℓ₂ →
                     CommutativeRing (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-  rawQuasigroup : RawQuasigroup a ℓ₁ → RawQuasigroup b ℓ₂ → 
+  rawQuasigroup : RawQuasigroup a ℓ₁ → RawQuasigroup b ℓ₂ →
                   RawQuasigroup (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   rawLoop : RawLoop a ℓ₁ → RawLoop b ℓ₂ → RawLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-  unitalMagma : UnitalMagma a ℓ₁ → UnitalMagma b ℓ₂ → 
+  unitalMagma : UnitalMagma a ℓ₁ → UnitalMagma b ℓ₂ →
                 UnitalMagma (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-  invertibleMagma : InvertibleMagma a ℓ₁ → InvertibleMagma b ℓ₂ → 
+  invertibleMagma : InvertibleMagma a ℓ₁ → InvertibleMagma b ℓ₂ →
                     InvertibleMagma (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
-  invertibleUnitalMagma : InvertibleUnitalMagma a ℓ₁ → InvertibleUnitalMagma b ℓ₂ → 
+  invertibleUnitalMagma : InvertibleUnitalMagma a ℓ₁ → InvertibleUnitalMagma b ℓ₂ →
                           InvertibleUnitalMagma (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   quasigroup : Quasigroup a ℓ₁ → Quasigroup b ℓ₂ → Quasigroup (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   loop : Loop a ℓ₁ → Loop b ℓ₂ → Loop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
@@ -985,7 +986,7 @@ Other minor changes
   combine-injectiveʳ : combine x y ≡ combine x z → y ≡ z
   combine-injective  : combine x y ≡ combine w z → x ≡ w × y ≡ z
   combine-surjective : ∀ x → ∃₂ λ y z → combine y z ≡ x
-  
+
   lower₁-injective   : lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
   ```
 
@@ -1052,11 +1053,11 @@ Other minor changes
   m^n≢0     : .{{_ : NonZero m}} → NonZero (m ^ n)
   m*n≢0     : .{{_ : NonZero m}} .{{_ : NonZero n}} → NonZero (m * n)
   m≤n⇒n∸m≤n : m ≤ n → n ∸ m ≤ n
-  
+
   1≤n!    : 1 ≤ n !
   _!≢0    : NonZero (n !)
   _!*_!≢0 : NonZero (m ! * n !)
-  
+
   anyUpTo? : ∀ (P? : U.Decidable P) (v : ℕ) → Dec (∃ λ n → n < v × P n)
   allUpTo? : ∀ (P? : U.Decidable P) (v : ℕ) → Dec (∀ {n} → n < v → P n)
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,13 @@ Non-backwards compatible changes
   ```
 * `Opₗ` and `Opᵣ` have moved from `Algebra.Core` to `Algebra.Module.Core`.
 
+* In `Data.Nat.GeneralisedArithmetic`, the `s` and `z` arguments to the following
+  functions have been made explicit:
+  * `fold-+`
+  * `fold-k`
+  * `fold-*`
+  * `fold-pull`
+
 Major improvements
 ------------------
 
@@ -1188,6 +1195,8 @@ Other minor changes
   foldr′ : (A → B → B) → B → Vec A n → B
   foldl′ : (B → A → B) → B → Vec A n → B
 
+  iterate : (A → A) → A → Vec A n
+
   diagonal           : Vec (Vec A n) n → Vec A n
   DiagonalBind._>>=_ : Vec A n → (A → Vec B n) → Vec B n
   _ʳ++_              : Vec A m → Vec A n → Vec A (m + n)
@@ -1642,4 +1651,10 @@ This is a full list of proofs that have changed form to use irrelevant instance 
   length-map : length (map f xs) ≡ length xs
   map-cong : f ≗ g → map f ≗ map g
   map-compose : map (g ∘ f) ≗ map g ∘ map f
+  ```
+
+* Added new functions and proofs in `Data.Nat.GeneralisedArithmetic`:
+  ```agda
+  iterate : (A → A) → A → ℕ → A
+  iterate-is-fold : ∀ (z : A) s m → fold z s m ≡ iterate s z m
   ```

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -126,8 +126,8 @@ interleave⁺ {A = A} (xs ∷ xss) = go [] xs xss
     tail (go rev xs (ys ∷ yss)) = go (tail xs ∷ rev) ys yss
 
 cycle : List⁺ A → Stream A
-cycle {A = A} (x ∷ xs) = cycleAux List.[]
-  where
+cycle {A = A} (x ∷ xs) = cycleAux []
+  module Cycle where
     cycleAux : List A → Stream A
     head (cycleAux []) = x
     tail (cycleAux []) = cycleAux xs

--- a/src/Codata/Guarded/Stream.agda
+++ b/src/Codata/Guarded/Stream.agda
@@ -133,7 +133,6 @@ cycle {A = A} (x ∷ xs) = cycleAux List.[]
     tail (cycleAux []) = cycleAux xs
     head (cycleAux (x ∷ xs)) = x
     tail (cycleAux (x ∷ xs)) = cycleAux xs
-  
 
 cantor : Stream (Stream A) → Stream A
 cantor ls = zig (head ls ∷ []) (tail ls)

--- a/src/Codata/Guarded/Stream/Properties.agda
+++ b/src/Codata/Guarded/Stream/Properties.agda
@@ -1,0 +1,110 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of infinite streams defined as coinductive records
+------------------------------------------------------------------------
+
+{-# OPTIONS --safe --without-K --guardedness #-}
+
+module Codata.Guarded.Stream.Properties where
+
+open import Codata.Guarded.Stream
+open import Codata.Guarded.Stream.Relation.Binary.Pointwise
+  as B using (_≈_; head; tail)
+
+open import Data.Nat.Base using (zero; suc)
+open import Data.Product as Prod using (_,_; proj₁; proj₂)
+open import Data.Vec.Base as Vec using (Vec; _∷_)
+open import Function.Base using (const; flip; id; _∘′_; _$′_; _⟨_⟩_)
+open import Level using (Level)
+open import Relation.Binary.PropositionalEquality as P using (_≡_; cong)
+
+private
+  variable
+    a b c : Level
+    A : Set a
+    B : Set b
+    C : Set c
+
+------------------------------------------------------------------------
+-- Properties of repeat
+
+lookup-repeat : ∀ n (a : A) → lookup n (repeat a) ≡ a
+lookup-repeat zero    a = P.refl
+lookup-repeat (suc n) a = lookup-repeat n a
+
+splitAt-repeat : ∀ n (a : A) → splitAt n (repeat a) ≡ (Vec.replicate a , repeat a)
+splitAt-repeat zero    a = P.refl
+splitAt-repeat (suc n) a = cong (Prod.map₁ (a ∷_)) (splitAt-repeat n a)
+
+take-repeat : ∀ n (a : A) → take n (repeat a) ≡ Vec.replicate a
+take-repeat n a = cong proj₁ (splitAt-repeat n a)
+
+drop-repeat : ∀ n (a : A) → drop n (repeat a) ≡ repeat a
+drop-repeat n a = cong proj₂ (splitAt-repeat n a)
+
+map-repeat : ∀ (f : A → B) a → map f (repeat a) ≈ repeat (f a)
+map-repeat f a .head = P.refl
+map-repeat f a .tail = map-repeat f a
+
+ap-repeat : ∀ (f : A → B) a → ap (repeat f) (repeat a) ≈ repeat (f a)
+ap-repeat f a .head = P.refl
+ap-repeat f a .tail = ap-repeat f a
+
+ap-repeatˡ : ∀ (f : A → B) as → ap (repeat f) as ≈ map f as
+ap-repeatˡ f as .head = P.refl
+ap-repeatˡ f as .tail = ap-repeatˡ f (as .tail)
+
+ap-repeatʳ : ∀ (fs : Stream (A → B)) a → ap fs (repeat a) ≈ map (_$′ a) fs
+ap-repeatʳ fs a .head = P.refl
+ap-repeatʳ fs a .tail = ap-repeatʳ (fs .tail) a
+
+interleave-repeat : (a : A) → interleave (repeat a) (repeat a) ≈ repeat a
+interleave-repeat a .head = P.refl
+interleave-repeat a .tail = interleave-repeat a
+
+zipWith-repeat : ∀ (f : A → B → C) a b →
+                 zipWith f (repeat a) (repeat b) ≈ repeat (f a b)
+zipWith-repeat f a b .head = P.refl
+zipWith-repeat f a b .tail = zipWith-repeat f a b
+
+------------------------------------------------------------------------
+-- Properties of map
+
+map-const : (a : A) (bs : Stream B) → map (const a) bs ≈ repeat a
+map-const a bs .head = P.refl
+map-const a bs .tail = map-const a (bs .tail)
+
+map-identity : (as : Stream A) → map id as ≈ as
+map-identity as .head = P.refl
+map-identity as .tail = map-identity (as .tail)
+
+map-fusion : ∀ (g : B → C) (f : A → B) as → map g (map f as) ≈ map (g ∘′ f) as
+map-fusion g f as .head = P.refl
+map-fusion g f as .tail = map-fusion g f (as .tail)
+
+------------------------------------------------------------------------
+-- Properties of zipWith
+
+zipWith-defn : ∀ (f : A → B → C) as bs →
+               zipWith f as bs ≈ (repeat f ⟨ ap ⟩ as ⟨ ap ⟩ bs)
+zipWith-defn f as bs .head = P.refl
+zipWith-defn f as bs .tail = zipWith-defn f (as .tail) (bs .tail)
+
+zipWith-const : (as : Stream A) (bs : Stream B) →
+                zipWith const as bs ≈ as
+zipWith-const as bs .head = P.refl
+zipWith-const as bs .tail = zipWith-const (as .tail) (bs .tail)
+
+zipWith-flip : ∀ (f : A → B → C) as bs →
+               zipWith (flip f) as bs ≈ zipWith f bs as
+zipWith-flip f as bs .head = P.refl
+zipWith-flip f as bs .tail = zipWith-flip f (as .tail) (bs. tail)
+
+------------------------------------------------------------------------
+-- Properties of interleave
+
+interleave-evens-odds : (as : Stream A) → interleave (evens as) (odds as) ≈ as
+interleave-evens-odds as .head       = P.refl
+interleave-evens-odds as .tail .head = P.refl
+interleave-evens-odds as .tail .tail = interleave-evens-odds (as .tail .tail)

--- a/src/Codata/Guarded/Stream/Properties.agda
+++ b/src/Codata/Guarded/Stream/Properties.agda
@@ -103,17 +103,17 @@ zipWith-repeat : ∀ (f : A → B → C) a b →
 zipWith-repeat f a b .head = P.refl
 zipWith-repeat f a b .tail = zipWith-repeat f a b
 
-{-
-
--- Oops the productivity checker doesn't like this .tail case!
 chunksOf-repeat : ∀ n (a : A) → chunksOf n (repeat a) ≈ repeat (Vec.replicate a)
-chunksOf-repeat n a .head = take-repeat n a
-chunksOf-repeat n a .tail = begin
-  chunksOf n (drop n (repeat a)) ≡⟨ cong (chunksOf n) (drop-repeat n a) ⟩
-  chunksOf n (repeat a)          ≈⟨ chunksOf-repeat n a ⟩
-  repeat (Vec.replicate a)       ∎ where open ≈-Reasoning
+chunksOf-repeat n a = begin go where
 
--}
+  open ≈-Reasoning
+
+  go : chunksOf n (repeat a) ≈∞ repeat (Vec.replicate a)
+  go .head = take-repeat n a
+  go .tail =
+    chunksOf n (drop n (repeat a)) ≡⟨ P.cong (chunksOf n) (drop-repeat n a) ⟩
+    chunksOf n (repeat a)          ↺⟨ go ⟩
+    repeat (Vec.replicate a)       ∎
 
 ------------------------------------------------------------------------
 -- Properties of map

--- a/src/Codata/Guarded/Stream/Properties.agda
+++ b/src/Codata/Guarded/Stream/Properties.agda
@@ -12,7 +12,7 @@ open import Codata.Guarded.Stream
 open import Codata.Guarded.Stream.Relation.Binary.Pointwise
   as B using (_≈_; head; tail; module ≈-Reasoning)
 
-open import Data.Nat.Base using (zero; suc; _+_)
+open import Data.Nat.Base using (zero; suc; _+_; _*_)
 import Data.Nat.GeneralisedArithmetic as ℕ
 open import Data.Product as Prod using (_,_; proj₁; proj₂)
 open import Data.Vec.Base as Vec using (Vec; _∷_)
@@ -30,6 +30,10 @@ private
 
 ------------------------------------------------------------------------
 -- Congruence
+
+cong-lookup : ∀ n {as bs : Stream A} → as ≈ bs → lookup n as ≡ lookup n bs
+cong-lookup zero    as≈bs = as≈bs .head
+cong-lookup (suc n) as≈bs = cong-lookup n (as≈bs .tail)
 
 cong-take : ∀ n {as bs : Stream A} → as ≈ bs → take n as ≡ take n bs
 cong-take zero    as≈bs = P.refl
@@ -139,6 +143,29 @@ map-interleave : ∀ (f : A → B) as bs →
                  map f (interleave as bs) ≈ interleave (map f as) (map f bs)
 map-interleave f as bs .head = P.refl
 map-interleave f as bs .tail = map-interleave f bs (as .tail)
+
+------------------------------------------------------------------------
+-- Properties of lookup
+
+lookup-drop : ∀ m n (as : Stream A) → lookup n (drop m as) ≡ lookup (m + n) as
+lookup-drop zero    n as = P.refl
+lookup-drop (suc m) n as = lookup-drop m n (as .tail)
+
+lookup-map : ∀ n (f : A → B) as → lookup n (map f as) ≡ f (lookup n as)
+lookup-map zero    f as = P.refl
+lookup-map (suc n) f as = lookup-map n f (as . tail)
+
+lookup-iterate : ∀ n f (x : A) → lookup n (iterate f x) ≡ ℕ.iterate f x n
+lookup-iterate zero    f x = P.refl
+lookup-iterate (suc n) f x = lookup-iterate n f (f x)
+
+lookup-evens : ∀ n (as : Stream A) → lookup n (evens as) ≡ lookup (n * 2) as
+lookup-evens zero    as = P.refl
+lookup-evens (suc n) as = lookup-evens n (as .tail .tail)
+
+lookup-odds : ∀ n (as : Stream A) → lookup n (odds as) ≡ lookup (suc (n * 2)) as
+lookup-odds zero    as = P.refl
+lookup-odds (suc n) as = lookup-odds n (as .tail .tail)
 
 ------------------------------------------------------------------------
 -- Properties of take

--- a/src/Codata/Guarded/Stream/Properties.agda
+++ b/src/Codata/Guarded/Stream/Properties.agda
@@ -32,17 +32,17 @@ private
 -- Congruence
 
 cong-lookup : ∀ n {as bs : Stream A} → as ≈ bs → lookup n as ≡ lookup n bs
-cong-lookup zero    as≈bs = as≈bs .head
-cong-lookup (suc n) as≈bs = cong-lookup n (as≈bs .tail)
+cong-lookup = B.lookup
 
 cong-take : ∀ n {as bs : Stream A} → as ≈ bs → take n as ≡ take n bs
 cong-take zero    as≈bs = P.refl
 cong-take (suc n) as≈bs = cong₂ _∷_ (as≈bs .head) (cong-take n (as≈bs .tail))
 
 cong-drop : ∀ n {as bs : Stream A} → as ≈ bs → drop n as ≈ drop n bs
-cong-drop zero    as≈bs = as≈bs
-cong-drop (suc n) as≈bs = cong-drop n (as≈bs .tail)
+cong-drop = B.drop⁺
 
+-- This is not map⁺ because the propositional equality relation is
+-- not the same on the input and output
 cong-map : ∀ (f : A → B) {as bs} → as ≈ bs → map f as ≈ map f bs
 cong-map f as≈bs .head = cong f (as≈bs .head)
 cong-map f as≈bs .tail = cong-map f (as≈bs .tail)

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -9,9 +9,9 @@
 module Codata.Guarded.Stream.Relation.Binary.Pointwise where
 
 open import Codata.Guarded.Stream as Stream using (Stream; head; tail)
-open import Data.Nat.Base using (ℕ)
-open import Function.Base using (_∘_)
-open import Level
+open import Data.Nat.Base using (ℕ; zero; suc)
+open import Function.Base using (_∘_; _on_)
+open import Level using (Level)
 open import Relation.Binary
 open import Relation.Binary.PropositionalEquality as Eq using (_≡_)
 
@@ -33,6 +33,10 @@ record Pointwise (_∼_ : REL A B ℓ) (as : Stream A) (bs : Stream B) : Set ℓ
     tail : Pointwise _∼_ (tail as) (tail bs)
 
 open Pointwise public
+
+lookup : ∀ n → Pointwise R ⇒ (R on (Stream.lookup n))
+lookup zero    rs = rs .head
+lookup (suc n) rs = lookup n (rs .tail)
 
 map : R ⇒ S → Pointwise R ⇒ Pointwise S
 head (map R⇒S xs) = R⇒S (head xs)
@@ -69,12 +73,12 @@ tail (antisymmetric RST-antisym xsRys ysSxs) = antisymmetric RST-antisym (tail x
 tabulate⁺ : ∀ {f : ℕ → A} {g : ℕ → B} →
             (∀ i → R (f i) (g i)) → Pointwise R (Stream.tabulate f) (Stream.tabulate g)
 head (tabulate⁺ f∼g) = f∼g 0
-tail (tabulate⁺ f∼g) = tabulate⁺ (f∼g ∘ ℕ.suc)
+tail (tabulate⁺ f∼g) = tabulate⁺ (f∼g ∘ suc)
 
 tabulate⁻ : ∀ {f : ℕ → A} {g : ℕ → B} →
             Pointwise R (Stream.tabulate f) (Stream.tabulate g) → (∀ i → R (f i) (g i))
-tabulate⁻ xsRys ℕ.zero = head xsRys
-tabulate⁻ xsRys (ℕ.suc i) = tabulate⁻ (tail xsRys) i
+tabulate⁻ xsRys zero    = head xsRys
+tabulate⁻ xsRys (suc i) = tabulate⁻ (tail xsRys) i
 
 map⁺ : ∀ (f : A → C) (g : B → D) →
        Pointwise (λ a b → R (f a) (g b)) xs ys →
@@ -87,6 +91,10 @@ map⁻ : ∀ (f : A → C) (g : B → D) →
        Pointwise (λ a b → R (f a) (g b)) xs ys
 head (map⁻ f g faRgb) = head faRgb
 tail (map⁻ f g faRgb) = map⁻ f g (tail faRgb)
+
+drop⁺ : ∀ n → Pointwise R ⇒ (Pointwise R on Stream.drop n)
+drop⁺ zero    as≈bs = as≈bs
+drop⁺ (suc n) as≈bs = drop⁺ n (as≈bs .tail)
 
 ------------------------------------------------------------------------
 -- Pointwise Equality as a Bisimilarity

--- a/src/Codata/Sized/Stream/Properties.agda
+++ b/src/Codata/Sized/Stream/Properties.agda
@@ -114,7 +114,7 @@ lookup-iterate-identity zero     f a = P.refl
 lookup-iterate-identity (suc n)  f a = begin
   lookup (suc n) (iterate f a) ≡⟨⟩
   lookup n (iterate f (f a))   ≡⟨ lookup-iterate-identity n f (f a) ⟩
-  fold (f a) f n               ≡⟨ fold-pull (const ∘′ f) (f a) P.refl (λ _ → P.refl) n ⟩
+  fold (f a) f n               ≡⟨ fold-pull a f (const ∘′ f) (f a) P.refl (λ _ → P.refl) n ⟩
   f (fold a f n)               ≡⟨⟩
   fold a f (suc n)             ∎ where open P.≡-Reasoning
 

--- a/src/Data/Nat/GeneralisedArithmetic.agda
+++ b/src/Data/Nat/GeneralisedArithmetic.agda
@@ -11,53 +11,67 @@ module Data.Nat.GeneralisedArithmetic where
 open import Data.Nat.Base
 open import Data.Nat.Properties
 open import Function.Base using (_∘′_; _∘_; id)
+open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
 open ≡-Reasoning
 
-module _ {a} {A : Set a} where
+private
+  variable
+    a : Level
+    A : Set a
 
-  fold : A → (A → A) → ℕ → A
-  fold z s zero    = z
-  fold z s (suc n) = s (fold z s n)
+fold : A → (A → A) → ℕ → A
+fold z s zero    = z
+fold z s (suc n) = s (fold z s n)
 
-  add : (0# : A) (1+ : A → A) → ℕ → A → A
-  add 0# 1+ n z = fold z 1+ n
+iterate : (A → A) → A → ℕ → A
+iterate f x zero    = x
+iterate f x (suc n) = iterate f (f x) n
 
-  mul : (0# : A) (1+ : A → A) → (+ : A → A → A) → (ℕ → A → A)
-  mul 0# 1+ _+_ n x = fold 0# (λ s → x + s) n
+add : (0# : A) (1+ : A → A) → ℕ → A → A
+add 0# 1+ n z = fold z 1+ n
+
+mul : (0# : A) (1+ : A → A) → (+ : A → A → A) → (ℕ → A → A)
+mul 0# 1+ _+_ n x = fold 0# (λ s → x + s) n
 
 -- Properties
 
-module _ {a} {A : Set a} where
+fold-+ : ∀ (z : A) (s : A → A) m {n} →
+         fold z s (m + n) ≡ fold (fold z s n) s m
+fold-+ z s zero    = refl
+fold-+ z s (suc m) = cong s (fold-+ z s m)
 
-  fold-+ : ∀ {s : A → A} {z : A} →
-           ∀ m {n} → fold z s (m + n) ≡ fold (fold z s n) s m
-  fold-+ zero    = refl
-  fold-+ {s = s} (suc m) = cong s (fold-+ m)
+fold-k : ∀ (z : A) (s : A → A) {k} m →
+         fold k (s ∘′_) m z ≡ fold (k z) s m
+fold-k z s zero    = refl
+fold-k z s (suc m) = cong s (fold-k z s m)
 
-  fold-k : ∀ {s : A → A} {z : A} {k} m →
-           fold k (s ∘′_) m z ≡ fold (k z) s m
-  fold-k zero    = refl
-  fold-k {s = s} (suc m) = cong s (fold-k m)
+fold-* : ∀ (z : A) (s : A → A) m {n} →
+         fold z s (m * n) ≡ fold z (fold id (s ∘_) n) m
+fold-* z s zero        = refl
+fold-* z s (suc m) {n} = let +n = fold id (s ∘′_) n in begin
+  fold z s (n + m * n)        ≡⟨ fold-+ z s n ⟩
+  fold (fold z s (m * n)) s n ≡⟨ cong (λ z → fold z s n) (fold-* z s m) ⟩
+  fold (fold z +n m) s n      ≡⟨ sym (fold-k _ s n) ⟩
+  fold z +n (suc m)           ∎
 
-  fold-* : ∀ {s : A → A} {z : A} m {n} →
-           fold z s (m * n) ≡ fold z (fold id (s ∘_) n) m
-  fold-*  zero        = refl
-  fold-* {s = s} {z} (suc m) {n} = let +n = fold id (s ∘′_) n in begin
-    fold z s (n + m * n)        ≡⟨ fold-+ n ⟩
-    fold (fold z s (m * n)) s n ≡⟨ cong (λ z → fold z s n) (fold-* m) ⟩
-    fold (fold z +n m) s n      ≡⟨ sym (fold-k n) ⟩
-    fold z +n (suc m)           ∎
+fold-pull : ∀ (z : A) (s : A → A) (g : A → A → A) (p : A)
+            (eqz : g z p ≡ p)
+            (eqs : ∀ l → s (g l p) ≡ g (s l) p) →
+            ∀ m → fold p s m ≡ g (fold z s m) p
+fold-pull z s _ _ eqz _ zero    = sym eqz
+fold-pull z s g p eqz eqs (suc m) = begin
+  s (fold p s m)       ≡⟨ cong s (fold-pull z s g p eqz eqs m) ⟩
+  s (g (fold z s m) p) ≡⟨ eqs (fold z s m) ⟩
+  g (s (fold z s m)) p ∎
 
-  fold-pull : ∀ {s : A → A} {z : A} (g : A → A → A) (p : A)
-              (eqz : g z p ≡ p)
-              (eqs : ∀ l → s (g l p) ≡ g (s l) p) →
-              ∀ m → fold p s m ≡ g (fold z s m) p
-  fold-pull _ _ eqz _ zero    = sym eqz
-  fold-pull {s = s} {z} g p eqz eqs (suc m) = begin
-    s (fold p s m)       ≡⟨ cong s (fold-pull g p eqz eqs m) ⟩
-    s (g (fold z s m) p) ≡⟨ eqs (fold z s m) ⟩
-    g (s (fold z s m)) p ∎
+iterate-is-fold : ∀ (z : A) s m → fold z s m ≡ iterate s z m
+iterate-is-fold z s zero    = refl
+iterate-is-fold z s (suc m) = begin
+  fold z s (suc m)  ≡⟨ cong (fold z s) (+-comm 1 m) ⟩
+  fold z s (m + 1)  ≡⟨ fold-+ z s m ⟩
+  fold (s z) s m    ≡⟨ iterate-is-fold (s z) s m ⟩
+  iterate s (s z) m ∎
 
 id-is-fold : ∀ m → fold zero suc m ≡ m
 id-is-fold zero    = refl
@@ -77,14 +91,14 @@ id-is-fold (suc m) = cong suc (id-is-fold m)
 
 *+-is-fold : ∀ m n {p} → fold p (n +_) m ≡ m * n + p
 *+-is-fold m n {p} = begin
-  fold p (n +_) m     ≡⟨ fold-pull _+_ p refl
+  fold p (n +_) m     ≡⟨ fold-pull _ _ _+_ p refl
                          (λ l → sym (+-assoc n l p)) m ⟩
   fold 0 (n +_) m + p ≡⟨ cong (_+ p) (*-is-fold m) ⟩
   m * n + p           ∎
 
 ^*-is-fold : ∀ m n {p} → fold p (m *_) n ≡ m ^ n * p
 ^*-is-fold m n {p} = begin
-  fold p (m *_) n     ≡⟨ fold-pull _*_ p (*-identityˡ p)
+  fold p (m *_) n     ≡⟨ fold-pull _ _ _*_ p (*-identityˡ p)
                          (λ l → sym (*-assoc m l p)) n ⟩
   fold 1 (m *_) n * p ≡⟨ cong (_* p) (^-is-fold n) ⟩
   m ^ n * p           ∎

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -60,6 +60,10 @@ lookup : Vec A n → Fin n → A
 lookup (x ∷ xs) zero    = x
 lookup (x ∷ xs) (suc i) = lookup xs i
 
+iterate : (A → A) → A → ∀ {n} → Vec A n
+iterate s z {zero}  = []
+iterate s z {suc n} = z ∷ iterate s (s z)
+
 insert : Vec A n → Fin (suc n) → A → Vec A (suc n)
 insert xs       zero     v = v ∷ xs
 insert (x ∷ xs) (suc i)  v = x ∷ insert xs i v


### PR DESCRIPTION
Following #1693, a bunch of properties.

I renamed some of the functions in `Codata.Guarded.Stream.Relation.Binary.Pointwise`
to match the definitions in `Codata.Sized.Stream.Bisimilarity`. This highlights an issue:
`Relation.Binary.Pointwise` vs. `Bisimilarity`. We should probably settle on one naming
scheme and use it throughout.