### PR TITLE
Show that strict orders over some datatypes are well-founded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,9 +490,9 @@ Non-backwards compatible changes
   * `fold-pull`
 
 * In `Data.Fin.Properties`:
-  + the `i` argument to `opposite-suc` has been made explicit
-  + `pigeonhole` has been strenghtened: wlog, we return a proof that `i < j` rather
-    than a mere `i ≢ j`.
+  + the `i` argument to `opposite-suc` has been made explicit;
+  + `pigeonhole` has been strengthened: wlog, we return a proof that
+    `i < j` rather than a mere `i ≢ j`.
 
 Major improvements
 ------------------
@@ -1061,12 +1061,25 @@ Other minor changes
   execState : State s a → s → s
   ```
 
+* Added new proofs in `Data.Bool.Properties`:
+  ```agda
+  <-wellFounded : WellFounded _<_
+  ```
+
 * Added new functions in `Data.Fin.Base`:
   ```
   finToFun  : Fin (m ^ n) → (Fin n → Fin m)
   funToFin  : (Fin m → Fin n) → Fin (n ^ m)
   quotient  : Fin (m * n) → Fin m
   remainder : Fin (m * n) → Fin n
+  ```
+
+* Added new proofs in `Data.Fin.Induction`:
+  every (strict) partial order is well-founded and Noetherian.
+
+  ```agda
+  spo-wellFounded : ∀ {r} {_⊏_ : Rel (Fin n) r} → IsStrictPartialOrder _≈_ _⊏_ → WellFounded _⊏_
+  spo-noetherian  : ∀ {r} {_⊏_ : Rel (Fin n) r} → IsStrictPartialOrder _≈_ _⊏_ → WellFounded (flip _⊏_)
   ```
 
 * Added new definitions and proofs in `Data.Fin.Permutation`:
@@ -1099,7 +1112,7 @@ Other minor changes
   combine-injectiveʳ : combine i j ≡ combine k l → j ≡ l
   combine-injective  : combine i j ≡ combine k l → i ≡ k × j ≡ l
   combine-surjective : ∀ i → ∃₂ λ j k → combine j k ≡ i
-  combine-monoˡ-<    :  i < j → combine i k < combine j l
+  combine-monoˡ-<    : i < j → combine i k < combine j l
 
   lower₁-injective   : lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
   pinch-injective    : suc i ≢ j → suc i ≢ k → pinch i j ≡ pinch i k → j ≡ k
@@ -1509,6 +1522,11 @@ Other minor changes
   return : _⟶_ ⇒ SymClosure _⟶_
   join   : SymClosure (SymClosure _⟶_) ⇒ SymClosure _⟶_
   _⋆     : _⟶₁_ ⇒ SymClosure _⟶₂_ → SymClosure _⟶₁_ ⇒ SymClosure _⟶₂_
+  ```
+
+* Added new proofs in `Relation.Binary.Properties.StrictPartialOrder`:
+  ```agda
+  >-strictPartialOrder : StrictPartialOrder s₁ s₂ s₃
   ```
 
 * Added new proofs in `Relation.Binary.PropositionalEquality.Properties`:

--- a/src/Algebra/Morphism/Construct/Composition.agda
+++ b/src/Algebra/Morphism/Construct/Composition.agda
@@ -263,3 +263,85 @@ module _ {R₁ : RawRing a ℓ₁}
     { isRingMonomorphism = isRingMonomorphism F.isRingMonomorphism G.isRingMonomorphism
     ; surjective         = Func.surjective (_≈_ R₁) _ _ ≈₃-trans G.⟦⟧-cong F.surjective G.surjective
     } where module F = IsRingIsomorphism f-iso; module G = IsRingIsomorphism g-iso
+
+------------------------------------------------------------------------
+-- Quasigroup
+
+module _ {Q₁ : RawQuasigroup a ℓ₁}
+         {Q₂ : RawQuasigroup b ℓ₂}
+         {Q₃ : RawQuasigroup c ℓ₃}
+         (open RawQuasigroup)
+         (≈₃-trans : Transitive (_≈_ Q₃))
+         {f : Carrier Q₁ → Carrier Q₂}
+         {g : Carrier Q₂ → Carrier Q₃}
+         where
+
+
+  isQuasigroupHomomorphism
+    : IsQuasigroupHomomorphism Q₁ Q₂ f
+    → IsQuasigroupHomomorphism Q₂ Q₃ g
+    → IsQuasigroupHomomorphism Q₁ Q₃ (g ∘ f)
+  isQuasigroupHomomorphism f-homo g-homo = record
+    { isRelHomomorphism = isRelHomomorphism F.isRelHomomorphism G.isRelHomomorphism
+    ; ∙-homo              = λ x y → ≈₃-trans (G.⟦⟧-cong ( F.∙-homo x y )) ( G.∙-homo (f x) (f y) )
+    ; \\-homo              = λ x y → ≈₃-trans (G.⟦⟧-cong ( F.\\-homo x y )) ( G.\\-homo (f x) (f y) )
+    ; //-homo              = λ x y → ≈₃-trans (G.⟦⟧-cong ( F.//-homo x y )) ( G.//-homo (f x) (f y) )
+    } where module F = IsQuasigroupHomomorphism f-homo; module G = IsQuasigroupHomomorphism g-homo
+
+  isQuasigroupMonomorphism
+    : IsQuasigroupMonomorphism Q₁ Q₂ f
+    → IsQuasigroupMonomorphism Q₂ Q₃ g
+    → IsQuasigroupMonomorphism Q₁ Q₃ (g ∘ f)
+  isQuasigroupMonomorphism f-mono g-mono = record
+    { isQuasigroupHomomorphism = isQuasigroupHomomorphism F.isQuasigroupHomomorphism G.isQuasigroupHomomorphism
+    ; injective = F.injective ∘ G.injective
+    } where module F = IsQuasigroupMonomorphism f-mono;  module G = IsQuasigroupMonomorphism g-mono
+
+  isQuasigroupIsomorphism
+    : IsQuasigroupIsomorphism Q₁ Q₂ f
+    → IsQuasigroupIsomorphism Q₂ Q₃ g
+    → IsQuasigroupIsomorphism Q₁ Q₃ (g ∘ f)
+  isQuasigroupIsomorphism f-iso g-iso = record
+    { isQuasigroupMonomorphism = isQuasigroupMonomorphism F.isQuasigroupMonomorphism G.isQuasigroupMonomorphism
+    ; surjective               = Func.surjective (_≈_ Q₁) (_≈_ Q₂) (_≈_ Q₃) ≈₃-trans G.⟦⟧-cong F.surjective G.surjective
+    } where module F = IsQuasigroupIsomorphism f-iso; module G = IsQuasigroupIsomorphism g-iso
+
+------------------------------------------------------------------------
+-- Loop
+
+module _ {L₁ : RawLoop a ℓ₁}
+         {L₂ : RawLoop b ℓ₂}
+         {L₃ : RawLoop c ℓ₃}
+         (open RawLoop)
+         (≈₃-trans : Transitive (_≈_ L₃))
+         {f : Carrier L₁ → Carrier L₂}
+         {g : Carrier L₂ → Carrier L₃}
+         where
+
+
+  isLoopHomomorphism
+    : IsLoopHomomorphism L₁ L₂ f
+    → IsLoopHomomorphism L₂ L₃ g
+    → IsLoopHomomorphism L₁ L₃ (g ∘ f)
+  isLoopHomomorphism f-homo g-homo = record
+    { isQuasigroupHomomorphism = isQuasigroupHomomorphism ≈₃-trans F.isQuasigroupHomomorphism G.isQuasigroupHomomorphism
+    ; ε-homo              = ≈₃-trans (G.⟦⟧-cong F.ε-homo) G.ε-homo
+    } where module F = IsLoopHomomorphism f-homo; module G = IsLoopHomomorphism g-homo
+
+  isLoopMonomorphism
+    : IsLoopMonomorphism L₁ L₂ f
+    → IsLoopMonomorphism L₂ L₃ g
+    → IsLoopMonomorphism L₁ L₃ (g ∘ f)
+  isLoopMonomorphism f-mono g-mono = record
+    { isLoopHomomorphism = isLoopHomomorphism F.isLoopHomomorphism G.isLoopHomomorphism
+    ; injective = F.injective ∘ G.injective
+    } where module F = IsLoopMonomorphism f-mono;  module G = IsLoopMonomorphism g-mono
+
+  isLoopIsomorphism
+    : IsLoopIsomorphism L₁ L₂ f
+    → IsLoopIsomorphism L₂ L₃ g
+    → IsLoopIsomorphism L₁ L₃ (g ∘ f)
+  isLoopIsomorphism f-iso g-iso = record
+    { isLoopMonomorphism = isLoopMonomorphism F.isLoopMonomorphism G.isLoopMonomorphism
+    ; surjective               = Func.surjective (_≈_ L₁) (_≈_ L₂) (_≈_ L₃) ≈₃-trans G.⟦⟧-cong F.surjective G.surjective
+    } where module F = IsLoopIsomorphism f-iso; module G = IsLoopIsomorphism g-iso

--- a/src/Algebra/Morphism/Construct/Identity.agda
+++ b/src/Algebra/Morphism/Construct/Identity.agda
@@ -16,6 +16,8 @@ open import Algebra.Morphism.Structures
         ; module NearSemiringMorphisms
         ; module SemiringMorphisms
         ; module RingMorphisms
+        ; module QuasigroupMorphisms
+        ; module LoopMorphisms
         )
 open import Data.Product using (_,_)
 open import Function.Base using (id)
@@ -26,6 +28,9 @@ open import Relation.Binary.Definitions using (Reflexive)
 private
   variable
     c ℓ : Level
+
+------------------------------------------------------------------------
+-- Magmas
 
 module _ (M : RawMagma c ℓ) (open RawMagma M) (refl : Reflexive _≈_) where
   open MagmaMorphisms M M
@@ -48,6 +53,9 @@ module _ (M : RawMagma c ℓ) (open RawMagma M) (refl : Reflexive _≈_) where
     ; surjective = _, refl
     }
 
+------------------------------------------------------------------------
+-- Monoids
+
 module _ (M : RawMonoid c ℓ) (open RawMonoid M) (refl : Reflexive _≈_) where
   open MonoidMorphisms M M
 
@@ -68,6 +76,9 @@ module _ (M : RawMonoid c ℓ) (open RawMonoid M) (refl : Reflexive _≈_) where
     { isMonoidMonomorphism = isMonoidMonomorphism
     ; surjective = _, refl
     }
+
+------------------------------------------------------------------------
+-- Groups
 
 module _ (G : RawGroup c ℓ) (open RawGroup G) (refl : Reflexive _≈_) where
   open GroupMorphisms G G
@@ -90,6 +101,9 @@ module _ (G : RawGroup c ℓ) (open RawGroup G) (refl : Reflexive _≈_) where
     ; surjective = _, refl
     }
 
+------------------------------------------------------------------------
+-- Near semirings
+
 module _ (R : RawNearSemiring c ℓ) (open RawNearSemiring R) (refl : Reflexive _≈_) where
   open NearSemiringMorphisms R R
 
@@ -110,6 +124,9 @@ module _ (R : RawNearSemiring c ℓ) (open RawNearSemiring R) (refl : Reflexive 
     { isNearSemiringMonomorphism = isNearSemiringMonomorphism
     ; surjective = _, refl
     }
+
+------------------------------------------------------------------------
+-- Semirings
 
 module _ (R : RawSemiring c ℓ) (open RawSemiring R) (refl : Reflexive _≈_) where
   open SemiringMorphisms R R
@@ -132,6 +149,9 @@ module _ (R : RawSemiring c ℓ) (open RawSemiring R) (refl : Reflexive _≈_) w
     ; surjective = _, refl
     }
 
+------------------------------------------------------------------------
+-- Rings
+
 module _ (R : RawRing c ℓ) (open RawRing R) (refl : Reflexive _≈_) where
   open RingMorphisms R R
 
@@ -150,5 +170,55 @@ module _ (R : RawRing c ℓ) (open RawRing R) (refl : Reflexive _≈_) where
   isRingIsomorphism : IsRingIsomorphism id
   isRingIsomorphism = record
     { isRingMonomorphism = isRingMonomorphism
+    ; surjective = _, refl
+    }
+
+------------------------------------------------------------------------
+-- Quasigroup
+
+module _ (Q : RawQuasigroup c ℓ) (open RawQuasigroup Q) (refl : Reflexive _≈_) where
+  open QuasigroupMorphisms Q Q
+
+  isQuasigroupHomomorphism : IsQuasigroupHomomorphism id
+  isQuasigroupHomomorphism = record
+    { isRelHomomorphism = isRelHomomorphism _
+    ; ∙-homo            = λ _ _ → refl
+    ; \\-homo            = λ _ _ → refl
+    ; //-homo            = λ _ _ → refl
+    }
+
+  isQuasigroupMonomorphism : IsQuasigroupMonomorphism id
+  isQuasigroupMonomorphism = record
+    { isQuasigroupHomomorphism = isQuasigroupHomomorphism
+    ; injective = id
+    }
+
+  isQuasigroupIsomorphism : IsQuasigroupIsomorphism id
+  isQuasigroupIsomorphism = record
+    { isQuasigroupMonomorphism = isQuasigroupMonomorphism
+    ; surjective = _, refl
+    }
+
+------------------------------------------------------------------------
+-- Loop
+
+module _ (L : RawLoop c ℓ) (open RawLoop L) (refl : Reflexive _≈_) where
+  open LoopMorphisms L L
+
+  isLoopHomomorphism : IsLoopHomomorphism id
+  isLoopHomomorphism = record
+    { isQuasigroupHomomorphism = isQuasigroupHomomorphism _ refl
+    ; ε-homo = refl
+    }
+
+  isLoopMonomorphism : IsLoopMonomorphism id
+  isLoopMonomorphism = record
+    { isLoopHomomorphism = isLoopHomomorphism
+    ; injective = id
+    }
+
+  isLoopIsomorphism : IsLoopIsomorphism id
+  isLoopIsomorphism = record
+    { isLoopMonomorphism = isLoopMonomorphism
     ; surjective = _, refl
     }

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -191,7 +191,7 @@ true  <? _     = no  (λ())
 <-wellFounded _ = acc <-acc
   where
     <-acc : ∀ {x} y → y < x → Acc _<_ y
-    <-acc .false f<t = acc (λ _ → λ())
+    <-acc false f<t = acc (λ _ → λ())
 
 -- Structures
 

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -19,6 +19,7 @@ open import Function.Base
 open import Function.Equality using (_⟨$⟩_)
 open import Function.Equivalence
   using (_⇔_; equivalence; module Equivalence)
+open import Induction.WellFounded using (WellFounded; Acc; acc)
 open import Level using (Level; 0ℓ)
 open import Relation.Binary hiding (_⇔_)
 open import Relation.Binary.PropositionalEquality hiding ([_])
@@ -185,6 +186,12 @@ true  <? _     = no  (λ())
 
 <-irrelevant : Irrelevant _<_
 <-irrelevant f<t f<t = refl
+
+<-wellFounded : WellFounded _<_
+<-wellFounded _ = acc <-acc
+  where
+    <-acc : ∀ {x} y → y < x → Acc _<_ y
+    <-acc .false f<t = acc (λ _ → λ())
 
 -- Structures
 

--- a/src/Data/Fin/Induction.agda
+++ b/src/Data/Fin/Induction.agda
@@ -21,10 +21,10 @@ open import Induction
 open import Induction.WellFounded as WF
 open import Level using (Level)
 open import Relation.Binary using (Rel; Decidable; IsPartialOrder; IsStrictPartialOrder; StrictPartialOrder)
+import Relation.Binary.Construct.Converse as Converse
 import Relation.Binary.Construct.Flip as Flip
 import Relation.Binary.Construct.NonStrictToStrict as ToStrict
 import Relation.Binary.Construct.On as On
-import Relation.Binary.Properties.StrictPartialOrder as SPO
 open import Relation.Binary.PropositionalEquality
 open import Relation.Nullary using (yes; no)
 open import Relation.Nullary.Negation using (contradiction)
@@ -103,7 +103,7 @@ module _ {ℓ} where
 ------------------------------------------------------------------------
 -- Well-foundedness of other (strict) partial orders on Fin
 
-module _ {n e} {_≈_ : Rel (Fin n) e} where
+module _ {_≈_ : Rel (Fin n) ℓ} where
 
   -- Every (strict) partial order over `Fin n' is well-founded.
 
@@ -141,11 +141,7 @@ module _ {n e} {_≈_ : Rel (Fin n) e} where
 
   spo-noetherian : ∀ {r} {_⊏_ : Rel (Fin n) r} →
                    IsStrictPartialOrder _≈_ _⊏_ → WellFounded (flip _⊏_)
-  spo-noetherian isSPO = spo-wellFounded >-isStrictPartialOrder
-    where
-      spo : StrictPartialOrder _ _ _
-      spo = record { isStrictPartialOrder = isSPO }
-      open SPO spo using (_>_; >-isStrictPartialOrder)
+  spo-noetherian isSPO = spo-wellFounded (Converse.isStrictPartialOrder isSPO)
 
   po-noetherian : ∀ {r} {_⊑_ : Rel (Fin n) r} → IsPartialOrder _≈_ _⊑_ →
                   WellFounded (flip (ToStrict._<_ _≈_ _⊑_))

--- a/src/Data/Fin/Induction.agda
+++ b/src/Data/Fin/Induction.agda
@@ -6,18 +6,28 @@
 
 {-# OPTIONS --without-K --safe #-}
 
+open import Data.Bool as Bool
+  using (Bool; false; true; if_then_else_; f≤t; b≤b; f<t)
 open import Data.Fin.Base
 open import Data.Fin.Properties
-open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _∸_)
+open import Data.Maybe using (Maybe; just; nothing; is-nothing)
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _∸_; z≤n; s≤s)
 import Data.Nat.Induction as ℕ
 import Data.Nat.Properties as ℕ
+open import Data.Product using (∃; _,_; proj₁; proj₂; curry; uncurry)
+open import Function using (_∘_; flip)
 open import Induction
 open import Induction.WellFounded as WF
 open import Level using (Level)
+open import Relation.Binary
+  using (Rel; Decidable; IsPartialOrder; IsStrictPartialOrder; StrictPartialOrder)
+import Relation.Binary.Construct.NonStrictToStrict as ToStrict
 import Relation.Binary.Construct.On as On
-open import Relation.Unary using (Pred)
-open import Relation.Nullary using (yes; no)
+import Relation.Binary.Properties.StrictPartialOrder as SPO
 open import Relation.Binary.PropositionalEquality
+open import Relation.Nullary using (yes; no)
+open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Unary using (Pred)
 
 module Data.Fin.Induction where
 
@@ -87,3 +97,174 @@ module _ {ℓ} where
     ; wfRec        to ≺-rec
     )
     hiding (wfRec-builder)
+
+
+------------------------------------------------------------------------
+-- Well-foundedness of other (strict) partial orders on Fin
+------------------------------------------------------------------------
+
+-- Every (strict) partial order over `Fin n' is well-founded, provided
+-- the underlying equality is decidable.
+
+module StrictWf {n e r} {_≈_ : Rel (Fin n) e} {_⊏_ : Rel (Fin n) r}
+                (_≈?_  : Decidable _≈_)
+                (isSPO : IsStrictPartialOrder _≈_ _⊏_) where
+
+  open IsStrictPartialOrder isSPO using (irrefl; module Eq)
+    renaming (trans to ⊏-trans; <-respʳ-≈ to ⊏-respʳ-≈)
+
+  -- Intuition: there cannot be any infinite descending chains simply
+  -- because Fin n has only finitely many inhabitants.  Thus any chain
+  -- of length > n must have a cycle (which is forbidden by
+  -- irreflexivity).
+
+  private  -- Private setup/helpers for the proof
+
+    -- Step 1: define prefix tables, a data structure to keep track of
+    -- the possible prefixes of a chain starting at `x'.  If the chain
+    -- has a prefix ending in `y', then the table contains a proof of
+    -- `x ⊏ y' in row `y'.  Otherwise, that row is blank (represented
+    -- by `nothing').  Since the "table" is really just a map from
+    -- `Fin n' to ⊏-proofs, we represent it using a function.
+
+    Prefixes : Fin n → Set r
+    Prefixes x = (y : Fin n) → Maybe (x ⊏ y)
+
+    -- The empty prefix table (all rows are blank).
+
+    empty : ∀ x → Prefixes x
+    empty _ _ = nothing
+
+    -- Extend every prefix in the the table with `x ⊏ y' and add a new
+    -- entry at `y'.
+
+    extend : ∀ {x y} → x ⊏ y → Prefixes y → Prefixes x
+    extend {_} {y} x⊏y ps z with ps z | y ≈? z
+    ... | just y⊏z | _       = just (⊏-trans x⊏y y⊏z)
+    ... | nothing  | yes y≈z = just (⊏-respʳ-≈ y≈z x⊏y)
+    ... | nothing  | no  y≉z = nothing
+
+    -- A helper: count the number of `true' instances in Boolean
+    -- valuation.
+
+    count : ∀ {k} → (Fin k → Bool) → ℕ
+    count {zero}  f = zero
+    count {suc k} f = if f zero then suc rest else rest
+      where rest = count (f ∘ suc)
+
+    -- The number of blank rows in a prefix table.
+
+    blanks : ∀ {x} → Prefixes x → ℕ
+    blanks ps = count (is-nothing ∘ ps)
+
+    -- Step 2: define a well-founded order on prefix tables.  We note
+    -- that the number of blanks in a prefix table strictly decreases
+    -- whenever we extend the table with a new ⊏-step.  This is
+    -- because a (decreasing) ⊏-chain can never revisit an element of
+    -- `Fin n' twice, otherwise there would be a cycle.  Hence an
+    -- extension by `x ⊏ y' must add a _new_ entry at `y' in the
+    -- prefix table (see proofs `extend-*' below).  Hence we may use
+    -- the number of blanks as a (termination) measure and derive a
+    -- well-founded order from it.
+
+    _≺P_ : Rel (∃ Prefixes) _
+    (_ , ps) ≺P (_ , ps′) = blanks ps ℕ.< blanks ps′
+
+    ≺P-wf : WellFounded _≺P_
+    ≺P-wf = On.wellFounded (blanks ∘ proj₂) ℕ.<-wellFounded
+
+    -- More helpers: pointwise greater valuations have a greater
+    -- number of `true' entries.
+
+    count-≤ : ∀ {k} {f g : Fin k → Bool} →
+              (∀ z → f z Bool.≤ g z) → count f ℕ.≤ count g
+    count-≤ {zero}          f≤g = z≤n
+    count-≤ {suc k} {f} {g} f≤g with f zero | g zero | f≤g zero
+    ... | .false | .true  | f≤t = ℕ.≤-step (count-≤ (f≤g ∘ suc))
+    ... | false  | .false | b≤b = count-≤ (f≤g ∘ suc)
+    ... | true   | .true  | b≤b = s≤s (count-≤ (f≤g ∘ suc))
+
+    count-< : ∀ {k} {f g : Fin k → Bool} x →
+              f x Bool.< g x → (∀ z → f z Bool.≤ g z) → count f ℕ.< count g
+    count-< {_} {f} {g} zero diff f≤g with f zero | g zero
+    count-< zero f<t f≤g | .false | .true = s≤s (count-≤ (f≤g ∘ suc))
+    count-< {_} {f} {g} (suc x) diff f≤g with f zero | g zero | f≤g zero
+    ... | .false | .true  | f≤t = s≤s (count-≤ (f≤g ∘ suc))
+    ... | false  | .false | b≤b = count-< x diff (f≤g ∘ suc)
+    ... | true   | .true  | b≤b = s≤s (count-< x diff (f≤g ∘ suc))
+
+    -- Extending a prefix table decreases the number of blanks.
+
+    extend-≤ : ∀ {x y} (p : x ⊏ y) (ps : Prefixes y) →
+               ∀ z → is-nothing ((extend p ps) z) Bool.≤ is-nothing (ps z)
+    extend-≤ {_} {y} x⊏y ps z with ps z | y ≈? z
+    ... | just _  | _       = b≤b
+    ... | nothing | yes y≈z = f≤t
+    ... | nothing | no _    = b≤b
+
+    extend-< : ∀ {x y} (p : x ⊏ y) (ps : Prefixes y) →
+               is-nothing ((extend p ps) y) Bool.< is-nothing (ps y)
+    extend-< {_} {y} x⊏y ps with ps y | y ≈? y
+    ... | just y⊏y | _      = contradiction y⊏y (irrefl Eq.refl)
+    ... | nothing  | yes _  = f<t
+    ... | nothing  | no y≉y = contradiction Eq.refl y≉y
+
+    extend-≺P : ∀ {x y} (p : x ⊏ y) (ps : Prefixes y) →
+               (x , extend p ps) ≺P (y , ps)
+    extend-≺P {_} {y} x⊏y ps = count-< y (extend-< x⊏y ps) (extend-≤ x⊏y ps)
+
+    -- Step 3: prove that very element `x' is accessible by
+    -- well-founded recursion on prefix tables.  Every recursive step
+    -- adds a new entry to the prefix table and thus decreases the
+    -- number of blank rows in the table, making the table "smaller".
+
+    ⊏-acc′ : ∀ x → (ps : Prefixes x) →
+             (∀ y → (qs : Prefixes y) → blanks qs ℕ.< blanks ps → Acc _⊏_ y) →
+             Acc _⊏_ x
+    ⊏-acc′ x ps rec = acc (λ y y⊏x → rec y (extend y⊏x ps) (extend-≺P y⊏x ps))
+
+  ⊏-acc : ∀ x → Acc _⊏_ x
+  ⊏-acc x =
+    All.wfRec ≺P-wf r (Acc _⊏_ ∘ proj₁)
+              (uncurry λ x ps rec → ⊏-acc′ x ps (curry rec)) (x , empty x)
+
+  ⊏-wellFounded : WellFounded _⊏_
+  ⊏-wellFounded x = ⊏-acc x
+
+module Wf {n e r} {_≈_ : Rel (Fin n) e} {_⊑_ : Rel (Fin n) r}
+          (_≈?_  : Decidable _≈_)
+          (isPO : IsPartialOrder _≈_ _⊑_) where
+
+  open StrictWf _≈?_ (ToStrict.<-isStrictPartialOrder _≈_ _⊑_ isPO) public
+    using (⊏-wellFounded)
+
+-- The inverse order is also well-founded, i.e. every (strict) partial
+-- order is also Noetherian.
+
+module StrictNoetherian {n e r} {_≈_ : Rel (Fin n) e} {_⊏_ : Rel (Fin n) r}
+                        (_≈?_  : Decidable _≈_)
+                        (isSPO : IsStrictPartialOrder _≈_ _⊏_) where
+
+  spo : StrictPartialOrder _ _ _
+  spo = record { isStrictPartialOrder = isSPO }
+  open SPO spo using (_>_; >-isStrictPartialOrder)
+  open StrictWf _≈?_ >-isStrictPartialOrder public
+    using () renaming (⊏-wellFounded to ⊏-noetherian)
+
+module Noetherian {n e r} {_≈_ : Rel (Fin n) e} {_⊑_ : Rel (Fin n) r}
+                  (_≈?_  : Decidable _≈_)
+                  (isPO : IsPartialOrder _≈_ _⊑_) where
+
+  open StrictNoetherian _≈?_ (ToStrict.<-isStrictPartialOrder _≈_ _⊑_ isPO)
+    public using (⊏-noetherian)
+
+-- A special case: every strict partial order over `Fin n' is
+-- well-founded and noetherian if the underlying equality is just _≡_.
+
+module _ {n r} {_⊏_ : Rel (Fin n) r} where
+
+  spo-wellFounded : IsStrictPartialOrder _≡_ _⊏_ → WellFounded _⊏_
+  spo-wellFounded spo = StrictWf.⊏-wellFounded _≟_ spo
+
+  spo-noetherian : IsStrictPartialOrder _≡_ _⊏_ → WellFounded (flip _⊏_)
+  spo-noetherian spo = StrictNoetherian.⊏-noetherian _≟_ spo

--- a/src/Data/Vec/Relation/Unary/Linked/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Linked/Properties.agda
@@ -53,15 +53,13 @@ module _ (trans : Transitive R) where
 ------------------------------------------------------------------------
 -- map
 
-module _ {R : Rel A ℓ} {f : B → A} where
+map⁺ : ∀ {f : B → A} {xs} → Linked (R on f) {n} xs → Linked R (map f xs)
+map⁺ []                  = []
+map⁺ [-]                 = [-]
+map⁺ (Rxy ∷ [-])         = Rxy ∷ [-]
+map⁺ (Rxy ∷ Rxs@(_ ∷ _)) = Rxy ∷ map⁺ Rxs
 
-  map⁺ : ∀ {xs} → Linked (R on f) {n} xs → Linked R (map f xs)
-  map⁺ []                  = []
-  map⁺ [-]                 = [-]
-  map⁺ (Rxy ∷ [-])         = Rxy ∷ [-]
-  map⁺ (Rxy ∷ Rxs@(_ ∷ _)) = Rxy ∷ map⁺ Rxs
-
-  map⁻ : ∀ {xs} → Linked R {n} (map f xs) → Linked (R on f) xs
-  map⁻ {xs = []}        []           = []
-  map⁻ {xs = x ∷ []}    [-]          = [-]
-  map⁻ {xs = x ∷ _ ∷ _} (Rxy ∷ Rxs)  = Rxy ∷ map⁻ Rxs
+map⁻ : ∀ {f : B → A} {xs} → Linked R {n} (map f xs) → Linked (R on f) xs
+map⁻ {xs = []}        []           = []
+map⁻ {xs = x ∷ []}    [-]          = [-]
+map⁻ {xs = x ∷ _ ∷ _} (Rxy ∷ Rxs)  = Rxy ∷ map⁻ Rxs

--- a/src/Relation/Binary/Properties/StrictPartialOrder.agda
+++ b/src/Relation/Binary/Properties/StrictPartialOrder.agda
@@ -11,14 +11,31 @@ open import Relation.Binary
 module Relation.Binary.Properties.StrictPartialOrder
        {s₁ s₂ s₃} (SPO : StrictPartialOrder s₁ s₂ s₃) where
 
-open import Data.Product using (_,_)
-open import Function using (flip; _∘_)
-private module SPO = Relation.Binary.StrictPartialOrder SPO
-open SPO hiding (Carrier; _≈_; trans; isEquivalence; module Eq)
-open import Relation.Binary.Construct.StrictToNonStrict SPO._≈_ _<_
+import Relation.Binary.Construct.Converse as Converse
+import Relation.Binary.Construct.StrictToNonStrict
+
+open Relation.Binary.StrictPartialOrder SPO
+
+------------------------------------------------------------------------
+-- The inverse relation is also a strict partial order.
+
+>-strictPartialOrder : StrictPartialOrder s₁ s₂ s₃
+>-strictPartialOrder = Converse.strictPartialOrder SPO
+
+open StrictPartialOrder >-strictPartialOrder public
+  using ()
+  renaming
+  ( _<_                  to _>_
+  ; irrefl               to >-irrefl
+  ; trans                to >-trans
+  ; <-resp-≈             to >-resp-≈
+  ; isStrictPartialOrder to >-isStrictPartialOrder
+  )
 
 ------------------------------------------------------------------------
 -- Strict partial orders can be converted to posets
+
+open Relation.Binary.Construct.StrictToNonStrict _≈_ _<_
 
 poset : Poset _ _ _
 poset = record
@@ -26,30 +43,3 @@ poset = record
   }
 
 open Poset poset public
-
-------------------------------------------------------------------------
--- The inverse relation is also a strict partial order.
-
-infix 4 _>_
-
-_>_ : Rel Carrier s₃
-x > y = y < x
-
->-isStrictPartialOrder : IsStrictPartialOrder _≈_ _>_
->-isStrictPartialOrder = record
-  { isEquivalence = isEquivalence
-  ; irrefl        = irrefl ∘ Eq.sym
-  ; trans         = flip SPO.trans
-  ; <-resp-≈      = <-respˡ-≈ , <-respʳ-≈
-  }
-
->-strictPartialOrder : StrictPartialOrder s₁ s₂ s₃
->-strictPartialOrder = record { isStrictPartialOrder = >-isStrictPartialOrder }
-
-open StrictPartialOrder >-strictPartialOrder public
-  using ()
-  renaming
-  ( irrefl   to >-irrefl
-  ; trans    to >-trans
-  ; <-resp-≈ to >-resp-≈
-  )

--- a/src/Relation/Binary/Properties/StrictPartialOrder.agda
+++ b/src/Relation/Binary/Properties/StrictPartialOrder.agda
@@ -11,9 +11,11 @@ open import Relation.Binary
 module Relation.Binary.Properties.StrictPartialOrder
        {s₁ s₂ s₃} (SPO : StrictPartialOrder s₁ s₂ s₃) where
 
-open Relation.Binary.StrictPartialOrder SPO
-  renaming (trans to <-trans)
-open import Relation.Binary.Construct.StrictToNonStrict _≈_ _<_
+open import Data.Product using (_,_)
+open import Function using (flip; _∘_)
+private module SPO = Relation.Binary.StrictPartialOrder SPO
+open SPO hiding (Carrier; _≈_; trans; isEquivalence; module Eq)
+open import Relation.Binary.Construct.StrictToNonStrict SPO._≈_ _<_
 
 ------------------------------------------------------------------------
 -- Strict partial orders can be converted to posets
@@ -24,3 +26,30 @@ poset = record
   }
 
 open Poset poset public
+
+------------------------------------------------------------------------
+-- The inverse relation is also a strict partial order.
+
+infix 4 _>_
+
+_>_ : Rel Carrier s₃
+x > y = y < x
+
+>-isStrictPartialOrder : IsStrictPartialOrder _≈_ _>_
+>-isStrictPartialOrder = record
+  { isEquivalence = isEquivalence
+  ; irrefl        = irrefl ∘ Eq.sym
+  ; trans         = flip SPO.trans
+  ; <-resp-≈      = <-respˡ-≈ , <-respʳ-≈
+  }
+
+>-strictPartialOrder : StrictPartialOrder s₁ s₂ s₃
+>-strictPartialOrder = record { isStrictPartialOrder = >-isStrictPartialOrder }
+
+open StrictPartialOrder >-strictPartialOrder public
+  using ()
+  renaming
+  ( irrefl   to >-irrefl
+  ; trans    to >-trans
+  ; <-resp-≈ to >-resp-≈
+  )


### PR DESCRIPTION
This PR adds proofs that strict partial orders defined over `Data.Bool` and `Data.Fin` are well-founded.

For `Data.Bool`, the proof is just about the "canonical" strict partial order (`_<_`); for `Data.Fin` there is a proof that _any_ strict partial order defined over `Fin` is well-founded (and Noetherian). That proof is more substantial and requires some additions to `Relation.Binary.Properties.StrictPartialOrder` (to show that the induced strict partial order of the inverse of a partial order is again a strict partial order).