### PR TITLE
Show that permuting a list index forwards then backwards is the identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1147,6 +1147,12 @@ Other minor changes
   xs≮[] : ¬ xs < []
   ```
 
+* Added new proofs to `Data.List.Relation.Binary.Permutation.Propositional.Properties`:
+  ```agda
+  Any-resp-[σ⁻¹∘σ] : (σ : xs ↭ ys) → (ix : Any P xs) → Any-resp-↭ (trans σ (↭-sym σ)) ix ≡ ix
+  ∈-resp-[σ⁻¹∘σ]   : (σ : xs ↭ ys) → (ix : x ∈ xs)   → ∈-resp-↭   (trans σ (↭-sym σ)) ix ≡ ix
+  ```
+
 * Added new functions in `Data.List.Relation.Unary.All`:
   ```
   decide :  Π[ P ∪ Q ] → Π[ All P ∪ Any Q ]

--- a/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional/Properties.agda
@@ -87,6 +87,31 @@ Any-resp-↭ (trans p p₁) wit                 = Any-resp-↭ p₁ (Any-resp-�
 ∈-resp-↭ : ∀ {x : A} → (x ∈_) Respects _↭_
 ∈-resp-↭ = Any-resp-↭
 
+Any-resp-[σ⁻¹∘σ] : {xs ys : List A} {P : Pred A p} →
+                   (σ : xs ↭ ys) →
+                   (ix : Any P xs) →
+                   Any-resp-↭ (trans σ (↭-sym σ)) ix ≡ ix
+Any-resp-[σ⁻¹∘σ] refl          ix               = refl
+Any-resp-[σ⁻¹∘σ] (prep _ _)    (here _)         = refl
+Any-resp-[σ⁻¹∘σ] (swap _ _ _)  (here _)         = refl
+Any-resp-[σ⁻¹∘σ] (swap _ _ _)  (there (here _)) = refl
+Any-resp-[σ⁻¹∘σ] (trans σ₁ σ₂) ix
+  rewrite Any-resp-[σ⁻¹∘σ] σ₂ (Any-resp-↭ σ₁ ix)
+  rewrite Any-resp-[σ⁻¹∘σ] σ₁ ix
+  = refl
+Any-resp-[σ⁻¹∘σ] (prep _ σ)    (there ix)
+  rewrite Any-resp-[σ⁻¹∘σ] σ ix
+  = refl
+Any-resp-[σ⁻¹∘σ] (swap _ _ σ)  (there (there ix))
+  rewrite Any-resp-[σ⁻¹∘σ] σ ix
+  = refl
+
+∈-resp-[σ⁻¹∘σ] : {xs ys : List A} {x : A} →
+                 (σ : xs ↭ ys) →
+                 (ix : x ∈ xs) →
+                 ∈-resp-↭ (trans σ (↭-sym σ)) ix ≡ ix
+∈-resp-[σ⁻¹∘σ] = Any-resp-[σ⁻¹∘σ]
+
 ------------------------------------------------------------------------
 -- map
 


### PR DESCRIPTION
This PR adds the following property to `Data.List.Relation.Binary.Permutation.Propositional.Properties`, which I had need of in some of my own developments. I asked about it [on Zulip](https://agda.zulipchat.com/#narrow/stream/259644-newcomers/topic/Lemmas.20for.20permutations.20on.20indices.20in.20the.20stdlib.3F/near/277941007), and @MatthewDaggitt indicated it might be welcome in the stdlib.

```agda
∈-resp-↭[sym-σ∘σ] : {xs ys : List A} {x : A} →
                    (σ : xs ↭ ys) →
                    (ix : x ∈ xs) →
                    ∈-resp-↭ (trans σ (↭-sym σ)) ix ≡ ix
```

To be honest, I have no idea what this ought to be called, or where in the file it should live. I'm very happy to call it whatever you all think makes the most sense 😅 It was originally called `σ-inv` in my developments, but I suspect that's far too ambiguous for the stdlib.