### PR TITLE
Use variables in `Data.Fin` and `Data.Fin.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1007,7 +1007,8 @@ Other minor changes
   combine-injectiveʳ : combine i j ≡ combine k l → j ≡ l
   combine-injective  : combine i j ≡ combine k l → i ≡ k × j ≡ l
   combine-surjective : ∀ i → ∃₂ λ j k → combine j k ≡ i
-
+  combine-monoˡ-<    :  i < j → combine i k < combine j l
+  
   lower₁-injective   : lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
 
   i<1+i              : i < suc i

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,8 @@ Non-backwards compatible changes
   * `fold-*`
   * `fold-pull`
 
+* In `Data.Fin.Properties` the `i` argument to `opposite-suc` has been made explicit.
+
 Major improvements
 ------------------
 
@@ -972,10 +974,10 @@ Other minor changes
 
 * Added new functions in `Data.Fin.Base`:
   ```
-  finToFun  : Fin (n ^ m) → (Fin m → Fin n)
+  finToFun  : Fin (m ^ n) → (Fin n → Fin m)
   funToFin  : (Fin m → Fin n) → Fin (n ^ m)
-  quotient  : Fin (n * k) → Fin n
-  remainder : Fin (n * k) → Fin k
+  quotient  : Fin (m * n) → Fin m
+  remainder : Fin (m * n) → Fin n
   ```
 
 * Added new definitions and proofs in `Data.Fin.Permutation`:
@@ -993,18 +995,18 @@ Other minor changes
   ↑ʳ-injective       : n ↑ʳ i ≡ n ↑ʳ j → i ≡ j
   finTofun-funToFin  : funToFin ∘ finToFun ≗ id
   funTofin-funToFun  : finToFun (funToFin f) ≗ f
-  ^↔→                : Extensionality _ _ → Fin (n ^ m) ↔ (Fin m → Fin n)
+  ^↔→                : Extensionality _ _ → Fin (m ^ n) ↔ (Fin n → Fin m)
 
   toℕ-mono-<         : i < j → toℕ i ℕ.< toℕ j
   toℕ-mono-≤         : i ≤ j → toℕ i ℕ.≤ toℕ j
   toℕ-cancel-≤       : toℕ i ℕ.≤ toℕ j → i ≤ j
   toℕ-cancel-<       : toℕ i ℕ.< toℕ j → i < j
 
-  toℕ-combine        : toℕ (combine x y) ≡ k ℕ.* toℕ x ℕ.+ toℕ y
-  combine-injectiveˡ : combine x z ≡ combine y z → x ≡ y
-  combine-injectiveʳ : combine x y ≡ combine x z → y ≡ z
-  combine-injective  : combine x y ≡ combine w z → x ≡ w × y ≡ z
-  combine-surjective : ∀ x → ∃₂ λ y z → combine y z ≡ x
+  toℕ-combine        : toℕ (combine i j) ≡ k ℕ.* toℕ i ℕ.+ toℕ j
+  combine-injectiveˡ : combine i j ≡ combine k l → i ≡ k
+  combine-injectiveʳ : combine i j ≡ combine k l → j ≡ l
+  combine-injective  : combine i j ≡ combine k l → i ≡ k × j ≡ l
+  combine-surjective : ∀ i → ∃₂ λ j k → combine j k ≡ i
 
   lower₁-injective   : lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
 

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -7,7 +7,6 @@
 -- Note that elements of Fin n can be seen as natural numbers in the
 -- set {m | m < n}. The notation "m" in comments below refers to this
 -- natural number view.
-
 {-# OPTIONS --without-K --safe #-}
 
 module Data.Fin.Base where
@@ -24,30 +23,34 @@ open import Relation.Binary.Core
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
 open import Relation.Binary.Indexed.Heterogeneous using (IRel)
 
+private
+  variable
+    m n : ℕ
+
 ------------------------------------------------------------------------
 -- Types
 
 -- Fin n is a type with n elements.
 
 data Fin : ℕ → Set where
-  zero : {n : ℕ} → Fin (suc n)
-  suc  : {n : ℕ} (i : Fin n) → Fin (suc n)
+  zero : Fin (suc n)
+  suc  : (i : Fin n) → Fin (suc n)
 
 -- A conversion: toℕ "i" = i.
 
-toℕ : ∀ {n} → Fin n → ℕ
+toℕ : Fin n → ℕ
 toℕ zero    = 0
 toℕ (suc i) = suc (toℕ i)
 
 -- A Fin-indexed variant of Fin.
 
-Fin′ : ∀ {n} → Fin n → Set
+Fin′ : Fin n → Set
 Fin′ i = Fin (toℕ i)
 
 ------------------------------------------------------------------------
 -- A cast that actually computes on constructors (as opposed to subst)
 
-cast : ∀ {m n} → .(_ : m ≡ n) → Fin m → Fin n
+cast : .(m ≡ n) → Fin m → Fin n
 cast {zero}  {zero}  eq k       = k
 cast {suc m} {suc n} eq zero    = zero
 cast {suc m} {suc n} eq (suc k) = suc (cast (cong ℕ.pred eq) k)
@@ -65,7 +68,7 @@ fromℕ (suc n) = suc (fromℕ n)
 
 -- fromℕ< {m} _ = "m".
 
-fromℕ< : ∀ {m n} → m ℕ.< n → Fin n
+fromℕ< : m ℕ.< n → Fin n
 fromℕ< {zero}  {suc n} z<s = zero
 fromℕ< {suc m} {suc n} (s<s m<n) = suc (fromℕ< m<n)
 
@@ -92,37 +95,37 @@ zero    ↑ʳ i = i
 
 -- reduce≥ "m + i" _ = "i".
 
-reduce≥ : ∀ {m n} (i : Fin (m ℕ.+ n)) (i≥m : toℕ i ℕ.≥ m) → Fin n
+reduce≥ : ∀ (i : Fin (m ℕ.+ n)) (i≥m : toℕ i ℕ.≥ m) → Fin n
 reduce≥ {zero}  i       i≥m       = i
 reduce≥ {suc m} (suc i) (s≤s i≥m) = reduce≥ i i≥m
 
 -- inject⋆ m "i" = "i".
 
-inject : ∀ {n} {i : Fin n} → Fin′ i → Fin n
+inject : ∀ {i : Fin n} → Fin′ i → Fin n
 inject {i = suc i} zero    = zero
 inject {i = suc i} (suc j) = suc (inject j)
 
-inject! : ∀ {n} {i : Fin (suc n)} → Fin′ i → Fin n
+inject! : ∀ {i : Fin (suc n)} → Fin′ i → Fin n
 inject! {n = suc _} {i = suc _}  zero    = zero
 inject! {n = suc _} {i = suc _}  (suc j) = suc (inject! j)
 
-inject₁ : ∀ {m} → Fin m → Fin (suc m)
+inject₁ : Fin n → Fin (suc n)
 inject₁ zero    = zero
 inject₁ (suc i) = suc (inject₁ i)
 
-inject≤ : ∀ {m n} → Fin m → m ℕ.≤ n → Fin n
+inject≤ : Fin m → m ℕ.≤ n → Fin n
 inject≤ {_} {suc n} zero    _        = zero
 inject≤ {_} {suc n} (suc i) (s≤s m≤n) = suc (inject≤ i m≤n)
 
 -- lower₁ "i" _ = "i".
 
-lower₁ : ∀ {n} → (i : Fin (suc n)) → (n ≢ toℕ i) → Fin n
-lower₁ {zero} zero ne = ⊥-elim (ne refl)
-lower₁ {suc n} zero _ = zero
+lower₁ : ∀ (i : Fin (suc n)) → n ≢ toℕ i → Fin n
+lower₁ {zero}  zero    ne = ⊥-elim (ne refl)
+lower₁ {suc n} zero    _  = zero
 lower₁ {suc n} (suc i) ne = suc (lower₁ i λ x → ne (cong suc x))
 
 -- A strengthening injection into the minimal Fin fibre.
-strengthen : ∀ {n} (i : Fin n) → Fin′ (suc i)
+strengthen : ∀ (i : Fin n) → Fin′ (suc i)
 strengthen zero    = zero
 strengthen (suc i) = suc (strengthen i)
 
@@ -142,33 +145,33 @@ join m n = [ _↑ˡ n , m ↑ʳ_ ]′
 -- quotRem k "i" = "i % k" , "i / k"
 -- This is dual to group from Data.Vec.
 
-quotRem : ∀ {n} k → Fin (n ℕ.* k) → Fin k × Fin n
-quotRem {suc n} k i with splitAt k i
+quotRem : ∀ n → Fin (m ℕ.* n) → Fin n × Fin m
+quotRem {suc m} n i with splitAt n i
 ... | inj₁ j = j , zero
-... | inj₂ j = Product.map₂ suc (quotRem {n} k j)
+... | inj₂ j = Product.map₂ suc (quotRem {m} n j)
 
 -- a variant of quotRem the type of whose result matches the order of multiplication
-remQuot : ∀ {n} k → Fin (n ℕ.* k) → Fin n × Fin k
-remQuot k = Product.swap ∘ quotRem k
+remQuot : ∀ n → Fin (m ℕ.* n) → Fin m × Fin n
+remQuot i = Product.swap ∘ quotRem i
 
-quotient : ∀ {n} k → Fin (n ℕ.* k) → Fin n
-quotient {n} k = proj₁ ∘ remQuot {n} k
+quotient : ∀ n → Fin (m ℕ.* n) → Fin m
+quotient n = proj₁ ∘ remQuot n
 
-remainder : ∀ {n} k → Fin (n ℕ.* k) → Fin k
-remainder {n} k = proj₂ ∘ remQuot {n} k
+remainder : ∀ n → Fin (m ℕ.* n) → Fin n
+remainder {m} n = proj₂ ∘ remQuot {m} n
 
 -- inverse of remQuot
-combine : ∀ {n k} → Fin n → Fin k → Fin (n ℕ.* k)
-combine {suc n} {k} zero    y = y ↑ˡ (n ℕ.* k)
-combine {suc n} {k} (suc x) y = k ↑ʳ (combine x y)
+combine : Fin m → Fin n → Fin (m ℕ.* n)
+combine {suc m} {n} zero    j = j ↑ˡ (m ℕ.* n)
+combine {suc m} {n} (suc i) j = n ↑ʳ (combine i j)
 
 -- Next in progression after splitAt and remQuot
-finToFun : ∀ {m n} → Fin (n ^ m) → (Fin m → Fin n)
-finToFun {suc m} {n} k zero    = quotient (n ^ m) k
-finToFun {suc m} {n} k (suc i) = finToFun (remainder {n} (n ^ m) k) i
+finToFun : Fin (m ^ n) → (Fin n → Fin m)
+finToFun {m} {suc n} i zero    = quotient (m ^ n) i
+finToFun {m} {suc n} i (suc j) = finToFun (remainder {m} (m ^ n) i) j
 
 -- inverse of above function
-funToFin : ∀ {m n} → (Fin m → Fin n) → Fin (n ^ m)
+funToFin : (Fin m → Fin n) → Fin (n ^ m)
 funToFin {zero}  f = zero
 funToFin {suc m} f = combine (f zero) (funToFin (f ∘ suc))
 
@@ -194,7 +197,7 @@ fold′ {n = suc n} T f x (suc i)  =
 
 -- Lifts functions.
 
-lift : ∀ {m n} k → (Fin m → Fin n) → Fin (k ℕ.+ m) → Fin (k ℕ.+ n)
+lift : ∀ k → (Fin m → Fin n) → Fin (k ℕ.+ m) → Fin (k ℕ.+ n)
 lift zero    f i       = f i
 lift (suc k) f zero    = zero
 lift (suc k) f (suc i) = suc (lift k f i)
@@ -203,7 +206,7 @@ lift (suc k) f (suc i) = suc (lift k f i)
 
 infixl 6 _+_
 
-_+_ : ∀ {m n} (i : Fin m) (j : Fin n) → Fin (toℕ i ℕ.+ n)
+_+_ : ∀ (i : Fin m) (j : Fin n) → Fin (toℕ i ℕ.+ n)
 zero  + j = j
 suc i + j = suc (i + j)
 
@@ -211,7 +214,7 @@ suc i + j = suc (i + j)
 
 infixl 6 _-_
 
-_-_ : ∀ {m} (i : Fin m) (j : Fin′ (suc i)) → Fin (m ℕ.∸ toℕ j)
+_-_ : ∀ (i : Fin n) (j : Fin′ (suc i)) → Fin (n ℕ.∸ toℕ j)
 i     - zero   = i
 suc i - suc j  = i - j
 
@@ -233,13 +236,13 @@ suc n ℕ-ℕ suc i  = n ℕ-ℕ i
 
 -- pred "i" = "pred i".
 
-pred : ∀ {n} → Fin n → Fin n
+pred : Fin n → Fin n
 pred zero    = zero
 pred (suc i) = inject₁ i
 
 -- opposite "i" = "n - i" (i.e. the additive inverse).
 
-opposite : ∀ {n} → Fin n → Fin n
+opposite : Fin n → Fin n
 opposite {suc n} zero    = fromℕ n
 opposite {suc n} (suc i) = inject₁ (opposite i)
 
@@ -247,22 +250,22 @@ opposite {suc n} (suc i) = inject₁ (opposite i)
 -- This is a variant of the thick function from Conor
 -- McBride's "First-order unification by structural recursion".
 
-punchOut : ∀ {m} {i j : Fin (suc m)} → i ≢ j → Fin m
+punchOut : ∀ {i j : Fin (suc n)} → i ≢ j → Fin n
 punchOut {_}     {zero}   {zero}  i≢j = ⊥-elim (i≢j refl)
 punchOut {_}     {zero}   {suc j} _   = j
-punchOut {suc m} {suc i}  {zero}  _   = zero
-punchOut {suc m} {suc i}  {suc j} i≢j = suc (punchOut (i≢j ∘ cong suc))
+punchOut {suc _} {suc i}  {zero}  _   = zero
+punchOut {suc _} {suc i}  {suc j} i≢j = suc (punchOut (i≢j ∘ cong suc))
 
 -- The function f(i,j) = if j≥i then j+1 else j
 
-punchIn : ∀ {m} → Fin (suc m) → Fin m → Fin (suc m)
+punchIn : Fin (suc n) → Fin n → Fin (suc n)
 punchIn zero    j       = suc j
 punchIn (suc i) zero    = zero
 punchIn (suc i) (suc j) = suc (punchIn i j)
 
 -- The function f(i,j) such that f(i,j) = if j≤i then j else j-1
 
-pinch : ∀ {n} → Fin n → Fin (suc n) → Fin n
+pinch : Fin n → Fin (suc n) → Fin n
 pinch {suc n} _       zero    = zero
 pinch {suc n} zero    (suc j) = j
 pinch {suc n} (suc i) (suc j) = suc (pinch i j)
@@ -298,7 +301,7 @@ data Ordering {n : ℕ} : Fin n → Fin n → Set where
   greater : ∀ greatest (least : Fin′ greatest) →
             Ordering greatest (inject least)
 
-compare : ∀ {n} (i j : Fin n) → Ordering i j
+compare : ∀ (i j : Fin n) → Ordering i j
 compare zero    zero    = equal   zero
 compare zero    (suc j) = less    (suc j) zero
 compare (suc i) zero    = greater (suc i) zero

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -77,7 +77,8 @@ reverse-involutive = opposite-involutive
 Please use opposite-involutive from Data.Fin.Properties instead."
 #-}
 
-reverse-suc = opposite-suc
+reverse-suc : ∀ {n} {i : Fin n} → toℕ (opposite (suc i)) ≡ toℕ (opposite i)
+reverse-suc {i = i} = opposite-suc i
 {-# WARNING_ON_USAGE reverse
 "Warning: reverse-suc was deprecated in v2.0.
 Please use opposite-suc from Data.Fin.Properties instead."

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -27,7 +27,9 @@ open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Sum.Properties using ([,]-map-commute; [,]-∘-distr)
 open import Function.Base using (_∘_; id; _$_; flip)
 open import Function.Bundles using (_↣_; _⇔_; _↔_; mk⇔; mk↔′)
+open import Function.Definitions using (Injective)
 open import Function.Definitions.Core2 using (Surjective)
+open import Level using (Level)
 open import Relation.Binary as B hiding (Decidable; _⇔_)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; refl; sym; trans; cong; cong₂; subst; _≗_; module ≡-Reasoning)
@@ -41,6 +43,13 @@ open import Relation.Nullary.Sum using (_⊎-dec_)
 open import Relation.Unary as U
   using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
 open import Relation.Unary.Properties using (U?)
+
+private
+  variable
+    a : Level
+    A : Set a
+    m n o : ℕ
+    i j : Fin n
 
 ------------------------------------------------------------------------
 -- Fin
@@ -62,12 +71,12 @@ open import Relation.Unary.Properties using (U?)
 -- Properties of _≡_
 ------------------------------------------------------------------------
 
-suc-injective : ∀ {o} {m n : Fin o} → Fin.suc m ≡ suc n → m ≡ n
+suc-injective : Fin.suc i ≡ suc j → i ≡ j
 suc-injective refl = refl
 
 infix 4 _≟_
 
-_≟_ : ∀ {n} → B.Decidable {A = Fin n} _≡_
+_≟_ : DecidableEquality (Fin n)
 zero  ≟ zero  = yes refl
 zero  ≟ suc y = no λ()
 suc x ≟ zero  = no λ()
@@ -76,7 +85,7 @@ suc x ≟ suc y = map′ (cong suc) suc-injective (x ≟ y)
 ------------------------------------------------------------------------
 -- Structures
 
-≡-isDecEquivalence : ∀ {n} → IsDecEquivalence (_≡_ {A = Fin n})
+≡-isDecEquivalence : IsDecEquivalence {A = Fin n} _≡_
 ≡-isDecEquivalence = record
   { isEquivalence = P.isEquivalence
   ; _≟_           = _≟_
@@ -100,13 +109,13 @@ suc x ≟ suc y = map′ (cong suc) suc-injective (x ≟ y)
 -- toℕ
 ------------------------------------------------------------------------
 
-toℕ-injective : ∀ {n} {i j : Fin n} → toℕ i ≡ toℕ j → i ≡ j
+toℕ-injective : toℕ i ≡ toℕ j → i ≡ j
 toℕ-injective {zero}  {}      {}      _
 toℕ-injective {suc n} {zero}  {zero}  eq = refl
 toℕ-injective {suc n} {suc i} {suc j} eq =
   cong suc (toℕ-injective (cong ℕ.pred eq))
 
-toℕ-strengthen : ∀ {n} (i : Fin n) → toℕ (strengthen i) ≡ toℕ i
+toℕ-strengthen : ∀ (i : Fin n) → toℕ (strengthen i) ≡ toℕ i
 toℕ-strengthen zero    = refl
 toℕ-strengthen (suc i) = cong suc (toℕ-strengthen i)
 
@@ -114,11 +123,11 @@ toℕ-strengthen (suc i) = cong suc (toℕ-strengthen i)
 -- toℕ-↑ˡ: "i" ↑ˡ n = "i" in Fin (m + n)
 ------------------------------------------------------------------------
 
-toℕ-↑ˡ : ∀ {m} (i : Fin m) n → toℕ (i ↑ˡ n) ≡ toℕ i
+toℕ-↑ˡ : ∀ (i : Fin m) n → toℕ (i ↑ˡ n) ≡ toℕ i
 toℕ-↑ˡ zero    n = refl
 toℕ-↑ˡ (suc i) n = cong suc (toℕ-↑ˡ i n)
 
-↑ˡ-injective : ∀ {m} n (i j : Fin m) → i ↑ˡ n ≡ j ↑ˡ n → i ≡ j
+↑ˡ-injective : ∀ n (i j : Fin m) → i ↑ˡ n ≡ j ↑ˡ n → i ≡ j
 ↑ˡ-injective n zero zero refl = refl
 ↑ˡ-injective n (suc i) (suc j) eq =
   cong suc (↑ˡ-injective n i j (suc-injective eq))
@@ -127,11 +136,11 @@ toℕ-↑ˡ (suc i) n = cong suc (toℕ-↑ˡ i n)
 -- toℕ-↑ʳ: n ↑ʳ "i" = "n + i" in Fin (n + m)
 ------------------------------------------------------------------------
 
-toℕ-↑ʳ : ∀ {m} n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
+toℕ-↑ʳ : ∀ n (i : Fin m) → toℕ (n ↑ʳ i) ≡ n ℕ.+ toℕ i
 toℕ-↑ʳ zero    i = refl
 toℕ-↑ʳ (suc n) i = cong suc (toℕ-↑ʳ n i)
 
-↑ʳ-injective : ∀ {m} n (i j : Fin m) → n ↑ʳ i ≡ n ↑ʳ j → i ≡ j
+↑ʳ-injective : ∀ n (i j : Fin m) → n ↑ʳ i ≡ n ↑ʳ j → i ≡ j
 ↑ʳ-injective zero i i refl = refl
 ↑ʳ-injective (suc n) i j eq = ↑ʳ-injective n i j (suc-injective eq)
 
@@ -139,35 +148,33 @@ toℕ-↑ʳ (suc n) i = cong suc (toℕ-↑ʳ n i)
 -- toℕ and the ordering relations
 ------------------------------------------------------------------------
 
-toℕ≤pred[n] : ∀ {n} (i : Fin n) → toℕ i ℕ.≤ ℕ.pred n
+toℕ≤pred[n] : ∀ (i : Fin n) → toℕ i ℕ.≤ ℕ.pred n
 toℕ≤pred[n] zero                 = z≤n
 toℕ≤pred[n] (suc {n = suc n} i)  = s≤s (toℕ≤pred[n] i)
 
-toℕ≤n : ∀ {n} → (i : Fin n) → toℕ i ℕ.≤ n
+toℕ≤n : ∀ (i : Fin n) → toℕ i ℕ.≤ n
 toℕ≤n {suc n} i = ℕₚ.≤-step (toℕ≤pred[n] i)
 
-toℕ<n : ∀ {n} (i : Fin n) → toℕ i ℕ.< n
+toℕ<n : ∀ (i : Fin n) → toℕ i ℕ.< n
 toℕ<n {suc n} i = s≤s (toℕ≤pred[n] i)
 
 -- A simpler implementation of toℕ≤pred[n],
 -- however, with a different reduction behavior.
 -- If no one needs the reduction behavior of toℕ≤pred[n],
 -- it can be removed in favor of toℕ≤pred[n]′.
-toℕ≤pred[n]′ : ∀ {n} (i : Fin n) → toℕ i ℕ.≤ ℕ.pred n
+toℕ≤pred[n]′ : ∀ (i : Fin n) → toℕ i ℕ.≤ ℕ.pred n
 toℕ≤pred[n]′ i = ℕₚ.<⇒≤pred (toℕ<n i)
 
--- In view of the defintions now in Data.Fin.Base,
--- are these four lemmas not all the identity function?
-toℕ-mono-< : ∀ {n} {i j : Fin n} → i < j → toℕ i ℕ.< toℕ j
+toℕ-mono-< : i < j → toℕ i ℕ.< toℕ j
 toℕ-mono-< i<j = i<j
 
-toℕ-mono-≤ : ∀ {n} {i j : Fin n} → i ≤ j → toℕ i ℕ.≤ toℕ j
+toℕ-mono-≤ : i ≤ j → toℕ i ℕ.≤ toℕ j
 toℕ-mono-≤ i≤j = i≤j
 
-toℕ-cancel-≤ : ∀ {n} {i j : Fin n} → toℕ i ℕ.≤ toℕ j → i ≤ j
+toℕ-cancel-≤ : toℕ i ℕ.≤ toℕ j → i ≤ j
 toℕ-cancel-≤ i≤j = i≤j
 
-toℕ-cancel-< : ∀ {n} {i j : Fin n} → toℕ i ℕ.< toℕ j → i < j
+toℕ-cancel-< : toℕ i ℕ.< toℕ j → i < j
 toℕ-cancel-< i<j = i<j
 
 ------------------------------------------------------------------------
@@ -178,22 +185,22 @@ toℕ-fromℕ : ∀ n → toℕ (fromℕ n) ≡ n
 toℕ-fromℕ zero    = refl
 toℕ-fromℕ (suc n) = cong suc (toℕ-fromℕ n)
 
-fromℕ-toℕ : ∀ {n} (i : Fin n) → fromℕ (toℕ i) ≡ strengthen i
+fromℕ-toℕ : ∀ (i : Fin n) → fromℕ (toℕ i) ≡ strengthen i
 fromℕ-toℕ zero    = refl
 fromℕ-toℕ (suc i) = cong suc (fromℕ-toℕ i)
 
-≤fromℕ : ∀ {n} → (i : Fin (ℕ.suc n)) → i ≤ fromℕ n
-≤fromℕ {n} i = subst (toℕ i ℕ.≤_) (sym (toℕ-fromℕ n)) (toℕ≤pred[n] i)
+≤fromℕ : ∀ (i : Fin (ℕ.suc n)) → i ≤ fromℕ n
+≤fromℕ i = subst (toℕ i ℕ.≤_) (sym (toℕ-fromℕ _)) (toℕ≤pred[n] i)
 
 ------------------------------------------------------------------------
 -- fromℕ<
 ------------------------------------------------------------------------
 
-fromℕ<-toℕ : ∀ {m} (i : Fin m) (i<m : toℕ i ℕ.< m) → fromℕ< i<m ≡ i
+fromℕ<-toℕ : ∀ (i : Fin n) (i<n : toℕ i ℕ.< n) → fromℕ< i<n ≡ i
 fromℕ<-toℕ zero    z<s       = refl
-fromℕ<-toℕ (suc i) (s<s m<n) = cong suc (fromℕ<-toℕ i m<n)
+fromℕ<-toℕ (suc i) (s<s i<n) = cong suc (fromℕ<-toℕ i i<n)
 
-toℕ-fromℕ< : ∀ {m n} (m<n : m ℕ.< n) → toℕ (fromℕ< m<n) ≡ m
+toℕ-fromℕ< : ∀ (m<n : m ℕ.< n) → toℕ (fromℕ< m<n) ≡ m
 toℕ-fromℕ< z<s               = refl
 toℕ-fromℕ< (s<s m<n@(s≤s _)) = cong suc (toℕ-fromℕ< m<n)
 
@@ -202,19 +209,14 @@ fromℕ-def : ∀ n → fromℕ n ≡ fromℕ< ℕₚ.≤-refl
 fromℕ-def zero    = refl
 fromℕ-def (suc n) = cong suc (fromℕ-def n)
 
-fromℕ<-cong : ∀ m n {o} → m ≡ n →
-              (m<o : m ℕ.< o) →
-              (n<o : n ℕ.< o) →
+fromℕ<-cong : ∀ m n {o} → m ≡ n → (m<o : m ℕ.< o) (n<o : n ℕ.< o) →
               fromℕ< m<o ≡ fromℕ< n<o
 fromℕ<-cong 0       0       r z<s       z<s  = refl
 fromℕ<-cong (suc _) (suc _) r (s<s m<n) (s<s n<o)
   = cong suc (fromℕ<-cong _ _ (ℕₚ.suc-injective r) m<n n<o)
 
-fromℕ<-injective : ∀ m n {o} →
-                   (m<o : m ℕ.< o) →
-                   (n<o : n ℕ.< o) →
-                   fromℕ< m<o ≡ fromℕ< n<o →
-                   m ≡ n
+fromℕ<-injective : ∀ m n {o} → (m<o : m ℕ.< o) (n<o : n ℕ.< o) →
+                   fromℕ< m<o ≡ fromℕ< n<o → m ≡ n
 fromℕ<-injective 0       0       z<s               z<s r = refl
 fromℕ<-injective (suc _) (suc _) (s<s m<n@(s≤s _)) (s<s n<o@(s≤s _)) r
   = cong suc (fromℕ<-injective _ _ m<n n<o (suc-injective r))
@@ -223,24 +225,24 @@ fromℕ<-injective (suc _) (suc _) (s<s m<n@(s≤s _)) (s<s n<o@(s≤s _)) r
 -- fromℕ<″
 ------------------------------------------------------------------------
 
-fromℕ<≡fromℕ<″ : ∀ {m n} (m<n : m ℕ.< n) (m<″n : m ℕ.<″ n) →
+fromℕ<≡fromℕ<″ : ∀ (m<n : m ℕ.< n) (m<″n : m ℕ.<″ n) →
                  fromℕ< m<n ≡ fromℕ<″ m m<″n
 fromℕ<≡fromℕ<″ z<s               (ℕ.less-than-or-equal refl) = refl
 fromℕ<≡fromℕ<″ (s<s m<n@(s≤s _)) (ℕ.less-than-or-equal refl) =
   cong suc (fromℕ<≡fromℕ<″ m<n (ℕ.less-than-or-equal refl))
 
-toℕ-fromℕ<″ : ∀ {m n} (m<n : m ℕ.<″ n) → toℕ (fromℕ<″ m m<n) ≡ m
+toℕ-fromℕ<″ : ∀ (m<n : m ℕ.<″ n) → toℕ (fromℕ<″ m m<n) ≡ m
 toℕ-fromℕ<″ {m} {n} m<n = begin
   toℕ (fromℕ<″ m m<n)  ≡⟨ cong toℕ (sym (fromℕ<≡fromℕ<″ (ℕₚ.≤″⇒≤ m<n) m<n)) ⟩
   toℕ (fromℕ< _)       ≡⟨ toℕ-fromℕ< (ℕₚ.≤″⇒≤ m<n) ⟩
-  m ∎
+  m                    ∎
   where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- cast
 ------------------------------------------------------------------------
 
-toℕ-cast : ∀ {m n} .(eq : m ≡ n) (k : Fin m) → toℕ (cast eq k) ≡ toℕ k
+toℕ-cast : ∀ .(eq : m ≡ n) (k : Fin m) → toℕ (cast eq k) ≡ toℕ k
 toℕ-cast {n = suc n} eq zero    = refl
 toℕ-cast {n = suc n} eq (suc k) = cong suc (toℕ-cast (cong ℕ.pred eq) k)
 
@@ -249,55 +251,55 @@ toℕ-cast {n = suc n} eq (suc k) = cong suc (toℕ-cast (cong ℕ.pred eq) k)
 ------------------------------------------------------------------------
 -- Relational properties
 
-≤-reflexive : ∀ {n} → _≡_ ⇒ (_≤_ {n})
+≤-reflexive : _≡_ ⇒ (_≤_ {n})
 ≤-reflexive refl = ℕₚ.≤-refl
 
-≤-refl : ∀ {n} → Reflexive (_≤_ {n})
+≤-refl : Reflexive (_≤_ {n})
 ≤-refl = ≤-reflexive refl
 
-≤-trans : ∀ {n} → Transitive (_≤_ {n})
+≤-trans : Transitive (_≤_ {n})
 ≤-trans = ℕₚ.≤-trans
 
-≤-antisym : ∀ {n} → Antisymmetric _≡_ (_≤_ {n})
+≤-antisym : Antisymmetric _≡_ (_≤_ {n})
 ≤-antisym x≤y y≤x = toℕ-injective (ℕₚ.≤-antisym x≤y y≤x)
 
-≤-total : ∀ {n} → Total (_≤_ {n})
+≤-total : Total (_≤_ {n})
 ≤-total x y = ℕₚ.≤-total (toℕ x) (toℕ y)
 
-≤-irrelevant : ∀ {m n} → Irrelevant (_≤_ {m} {n})
+≤-irrelevant : Irrelevant (_≤_ {m} {n})
 ≤-irrelevant = ℕₚ.≤-irrelevant
 
 infix 4 _≤?_ _<?_
 
-_≤?_ : ∀ {m n} → B.Decidable (_≤_ {m} {n})
+_≤?_ : B.Decidable (_≤_ {m} {n})
 a ≤? b = toℕ a ℕₚ.≤? toℕ b
 
-_<?_ : ∀ {m n} → B.Decidable (_<_ {m} {n})
+_<?_ : B.Decidable (_<_ {m} {n})
 m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 
 ------------------------------------------------------------------------
 -- Structures
 
-≤-isPreorder : ∀ {n} → IsPreorder _≡_ (_≤_ {n})
+≤-isPreorder : IsPreorder {A = Fin n} _≡_ _≤_
 ≤-isPreorder = record
   { isEquivalence = P.isEquivalence
   ; reflexive     = ≤-reflexive
   ; trans         = ≤-trans
   }
 
-≤-isPartialOrder : ∀ {n} → IsPartialOrder _≡_ (_≤_ {n})
+≤-isPartialOrder : IsPartialOrder {A = Fin n} _≡_ _≤_
 ≤-isPartialOrder = record
   { isPreorder = ≤-isPreorder
   ; antisym    = ≤-antisym
   }
 
-≤-isTotalOrder : ∀ {n} → IsTotalOrder _≡_ (_≤_ {n})
+≤-isTotalOrder : IsTotalOrder {A = Fin n} _≡_ _≤_
 ≤-isTotalOrder = record
   { isPartialOrder = ≤-isPartialOrder
   ; total          = ≤-total
   }
 
-≤-isDecTotalOrder : ∀ {n} → IsDecTotalOrder _≡_ (_≤_ {n})
+≤-isDecTotalOrder : IsDecTotalOrder {A = Fin n} _≡_ _≤_
 ≤-isDecTotalOrder = record
   { isTotalOrder = ≤-isTotalOrder
   ; _≟_          = _≟_
@@ -332,16 +334,16 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 ------------------------------------------------------------------------
 -- Relational properties
 
-<-irrefl : ∀ {n} → Irreflexive _≡_ (_<_ {n})
+<-irrefl : Irreflexive _≡_ (_<_ {n})
 <-irrefl refl = ℕₚ.<-irrefl refl
 
-<-asym : ∀ {n} → Asymmetric (_<_ {n})
+<-asym : Asymmetric (_<_ {n})
 <-asym = ℕₚ.<-asym
 
-<-trans : ∀ {n} → Transitive (_<_ {n})
+<-trans : Transitive (_<_ {n})
 <-trans = ℕₚ.<-trans
 
-<-cmp : ∀ {n} → Trichotomous _≡_ (_<_ {n})
+<-cmp : Trichotomous _≡_ (_<_ {n})
 <-cmp zero    zero    = tri≈ (λ()) refl  (λ())
 <-cmp zero    (suc j) = tri< z<s   (λ()) (λ())
 <-cmp (suc i) zero    = tri> (λ()) (λ()) z<s
@@ -350,22 +352,22 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 ... | tri> i≮j i≢j j<i = tri> (i≮j ∘ ℕₚ.≤-pred) (i≢j ∘ suc-injective) (s<s j<i)
 ... | tri≈ i≮j i≡j j≮i = tri≈ (i≮j ∘ ℕₚ.≤-pred) (cong suc i≡j)        (j≮i ∘ ℕₚ.≤-pred)
 
-<-respˡ-≡ : ∀ {m n} → (_<_ {m} {n}) Respectsˡ _≡_
+<-respˡ-≡ : (_<_ {m} {n}) Respectsˡ _≡_
 <-respˡ-≡ refl x≤y = x≤y
 
-<-respʳ-≡ : ∀ {m n} → (_<_ {m} {n}) Respectsʳ _≡_
+<-respʳ-≡ : (_<_ {m} {n}) Respectsʳ _≡_
 <-respʳ-≡ refl x≤y = x≤y
 
-<-resp₂-≡ : ∀ {n} → (_<_ {n}) Respects₂ _≡_
+<-resp₂-≡ : (_<_ {n}) Respects₂ _≡_
 <-resp₂-≡ = <-respʳ-≡ , <-respˡ-≡
 
-<-irrelevant : ∀ {m n} → Irrelevant (_<_ {m} {n})
+<-irrelevant : Irrelevant (_<_ {m} {n})
 <-irrelevant = ℕₚ.<-irrelevant
 
 ------------------------------------------------------------------------
 -- Structures
 
-<-isStrictPartialOrder : ∀ {n} → IsStrictPartialOrder _≡_ (_<_ {n})
+<-isStrictPartialOrder : IsStrictPartialOrder {A = Fin n} _≡_ _<_
 <-isStrictPartialOrder = record
   { isEquivalence = P.isEquivalence
   ; irrefl        = <-irrefl
@@ -373,7 +375,7 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
   ; <-resp-≈      = <-resp₂-≡
   }
 
-<-isStrictTotalOrder : ∀ {n} → IsStrictTotalOrder _≡_ (_<_ {n})
+<-isStrictTotalOrder : IsStrictTotalOrder {A = Fin n} _≡_ _<_
 <-isStrictTotalOrder = record
   { isEquivalence = P.isEquivalence
   ; trans         = <-trans
@@ -396,13 +398,13 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 ------------------------------------------------------------------------
 -- Other properties
 
-i<1+i : ∀ {n} (i : Fin n) → i < suc i
+i<1+i : ∀ (i : Fin n) → i < suc i
 i<1+i = ℕₚ.n<1+n ∘ toℕ
 
-<⇒≢ : ∀ {n} {i j : Fin n} → i < j → i ≢ j
+<⇒≢ : i < j → i ≢ j
 <⇒≢ i<i refl = ℕₚ.n≮n _ i<i
 
-≤∧≢⇒< : ∀ {n} {i j : Fin n} → i ≤ j → i ≢ j → i < j
+≤∧≢⇒< : i ≤ j → i ≢ j → i < j
 ≤∧≢⇒< {i = zero}  {zero}  _         0≢0     = contradiction refl 0≢0
 ≤∧≢⇒< {i = zero}  {suc j} _         _       = z<s
 ≤∧≢⇒< {i = suc i} {suc j} (s≤s i≤j) 1+i≢1+j =
@@ -412,8 +414,7 @@ i<1+i = ℕₚ.n<1+n ∘ toℕ
 -- inject
 ------------------------------------------------------------------------
 
-toℕ-inject : ∀ {n} {i : Fin n} (j : Fin′ i) →
-             toℕ (inject j) ≡ toℕ j
+toℕ-inject : ∀ {i : Fin n} (j : Fin′ i) → toℕ (inject j) ≡ toℕ j
 toℕ-inject {i = suc i} zero    = refl
 toℕ-inject {i = suc i} (suc j) = cong suc (toℕ-inject j)
 
@@ -421,114 +422,110 @@ toℕ-inject {i = suc i} (suc j) = cong suc (toℕ-inject j)
 -- inject₁
 ------------------------------------------------------------------------
 
-inject₁-injective : ∀ {n} {i j : Fin n} → inject₁ i ≡ inject₁ j → i ≡ j
+inject₁-injective : inject₁ i ≡ inject₁ j → i ≡ j
 inject₁-injective {i = zero}  {zero}  i≡j = refl
 inject₁-injective {i = suc i} {suc j} i≡j =
   cong suc (inject₁-injective (suc-injective i≡j))
 
-toℕ-inject₁ : ∀ {n} (i : Fin n) → toℕ (inject₁ i) ≡ toℕ i
+toℕ-inject₁ : ∀ (i : Fin n) → toℕ (inject₁ i) ≡ toℕ i
 toℕ-inject₁ zero    = refl
 toℕ-inject₁ (suc i) = cong suc (toℕ-inject₁ i)
 
-toℕ-inject₁-≢ : ∀ {n}(i : Fin n) → n ≢ toℕ (inject₁ i)
+toℕ-inject₁-≢ : ∀ (i : Fin n) → n ≢ toℕ (inject₁ i)
 toℕ-inject₁-≢ (suc i) = toℕ-inject₁-≢ i ∘ ℕₚ.suc-injective
 
-inject₁ℕ< : ∀ {n} → (i : Fin n) → toℕ (inject₁ i) ℕ.< n
-inject₁ℕ< {n} i = subst (ℕ._< n) (sym (toℕ-inject₁ i)) (toℕ<n i)
+inject₁ℕ< : ∀ (i : Fin n) → toℕ (inject₁ i) ℕ.< n
+inject₁ℕ< i rewrite toℕ-inject₁ i = toℕ<n i
 
-inject₁ℕ≤ : ∀ {n} → (i : Fin n) → toℕ (inject₁ i) ℕ.≤ n
+inject₁ℕ≤ : ∀ (i : Fin n) → toℕ (inject₁ i) ℕ.≤ n
 inject₁ℕ≤ = ℕₚ.<⇒≤ ∘ inject₁ℕ<
 
-≤̄⇒inject₁< : ∀ {n} → {i j : Fin n} → j ≤ i → inject₁ j < suc i
-≤̄⇒inject₁< {i = i} {j} p = subst (ℕ._< toℕ (suc i)) (sym (toℕ-inject₁ j)) (s<s p)
+≤̄⇒inject₁< : i ≤ j → inject₁ i < suc j
+≤̄⇒inject₁< {i = i} i≤j rewrite sym (toℕ-inject₁ i) = s<s i≤j
 
-ℕ<⇒inject₁< : ∀ {n} → {i : Fin (ℕ.suc n)} → {j : Fin n} →
-              toℕ j ℕ.< toℕ i → inject₁ j < i
+ℕ<⇒inject₁< : ∀ {i : Fin (ℕ.suc n)} {j : Fin n} → j < i → inject₁ j < i
 ℕ<⇒inject₁< {i = suc i} (s≤s j≤i) = ≤̄⇒inject₁< j≤i
 
 ------------------------------------------------------------------------
 -- lower₁
 ------------------------------------------------------------------------
 
-toℕ-lower₁ : ∀ {m} x → (p : m ≢ toℕ x) → toℕ (lower₁ x p) ≡ toℕ x
-toℕ-lower₁ {ℕ.zero} zero p     = contradiction refl p
-toℕ-lower₁ {ℕ.suc m} zero p    = refl
-toℕ-lower₁ {ℕ.suc m} (suc x) p = cong ℕ.suc (toℕ-lower₁ x (p ∘ cong ℕ.suc))
+toℕ-lower₁ : ∀ i (p : n ≢ toℕ i) → toℕ (lower₁ i p) ≡ toℕ i
+toℕ-lower₁ {ℕ.zero}  zero    p = contradiction refl p
+toℕ-lower₁ {ℕ.suc m} zero    p = refl
+toℕ-lower₁ {ℕ.suc m} (suc i) p = cong ℕ.suc (toℕ-lower₁ i (p ∘ cong ℕ.suc))
 
-lower₁-injective : ∀ {n} {i j} {n≢i : n ≢ toℕ i} {n≢j : n ≢ toℕ j} →
+lower₁-injective : ∀ {n≢i : n ≢ toℕ i} {n≢j : n ≢ toℕ j} →
                    lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
-lower₁-injective {zero}  {zero}  {_}     {n≢i} {_}   _ = ⊥-elim (n≢i refl)
-lower₁-injective {zero}  {_}     {zero}  {_}   {n≢j} _ = ⊥-elim (n≢j refl)
-lower₁-injective {suc n} {0F}    {0F}    {_}   {_}   refl = refl
-lower₁-injective {suc n} {suc i} {suc j} {n≢i} {n≢j} eq =
+lower₁-injective {zero}  {zero}  {_}     {n≢i} {_}   _    = ⊥-elim (n≢i refl)
+lower₁-injective {zero}  {_}     {zero}  {_}   {n≢j} _    = ⊥-elim (n≢j refl)
+lower₁-injective {suc n} {zero}  {zero}  {_}   {_}   refl = refl
+lower₁-injective {suc n} {suc i} {suc j} {n≢i} {n≢j} eq   =
   cong suc (lower₁-injective (suc-injective eq))
 
 ------------------------------------------------------------------------
 -- inject₁ and lower₁
 
-inject₁-lower₁ : ∀ {n} (i : Fin (suc n)) (n≢i : n ≢ toℕ i) →
+inject₁-lower₁ : ∀ (i : Fin (suc n)) (n≢i : n ≢ toℕ i) →
                  inject₁ (lower₁ i n≢i) ≡ i
 inject₁-lower₁ {zero}  zero     0≢0     = contradiction refl 0≢0
 inject₁-lower₁ {suc n} zero     _       = refl
 inject₁-lower₁ {suc n} (suc i)  n+1≢i+1 =
   cong suc (inject₁-lower₁ i  (n+1≢i+1 ∘ cong suc))
 
-lower₁-inject₁′ : ∀ {n} (i : Fin n) (n≢i : n ≢ toℕ (inject₁ i)) →
+lower₁-inject₁′ : ∀ (i : Fin n) (n≢i : n ≢ toℕ (inject₁ i)) →
                   lower₁ (inject₁ i) n≢i ≡ i
 lower₁-inject₁′ zero    _       = refl
 lower₁-inject₁′ (suc i) n+1≢i+1 =
   cong suc (lower₁-inject₁′ i (n+1≢i+1 ∘ cong suc))
 
-lower₁-inject₁ : ∀ {n} (i : Fin n) →
+lower₁-inject₁ : ∀ (i : Fin n) →
                  lower₁ (inject₁ i) (toℕ-inject₁-≢ i) ≡ i
 lower₁-inject₁ i = lower₁-inject₁′ i (toℕ-inject₁-≢ i)
 
-lower₁-irrelevant : ∀ {n} (i : Fin (suc n)) n≢i₁ n≢i₂ →
-             lower₁ {n} i n≢i₁ ≡ lower₁ {n} i n≢i₂
+lower₁-irrelevant : ∀ (i : Fin (suc n)) (n≢i₁ n≢i₂ : n ≢ toℕ i) →
+                    lower₁ i n≢i₁ ≡ lower₁ i n≢i₂
 lower₁-irrelevant {zero}  zero     0≢0 _ = contradiction refl 0≢0
 lower₁-irrelevant {suc n} zero     _   _ = refl
 lower₁-irrelevant {suc n} (suc i)  _   _ =
   cong suc (lower₁-irrelevant i _ _)
 
-inject₁≡⇒lower₁≡ : ∀ {n} → {i : Fin n} →
-                  {j : Fin (ℕ.suc n)} →
-                  (≢p : n ≢ (toℕ j)) →
-                  inject₁ i ≡ j →
-                  lower₁ j ≢p ≡ i
-inject₁≡⇒lower₁≡ ≢p ≡p = inject₁-injective (trans (inject₁-lower₁ _ ≢p) (sym ≡p))
+inject₁≡⇒lower₁≡ : ∀ {i : Fin n} {j : Fin (ℕ.suc n)} →
+                  (n≢j : n ≢ toℕ j) → inject₁ i ≡ j → lower₁ j n≢j ≡ i
+inject₁≡⇒lower₁≡ n≢j i≡j = inject₁-injective (trans (inject₁-lower₁ _ n≢j) (sym i≡j))
 
 ------------------------------------------------------------------------
 -- inject≤
 ------------------------------------------------------------------------
 
-toℕ-inject≤ : ∀ {m n} (i : Fin m) (m≤n : m ℕ.≤ n) →
-                toℕ (inject≤ i m≤n) ≡ toℕ i
+toℕ-inject≤ : ∀ i (m≤n : m ℕ.≤ n) → toℕ (inject≤ i m≤n) ≡ toℕ i
 toℕ-inject≤ {_} {suc n} zero    _         = refl
 toℕ-inject≤ {_} {suc n} (suc i) (s≤s m≤n) = cong suc (toℕ-inject≤ i m≤n)
 
-inject≤-refl : ∀ {n} (i : Fin n) (n≤n : n ℕ.≤ n) → inject≤ i n≤n ≡ i
-inject≤-refl {suc n} zero    _   = refl
+inject≤-refl : ∀ i (n≤n : n ℕ.≤ n) → inject≤ i n≤n ≡ i
+inject≤-refl {suc n} zero    _         = refl
 inject≤-refl {suc n} (suc i) (s≤s n≤n) = cong suc (inject≤-refl i n≤n)
 
-inject≤-idempotent : ∀ {m n k} (i : Fin m)
-                     (m≤n : m ℕ.≤ n) (n≤k : n ℕ.≤ k) (m≤k : m ℕ.≤ k) →
-                     inject≤ (inject≤ i m≤n) n≤k ≡ inject≤ i m≤k
-inject≤-idempotent {_} {suc n} {suc k} zero    _   _   _ = refl
-inject≤-idempotent {_} {suc n} {suc k} (suc i) (s≤s m≤n) (s≤s n≤k) (s≤s m≤k) =
-  cong suc (inject≤-idempotent i m≤n n≤k m≤k)
+inject≤-idempotent : ∀ (i : Fin m)
+                     (m≤n : m ℕ.≤ n) (n≤o : n ℕ.≤ o) (m≤o : m ℕ.≤ o) →
+                     inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i m≤o
+inject≤-idempotent {_} {suc n} {suc o} zero    _   _   _ = refl
+inject≤-idempotent {_} {suc n} {suc o} (suc i) (s≤s m≤n) (s≤s n≤o) (s≤s m≤o) =
+  cong suc (inject≤-idempotent i m≤n n≤o m≤o)
 
-inject≤-injective : ∀ {n m} (n≤m n≤m′ : n ℕ.≤ m) x y → inject≤ x n≤m ≡ inject≤ y n≤m′ → x ≡ y
-inject≤-injective (s≤s p) (s≤s q) zero zero eq = refl
-inject≤-injective (s≤s p) (s≤s q) (suc x) (suc y) eq =
-  cong suc (inject≤-injective p q x y (suc-injective eq))
+inject≤-injective : ∀ (m≤n m≤n′ : m ℕ.≤ n) i j →
+                    inject≤ i m≤n ≡ inject≤ j m≤n′ → i ≡ j
+inject≤-injective (s≤s p) (s≤s q) zero    zero    eq = refl
+inject≤-injective (s≤s p) (s≤s q) (suc i) (suc j) eq =
+  cong suc (inject≤-injective p q i j (suc-injective eq))
 
 ------------------------------------------------------------------------
 -- pred
 ------------------------------------------------------------------------
 
-pred< : ∀ {n} → (i : Fin (suc n)) → i ≢ zero → pred i < i
-pred< zero p = contradiction refl p
-pred< (suc i) p = ≤̄⇒inject₁< ℕₚ.≤-refl
+pred< : ∀ (i : Fin (suc n)) → i ≢ zero → pred i < i
+pred< zero    i≢0 = contradiction refl i≢0
+pred< (suc i) _   = ≤̄⇒inject₁< ℕₚ.≤-refl
 
 ------------------------------------------------------------------------
 -- splitAt
@@ -560,20 +557,22 @@ join-splitAt (suc m) n (suc i) = begin
 
 -- splitAt "m" "i" ≡ inj₁ "i" if i < m
 
-splitAt-< : ∀ m {n} i → (i<m : toℕ i ℕ.< m) → splitAt m {n} i ≡ inj₁ (fromℕ< i<m)
+splitAt-< : ∀ m {n} (i : Fin (m ℕ.+ n)) (i<m : toℕ i ℕ.< m) →
+            splitAt m i ≡ inj₁ (fromℕ< i<m)
 splitAt-< (suc m) zero    z<s               = refl
 splitAt-< (suc m) (suc i) (s<s i<m) = cong (Sum.map suc id) (splitAt-< m i i<m)
 
 -- splitAt "m" "i" ≡ inj₂ "i - m" if i ≥ m
 
-splitAt-≥ : ∀ m {n} i → (i≥m : toℕ i ℕ.≥ m) → splitAt m {n} i ≡ inj₂ (reduce≥ i i≥m)
+splitAt-≥ : ∀ m {n} (i : Fin (m ℕ.+ n)) (i≥m : toℕ i ℕ.≥ m) →
+            splitAt m i ≡ inj₂ (reduce≥ i i≥m)
 splitAt-≥ zero    i       _         = refl
 splitAt-≥ (suc m) (suc i) (s≤s i≥m) = cong (Sum.map suc id) (splitAt-≥ m i i≥m)
 
 ------------------------------------------------------------------------
 -- Bundles
 
-+↔⊎ : ∀ {m n} → Fin (m ℕ.+ n) ↔ (Fin m ⊎ Fin n)
++↔⊎ : Fin (m ℕ.+ n) ↔ (Fin m ⊎ Fin n)
 +↔⊎ {m} {n} = mk↔′ (splitAt m {n}) (join m n) (splitAt-join m n) (join-splitAt m n)
 
 ------------------------------------------------------------------------
@@ -583,8 +582,9 @@ splitAt-≥ (suc m) (suc i) (s≤s i≥m) = cong (Sum.map suc id) (splitAt-≥ m
 -- Fin (m * n) ↔ Fin m × Fin n
 
 remQuot-combine : ∀ {n k} (i : Fin n) j → remQuot k (combine i j) ≡ (i , j)
-remQuot-combine {suc n} {k} 0F j rewrite splitAt-↑ˡ k j (n ℕ.* k) = refl
-remQuot-combine {suc n} {k} (suc i) j rewrite splitAt-↑ʳ k (n ℕ.* k) (combine i j) = cong (Data.Product.map₁ suc) (remQuot-combine i j)
+remQuot-combine {suc n} {k} zero    j rewrite splitAt-↑ˡ k j (n ℕ.* k) = refl
+remQuot-combine {suc n} {k} (suc i) j rewrite splitAt-↑ʳ k   (n ℕ.* k) (combine i j) =
+  cong (Data.Product.map₁ suc) (remQuot-combine i j)
 
 combine-remQuot : ∀ {n} k (i : Fin (n ℕ.* k)) → uncurry combine (remQuot {n} k i) ≡ i
 combine-remQuot {suc n} k i with splitAt k i | P.inspect (splitAt k) i
@@ -600,85 +600,71 @@ combine-remQuot {suc n} k i with splitAt k i | P.inspect (splitAt k) i
   i                                        ∎
   where open ≡-Reasoning
 
-toℕ-combine : ∀ {n m} (i : Fin n) (j : Fin m) → toℕ (combine i j) ≡ m ℕ.* toℕ i ℕ.+ toℕ j
-toℕ-combine {n = suc n} {m} i@0F j = begin
+toℕ-combine : ∀ (i : Fin m) (j : Fin n) → toℕ (combine i j) ≡ n ℕ.* toℕ i ℕ.+ toℕ j
+toℕ-combine {suc m} {n} i@0F j = begin
   toℕ (combine i j)          ≡⟨⟩
-  toℕ (j ↑ˡ (n ℕ.* m))       ≡⟨ toℕ-↑ˡ j (n ℕ.* m) ⟩
+  toℕ (j ↑ˡ (m ℕ.* n))       ≡⟨ toℕ-↑ˡ j (m ℕ.* n) ⟩
   toℕ j                      ≡⟨⟩
-  0 ℕ.+ toℕ j                ≡˘⟨ cong (ℕ._+ toℕ j) (ℕₚ.*-zeroʳ m) ⟩
-  m ℕ.* toℕ i ℕ.+ toℕ j      ∎
+  0 ℕ.+ toℕ j                ≡˘⟨ cong (ℕ._+ toℕ j) (ℕₚ.*-zeroʳ n) ⟩
+  n ℕ.* toℕ i ℕ.+ toℕ j      ∎
   where open ≡-Reasoning
-toℕ-combine {n = suc n} {m} (suc i) j = begin
+toℕ-combine {suc m} {n} (suc i) j = begin
   toℕ (combine (suc i) j)        ≡⟨⟩
-  toℕ (m ↑ʳ combine i j)         ≡⟨ toℕ-↑ʳ m (combine i j) ⟩
-  m ℕ.+ toℕ (combine i j)        ≡⟨ cong (m ℕ.+_) (toℕ-combine i j) ⟩
-  m ℕ.+ (m ℕ.* toℕ i ℕ.+ toℕ j)  ≡⟨ solve 3 (λ m i j → m :+ (m :* i :+ j) := m :* (con 1 :+ i) :+ j) refl m (toℕ i) (toℕ j) ⟩
-  m ℕ.* toℕ (suc i) ℕ.+ toℕ j    ∎
-  where
-    open ≡-Reasoning
-    open +-*-Solver
+  toℕ (n ↑ʳ combine i j)         ≡⟨ toℕ-↑ʳ n (combine i j) ⟩
+  n ℕ.+ toℕ (combine i j)        ≡⟨ cong (n ℕ.+_) (toℕ-combine i j) ⟩
+  n ℕ.+ (n ℕ.* toℕ i ℕ.+ toℕ j)  ≡⟨ solve 3 (λ n i j → n :+ (n :* i :+ j) := n :* (con 1 :+ i) :+ j) refl n (toℕ i) (toℕ j) ⟩
+  n ℕ.* toℕ (suc i) ℕ.+ toℕ j    ∎
+  where open ≡-Reasoning; open +-*-Solver
 
-combine-injectiveˡ : ∀ {n m} (i j : Fin n) (k : Fin m) → combine i k ≡ combine j k → i ≡ j
-combine-injectiveˡ {n} {m@(suc _)} i j k combine[i,k]≡combine[j,k] =
-  toℕ-injective (ℕₚ.*-cancelˡ-≡ m (ℕₚ.+-cancelʳ-≡ (m ℕ.* toℕ i) (m ℕ.* toℕ j) (begin
-    m ℕ.* toℕ i ℕ.+ toℕ k      ≡˘⟨ toℕ-combine i k ⟩
-    toℕ (combine i k)          ≡⟨ cong toℕ combine[i,k]≡combine[j,k] ⟩
-    toℕ (combine j k)          ≡⟨ toℕ-combine j k ⟩
-    m ℕ.* toℕ j ℕ.+ toℕ k      ∎)))
+combine-monoˡ-< : ∀ {i j : Fin m} (k l : Fin n) →
+                  i < j → combine i k < combine j l
+combine-monoˡ-< {m} {n} {i} {j} k l i<j = begin-strict
+  toℕ (combine i k)      ≡⟨ toℕ-combine i k ⟩
+  n ℕ.* toℕ i ℕ.+ toℕ k  <⟨ ℕₚ.+-monoʳ-< (n ℕ.* toℕ i) (toℕ<n k) ⟩
+  n ℕ.* toℕ i ℕ.+ n      ≡⟨ ℕₚ.+-comm _ n ⟩
+  n ℕ.+ n ℕ.* toℕ i      ≡⟨ cong (n ℕ.+_) (ℕₚ.*-comm n _) ⟩
+  n ℕ.+ toℕ i ℕ.* n      ≡⟨ ℕₚ.*-comm (suc (toℕ i)) n ⟩
+  n ℕ.* suc (toℕ i)      ≤⟨ ℕₚ.*-monoʳ-≤ n (toℕ-mono-< i<j) ⟩
+  n ℕ.* toℕ j            ≤⟨ ℕₚ.m≤m+n (n ℕ.* toℕ j) (toℕ l) ⟩
+  n ℕ.* toℕ j ℕ.+ toℕ l  ≡˘⟨ toℕ-combine j l ⟩
+  toℕ (combine j l)      ∎
+  where open ℕₚ.≤-Reasoning; open +-*-Solver
+
+combine-injectiveˡ : ∀ (i : Fin m) (j : Fin n) (k : Fin m) (l : Fin n) →
+                     combine i j ≡ combine k l → i ≡ k
+combine-injectiveˡ i j k l cᵢⱼ≡cₖₗ with <-cmp i k
+... | tri< i<k _ _ = contradiction cᵢⱼ≡cₖₗ (<⇒≢ (combine-monoˡ-< j l i<k))
+... | tri≈ _ i≡k _ = i≡k
+... | tri> _ _ i>k = contradiction (sym cᵢⱼ≡cₖₗ) (<⇒≢ (combine-monoˡ-< l j i>k))
+
+combine-injectiveʳ : ∀ (i : Fin m) (j : Fin n) (k : Fin m) (l : Fin n) →
+                     combine i j ≡ combine k l → j ≡ l
+combine-injectiveʳ {m} {n} i j k l cᵢⱼ≡cₖₗ with combine-injectiveˡ i j k l cᵢⱼ≡cₖₗ
+... | refl = toℕ-injective (ℕₚ.+-cancelˡ-≡ (n ℕ.* toℕ i) (begin
+  n ℕ.* toℕ i ℕ.+ toℕ j ≡˘⟨ toℕ-combine i j ⟩
+  toℕ (combine i j)     ≡⟨ cong toℕ cᵢⱼ≡cₖₗ ⟩
+  toℕ (combine i l)     ≡⟨ toℕ-combine i l ⟩
+  n ℕ.* toℕ i ℕ.+ toℕ l ∎))
   where open ≡-Reasoning
 
-combine-injectiveʳ : ∀ {n m} (i : Fin n) (j k : Fin m) → combine i j ≡ combine i k → j ≡ k
-combine-injectiveʳ {n} {m} i j k combine[i,k]≡combine[j,k] = toℕ-injective (ℕₚ.+-cancelˡ-≡ (m ℕ.* toℕ i) (begin
-  m ℕ.* toℕ i ℕ.+ toℕ j ≡˘⟨ toℕ-combine i j ⟩
-  toℕ (combine i j)     ≡⟨ cong toℕ combine[i,k]≡combine[j,k] ⟩
-  toℕ (combine i k)     ≡⟨ toℕ-combine i k ⟩
-  m ℕ.* toℕ i ℕ.+ toℕ k ∎))
-  where open ≡-Reasoning
+combine-injective : ∀ (i : Fin m) (j : Fin n) (k : Fin m) (l : Fin n) →
+                    combine i j ≡ combine k l → i ≡ k × j ≡ l
+combine-injective i j k l cᵢⱼ≡cₖₗ =
+  combine-injectiveˡ i j k l cᵢⱼ≡cₖₗ ,
+  combine-injectiveʳ i j k l cᵢⱼ≡cₖₗ
 
-combine-injective : ∀ {n m} (i : Fin n) (j : Fin m) (k : Fin n) (l : Fin m) → combine i j ≡ combine k l → i ≡ k × j ≡ l
-combine-injective i j k l combine[i,j]≡combine[k,l] =
-  lemma₂ i j k l combine[i,j]≡combine[k,l] , lemma₃ i j k l combine[i,j]≡combine[k,l]
-  where
-    lemma₁ : ∀ {n m} (i : Fin n) (j : Fin m) (k : Fin n) (l : Fin m) → i < k → combine i j < combine k l
-    lemma₁ {n} {m} i j k l i<k = begin-strict
-      toℕ (combine i j)      ≡⟨ toℕ-combine i j ⟩
-      m ℕ.* toℕ i ℕ.+ toℕ j  <⟨ ℕₚ.+-monoʳ-< (m ℕ.* toℕ i) (toℕ<n j) ⟩
-      m ℕ.* toℕ i ℕ.+ m      ≡⟨ ℕₚ.+-comm _ m ⟩
-      m ℕ.+ m ℕ.* toℕ i      ≡⟨ cong (m ℕ.+_) (ℕₚ.*-comm m _) ⟩
-      m ℕ.+ toℕ i ℕ.* m      ≡⟨ ℕₚ.*-comm (suc (toℕ i)) m ⟩
-      m ℕ.* suc (toℕ i)      ≤⟨ ℕₚ.*-monoʳ-≤ m (toℕ-mono-< i<k) ⟩
-      m ℕ.* toℕ k            ≤⟨ ℕₚ.m≤m+n (m ℕ.* toℕ k) (toℕ l) ⟩
-      m ℕ.* toℕ k ℕ.+ toℕ l  ≡˘⟨ toℕ-combine k l ⟩
-      toℕ (combine k l)      ∎
-      where
-        open ℕₚ.≤-Reasoning
-        open +-*-Solver
-
-    lemma₂ : ∀ {n m} (i : Fin n) (j : Fin m) (k : Fin n) (l : Fin m) → combine i j ≡ combine k l → i ≡ k
-    lemma₂ i j k l combine[i,j]≡combine[k,l] with <-cmp i k
-    ... | tri< i<k _ _ = contradiction combine[i,j]≡combine[k,l] (<⇒≢ (lemma₁ i j k l i<k))
-    ... | tri≈ _ i≡k _ = i≡k
-    ... | tri> _ _ i>k = contradiction (sym combine[i,j]≡combine[k,l]) (<⇒≢ (lemma₁ k l i j i>k))
-
-    lemma₃ : ∀ {n m} (i : Fin n) (j : Fin m) (k : Fin n) (l : Fin m) → combine i j ≡ combine k l → j ≡ l
-    lemma₃ i j k l combine[i,j]≡combine[k,l] = combine-injectiveʳ i j l (begin
-      combine i j ≡⟨ combine[i,j]≡combine[k,l] ⟩
-      combine k l ≡˘⟨ cong (λ h → combine h l) (lemma₂ i j k l combine[i,j]≡combine[k,l]) ⟩
-      combine i l ∎)
-      where open ≡-Reasoning
-
-combine-surjective : ∀ {n m} (i : Fin (n ℕ.* m)) → Σ[ j ∈ Fin n ] Σ[ k ∈ Fin m ] combine j k ≡ i
-combine-surjective {n} {m} i with remQuot {n} m i | P.inspect (remQuot {n} m) i
+combine-surjective : ∀ (i : Fin (m ℕ.* n)) → ∃₂ λ j k → combine j k ≡ i
+combine-surjective {m} {n} i with remQuot {m} n i | P.inspect (remQuot {m} n) i
 ... | j , k | P.[ eq ] = j , k , (begin
   combine j k                       ≡˘⟨ uncurry (cong₂ combine) (,-injective eq) ⟩
-  uncurry combine (remQuot {n} m i) ≡⟨ combine-remQuot {n} m i ⟩
+  uncurry combine (remQuot {m} n i) ≡⟨ combine-remQuot {m} n i ⟩
   i                                 ∎)
   where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- Bundles
 
-*↔× : ∀ {m n} → Fin (m ℕ.* n) ↔ (Fin m × Fin n)
+*↔× : Fin (m ℕ.* n) ↔ (Fin m × Fin n)
 *↔× {m} {n} = mk↔′ (remQuot {m} n) (uncurry combine)
   (uncurry remQuot-combine)
   (combine-remQuot {m} n)
@@ -687,14 +673,14 @@ combine-surjective {n} {m} i with remQuot {n} m i | P.inspect (remQuot {n} m) i
 -- fin→fun
 ------------------------------------------------------------------------
 
-funToFin-finToFin : ∀ {m n} → funToFin {m} {n} ∘ finToFun ≗ id
+funToFin-finToFin : funToFin {m} {n} ∘ finToFun ≗ id
 funToFin-finToFin {zero}  {n} zero = refl
-funToFin-finToFin {suc m} {n} k =
+funToFin-finToFin {suc m} {n} k    =
   begin
-    combine (finToFun {suc m} {n} k zero) (funToFin (finToFun {suc m} {n} k ∘ suc))
+    combine (finToFun {n} {suc m} k zero) (funToFin (finToFun {n} {suc m} k ∘ suc))
   ≡⟨⟩
     combine (quotient {n} (n ^ m) k)
-      (funToFin (finToFun {m} (remainder {n} (n ^ m) k)))
+      (funToFin (finToFun {n} {m} (remainder {n} (n ^ m) k)))
   ≡⟨ cong (combine (quotient {n} (n ^ m) k))
        (funToFin-finToFin {m} (remainder {n} (n ^ m) k)) ⟩
     combine (quotient {n} (n ^ m) k) (remainder {n} (n ^ m) k)
@@ -704,7 +690,7 @@ funToFin-finToFin {suc m} {n} k =
     k
   ∎ where open ≡-Reasoning
 
-finToFun-funToFin : ∀ {m n} (f : Fin m → Fin n) → finToFun (funToFin f) ≗ f
+finToFun-funToFin : (f : Fin m → Fin n) → finToFun (funToFin f) ≗ f
 finToFun-funToFin {suc m} {n} f  zero   =
   begin
     quotient (n ^ m) (combine (f zero) (funToFin (f ∘ suc)))
@@ -729,22 +715,21 @@ finToFun-funToFin {suc m} {n} f (suc i) =
 ------------------------------------------------------------------------
 -- Bundles
 
-^↔→ : ∀ {m n} → Extensionality _ _ → Fin (n ^ m) ↔ (Fin m → Fin n)
+^↔→ : Extensionality _ _ → Fin (m ^ n) ↔ (Fin n → Fin m)
 ^↔→ {m} {n} ext = mk↔′ finToFun funToFin
   (ext ∘ finToFun-funToFin)
-  (funToFin-finToFin {m} {n})
+  (funToFin-finToFin {n} {m})
 
 ------------------------------------------------------------------------
 -- lift
 ------------------------------------------------------------------------
 
-lift-injective : ∀ {m n} (f : Fin m → Fin n) →
-                 (∀ {x y} → f x ≡ f y → x ≡ y) →
-                 ∀ k {x y} → lift k f x ≡ lift k f y → x ≡ y
-lift-injective f inj zero                    eq = inj eq
-lift-injective f inj (suc k) {0F} {0F}       eq = refl
-lift-injective f inj (suc k) {suc i} {suc y} eq = cong suc (lift-injective f inj k (suc-injective eq))
-
+lift-injective : ∀ (f : Fin m → Fin n) → Injective _≡_ _≡_ f →
+                 ∀ k → Injective _≡_ _≡_ (lift k f)
+lift-injective f inj zero    {_}     {_}     eq = inj eq
+lift-injective f inj (suc k) {zero}  {zero}  eq = refl
+lift-injective f inj (suc k) {suc _} {suc _} eq =
+  cong suc (lift-injective f inj k (suc-injective eq))
 
 ------------------------------------------------------------------------
 -- _≺_
@@ -754,8 +739,7 @@ lift-injective f inj (suc k) {suc i} {suc y} eq = cong suc (lift-injective f inj
 ≺⇒<′ (n ≻toℕ i) = ℕₚ.≤⇒≤′ (toℕ<n i)
 
 <′⇒≺ : ℕ._<′_ ⇒ _≺_
-<′⇒≺ {n} ℕ.≤′-refl = subst (_≺ suc n) (toℕ-fromℕ n)
-                              (suc n ≻toℕ fromℕ n)
+<′⇒≺ {n} ℕ.≤′-refl = subst (_≺ suc n) (toℕ-fromℕ n) (suc n ≻toℕ fromℕ n)
 <′⇒≺ (ℕ.≤′-step m≤′n) with <′⇒≺ m≤′n
 ... | n ≻toℕ i = subst (_≺ suc n) (toℕ-inject₁ i) (suc n ≻toℕ _)
 
@@ -763,10 +747,9 @@ lift-injective f inj (suc k) {suc i} {suc y} eq = cong suc (lift-injective f inj
 -- pred
 ------------------------------------------------------------------------
 
-<⇒≤pred : ∀ {n} {i j : Fin n} → j < i → j ≤ pred i
-<⇒≤pred {i = suc i} {zero}  z<s       = z≤n
-<⇒≤pred {i = suc i} {suc j} (s<s j<i) =
-  subst (_ ℕ.≤_) (sym (toℕ-inject₁ i)) j<i
+<⇒≤pred : i < j → i ≤ pred j
+<⇒≤pred {i = zero}  {j = suc j} z<s       = z≤n
+<⇒≤pred {i = suc i} {j = suc j} (s<s i<j) rewrite toℕ-inject₁ j = i<j
 
 ------------------------------------------------------------------------
 -- _ℕ-_
@@ -792,14 +775,14 @@ nℕ-ℕi≤n (suc n) (suc i)  = begin
 -- punchIn
 ------------------------------------------------------------------------
 
-punchIn-injective : ∀ {m} i (j k : Fin m) →
+punchIn-injective : ∀ i (j k : Fin n) →
                     punchIn i j ≡ punchIn i k → j ≡ k
 punchIn-injective zero    _       _       refl      = refl
 punchIn-injective (suc i) zero    zero    _         = refl
 punchIn-injective (suc i) (suc j) (suc k) ↑j+1≡↑k+1 =
   cong suc (punchIn-injective i j k (suc-injective ↑j+1≡↑k+1))
 
-punchInᵢ≢i : ∀ {m} i (j : Fin m) → punchIn i j ≢ i
+punchInᵢ≢i : ∀ i (j : Fin n) → punchIn i j ≢ i
 punchInᵢ≢i (suc i) (suc j) = punchInᵢ≢i i j ∘ suc-injective
 
 ------------------------------------------------------------------------
@@ -809,21 +792,23 @@ punchInᵢ≢i (suc i) (suc j) = punchInᵢ≢i i j ∘ suc-injective
 -- A version of 'cong' for 'punchOut' in which the inequality argument can be
 -- changed out arbitrarily (reflecting the proof-irrelevance of that argument).
 
-punchOut-cong : ∀ {n} (i : Fin (suc n)) {j k} {i≢j : i ≢ j} {i≢k : i ≢ k} → j ≡ k → punchOut i≢j ≡ punchOut i≢k
-punchOut-cong zero {zero} {i≢j = 0≢0} = contradiction refl 0≢0
-punchOut-cong zero {suc j} {zero} {i≢k = 0≢0} = contradiction refl 0≢0
-punchOut-cong zero {suc j} {suc k} = suc-injective
-punchOut-cong {suc n} (suc i) {zero} {zero} _ = refl
-punchOut-cong {suc n} (suc i) {suc j} {suc k} = cong suc ∘ punchOut-cong i ∘ suc-injective
+punchOut-cong : ∀ (i : Fin (suc n)) {j k} {i≢j : i ≢ j} {i≢k : i ≢ k} →
+                j ≡ k → punchOut i≢j ≡ punchOut i≢k
+punchOut-cong {_}     zero    {zero}         {i≢j = 0≢0} = contradiction refl 0≢0
+punchOut-cong {_}     zero    {suc j} {zero} {i≢k = 0≢0} = contradiction refl 0≢0
+punchOut-cong {_}     zero    {suc j} {suc k}            = suc-injective
+punchOut-cong {suc n} (suc i) {zero}  {zero}   _ = refl
+punchOut-cong {suc n} (suc i) {suc j} {suc k}    = cong suc ∘ punchOut-cong i ∘ suc-injective
 
 -- An alternative to 'punchOut-cong' in the which the new inequality argument is
 -- specific. Useful for enabling the omission of that argument during equational
 -- reasoning.
 
-punchOut-cong′ : ∀ {n} (i : Fin (suc n)) {j k} {p : i ≢ j} (q : j ≡ k) → punchOut p ≡ punchOut (p ∘ sym ∘ trans q ∘ sym)
+punchOut-cong′ : ∀ (i : Fin (suc n)) {j k} {p : i ≢ j} (q : j ≡ k) →
+                 punchOut p ≡ punchOut (p ∘ sym ∘ trans q ∘ sym)
 punchOut-cong′ i q = punchOut-cong i q
 
-punchOut-injective : ∀ {m} {i j k : Fin (suc m)}
+punchOut-injective : ∀ {i j k : Fin (suc n)}
                      (i≢j : i ≢ j) (i≢k : i ≢ k) →
                      punchOut i≢j ≡ punchOut i≢k → j ≡ k
 punchOut-injective {_}     {zero}   {zero}  {_}     0≢0 _   _     = contradiction refl 0≢0
@@ -833,7 +818,7 @@ punchOut-injective {suc n} {suc i}  {zero}  {zero}  _   _    _    = refl
 punchOut-injective {suc n} {suc i}  {suc j} {suc k} i≢j i≢k pⱼ≡pₖ =
   cong suc (punchOut-injective (i≢j ∘ cong suc) (i≢k ∘ cong suc) (suc-injective pⱼ≡pₖ))
 
-punchIn-punchOut : ∀ {m} {i j : Fin (suc m)} (i≢j : i ≢ j) →
+punchIn-punchOut : ∀ {i j : Fin (suc n)} (i≢j : i ≢ j) →
                    punchIn i (punchOut i≢j) ≡ j
 punchIn-punchOut {_}     {zero}   {zero}  0≢0 = contradiction refl 0≢0
 punchIn-punchOut {_}     {zero}   {suc j} _   = refl
@@ -841,9 +826,9 @@ punchIn-punchOut {suc m} {suc i}  {zero}  i≢j = refl
 punchIn-punchOut {suc m} {suc i}  {suc j} i≢j =
   cong suc (punchIn-punchOut (i≢j ∘ cong suc))
 
-punchOut-punchIn : ∀ {n} i {j : Fin n} → punchOut {i = i} {j = punchIn i j} (punchInᵢ≢i i j ∘ sym) ≡ j
-punchOut-punchIn zero {j} = refl
-punchOut-punchIn (suc i) {zero} = refl
+punchOut-punchIn : ∀ i {j : Fin n} → punchOut {i = i} {j = punchIn i j} (punchInᵢ≢i i j ∘ sym) ≡ j
+punchOut-punchIn zero    {j}     = refl
+punchOut-punchIn (suc i) {zero}  = refl
 punchOut-punchIn (suc i) {suc j} = cong suc (begin
   punchOut (punchInᵢ≢i i j ∘ suc-injective ∘ sym ∘ cong suc)  ≡⟨ punchOut-cong i refl ⟩
   punchOut (punchInᵢ≢i i j ∘ sym)                             ≡⟨ punchOut-punchIn i ⟩
@@ -855,12 +840,12 @@ punchOut-punchIn (suc i) {suc j} = cong suc (begin
 -- pinch
 ------------------------------------------------------------------------
 
-pinch-surjective : ∀ {m} (i : Fin m) → Surjective _≡_ (pinch i)
+pinch-surjective : ∀ (i : Fin n) → Surjective _≡_ (pinch i)
 pinch-surjective _       zero    = zero , refl
 pinch-surjective zero    (suc j) = suc (suc j) , refl
 pinch-surjective (suc i) (suc j) = map suc (cong suc) (pinch-surjective i j)
 
-pinch-mono-≤ : ∀ {m} (i : Fin m) → (pinch i) Preserves _≤_ ⟶ _≤_
+pinch-mono-≤ : ∀ (i : Fin n) → (pinch i) Preserves _≤_ ⟶ _≤_
 pinch-mono-≤ 0F      {0F}    {k}     0≤n       = z≤n
 pinch-mono-≤ 0F      {suc j} {suc k} (s≤s j≤k) = j≤k
 pinch-mono-≤ (suc i) {0F}    {k}     0≤n       = z≤n
@@ -870,7 +855,7 @@ pinch-mono-≤ (suc i) {suc j} {suc k} (s≤s j≤k) = s≤s (pinch-mono-≤ i j
 -- Quantification
 ------------------------------------------------------------------------
 
-module _ {n p} {P : Pred (Fin (suc n)) p} where
+module _ {p} {P : Pred (Fin (suc n)) p} where
 
   ∀-cons : P zero → Π[ P ∘ suc ] → Π[ P ]
   ∀-cons z s zero    = z
@@ -892,9 +877,9 @@ module _ {n p} {P : Pred (Fin (suc n)) p} where
   ⊎⇔∃ : (P zero ⊎ ∃⟨ P ∘ suc ⟩) ⇔ ∃⟨ P ⟩
   ⊎⇔∃ = mk⇔ [ ∃-here , ∃-there ] ∃-toSum
 
-decFinSubset : ∀ {n p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
-               Decidable Q → (∀ {f} → Q f → Dec (P f)) → Dec (Q ⊆ P)
-decFinSubset {zero} Q? P? = yes λ {}
+decFinSubset : ∀ {p q} {P : Pred (Fin n) p} {Q : Pred (Fin n) q} →
+               Decidable Q → (∀ {i} → Q i → Dec (P i)) → Dec (Q ⊆ P)
+decFinSubset {zero}  {_}     {_} Q? P? = yes λ {}
 decFinSubset {suc n} {P = P} {Q} Q? P?
   with Q? zero | ∀-cons {P = λ x → Q x → P x}
 ... | false because [¬Q0] | cons =
@@ -906,12 +891,11 @@ decFinSubset {suc n} {P = P} {Q} Q? P?
        < _$ invert [Q0] , (λ f {x} → f {suc x}) >
        (P? (invert [Q0]) ×-dec decFinSubset (Q? ∘ suc) P?)
 
-any? : ∀ {n p} {P : Fin n → Set p} → Decidable P → Dec (∃ P)
+any? : ∀ {p} {P : Pred (Fin n) p} → Decidable P → Dec (∃ P)
 any? {zero}  {P = _} P? = no λ { (() , _) }
 any? {suc n} {P = P} P? = Dec.map ⊎⇔∃ (P? zero ⊎-dec any? (P? ∘ suc))
 
-all? : ∀ {n p} {P : Pred (Fin n) p} →
-       Decidable P → Dec (∀ f → P f)
+all? : ∀ {p} {P : Pred (Fin n) p} → Decidable P → Dec (∀ f → P f)
 all? P? = map′ (λ ∀p f → ∀p tt) (λ ∀p {x} _ → ∀p x)
                (decFinSubset U? (λ {f} _ → P? f))
 
@@ -932,7 +916,7 @@ private
 ¬∀⟶∃¬-smallest zero    P P? ¬∀P = contradiction (λ()) ¬∀P
 ¬∀⟶∃¬-smallest (suc n) P P? ¬∀P with P? zero
 ... | false because [¬P₀] = (zero , invert [¬P₀] , λ ())
-... |  true because  [P₀] = map suc (map id (∀-cons (invert [P₀])))
+... | true  because  [P₀] = map suc (map id (∀-cons (invert [P₀])))
   (¬∀⟶∃¬-smallest n (P ∘ suc) (P? ∘ suc) (¬∀P ∘ (∀-cons (invert [P₀]))))
 
 -- When P is a decidable predicate over a finite set the following
@@ -944,9 +928,8 @@ private
 
 -- The pigeonhole principle.
 
-pigeonhole : ∀ {m n} → m ℕ.< n → (f : Fin n → Fin m) →
-             ∃₂ λ i j → i ≢ j × f i ≡ f j
-pigeonhole z<s       f = contradiction (f zero) λ()
+pigeonhole : m ℕ.< n → (f : Fin n → Fin m) → ∃₂ λ i j → i ≢ j × f i ≡ f j
+pigeonhole z<s               f = contradiction (f zero) λ()
 pigeonhole (s<s m<n@(s≤s _)) f with any? (λ k → f zero ≟ f (suc k))
 ... | yes (j , f₀≡fⱼ) = zero , suc j , (λ()) , f₀≡fⱼ
 ... | no  f₀≢fₖ with pigeonhole m<n (λ j → punchOut (f₀≢fₖ ∘ (j ,_ )))
@@ -976,41 +959,39 @@ module _ {f} {F : Set f → Set f} (RF : RawFunctor F) where
   sequence⁻¹ F∀iPi i = (λ f → f i) <$> F∀iPi
 
 ------------------------------------------------------------------------
--- If there is an injection from a type to a finite set, then the type
+-- If there is an injection from a type A to a finite set, then the type
 -- has decidable equality.
 
-module _ {a} {A : Set a} where
-
-  eq? : ∀ {n} → A ↣ Fin n → B.Decidable {A = A} _≡_
-  eq? inj = Dec.via-injection inj _≟_
+eq? : A ↣ Fin n → DecidableEquality A
+eq? inj = Dec.via-injection inj _≟_
 
 ------------------------------------------------------------------------
 -- Opposite
 ------------------------------------------------------------------------
 
-opposite-prop : ∀ {n} → (i : Fin n) → toℕ (opposite i) ≡ n ∸ suc (toℕ i)
-opposite-prop {suc n} zero = toℕ-fromℕ n
+opposite-prop : ∀ (i : Fin n) → toℕ (opposite i) ≡ n ∸ suc (toℕ i)
+opposite-prop {suc n} zero    = toℕ-fromℕ n
 opposite-prop {suc n} (suc i) = begin
   toℕ (inject₁ (opposite i)) ≡⟨ toℕ-inject₁ (opposite i) ⟩
   toℕ (opposite i)           ≡⟨ opposite-prop i ⟩
   n ∸ suc (toℕ i)            ∎
   where open ≡-Reasoning
 
-opposite-involutive : ∀ {n} → Involutive {A = Fin n} _≡_ opposite
+opposite-involutive : Involutive {A = Fin n} _≡_ opposite
 opposite-involutive {suc n} i = toℕ-injective (begin
   toℕ (opposite (opposite i)) ≡⟨ opposite-prop (opposite i) ⟩
-  n ∸ (toℕ (opposite i))     ≡⟨ cong (n ∸_) (opposite-prop i) ⟩
-  n ∸ (n ∸ (toℕ i))         ≡⟨ ℕₚ.m∸[m∸n]≡n (toℕ≤pred[n] i) ⟩
-  toℕ i                     ∎)
+  n ∸ (toℕ (opposite i))      ≡⟨ cong (n ∸_) (opposite-prop i) ⟩
+  n ∸ (n ∸ (toℕ i))           ≡⟨ ℕₚ.m∸[m∸n]≡n (toℕ≤pred[n] i) ⟩
+  toℕ i                       ∎)
   where open ≡-Reasoning
 
-opposite-suc : ∀ {n} {i : Fin n} → toℕ (opposite (suc i)) ≡ toℕ (opposite i)
-opposite-suc {n} {i} = begin
-  toℕ (opposite (suc i))      ≡⟨ opposite-prop (suc i) ⟩
+opposite-suc : ∀ (i : Fin n) → toℕ (opposite (suc i)) ≡ toℕ (opposite i)
+opposite-suc {n} i = begin
+  toℕ (opposite (suc i))     ≡⟨ opposite-prop (suc i) ⟩
   suc n ∸ suc (toℕ (suc i))  ≡⟨⟩
   n ∸ toℕ (suc i)            ≡⟨⟩
   n ∸ suc (toℕ i)            ≡⟨ sym (opposite-prop i) ⟩
-  toℕ (opposite i)            ∎
+  toℕ (opposite i)           ∎
   where open ≡-Reasoning
 
 


### PR DESCRIPTION
Goes through the files using variables where possible to clean up the type signatures. Also a minor bit of refactoring to ensure the more recent additions to the file obey the conventions in the style guide. The breaking change is the moving of the argument of `opposite-suc` from implicit to explicit.