### PR TITLE
Added new Fin Inequality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2075,7 +2075,7 @@ This is a full list of proofs that have changed form to use irrelevant instance 
     í ≤′ inject₁ j → i ≤′ suc j
   _<′_ : Rel (Fin n) 0ℓ
   pattern <′-base          = ≤′-refl
-  pattern <′-step {n} m<′n = ≤′-step {n} m<′n
+  pattern <′-step {j} i<′j = ≤′-step {j} i<′j
   _≥′_ : Rel (Fin n) 0ℓ
   _>′_ : Rel (Fin n) 0ℓ
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2067,3 +2067,15 @@ This is a full list of proofs that have changed form to use irrelevant instance 
   Inverse⇒Injection : Inverse S T → Injection S T
   ↔⇒↣ : A ↔ B → A ↣ B
   ```
+
+* Added new inequality definition in `Data.Fin.Base`:
+  ```agda
+  data _≤′_ : Rel (Fin n) 0ℓ
+    ≤′-refl : i ≤′ i
+    í ≤′ inject₁ j → i ≤′ suc j
+  _<′_ : Rel (Fin n) 0ℓ
+  pattern <′-base          = ≤′-refl
+  pattern <′-step {n} m<′n = ≤′-step {n} m<′n
+  _≥′_ : Rel (Fin n) 0ℓ
+  _>′_ : Rel (Fin n) 0ℓ
+  ```

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -292,6 +292,31 @@ data _≺_ : ℕ → ℕ → Set where
   _≻toℕ_ : ∀ n (i : Fin n) → toℕ i ≺ n
 
 ------------------------------------------------------------------------
+-- Alternative definition of _≤_
+
+-- The following definition of _≤_ is more suitable for well-founded
+
+infix 4 _≤′_ _<′_ _≥′_ _>′_
+
+data _≤′_ : Rel (Fin n) 0ℓ  where
+  ≤′-refl : ∀ {i : Fin n}                             → i ≤′ i
+  ≤′-step : ∀ {i} {j : Fin n} (i≤′j : i ≤′ inject₁ j) → i ≤′ suc j
+
+_<′_ : Rel (Fin n) 0ℓ
+m <′ n = suc m ≤′ inject₁ n
+
+-- Smart constructors of _<′_
+
+pattern <′-base          = ≤′-refl
+pattern <′-step {n} m<′n = ≤′-step {n} m<′n
+
+_≥′_ : Rel (Fin n) 0ℓ
+m ≥′ n = n ≤′ m
+
+_>′_ : Rel (Fin n) 0ℓ
+m >′ n = n <′ m
+
+------------------------------------------------------------------------
 -- An ordering view.
 
 data Ordering {n : ℕ} : Fin n → Fin n → Set where

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -303,18 +303,18 @@ data _≤′_ : Rel (Fin n) 0ℓ  where
   ≤′-step : ∀ {i} {j : Fin n} (i≤′j : i ≤′ inject₁ j) → i ≤′ suc j
 
 _<′_ : Rel (Fin n) 0ℓ
-m <′ n = suc m ≤′ inject₁ n
+i <′ j = suc i ≤′ inject₁ j
 
 -- Smart constructors of _<′_
 
 pattern <′-base          = ≤′-refl
-pattern <′-step {n} m<′n = ≤′-step {n} m<′n
+pattern <′-step {j} i<′j = ≤′-step {j} i<′j
 
 _≥′_ : Rel (Fin n) 0ℓ
-m ≥′ n = n ≤′ m
+i ≥′ j = j ≤′ i
 
 _>′_ : Rel (Fin n) 0ℓ
-m >′ n = n <′ m
+i >′ j = j <′ i
 
 ------------------------------------------------------------------------
 -- An ordering view.


### PR DESCRIPTION
This new Fin inequality is that:
```agda
data _≤′_ : Rel (Fin n) 0ℓ  where
  ≤′-refl : ∀ {i : Fin n}                             → i ≤′ i
  ≤′-step : ∀ {i} {j : Fin n} (i≤′j : i ≤′ inject₁ j) → i ≤′ suc j
```