### PR TITLE
[ doc ] update installation instructions to 1.7.1

### DIFF
--- a/notes/installation-guide.md
+++ b/notes/installation-guide.md
@@ -3,7 +3,7 @@ Installation instructions
 
 Note: the full story on installing Agda libraries can be found at [readthedocs](http://agda.readthedocs.io/en/latest/tools/package-system.html).
 
-Use version v1.7.1 of the standard library with Agda 2.6.2.1 or 2.6.2.
+Use version v1.7.1 of the standard library with Agda 2.6.2.2, 2.6.2.1, or 2.6.2.
 
 1. Navigate to a suitable directory `$HERE` (replace appropriately) where
    you would like to install the library.

--- a/notes/installation-guide.md
+++ b/notes/installation-guide.md
@@ -3,19 +3,19 @@ Installation instructions
 
 Note: the full story on installing Agda libraries can be found at [readthedocs](http://agda.readthedocs.io/en/latest/tools/package-system.html).
 
-Use version v1.7 of the standard library with Agda 2.6.2.
+Use version v1.7.1 of the standard library with Agda 2.6.2.1 or 2.6.2.
 
 1. Navigate to a suitable directory `$HERE` (replace appropriately) where
    you would like to install the library.
 
-2. Download the tarball of v1.7 of the standard library. This can either be
+2. Download the tarball of v1.7.1 of the standard library. This can either be
    done manually by visiting the Github repository for the library, or via the
    command line as follows:
    ```
-   wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/archive/v1.7.tar.gz
+   wget -O agda-stdlib.tar https://github.com/agda/agda-stdlib/archive/v1.7.1.tar.gz
    ```
    Note that you can replace `wget` with other popular tools such as `curl` and that
-   you can replace `1.7` with any other version of the library you desire.
+   you can replace `1.7.1` with any other version of the library you desire.
 
 3. Extract the standard library from the tarball. Again this can either be
    done manually or via the command line as follows:
@@ -26,7 +26,7 @@ Use version v1.7 of the standard library with Agda 2.6.2.
 4. [ OPTIONAL ] If using [cabal](https://www.haskell.org/cabal/) then run
    the commands to install via cabal:
    ```
-   cd agda-stdlib-1.7
+   cd agda-stdlib-1.7.1
    cabal install
    ```
 
@@ -40,7 +40,7 @@ Use version v1.7 of the standard library with Agda 2.6.2.
 6. Register the standard library with Agda's package system by adding
    the following line to `$HOME/.agda/libraries`:
    ```
-   $HERE/agda-stdlib-1.7/standard-library.agda-lib
+   $HERE/agda-stdlib-1.7.1/standard-library.agda-lib
    ```
 
 Now, the standard library is ready to be used either:


### PR DESCRIPTION
I noticed that the installation instructions still refer to version 1.7, so I updated the versions mentioned to what I think the current ones are.