### PR TITLE
Add an Inverse for `swap` in module `Data.Sum.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1171,6 +1171,10 @@ Other minor changes
   ≤-isDecTotalOrder-≈ : IsDecTotalOrder _≈_ _≤_
   ≤-decTotalOrder-≈   :  DecTotalOrder _ _ _
   ```
+* Added new definitions in `Data.Sum.Properties`:
+  ```
+  swap-↔ : (A ⊎ B) ↔ (B ⊎ A)
+  ```
 
 * Added new proofs in `Data.Sum.Properties`:
   ```

--- a/src/Data/Sum/Properties.agda
+++ b/src/Data/Sum/Properties.agda
@@ -11,10 +11,12 @@ module Data.Sum.Properties where
 open import Level
 open import Data.Sum.Base
 open import Function
+open import Function.Bundles using (mk↔′)
 open import Relation.Binary using (Decidable)
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Decidable using (map′)
+
 
 private
   variable
@@ -113,3 +115,6 @@ map₂-cong : {g g′ : C → D} →
             g ≗ g′ →
             map₂ {A = A} g ≗ map₂ g′
 map₂-cong g≗g′ = [,-]-cong ((cong inj₂) ∘ g≗g′)
+
+swap↔ : (A ⊎ B) ↔ (B ⊎ A)
+swap↔ = mk↔′ swap swap swap-involutive swap-involutive

--- a/src/Data/Sum/Properties.agda
+++ b/src/Data/Sum/Properties.agda
@@ -46,6 +46,9 @@ module _ (dec₁ : Decidable {A = A} {B = A} _≡_)
 swap-involutive : swap {A = A} {B = B} ∘ swap ≗ id
 swap-involutive = [ (λ _ → refl) , (λ _ → refl) ]
 
+swap-↔ : (A ⊎ B) ↔ (B ⊎ A)
+swap-↔ = mk↔′ swap swap swap-involutive swap-involutive
+
 map-id : map {A = A} {B = B} id id ≗ id
 map-id (inj₁ _) = refl
 map-id (inj₂ _) = refl
@@ -115,6 +118,3 @@ map₂-cong : {g g′ : C → D} →
             g ≗ g′ →
             map₂ {A = A} g ≗ map₂ g′
 map₂-cong g≗g′ = [,-]-cong ((cong inj₂) ∘ g≗g′)
-
-swap↔ : (A ⊎ B) ↔ (B ⊎ A)
-swap↔ = mk↔′ swap swap swap-involutive swap-involutive


### PR DESCRIPTION
Recently I found myself wanting to write this function

```agda
  splitPermute↔ : (m : ℕ) {n : ℕ} → 𝔽 (m + n) ↔ 𝔽 (n + m)
  splitPermute↔ m {n} = +↔⊎ {m} {n} ∘-↔ (swap↔ ∘-↔ flip +↔⊎)
```

where `flip` is defined as

```agda
  flip : ∀ {a b} {A : Set a} {B : Set b} → A ↔ B → B ↔ A
  flip A↔B =
    record { f = f⁻¹ A↔B
           ; f⁻¹ = f A↔B
           ; cong₁ = cong₂ A↔B
           ; cong₂ = cong₁ A↔B
           ; inverse = ×-swap (inverse A↔B) }
    where
      open import Data.Product using () renaming (swap to ×-swap)
```

`swap↔` wasn't available so I've added it in module `Data.Sum.Properties`. It's similar to `+↔⊎` in `Data.Fin.Properties`. 

I would also be very interested in suggestions about whether you think there is a need for the `flip` function somewhere in the Standard Library. Or perhaps there is already a function which does the same thing? 