### PR TITLE
Change field names in new function hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,10 +148,10 @@ Non-backwards compatible changes
 * Added new aliases `Is(Meet/Join)(Bounded)Semilattice` for `Is(Bounded)Semilattice`
   which can be used to indicate meet/join-ness of the original structures.
 
-#### Switch to new function hierarchy
+#### Function hierarchy
 
-* Various modules have changed the types of some definitions to use the new
-  function hierachy:
+* The switch to the new function hierarchy is complete and the following definitions
+  now use the new definitions instead of the old ones:
   * `Data.Fin.Properties`
     * `∀-cons-⇔`
     * `⊎⇔∃`
@@ -207,6 +207,9 @@ Non-backwards compatible changes
     * `equivalent`
   * `Relation.Nullary.Decidable`
     * `map`
+
+* The names of the fields in the records of the new hierarchy have been
+  changed from `f`, `g`, `cong₁`, `cong₂` to `to`, `from`, `to-cong`, `from-cong`.
 
 #### Proofs of non-zeroness/positivity/negativity as instance arguments
 

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -125,11 +125,11 @@ record _⊕_ (counted : List Elem) (n : ℕ) : Set where
 
 empty : ∀ {n} → Injection D.setoid (PropEq.setoid (Fin n)) → [] ⊕ n
 empty inj =
-  record { kind      = inj₂ ∘ f
+  record { kind      = inj₂ ∘ to
          ; injective = λ {x} {y} {i} eq₁ eq₂ → injective (begin
-             f x ≡⟨ inj₂-injective eq₁ ⟩
-             i   ≡⟨ PropEq.sym $ inj₂-injective eq₂ ⟩
-             f y ∎)
+             to x ≡⟨ inj₂-injective eq₁ ⟩
+             i    ≡⟨ PropEq.sym $ inj₂-injective eq₂ ⟩
+             to y ∎)
          }
   where open Injection inj
 
@@ -138,8 +138,8 @@ empty inj =
 emptyFromList : (counted : List Elem) → (∀ x → x ∈ counted) →
                 [] ⊕ length counted
 emptyFromList counted complete = empty record
-  { f = λ x → first-index x (complete x)
-  ; cong = first-index-cong (complete _) (complete _)
+  { to        = λ x → first-index x (complete x)
+  ; cong      = first-index-cong (complete _) (complete _)
   ; injective = first-index-injective (complete _) (complete _)
   }
 

--- a/src/Data/List/Relation/Unary/Enumerates/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Unary/Enumerates/Setoid/Properties.agda
@@ -38,7 +38,7 @@ private
 module _ (S : Setoid a ℓ₁) (T : Setoid b ℓ₂) (surj : Surjection S T) where
   open Surjection surj
 
-  map⁺ : ∀ {xs} → IsEnumeration S xs → IsEnumeration T (map f xs)
+  map⁺ : ∀ {xs} → IsEnumeration S xs → IsEnumeration T (map to xs)
   map⁺ _∈xs y with surjective y
   ... | (x , fx≈y) = ∈-resp-≈ T fx≈y (∈-map⁺ S T cong (x ∈xs))
 

--- a/src/Data/List/Relation/Unary/Grouped/Properties.agda
+++ b/src/Data/List/Relation/Unary/Grouped/Properties.agda
@@ -39,8 +39,8 @@ module _ (P : Rel A p) (Q : Rel B q) where
   map⁺ {f} {x ∷ xs} P⇔Q (all[¬Px,xs] ∷≉ g) = aux all[¬Px,xs] ∷≉ map⁺ P⇔Q g where
     aux : ∀ {ys} → All (λ y → ¬ P x y) ys → All (λ y → ¬ Q (f x) y) (map f ys)
     aux [] = []
-    aux (py ∷ pys) = py ∘ Equivalence.g P⇔Q ∷ aux pys
-  map⁺ {f} {x₁ ∷ x₂ ∷ xs} P⇔Q (Px₁x₂ ∷≈ g) = Equivalence.f P⇔Q Px₁x₂ ∷≈ map⁺ P⇔Q g
+    aux (py ∷ pys) = py ∘ Equivalence.from P⇔Q ∷ aux pys
+  map⁺ {f} {x₁ ∷ x₂ ∷ xs} P⇔Q (Px₁x₂ ∷≈ g) = Equivalence.to P⇔Q Px₁x₂ ∷≈ map⁺ P⇔Q g
 
   map⁻ : ∀ {f xs} → (∀ {x y} → P x y ⇔ Q (f x) (f y)) → Grouped Q (map f xs) → Grouped P xs
   map⁻ {f} {[]} P⇔Q [] = []
@@ -48,8 +48,8 @@ module _ (P : Rel A p) (Q : Rel B q) where
   map⁻ {f} {x₁ ∷ x₂ ∷ xs} P⇔Q (all[¬Qx,xs] ∷≉ g) = aux all[¬Qx,xs] ∷≉ map⁻ P⇔Q g where
     aux : ∀ {ys} → All (λ y → ¬ Q (f x₁) y) (map f ys) → All (λ y → ¬ P x₁ y) ys
     aux {[]} [] = []
-    aux {y ∷ ys} (py ∷ pys) = py ∘ Equivalence.f P⇔Q ∷ aux pys
-  map⁻ {f} {x₁ ∷ x₂ ∷ xs} P⇔Q (Qx₁x₂ ∷≈ g) = Equivalence.g P⇔Q Qx₁x₂ ∷≈ map⁻ P⇔Q g
+    aux {y ∷ ys} (py ∷ pys) = py ∘ Equivalence.to P⇔Q ∷ aux pys
+  map⁻ {f} {x₁ ∷ x₂ ∷ xs} P⇔Q (Qx₁x₂ ∷≈ g) = Equivalence.from P⇔Q Qx₁x₂ ∷≈ map⁻ P⇔Q g
 
 ------------------------------------------------------------------------
 -- [_]

--- a/src/Data/Product/Algebra.agda
+++ b/src/Data/Product/Algebra.agda
@@ -55,7 +55,7 @@ private
 
 -- × is a congruence
 ×-cong : A ↔ B → C ↔ D → (A × C) ↔ (B × D)
-×-cong i j = mk↔′ (map I.f J.f) (map I.f⁻¹ J.f⁻¹)
+×-cong i j = mk↔′ (map I.to J.to) (map I.from J.from)
   (λ {(a , b) → cong₂ _,_ (I.inverseˡ a) (J.inverseˡ b)})
   (λ {(a , b) → cong₂ _,_ (I.inverseʳ a) (J.inverseʳ b)})
   where module I = Inverse i; module J = Inverse j

--- a/src/Data/Sum/Algebra.agda
+++ b/src/Data/Sum/Algebra.agda
@@ -45,7 +45,7 @@ private
 -- Algebraic properties
 
 ⊎-cong : A ↔ B → C ↔ D → (A ⊎ C) ↔ (B ⊎ D)
-⊎-cong i j = mk↔′ (map I.f J.f) (map I.f⁻¹ J.f⁻¹)
+⊎-cong i j = mk↔′ (map I.to J.to) (map I.from J.from)
   [ cong inj₁ ∘ I.inverseˡ , cong inj₂ ∘ J.inverseˡ ]
   [ cong inj₁ ∘ I.inverseʳ , cong inj₂ ∘ J.inverseʳ ]
   where module I = Inverse i; module J = Inverse j

--- a/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
+++ b/src/Data/Vec/Relation/Binary/Pointwise/Extensional.agda
@@ -158,9 +158,9 @@ module _ {_∼_ : Rel A ℓ} where
   ∙⁺⇒⁺∙ : ∀ {n} {xs ys : Vec A n} → Reflexive _∼_ →
           Pointwise (Plus _∼_) xs ys → Plus (Pointwise _∼_) xs ys
   ∙⁺⇒⁺∙ rfl =
-    Plus.map (Equivalence.g equivalent) ∘
+    Plus.map (Equivalence.from equivalent) ∘
     helper ∘
-    Equivalence.f equivalent
+    Equivalence.to equivalent
     where
     helper : ∀ {n} {xs ys : Vec A n} →
              IPointwise (Plus _∼_) xs ys → Plus (IPointwise _∼_) xs ys
@@ -209,6 +209,7 @@ private
          Pointwise (Plus _R_) xs ys →
          Plus (Pointwise _R_) xs ys)
   counterexample ∙⁺⇒⁺∙ =
-    ¬ix⁺∙jz (Equivalence.f Plus.equivalent
-              (Plus.map (Equivalence.f equivalent)
-                (∙⁺⇒⁺∙ (Equivalence.g equivalent ix∙⁺jz))))
+    ¬ix⁺∙jz (Equivalence.to Plus.equivalent
+              (Plus.map (Equivalence.to equivalent)
+                (∙⁺⇒⁺∙ (Equivalence.from equivalent ix∙⁺jz))))
+

--- a/src/Function/Bundles.agda
+++ b/src/Function/Bundles.agda
@@ -51,10 +51,10 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
   -- with the top-level module.
   record Func : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f    : A → B
-      cong : f Preserves _≈₁_ ⟶ _≈₂_
+      to   : A → B
+      cong : to Preserves _≈₁_ ⟶ _≈₂_
 
-    isCongruent : IsCongruent f
+    isCongruent : IsCongruent to
     isCongruent = record
       { cong           = cong
       ; isEquivalence₁ = isEquivalence From
@@ -67,20 +67,20 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
   record Injection : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f           : A → B
-      cong        : f Preserves _≈₁_ ⟶ _≈₂_
-      injective   : Injective f
+      to          : A → B
+      cong        : to Preserves _≈₁_ ⟶ _≈₂_
+      injective   : Injective to
 
     function : Func
     function = record
-      { f    = f
+      { to   = to
       ; cong = cong
       }
 
     open Func function public
-      hiding (f; cong)
+      hiding (to; cong)
 
-    isInjection : IsInjection f
+    isInjection : IsInjection to
     isInjection = record
       { isCongruent = isCongruent
       ; injective   = injective
@@ -89,14 +89,14 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
   record Surjection : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f          : A → B
-      cong       : f Preserves _≈₁_ ⟶ _≈₂_
-      surjective : Surjective f
+      to         : A → B
+      cong       : to Preserves _≈₁_ ⟶ _≈₂_
+      surjective : Surjective to
 
-    f⁻ : B → A
-    f⁻ = proj₁ ∘ surjective
+    to⁻ : B → A
+    to⁻ = proj₁ ∘ surjective
 
-    isCongruent : IsCongruent f
+    isCongruent : IsCongruent to
     isCongruent = record
       { cong           = cong
       ; isEquivalence₁ = isEquivalence From
@@ -105,7 +105,7 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
     open IsCongruent isCongruent public using (module Eq₁; module Eq₂)
 
-    isSurjection : IsSurjection f
+    isSurjection : IsSurjection to
     isSurjection = record
       { isCongruent = isCongruent
       ; surjective  = surjective
@@ -114,14 +114,14 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
   record Bijection : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f         : A → B
-      cong      : f Preserves _≈₁_ ⟶ _≈₂_
-      bijective : Bijective f
+      to        : A → B
+      cong      : to Preserves _≈₁_ ⟶ _≈₂_
+      bijective : Bijective to
 
-    injective : Injective f
+    injective : Injective to
     injective = proj₁ bijective
 
-    surjective : Surjective f
+    surjective : Surjective to
     surjective = proj₂ bijective
 
     injection : Injection
@@ -137,9 +137,9 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
       }
 
     open Injection  injection  public using (isInjection)
-    open Surjection surjection public using (isSurjection; f⁻)
+    open Surjection surjection public using (isSurjection; to⁻)
 
-    isBijection : IsBijection f
+    isBijection : IsBijection to
     isBijection = record
       { isInjection = isInjection
       ; surjective  = surjective
@@ -153,104 +153,104 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
   record Equivalence : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f     : A → B
-      g     : B → A
-      cong₁ : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂ : g Preserves _≈₂_ ⟶ _≈₁_
+      to        : A → B
+      from      : B → A
+      to-cong   : to Preserves _≈₁_ ⟶ _≈₂_
+      from-cong : from Preserves _≈₂_ ⟶ _≈₁_
 
 
   record LeftInverse : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f         : A → B
-      g         : B → A
-      cong₁     : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂     : g Preserves _≈₂_ ⟶ _≈₁_
-      inverseˡ  : Inverseˡ f g
+      to        : A → B
+      from      : B → A
+      to-cong   : to Preserves _≈₁_ ⟶ _≈₂_
+      from-cong : from Preserves _≈₂_ ⟶ _≈₁_
+      inverseˡ  : Inverseˡ to from
 
-    isCongruent : IsCongruent f
+    isCongruent : IsCongruent to
     isCongruent = record
-      { cong           = cong₁
+      { cong           = to-cong
       ; isEquivalence₁ = isEquivalence From
       ; isEquivalence₂ = isEquivalence To
       }
 
     open IsCongruent isCongruent public using (module Eq₁; module Eq₂)
 
-    isLeftInverse : IsLeftInverse f g
+    isLeftInverse : IsLeftInverse to from
     isLeftInverse = record
       { isCongruent = isCongruent
-      ; cong₂       = cong₂
+      ; from-cong   = from-cong
       ; inverseˡ    = inverseˡ
       }
 
     equivalence : Equivalence
     equivalence = record
-      { cong₁ = cong₁
-      ; cong₂ = cong₂
+      { to-cong   = to-cong
+      ; from-cong = from-cong
       }
 
 
   record RightInverse : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f         : A → B
-      g         : B → A
-      cong₁     : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂     : g Preserves _≈₂_ ⟶ _≈₁_
-      inverseʳ  : Inverseʳ f g
+      to        : A → B
+      from      : B → A
+      to-cong   : to Preserves _≈₁_ ⟶ _≈₂_
+      from-cong : from Preserves _≈₂_ ⟶ _≈₁_
+      inverseʳ  : Inverseʳ to from
 
-    isCongruent : IsCongruent f
+    isCongruent : IsCongruent to
     isCongruent = record
-      { cong           = cong₁
+      { cong           = to-cong
       ; isEquivalence₁ = isEquivalence From
       ; isEquivalence₂ = isEquivalence To
       }
 
-    isRightInverse : IsRightInverse f g
+    isRightInverse : IsRightInverse to from
     isRightInverse = record
       { isCongruent = isCongruent
-      ; cong₂       = cong₂
+      ; from-cong   = from-cong
       ; inverseʳ    = inverseʳ
       }
 
     equivalence : Equivalence
     equivalence = record
-      { cong₁ = cong₁
-      ; cong₂ = cong₂
+      { to-cong   = to-cong
+      ; from-cong = from-cong
       }
 
 
   record Inverse : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f         : A → B
-      f⁻¹       : B → A
-      cong₁     : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂     : f⁻¹ Preserves _≈₂_ ⟶ _≈₁_
-      inverse   : Inverseᵇ f f⁻¹
+      to        : A → B
+      from      : B → A
+      to-cong   : to Preserves _≈₁_ ⟶ _≈₂_
+      from-cong : from Preserves _≈₂_ ⟶ _≈₁_
+      inverse   : Inverseᵇ to from
 
-    inverseˡ : Inverseˡ f f⁻¹
+    inverseˡ : Inverseˡ to from
     inverseˡ = proj₁ inverse
 
-    inverseʳ : Inverseʳ f f⁻¹
+    inverseʳ : Inverseʳ to from
     inverseʳ = proj₂ inverse
 
     leftInverse : LeftInverse
     leftInverse = record
-      { cong₁    = cong₁
-      ; cong₂    = cong₂
-      ; inverseˡ = inverseˡ
+      { to-cong   = to-cong
+      ; from-cong = from-cong
+      ; inverseˡ  = inverseˡ
       }
 
     rightInverse : RightInverse
     rightInverse = record
-      { cong₁    = cong₁
-      ; cong₂    = cong₂
-      ; inverseʳ = inverseʳ
+      { to-cong   = to-cong
+      ; from-cong = from-cong
+      ; inverseʳ  = inverseʳ
       }
 
     open LeftInverse leftInverse   public using (isLeftInverse)
     open RightInverse rightInverse public using (isRightInverse)
 
-    isInverse : IsInverse f f⁻¹
+    isInverse : IsInverse to from
     isInverse = record
       { isLeftInverse = isLeftInverse
       ; inverseʳ      = inverseʳ
@@ -264,46 +264,46 @@ module _ (From : Setoid a ℓ₁) (To : Setoid b ℓ₂) where
 
   record BiEquivalence : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f     : A → B
-      g₁    : B → A
-      g₂    : B → A
-      cong₁ : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂ : g₁ Preserves _≈₂_ ⟶ _≈₁_
-      cong₃ : g₂ Preserves _≈₂_ ⟶ _≈₁_
+      to         : A → B
+      from₁      : B → A
+      from₂      : B → A
+      to-cong    : to Preserves _≈₁_ ⟶ _≈₂_
+      from₁-cong : from₁ Preserves _≈₂_ ⟶ _≈₁_
+      from₂-cong : from₂ Preserves _≈₂_ ⟶ _≈₁_
 
 
   record BiInverse : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     field
-      f         : A → B
-      g₁        : B → A
-      g₂        : B → A
-      cong₁     : f Preserves _≈₁_ ⟶ _≈₂_
-      cong₂     : g₁ Preserves _≈₂_ ⟶ _≈₁_
-      cong₃     : g₂ Preserves _≈₂_ ⟶ _≈₁_
-      inverseˡ  : Inverseˡ f g₁
-      inverseʳ  : Inverseʳ f g₂
+      to         : A → B
+      from₁        : B → A
+      from₂        : B → A
+      to-cong     : to Preserves _≈₁_ ⟶ _≈₂_
+      from₁-cong     : from₁ Preserves _≈₂_ ⟶ _≈₁_
+      from₂-cong     : from₂ Preserves _≈₂_ ⟶ _≈₁_
+      inverseˡ  : Inverseˡ to from₁
+      inverseʳ  : Inverseʳ to from₂
 
-    f-isCongruent : IsCongruent f
-    f-isCongruent = record
-      { cong           = cong₁
+    to-isCongruent : IsCongruent to
+    to-isCongruent = record
+      { cong           = to-cong
       ; isEquivalence₁ = isEquivalence From
       ; isEquivalence₂ = isEquivalence To
       }
 
-    isBiInverse : IsBiInverse f g₁ g₂
+    isBiInverse : IsBiInverse to from₁ from₂
     isBiInverse = record
-      { f-isCongruent = f-isCongruent
-      ; cong₂         = cong₂
-      ; inverseˡ      = inverseˡ
-      ; cong₃         = cong₃
-      ; inverseʳ      = inverseʳ
+      { to-isCongruent = to-isCongruent
+      ; from₁-cong     = from₁-cong
+      ; from₂-cong     = from₂-cong
+      ; inverseˡ       = inverseˡ
+      ; inverseʳ       = inverseʳ
       }
 
     biEquivalence : BiEquivalence
     biEquivalence = record
-      { cong₁ = cong₁
-      ; cong₂ = cong₂
-      ; cong₃ = cong₃
+      { to-cong    = to-cong
+      ; from₁-cong = from₁-cong
+      ; from₂-cong = from₂-cong
       }
 
 
@@ -347,80 +347,80 @@ module _ {A : Set a} {B : Set b} where
   open FunctionDefinitions {A = A} {B} _≡_ _≡_
 
   mk⟶ : (A → B) → A ⟶ B
-  mk⟶ f = record
-    { f         = f
-    ; cong      = ≡.cong f
+  mk⟶ to = record
+    { to        = to
+    ; cong      = ≡.cong to
     }
 
-  mk↣ : ∀ {f : A → B} → Injective f → A ↣ B
-  mk↣ {f} inj = record
-    { f         = f
-    ; cong      = ≡.cong f
+  mk↣ : ∀ {to : A → B} → Injective to → A ↣ B
+  mk↣ {to} inj = record
+    { to         = to
+    ; cong      = ≡.cong to
     ; injective = inj
     }
 
-  mk↠ : ∀ {f : A → B} → Surjective f → A ↠ B
-  mk↠ {f} surj = record
-    { f          = f
-    ; cong       = ≡.cong f
+  mk↠ : ∀ {to : A → B} → Surjective to → A ↠ B
+  mk↠ {to} surj = record
+    { to         = to
+    ; cong       = ≡.cong to
     ; surjective = surj
     }
 
-  mk⤖ : ∀ {f : A → B} → Bijective f → A ⤖ B
-  mk⤖ {f} bij = record
-    { f         = f
-    ; cong      = ≡.cong f
+  mk⤖ : ∀ {to : A → B} → Bijective to → A ⤖ B
+  mk⤖ {to} bij = record
+    { to        = to
+    ; cong      = ≡.cong to
     ; bijective = bij
     }
 
-  mk⇔ : ∀ (f : A → B) (g : B → A) → A ⇔ B
-  mk⇔ f g = record
-    { f     = f
-    ; g     = g
-    ; cong₁ = ≡.cong f
-    ; cong₂ = ≡.cong g
+  mk⇔ : ∀ (to : A → B) (from : B → A) → A ⇔ B
+  mk⇔ to from = record
+    { to        = to
+    ; from      = from
+    ; to-cong   = ≡.cong to
+    ; from-cong = ≡.cong from
     }
 
-  mk↩ : ∀ {f : A → B} {g : B → A} → Inverseˡ f g → A ↩ B
-  mk↩ {f} {g} invˡ = record
-    { f        = f
-    ; g        = g
-    ; cong₁    = ≡.cong f
-    ; cong₂    = ≡.cong g
-    ; inverseˡ = invˡ
+  mk↩ : ∀ {to : A → B} {from : B → A} → Inverseˡ to from → A ↩ B
+  mk↩ {to} {from} invˡ = record
+    { to        = to
+    ; from      = from
+    ; to-cong   = ≡.cong to
+    ; from-cong = ≡.cong from
+    ; inverseˡ  = invˡ
     }
 
-  mk↪ : ∀ {f : A → B} {g : B → A} → Inverseʳ f g → A ↪ B
-  mk↪ {f} {g} invʳ = record
-    { f        = f
-    ; g        = g
-    ; cong₁    = ≡.cong f
-    ; cong₂    = ≡.cong g
-    ; inverseʳ = invʳ
+  mk↪ : ∀ {to : A → B} {from : B → A} → Inverseʳ to from → A ↪ B
+  mk↪ {to} {from} invʳ = record
+    { to        = to
+    ; from      = from
+    ; to-cong   = ≡.cong to
+    ; from-cong = ≡.cong from
+    ; inverseʳ  = invʳ
     }
 
-  mk↩↪ : ∀ {f : A → B} {g₁ : B → A} {g₂ : B → A} →
-         Inverseˡ f g₁ → Inverseʳ f g₂ → A ↩↪ B
-  mk↩↪ {f} {g₁} {g₂} invˡ invʳ = record
-    { f        = f
-    ; g₁       = g₁
-    ; g₂       = g₂
-    ; cong₁    = ≡.cong f
-    ; cong₂    = ≡.cong g₁
-    ; cong₃    = ≡.cong g₂
-    ; inverseˡ = invˡ
-    ; inverseʳ = invʳ
+  mk↩↪ : ∀ {to : A → B} {from₁ : B → A} {from₂ : B → A} →
+         Inverseˡ to from₁ → Inverseʳ to from₂ → A ↩↪ B
+  mk↩↪ {to} {from₁} {from₂} invˡ invʳ = record
+    { to         = to
+    ; from₁      = from₁
+    ; from₂      = from₂
+    ; to-cong    = ≡.cong to
+    ; from₁-cong = ≡.cong from₁
+    ; from₂-cong = ≡.cong from₂
+    ; inverseˡ   = invˡ
+    ; inverseʳ   = invʳ
     }
 
-  mk↔ : ∀ {f : A → B} {f⁻¹ : B → A} → Inverseᵇ f f⁻¹ → A ↔ B
-  mk↔ {f} {f⁻¹} inv = record
-    { f       = f
-    ; f⁻¹     = f⁻¹
-    ; cong₁   = ≡.cong f
-    ; cong₂   = ≡.cong f⁻¹
-    ; inverse = inv
+  mk↔ : ∀ {to : A → B} {from : B → A} → Inverseᵇ to from → A ↔ B
+  mk↔ {to} {from} inv = record
+    { to        = to
+    ; from      = from
+    ; to-cong   = ≡.cong to
+    ; from-cong = ≡.cong from
+    ; inverse   = inv
     }
 
   -- Sometimes the implicit arguments above cannot be inferred
-  mk↔′ : ∀ (f : A → B) (f⁻¹ : B → A) → Inverseˡ f f⁻¹ → Inverseʳ f f⁻¹ → A ↔ B
-  mk↔′ f f⁻¹ invˡ invʳ = mk↔ {f = f} {f⁻¹ = f⁻¹} (invˡ , invʳ)
+  mk↔′ : ∀ (to : A → B) (from : B → A) → Inverseˡ to from → Inverseʳ to from → A ↔ B
+  mk↔′ to from invˡ invʳ = mk↔ {to = to} {from = from} (invˡ , invʳ)

--- a/src/Function/Construct/Composition.agda
+++ b/src/Function/Construct/Composition.agda
@@ -16,9 +16,7 @@ open import Relation.Binary as B hiding (_⇔_; IsEquivalence)
 private
   variable
     a b c ℓ₁ ℓ₂ ℓ₃ : Level
-    A : Set a
-    B : Set b
-    C : Set c
+    A B C : Set a
 
 ------------------------------------------------------------------------
 -- Properties
@@ -95,7 +93,7 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
                  IsSurjection ≈₁ ≈₃ (g ∘ f)
   isSurjection f-surj g-surj = record
     { isCongruent = isCongruent F.isCongruent G.isCongruent
-    ; surjective   = surjective ≈₁ ≈₂ ≈₃ G.Eq₂.trans G.cong F.surjective G.surjective
+    ; surjective  = surjective ≈₁ ≈₂ ≈₃ G.Eq₂.trans G.cong F.surjective G.surjective
     } where module F = IsSurjection f-surj; module G = IsSurjection g-surj
 
   isBijection : IsBijection ≈₁ ≈₂ f → IsBijection ≈₂ ≈₃ g →
@@ -113,23 +111,23 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂} {≈₃ : Rel C ℓ₃}
                   IsLeftInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
   isLeftInverse f-invˡ g-invˡ = record
     { isCongruent = isCongruent F.isCongruent G.isCongruent
-    ; cong₂       = congruent ≈₃ ≈₂ ≈₁ G.cong₂ F.cong₂
-    ; inverseˡ    = inverseˡ ≈₁ ≈₂ ≈₃ f _ G.Eq₂.trans G.cong₁ F.inverseˡ G.inverseˡ
+    ; from-cong       = congruent ≈₃ ≈₂ ≈₁ G.from-cong F.from-cong
+    ; inverseˡ    = inverseˡ ≈₁ ≈₂ ≈₃ f _ G.Eq₂.trans G.to-cong F.inverseˡ G.inverseˡ
     } where module F = IsLeftInverse f-invˡ; module G = IsLeftInverse g-invˡ
 
   isRightInverse : IsRightInverse ≈₁ ≈₂ f f⁻¹ → IsRightInverse ≈₂ ≈₃ g g⁻¹ →
                    IsRightInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
   isRightInverse f-invʳ g-invʳ = record
     { isCongruent = isCongruent F.isCongruent G.isCongruent
-    ; cong₂       = congruent ≈₃ ≈₂ ≈₁ G.cong₂ F.cong₂
-    ; inverseʳ    = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.cong₂ F.inverseʳ G.inverseʳ
+    ; from-cong       = congruent ≈₃ ≈₂ ≈₁ G.from-cong F.from-cong
+    ; inverseʳ    = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.from-cong F.inverseʳ G.inverseʳ
     } where module F = IsRightInverse f-invʳ; module G = IsRightInverse g-invʳ
 
   isInverse : IsInverse ≈₁ ≈₂ f f⁻¹ → IsInverse ≈₂ ≈₃ g g⁻¹ →
               IsInverse ≈₁ ≈₃ (g ∘ f) (f⁻¹ ∘ g⁻¹)
   isInverse f-inv g-inv = record
     { isLeftInverse = isLeftInverse F.isLeftInverse G.isLeftInverse
-    ; inverseʳ      = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.cong₂ F.inverseʳ G.inverseʳ
+    ; inverseʳ      = inverseʳ ≈₁ ≈₂ ≈₃ _ g⁻¹ F.Eq₁.trans F.from-cong F.inverseʳ G.inverseʳ
     } where module F = IsInverse f-inv; module G = IsInverse g-inv
 
 ------------------------------------------------------------------------
@@ -141,64 +139,64 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} {T : Setoid c ℓ₃} where
 
   function : Func R S → Func S T → Func R T
   function f g = record
-    { f    = G.f ∘ F.f
+    { to   = G.to ∘ F.to
     ; cong = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
     } where module F = Func f; module G = Func g
 
   injection : Injection R S → Injection S T → Injection R T
   injection inj₁ inj₂ = record
-    { f         = G.f ∘ F.f
+    { to        = G.to ∘ F.to
     ; cong      = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
     ; injective = injective (≈ R) (≈ S) (≈ T) F.injective G.injective
     } where module F = Injection inj₁; module G = Injection inj₂
 
   surjection : Surjection R S → Surjection S T → Surjection R T
   surjection surj₁ surj₂ = record
-    { f          = G.f ∘ F.f
+    { to         = G.to ∘ F.to
     ; cong       = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
     ; surjective = surjective (≈ R) (≈ S) (≈ T) G.Eq₂.trans G.cong F.surjective G.surjective
     } where module F = Surjection surj₁; module G = Surjection surj₂
 
   bijection : Bijection R S → Bijection S T → Bijection R T
   bijection bij₁ bij₂ = record
-    { f         = G.f ∘ F.f
+    { to        = G.to ∘ F.to
     ; cong      = congruent (≈ R) (≈ S) (≈ T) F.cong G.cong
     ; bijective = bijective (≈ R) (≈ S) (≈ T) (trans T) G.cong F.bijective G.bijective
     } where module F = Bijection bij₁; module G = Bijection bij₂
 
   equivalence : Equivalence R S → Equivalence S T → Equivalence R T
   equivalence equiv₁ equiv₂ = record
-    { f        = G.f ∘ F.f
-    ; g        = F.g ∘ G.g
-    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
-    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
+    { to        = G.to ∘ F.to
+    ; from      = F.from ∘ G.from
+    ; to-cong   = congruent (≈ R) (≈ S) (≈ T) F.to-cong G.to-cong
+    ; from-cong = congruent (≈ T) (≈ S) (≈ R) G.from-cong F.from-cong
     } where module F = Equivalence equiv₁; module G = Equivalence equiv₂
 
   leftInverse : LeftInverse R S → LeftInverse S T → LeftInverse R T
   leftInverse invˡ₁ invˡ₂ = record
-    { f        = G.f ∘ F.f
-    ; g        = F.g ∘ G.g
-    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
-    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
-    ; inverseˡ = inverseˡ (≈ R) (≈ S) (≈ T) F.f _ (trans T) G.cong₁ F.inverseˡ G.inverseˡ
+    { to        = G.to ∘ F.to
+    ; from      = F.from ∘ G.from
+    ; to-cong   = congruent (≈ R) (≈ S) (≈ T) F.to-cong G.to-cong
+    ; from-cong = congruent (≈ T) (≈ S) (≈ R) G.from-cong F.from-cong
+    ; inverseˡ  = inverseˡ  (≈ R) (≈ S) (≈ T) F.to _ (trans T) G.to-cong F.inverseˡ G.inverseˡ
     } where module F = LeftInverse invˡ₁; module G = LeftInverse invˡ₂
 
   rightInverse : RightInverse R S → RightInverse S T → RightInverse R T
   rightInverse invʳ₁ invʳ₂ = record
-    { f        = G.f ∘ F.f
-    ; g        = F.g ∘ G.g
-    ; cong₁    = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
-    ; cong₂    = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
-    ; inverseʳ = inverseʳ (≈ R) (≈ S) (≈ T) _ G.g (trans R) F.cong₂ F.inverseʳ G.inverseʳ
+    { to        = G.to ∘ F.to
+    ; from      = F.from ∘ G.from
+    ; to-cong   = congruent (≈ R) (≈ S) (≈ T) F.to-cong G.to-cong
+    ; from-cong = congruent (≈ T) (≈ S) (≈ R) G.from-cong F.from-cong
+    ; inverseʳ  = inverseʳ  (≈ R) (≈ S) (≈ T) _ G.from (trans R) F.from-cong F.inverseʳ G.inverseʳ
     } where module F = RightInverse invʳ₁; module G = RightInverse invʳ₂
 
   inverse : Inverse R S → Inverse S T → Inverse R T
   inverse inv₁ inv₂ = record
-    { f       = G.f ∘ F.f
-    ; f⁻¹     = F.f⁻¹ ∘ G.f⁻¹
-    ; cong₁   = congruent (≈ R) (≈ S) (≈ T) F.cong₁ G.cong₁
-    ; cong₂   = congruent (≈ T) (≈ S) (≈ R) G.cong₂ F.cong₂
-    ; inverse = inverseᵇ (≈ R) (≈ S) (≈ T) _ G.f⁻¹ (trans R) (trans T) G.cong₁ F.cong₂ F.inverse G.inverse
+    { to        = G.to ∘ F.to
+    ; from      = F.from ∘ G.from
+    ; to-cong   = congruent (≈ R) (≈ S) (≈ T) F.to-cong G.to-cong
+    ; from-cong = congruent (≈ T) (≈ S) (≈ R) G.from-cong F.from-cong
+    ; inverse   = inverseᵇ  (≈ R) (≈ S) (≈ T) _ G.from (trans R) (trans T) G.to-cong F.from-cong F.inverse G.inverse
     } where module F = Inverse inv₁; module G = Inverse inv₂
 
 ------------------------------------------------------------------------

--- a/src/Function/Construct/Identity.agda
+++ b/src/Function/Construct/Identity.agda
@@ -86,14 +86,14 @@ module _ {_≈_ : Rel A ℓ} (isEq : B.IsEquivalence _≈_) where
   isLeftInverse : IsLeftInverse id id
   isLeftInverse = record
     { isCongruent = isCongruent
-    ; cong₂       = id
+    ; from-cong   = id
     ; inverseˡ    = inverseˡ _≈_ refl
     }
 
   isRightInverse : IsRightInverse id id
   isRightInverse = record
     { isCongruent = isCongruent
-    ; cong₂       = id
+    ; from-cong   = id
     ; inverseʳ    = inverseʳ _≈_ refl
     }
 
@@ -112,64 +112,64 @@ module _ (S : Setoid a ℓ) where
 
   function : Func S S
   function = record
-    { f    = id
+    { to   = id
     ; cong = id
     }
 
   injection : Injection S S
   injection = record
-    { f         = id
+    { to        = id
     ; cong      = id
     ; injective = injective _≈_
     }
 
   surjection : Surjection S S
   surjection = record
-    { f          = id
+    { to         = id
     ; cong       = id
     ; surjective = surjective _≈_ refl
     }
 
   bijection : Bijection S S
   bijection = record
-    { f         = id
+    { to        = id
     ; cong      = id
     ; bijective = bijective _≈_ refl
     }
 
   equivalence : Equivalence S S
   equivalence = record
-    { f     = id
-    ; g     = id
-    ; cong₁ = id
-    ; cong₂ = id
+    { to        = id
+    ; from      = id
+    ; to-cong   = id
+    ; from-cong = id
     }
 
   leftInverse : LeftInverse S S
   leftInverse = record
-    { f        = id
-    ; g        = id
-    ; cong₁    = id
-    ; cong₂    = id
-    ; inverseˡ = inverseˡ _≈_ refl
+    { to        = id
+    ; from      = id
+    ; to-cong   = id
+    ; from-cong = id
+    ; inverseˡ  = inverseˡ _≈_ refl
     }
 
   rightInverse : RightInverse S S
   rightInverse = record
-    { f        = id
-    ; g        = id
-    ; cong₁    = id
-    ; cong₂    = id
-    ; inverseʳ = inverseʳ _≈_ refl
+    { to        = id
+    ; from      = id
+    ; to-cong   = id
+    ; from-cong = id
+    ; inverseʳ  = inverseʳ _≈_ refl
     }
 
   inverse : Inverse S S
   inverse = record
-    { f       = id
-    ; f⁻¹     = id
-    ; cong₁   = id
-    ; cong₂   = id
-    ; inverse = inverseᵇ _≈_ refl
+    { to        = id
+    ; from      = id
+    ; to-cong   = id
+    ; from-cong = id
+    ; inverse   = inverseᵇ _≈_ refl
     }
 
 ------------------------------------------------------------------------

--- a/src/Function/Construct/Symmetry.agda
+++ b/src/Function/Construct/Symmetry.agda
@@ -17,9 +17,7 @@ open import Relation.Binary.PropositionalEquality
 private
   variable
     a b c ℓ₁ ℓ₂ ℓ₃ : Level
-    A : Set a
-    B : Set b
-    C : Set c
+    A B C : Set a
 
 ------------------------------------------------------------------------
 -- Properties
@@ -101,15 +99,15 @@ module _ {≈₁ : Rel A ℓ₁} {≈₂ : Rel B ℓ₂}
 
   isLeftInverse : IsRightInverse ≈₁ ≈₂ f f⁻¹ → IsLeftInverse ≈₂ ≈₁ f⁻¹ f
   isLeftInverse inv = record
-    { isCongruent = isCongruent F.isCongruent F.cong₂
-    ; cong₂       = F.cong₁
+    { isCongruent = isCongruent F.isCongruent F.from-cong
+    ; from-cong   = F.cong₁
     ; inverseˡ    = inverseˡ ≈₁ ≈₂ f {f⁻¹} F.inverseʳ
     } where module F = IsRightInverse inv
 
   isRightInverse : IsLeftInverse ≈₁ ≈₂ f f⁻¹ → IsRightInverse ≈₂ ≈₁ f⁻¹ f
   isRightInverse inv = record
-    { isCongruent = isCongruent F.isCongruent F.cong₂
-    ; cong₂       = F.cong₁
+    { isCongruent = isCongruent F.isCongruent F.from-cong
+    ; from-cong   = F.to-cong
     ; inverseʳ    = inverseʳ ≈₁ ≈₂ f {f⁻¹} F.inverseˡ
     } where module F = IsLeftInverse inv
 
@@ -126,13 +124,13 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} (bij : Bijection R S) where
 
   private
     module IB = Bijection bij
-    f⁻¹       = proj₁ ∘ IB.surjective
+    from      = proj₁ ∘ IB.surjective
 
   -- We can only flip a bijection if the witness produced by the
   -- surjection proof respects the equality on the codomain.
-  bijection : Congruent IB.Eq₂._≈_ IB.Eq₁._≈_ f⁻¹ → Bijection S R
+  bijection : Congruent IB.Eq₂._≈_ IB.Eq₁._≈_ from → Bijection S R
   bijection cong = record
-    { f         = f⁻¹
+    { to        = from
     ; cong      = cong
     ; bijective = bijective IB.bijective IB.Eq₂.sym IB.Eq₂.trans IB.cong
     }
@@ -148,37 +146,37 @@ module _ {R : Setoid a ℓ₁} {S : Setoid b ℓ₂} where
 
   equivalence : Equivalence R S → Equivalence S R
   equivalence equiv = record
-    { f     = E.g
-    ; g     = E.f
-    ; cong₁ = E.cong₂
-    ; cong₂ = E.cong₁
+    { to        = E.from
+    ; from      = E.to
+    ; to-cong   = E.from-cong
+    ; from-cong = E.to-cong
     } where module E = Equivalence equiv
 
   rightInverse : LeftInverse R S → RightInverse S R
   rightInverse left = record
-    { f        = L.g
-    ; g        = L.f
-    ; cong₁    = L.cong₂
-    ; cong₂    = L.cong₁
-    ; inverseʳ = L.inverseˡ
+    { to         = L.from
+    ; from       = L.to
+    ; to-cong    = L.from-cong
+    ; from-cong  = L.to-cong
+    ; inverseʳ   = L.inverseˡ
     } where module L = LeftInverse left
 
   leftInverse : RightInverse R S → LeftInverse S R
   leftInverse right = record
-    { f     = R.g
-    ; g     = R.f
-    ; cong₁ = R.cong₂
-    ; cong₂ = R.cong₁
-    ; inverseˡ = R.inverseʳ
+    { to        = R.from
+    ; from      = R.to
+    ; to-cong   = R.from-cong
+    ; from-cong = R.to-cong
+    ; inverseˡ  = R.inverseʳ
     } where module R = RightInverse right
 
   inverse : Inverse R S → Inverse S R
   inverse inv = record
-    { f       = I.f⁻¹
-    ; f⁻¹     = I.f
-    ; cong₁   = I.cong₂
-    ; cong₂   = I.cong₁
-    ; inverse = swap I.inverse
+    { to        = I.from
+    ; from      = I.to
+    ; to-cong   = I.from-cong
+    ; from-cong = I.to-cong
+    ; inverse   = swap I.inverse
     } where module I = Inverse inv
 
 ------------------------------------------------------------------------

--- a/src/Function/Properties.agda
+++ b/src/Function/Properties.agda
@@ -40,8 +40,8 @@ private
          Extensionality a c → Extensionality b d →
          A ↔ B → C ↔ D → (A → C) ↔ (B → D)
 →-cong-↔ extAC extBD A↔B C↔D = mk↔′
-  (λ h → C↔D.f   ∘ h ∘ A↔B.f⁻¹)
-  (λ g → C↔D.f⁻¹ ∘ g ∘ A↔B.f  )
+  (λ h → C↔D.to   ∘ h ∘ A↔B.from)
+  (λ g → C↔D.from ∘ g ∘ A↔B.to  )
   (λ h → extBD λ x → trans (C↔D.inverseˡ _) (cong h (A↔B.inverseˡ x)))
   (λ g → extAC λ x → trans (C↔D.inverseʳ _) (cong g (A↔B.inverseʳ x)))
   where module A↔B = Inverse A↔B; module C↔D = Inverse C↔D

--- a/src/Function/Properties/Bijection.agda
+++ b/src/Function/Properties/Bijection.agda
@@ -56,17 +56,17 @@ trans = Composition.bijection
 
 Bijection⇒Inverse : Bijection S T → Inverse S T
 Bijection⇒Inverse {S = S} {T = T} b = record
-  { f     = f
-  ; f⁻¹   = f⁻
-  ; cong₁ = cong
-  ; cong₂ = λ {x} {y} x≈y → injective (begin
-      f (f⁻ x)  ≈⟨ f∘f⁻ x ⟩
-      x         ≈⟨ x≈y ⟩
-      y         ≈˘⟨ f∘f⁻ y ⟩
-      f (f⁻ y)  ∎)
-  ; inverse = f∘f⁻ , injective ∘ f∘f⁻ ∘ f
+  { to        = to
+  ; from      = to⁻
+  ; to-cong   = cong
+  ; from-cong = λ {x} {y} x≈y → injective (begin
+      to (to⁻ x) ≈⟨ to∘to⁻ x ⟩
+      x          ≈⟨ x≈y ⟩
+      y          ≈˘⟨ to∘to⁻ y ⟩
+      to (to⁻ y) ∎)
+  ; inverse = to∘to⁻ , injective ∘ to∘to⁻ ∘ to
   }
-  where open SetoidReasoning T; open Bijection b; f∘f⁻ = proj₂ ∘ surjective
+  where open SetoidReasoning T; open Bijection b; to∘to⁻ = proj₂ ∘ surjective
 
 Bijection⇒Equivalence : Bijection T S → Equivalence T S
 Bijection⇒Equivalence = Inverse⇒Equivalence ∘ Bijection⇒Inverse
@@ -76,4 +76,3 @@ Bijection⇒Equivalence = Inverse⇒Equivalence ∘ Bijection⇒Inverse
 
 ⤖⇒⇔ : A ⤖ B → A ⇔ B
 ⤖⇒⇔ = Bijection⇒Equivalence
-

--- a/src/Function/Properties/Inverse.agda
+++ b/src/Function/Properties/Inverse.agda
@@ -53,17 +53,17 @@ isEquivalence = record
 
 Inverse⇒Bijection : Inverse S T → Bijection S T
 Inverse⇒Bijection {S = S} I = record
-  { f         = f
-  ; cong      = cong₁
-  ; bijective = inverseᵇ⇒bijective S cong₂ inverse
+  { to        = to
+  ; cong      = to-cong
+  ; bijective = inverseᵇ⇒bijective S from-cong inverse
   } where open Inverse I
 
 Inverse⇒Equivalence : Inverse S T → Equivalence S T
 Inverse⇒Equivalence I = record
-  { f     = f
-  ; g     = f⁻¹
-  ; cong₁ = cong₁
-  ; cong₂ = cong₂
+  { to        = to
+  ; from      = from
+  ; to-cong   = to-cong
+  ; from-cong = from-cong
   } where open Inverse I
 
 ↔⇒⤖ : A ↔ B → A ⤖ B

--- a/src/Function/Properties/RightInverse.agda
+++ b/src/Function/Properties/RightInverse.agda
@@ -25,9 +25,9 @@ private
 
 RightInverse⇒Surjection : RightInverse S T → Surjection T S
 RightInverse⇒Surjection I = record
-  { f          = g
-  ; cong       = cong₂
-  ; surjective = λ a → f a , inverseʳ a
+  { to         = from
+  ; cong       = from-cong
+  ; surjective = λ a → to a , inverseʳ a
   } where open RightInverse I
 
 ↪⇒↠ : B ↪ A → A ↠ B

--- a/src/Function/Properties/Surjection.agda
+++ b/src/Function/Properties/Surjection.agda
@@ -16,16 +16,15 @@ open import Data.Product
 private
   variable
     a b : Level
-    A : Set a
-    B : Set b
+    A B : Set a
 
 ------------------------------------------------------------------------
 -- Conversion functions
 
 ↠⇒↪ : A ↠ B → B ↪ A
-↠⇒↪ s = mk↪ {f = proj₁ ∘ surjective} {g = f} (proj₂ ∘ surjective)
+↠⇒↪ s = mk↪ {to = proj₁ ∘ surjective} {from = to} (proj₂ ∘ surjective)
   where open Surjection s
 
 ↠⇒⇔ : A ↠ B → A ⇔ B
-↠⇒⇔ s = mk⇔ f (proj₁ ∘ surjective)
+↠⇒⇔ s = mk⇔ to (proj₁ ∘ surjective)
   where open Surjection s

--- a/src/Function/Related.agda
+++ b/src/Function/Related.agda
@@ -86,17 +86,17 @@ A ∼[ surjection          ] B = Surjection  (P.setoid A) (P.setoid B)
 A ∼[ bijection           ] B = Inverse     (P.setoid A) (P.setoid B)
 
 toRelated : {K : Kind} → A R.∼[ K ] B → A ∼[ K ] B
-toRelated {K = implication}         rel = B.Func.f rel
-toRelated {K = reverse-implication} rel = lam (B.Func.f rel)
-toRelated {K = equivalence}         rel = Eq.equivalence (B.Equivalence.f rel) (B.Equivalence.g rel)
-toRelated {K = injection}           rel = Inj.injection (B.Injection.f rel) (B.Injection.injective rel)
-toRelated {K = reverse-injection}   rel = lam (Inj.injection (B.Injection.f rel) (B.Injection.injective rel))
+toRelated {K = implication}         rel = B.Func.to rel
+toRelated {K = reverse-implication} rel = lam (B.Func.to rel)
+toRelated {K = equivalence}         rel = Eq.equivalence (B.Equivalence.to rel) (B.Equivalence.from rel)
+toRelated {K = injection}           rel = Inj.injection (B.Injection.to rel) (B.Injection.injective rel)
+toRelated {K = reverse-injection}   rel = lam (Inj.injection (B.Injection.to rel) (B.Injection.injective rel))
 toRelated {K = left-inverse}        rel =
-  LeftInv.leftInverse (B.RightInverse.f rel) (B.RightInverse.g rel) (B.RightInverse.inverseʳ rel)
+  LeftInv.leftInverse (B.RightInverse.to rel) (B.RightInverse.from rel) (B.RightInverse.inverseʳ rel)
 toRelated {K = surjection}          rel with B.Surjection.surjective rel
-... | surj = Surj.surjection (B.Surjection.f rel) (proj₁ ∘ surj) (proj₂ ∘ surj)
+... | surj = Surj.surjection (B.Surjection.to rel) (proj₁ ∘ surj) (proj₂ ∘ surj)
 toRelated {K = bijection}           rel with B.Bijection.bijective rel
-... | (inj , surj) = Inv.inverse (B.Bijection.f rel) (proj₁ ∘ surj) (inj ∘ proj₂ ∘ surj ∘ (B.Bijection.f rel)) (proj₂ ∘ surj)
+... | (inj , surj) = Inv.inverse (B.Bijection.to rel) (proj₁ ∘ surj) (inj ∘ proj₂ ∘ surj ∘ (B.Bijection.to rel)) (proj₂ ∘ surj)
 
 fromRelated : {K : Kind} → A ∼[ K ] B → A R.∼[ K ] B
 fromRelated {K = implication}         rel = B.mk⟶ rel
@@ -105,9 +105,9 @@ fromRelated {K = equivalence}         record { to = to ; from = from } = B.mk⇔
 fromRelated {K = injection}           rel = B.mk↣ (Inj.Injection.injective rel)
 fromRelated {K = reverse-injection}   (lam app-↢) = B.mk↣ (Inj.Injection.injective app-↢)
 fromRelated {K = left-inverse}        record { to = to ; from = from ; left-inverse-of = left-inverse-of } =
-  B.mk↪ {f = to ⟨$⟩_} {g = from ⟨$⟩_} left-inverse-of
+  B.mk↪ {to = to ⟨$⟩_} {from = from ⟨$⟩_} left-inverse-of
 fromRelated {K = surjection}          record { to = to ; surjective = surjective } with surjective
-... | record { from = from ; right-inverse-of = right-inverse-of } = B.mk↠ {f = to ⟨$⟩_} < from ⟨$⟩_ , right-inverse-of >
+... | record { from = from ; right-inverse-of = right-inverse-of } = B.mk↠ {to = to ⟨$⟩_} < from ⟨$⟩_ , right-inverse-of >
 fromRelated {K = bijection}           record { to = to ; from = from ; inverse-of = inverse-of } with inverse-of
 ... | record { left-inverse-of = left-inverse-of ; right-inverse-of = right-inverse-of } = B.mk⤖
   ((λ {x y} h → P.subst₂ P._≡_ (left-inverse-of x) (left-inverse-of y) (P.cong (from ⟨$⟩_) h)) ,

--- a/src/Function/Related/Propositional.agda
+++ b/src/Function/Related/Propositional.agda
@@ -74,8 +74,8 @@ Related k A B = A ∼[ k ] B
 -- The bijective equality implies any kind of relatedness.
 
 ⤖⇒ : A ∼[ bijection ] B → A ∼[ k ] B
-⤖⇒ {k = implication}        = mk⟶ ∘ Bijection.f
-⤖⇒ {k = reverseImplication} = mk⟶ ∘ Inverse.f⁻¹ ∘ ⤖⇒↔
+⤖⇒ {k = implication}        = mk⟶ ∘ Bijection.to
+⤖⇒ {k = reverseImplication} = mk⟶ ∘ Inverse.from ∘ ⤖⇒↔
 ⤖⇒ {k = equivalence}        = ⤖⇒⇔
 ⤖⇒ {k = injection}          = Bijection.injection
 ⤖⇒ {k = reverseInjection}   = Bijection.injection ∘ ↔⇒⤖ ∘ Symmetry.inverse ∘ ⤖⇒↔
@@ -129,12 +129,12 @@ data ForwardKind : Set where
 -- The function.
 
 ⇒→ : ∀ {k} → A ∼[ ⌊ k ⌋→ ] B → A → B
-⇒→ {k = implication} = Func.f
-⇒→ {k = equivalence} = Equivalence.f
-⇒→ {k = injection}   = Injection.f
-⇒→ {k = leftInverse} = RightInverse.f
-⇒→ {k = surjection}  = Surjection.f
-⇒→ {k = bijection}   = Bijection.f
+⇒→ {k = implication} = Func.to
+⇒→ {k = equivalence} = Equivalence.to
+⇒→ {k = injection}   = Injection.to
+⇒→ {k = leftInverse} = RightInverse.to
+⇒→ {k = surjection}  = Surjection.to
+⇒→ {k = bijection}   = Bijection.to
 
 -- Kinds whose interpretation include a function which "goes backwards".
 
@@ -159,12 +159,12 @@ data BackwardKind : Set where
 -- The function.
 
 ⇒← : ∀ {k} → A ∼[ ⌊ k ⌋← ] B → B → A
-⇒← {k = reverseImplication} = Func.f
-⇒← {k = equivalence}        = Equivalence.g
-⇒← {k = reverseInjection}   = Injection.f
-⇒← {k = leftInverse}        = RightInverse.g
-⇒← {k = surjection}         = RightInverse.f ∘ ↠⇒↪
-⇒← {k = bijection}          = Inverse.f⁻¹ ∘ ⤖⇒↔
+⇒← {k = reverseImplication} = Func.to
+⇒← {k = equivalence}        = Equivalence.from
+⇒← {k = reverseInjection}   = Injection.to
+⇒← {k = leftInverse}        = RightInverse.from
+⇒← {k = surjection}         = RightInverse.to ∘ ↠⇒↪
+⇒← {k = bijection}          = Inverse.from ∘ ⤖⇒↔
 
 -- Kinds whose interpretation include functions going in both
 -- directions.

--- a/src/Function/Structures.agda
+++ b/src/Function/Structures.agda
@@ -24,9 +24,9 @@ open import Level using (_⊔_)
 -- One element structures
 ------------------------------------------------------------------------
 
-record IsCongruent (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+record IsCongruent (to : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    cong           : Congruent _≈₁_ _≈₂_ f
+    cong           : Congruent _≈₁_ _≈₂_ to
     isEquivalence₁ : IsEquivalence _≈₁_
     isEquivalence₂ : IsEquivalence _≈₂_
 
@@ -49,10 +49,10 @@ record IsCongruent (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
     open Setoid setoid public
 
 
-record IsInjection (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+record IsInjection (to : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    isCongruent : IsCongruent f
-    injective   : Injective _≈₁_ _≈₂_ f
+    isCongruent : IsCongruent to
+    injective   : Injective _≈₁_ _≈₂_ to
 
   open IsCongruent isCongruent public
 
@@ -86,41 +86,41 @@ record IsBijection (f : A → B) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
 -- Two element structures
 ------------------------------------------------------------------------
 
-record IsLeftInverse (f : A → B) (g : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+record IsLeftInverse (to : A → B) (from : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    isCongruent  : IsCongruent f
-    cong₂        : Congruent _≈₂_ _≈₁_ g
-    inverseˡ     : Inverseˡ _≈₁_ _≈₂_ f g
+    isCongruent  : IsCongruent to
+    from-cong    : Congruent _≈₂_ _≈₁_ from
+    inverseˡ     : Inverseˡ _≈₁_ _≈₂_ to from
+
+  open IsCongruent isCongruent public
+    renaming (cong to to-cong)
+
+
+record IsRightInverse (to : A → B) (from : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+  field
+    isCongruent : IsCongruent to
+    from-cong   : Congruent _≈₂_ _≈₁_ from
+    inverseʳ    : Inverseʳ _≈₁_ _≈₂_ to from
 
   open IsCongruent isCongruent public
     renaming (cong to cong₁)
 
 
-record IsRightInverse (f : A → B) (g : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+record IsInverse (to : A → B) (from : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    isCongruent : IsCongruent f
-    cong₂       : Congruent _≈₂_ _≈₁_ g
-    inverseʳ    : Inverseʳ _≈₁_ _≈₂_ f g
-
-  open IsCongruent isCongruent public
-    renaming (cong to cong₁)
-
-
-record IsInverse (f : A → B) (g : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
-  field
-    isLeftInverse : IsLeftInverse f g
-    inverseʳ      : Inverseʳ _≈₁_ _≈₂_ f g
+    isLeftInverse : IsLeftInverse to from
+    inverseʳ      : Inverseʳ _≈₁_ _≈₂_ to from
 
   open IsLeftInverse isLeftInverse public
 
-  isRightInverse : IsRightInverse f g
+  isRightInverse : IsRightInverse to from
   isRightInverse = record
     { isCongruent = isCongruent
-    ; cong₂       = cong₂
+    ; from-cong   = from-cong
     ; inverseʳ    = inverseʳ
     }
 
-  inverse : Inverseᵇ _≈₁_ _≈₂_ f g
+  inverse : Inverseᵇ _≈₁_ _≈₂_ to from
   inverse = inverseˡ , inverseʳ
 
 
@@ -129,24 +129,24 @@ record IsInverse (f : A → B) (g : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ�
 ------------------------------------------------------------------------
 
 record IsBiEquivalence
-  (f : A → B) (g₁ : B → A) (g₂ : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+  (to : A → B) (from₁ : B → A) (from₂ : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    f-isCongruent : IsCongruent f
-    cong₂         : Congruent _≈₂_ _≈₁_ g₁
-    cong₃         : Congruent _≈₂_ _≈₁_ g₂
+    to-isCongruent : IsCongruent to
+    from₁-cong    : Congruent _≈₂_ _≈₁_ from₁
+    from₂-cong    : Congruent _≈₂_ _≈₁_ from₂
 
-  open IsCongruent f-isCongruent public
-    renaming (cong to cong₁)
+  open IsCongruent to-isCongruent public
+    renaming (cong to to-cong₁)
 
 
 record IsBiInverse
-  (f : A → B) (g₁ : B → A) (g₂ : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
+  (to : A → B) (from₁ : B → A) (from₂ : B → A) : Set (a ⊔ b ⊔ ℓ₁ ⊔ ℓ₂) where
   field
-    f-isCongruent : IsCongruent f
-    cong₂         : Congruent _≈₂_ _≈₁_ g₁
-    inverseˡ      : Inverseˡ _≈₁_ _≈₂_ f g₁
-    cong₃         : Congruent _≈₂_ _≈₁_ g₂
-    inverseʳ      : Inverseʳ _≈₁_ _≈₂_ f g₂
+    to-isCongruent : IsCongruent to
+    from₁-cong     : Congruent _≈₂_ _≈₁_ from₁
+    from₂-cong     : Congruent _≈₂_ _≈₁_ from₂
+    inverseˡ       : Inverseˡ _≈₁_ _≈₂_ to from₁
+    inverseʳ       : Inverseʳ _≈₁_ _≈₂_ to from₂
 
-  open IsCongruent f-isCongruent public
-    renaming (cong to cong₁)
+  open IsCongruent to-isCongruent public
+    renaming (cong to to-cong)

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -34,7 +34,7 @@ open import Relation.Nullary.Decidable.Core public
 -- Maps
 
 map : P ⇔ Q → Dec P → Dec Q
-map P⇔Q = map′ f g
+map P⇔Q = map′ to from
   where open Equivalence P⇔Q
 
 module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
@@ -51,7 +51,7 @@ module _ {a₁ a₂ b₁ b₂} {A : Setoid a₁ a₂} {B : Setoid b₁ b₂}
 
   via-injection : Decidable _≈B_ → Decidable _≈A_
   via-injection dec x y =
-    map′ injective cong (dec (f x) (f y))
+    map′ injective cong (dec (to x) (to y))
 
 ------------------------------------------------------------------------
 -- A lemma relating True and Dec


### PR DESCRIPTION
Fixes https://github.com/agda/agda-stdlib/issues/1493. Changes the names of the fields in the records of the new function hierarchy from `f`, `g`, `cong₁`, `cong₂` to `to`, `from`, `to-cong`, `from-cong`.

Haven't yet implemented @andreasabel's request for the old `_<$>_` notation. I guess it could be added as an intern definition in `Func` ... Thoughts?