### PR TITLE
Fix issue #1778

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1840,6 +1840,34 @@ Other minor changes
   ∈-++↔++ : ∀ {v} xs ys → v ∈ xs ++ ys ↔ v ∈ ys ++ xs
   ```
 
+* Exposed container combinator conversion functions from `Data.Container.Combinator.Properties` separate from their correctness proofs in `Data.Container.Combinator`:
+  ```
+  to-id      : ∀ {s p x} {X : Set x} → F.id X → ⟦ id {s} {p} ⟧ X
+  from-id    : ∀ {s p x} {X : Set x} → ⟦ id {s} {p} ⟧ X → F.id X
+  to-const   : ∀ {s p y} (X : Set s) {Y : Set y} → X → ⟦ const {p = p} X ⟧ Y
+  from-const : ∀ {s p y} (X : Set s) {Y : Set y} → ⟦ const {p = p} X ⟧ Y → X
+  to-_∘_     : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
+               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₁ ∘ C₂ ⟧ X
+  from-_∘_   : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
+               ∀ {x} {X : Set x} → ⟦ C₁ ∘ C₂ ⟧ X → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)
+  to-_×_     : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
+               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X → ⟦ C₁ × C₂ ⟧ X
+  from-_×_   : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
+               ∀ {x} {X : Set x} → ⟦ C₁ × C₂ ⟧ X → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X
+  to-Π       : ∀ {i s p} (I : Set i) (Cᵢ : I → Container s p) →
+               ∀ {x} {X : Set x} → (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π I Cᵢ ⟧ X
+  from-Π     : ∀ {i s p} (I : Set i) (Cᵢ : I → Container s p) →
+               ∀ {x} {X : Set x} → ⟦ Π I Cᵢ ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
+  to-_⊎_     : ∀ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) →
+               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X → ⟦ C₁ ⊎ C₂ ⟧ X
+  from-_⊎_   : ∀ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) →
+               ∀ {x} {X : Set x} → ⟦ C₁ ⊎ C₂ ⟧ X → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X
+  to-Σ       : ∀ {i s p} (I : Set i) (C : I → Container s p) →
+               ∀ {x} {X : Set x} → (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ I C ⟧ X
+  from-Σ     : ∀ {i s p} (I : Set i) (C : I → Container s p) →
+               ∀ {x} {X : Set x} → ⟦ Σ I C ⟧ X → ∃ λ i → ⟦ C i ⟧ X
+  ```
+
 NonZero/Positive/Negative changes
 ---------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1842,30 +1842,20 @@ Other minor changes
 
 * Exposed container combinator conversion functions from `Data.Container.Combinator.Properties` separate from their correctness proofs in `Data.Container.Combinator`:
   ```
-  to-id      : ∀ {s p x} {X : Set x} → F.id X → ⟦ id {s} {p} ⟧ X
-  from-id    : ∀ {s p x} {X : Set x} → ⟦ id {s} {p} ⟧ X → F.id X
-  to-const   : ∀ {s p y} (X : Set s) {Y : Set y} → X → ⟦ const {p = p} X ⟧ Y
-  from-const : ∀ {s p y} (X : Set s) {Y : Set y} → ⟦ const {p = p} X ⟧ Y → X
-  to-_∘_     : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
-               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₁ ∘ C₂ ⟧ X
-  from-_∘_   : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
-               ∀ {x} {X : Set x} → ⟦ C₁ ∘ C₂ ⟧ X → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)
-  to-_×_     : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
-               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X → ⟦ C₁ × C₂ ⟧ X
-  from-_×_   : ∀ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) →
-               ∀ {x} {X : Set x} → ⟦ C₁ × C₂ ⟧ X → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X
-  to-Π       : ∀ {i s p} (I : Set i) (Cᵢ : I → Container s p) →
-               ∀ {x} {X : Set x} → (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π I Cᵢ ⟧ X
-  from-Π     : ∀ {i s p} (I : Set i) (Cᵢ : I → Container s p) →
-               ∀ {x} {X : Set x} → ⟦ Π I Cᵢ ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
-  to-_⊎_     : ∀ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) →
-               ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X → ⟦ C₁ ⊎ C₂ ⟧ X
-  from-_⊎_   : ∀ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) →
-               ∀ {x} {X : Set x} → ⟦ C₁ ⊎ C₂ ⟧ X → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X
-  to-Σ       : ∀ {i s p} (I : Set i) (C : I → Container s p) →
-               ∀ {x} {X : Set x} → (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ I C ⟧ X
-  from-Σ     : ∀ {i s p} (I : Set i) (C : I → Container s p) →
-               ∀ {x} {X : Set x} → ⟦ Σ I C ⟧ X → ∃ λ i → ⟦ C i ⟧ X
+  to-id      : F.id A → ⟦ id ⟧ A
+  from-id    : ⟦ id ⟧ A → F.id A
+  to-const   : (A : Set s) → A → ⟦ const A ⟧ B
+  from-const : (A : Set s) → ⟦ const A ⟧ B → A
+  to-_∘_     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ C₁ ∘ C₂ ⟧ A
+  from-_∘_   : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ∘ C₂ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
+  to-_×_     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ C₁ × C₂ ⟧ A
+  from-_×_   : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ × C₂ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
+  to-Π       : (I : Set i) (Cᵢ : I → Container s p) → (∀ i → ⟦ Cᵢ i ⟧ A) → ⟦ Π I Cᵢ ⟧ A
+  from-Π     : (I : Set i) (Cᵢ : I → Container s p) → ⟦ Π I Cᵢ ⟧ A → ∀ i → ⟦ Cᵢ i ⟧ A
+  to-_⊎_     : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ C₁ ⊎ C₂ ⟧ A
+  from-_⊎_   : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⊎ C₂ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
+  to-Σ       : (I : Set i) (C : I → Container s p) → (∃ λ i → ⟦ C i ⟧ A) → ⟦ Σ I C ⟧ A
+  from-Σ     : (I : Set i) (C : I → Container s p) → ⟦ Σ I C ⟧ A → ∃ λ i → ⟦ C i ⟧ A
   ```
 
 NonZero/Positive/Negative changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1846,14 +1846,14 @@ Other minor changes
   from-id    : ⟦ id ⟧ A → F.id A
   to-const   : (A : Set s) → A → ⟦ const A ⟧ B
   from-const : (A : Set s) → ⟦ const A ⟧ B → A
-  to-_∘_     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ C₁ ∘ C₂ ⟧ A
-  from-_∘_   : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ∘ C₂ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
-  to-_×_     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ C₁ × C₂ ⟧ A
-  from-_×_   : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ × C₂ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
+  to-∘       : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ C₁ ∘ C₂ ⟧ A
+  from-∘     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ∘ C₂ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
+  to-×       : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ C₁ × C₂ ⟧ A
+  from-×     : (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) → ⟦ C₁ × C₂ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
   to-Π       : (I : Set i) (Cᵢ : I → Container s p) → (∀ i → ⟦ Cᵢ i ⟧ A) → ⟦ Π I Cᵢ ⟧ A
   from-Π     : (I : Set i) (Cᵢ : I → Container s p) → ⟦ Π I Cᵢ ⟧ A → ∀ i → ⟦ Cᵢ i ⟧ A
-  to-_⊎_     : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ C₁ ⊎ C₂ ⟧ A
-  from-_⊎_   : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⊎ C₂ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
+  to-⊎       : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ C₁ ⊎ C₂ ⟧ A
+  from-⊎     : (C₁ : Container s₁ p) (C₂ : Container s₂ p) → ⟦ C₁ ⊎ C₂ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
   to-Σ       : (I : Set i) (C : I → Container s p) → (∃ λ i → ⟦ C i ⟧ A) → ⟦ Σ I C ⟧ A
   from-Σ     : (I : Set i) (C : I → Container s p) → ⟦ Σ I C ⟧ A → ∃ λ i → ⟦ C i ⟧ A
   ```

--- a/src/Data/Container/Combinator.agda
+++ b/src/Data/Container/Combinator.agda
@@ -29,22 +29,22 @@ module _ {s p : Level} where
   id .Shape    = ⊤
   id .Position = F.const ⊤
 
-  to-id : ∀ {x} {X : Set x} → F.id X → ⟦ id ⟧ X
+  to-id : ∀ {a} {A : Set a} → F.id A → ⟦ id ⟧ A
   to-id x = (_ , λ _ → x)
 
-  from-id : ∀ {x} {X : Set x} → ⟦ id ⟧ X → F.id X
+  from-id : ∀ {a} {A : Set a} → ⟦ id ⟧ A → F.id A
   from-id xs = proj₂ xs _
 
 -- Constant.
 
   const : Set s → Container s p
-  const X .Shape    = X
-  const X .Position = F.const ⊥
+  const A .Shape    = A
+  const A .Position = F.const ⊥
 
-  to-const : ∀ {y} (X : Set s) {Y : Set y} → X → ⟦ const X ⟧ Y
+  to-const : ∀ {b} (A : Set s) {B : Set b} → A → ⟦ const A ⟧ B
   to-const _ = _, ⊥-elim {Whatever = F.const _}
 
-  from-const : ∀ {y} (X : Set s) {Y : Set y} → ⟦ const X ⟧ Y → X
+  from-const : ∀ {b} (A : Set s) {B : Set b} → ⟦ const A ⟧ B → A
   from-const _ = proj₁
 
 module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
@@ -57,10 +57,10 @@ module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s�
   _∘_ .Shape    = ⟦ C₁ ⟧ (Shape C₂)
   _∘_ .Position = ◇ C₁ (Position C₂)
 
-  to-_∘_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ _∘_ ⟧ X
+  to-_∘_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ _∘_ ⟧ A
   to-_∘_ (s , f) = ((s , proj₁ F.∘ f) , P.uncurry (proj₂ F.∘ f) F.∘′ ◇.proof)
 
-  from-_∘_ : ∀ {x} {X : Set x} → ⟦ _∘_ ⟧ X → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)
+  from-_∘_ : ∀ {a} {A : Set a} → ⟦ _∘_ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
   from-_∘_ ((s , f) , g) = (s , < f , P.curry (g F.∘′ any) >)
 
 -- Product. (Note that, up to isomorphism, this is a special case of
@@ -72,10 +72,10 @@ module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s�
   _×_ .Shape    = Shape C₁ P.× Shape C₂
   _×_ .Position = P.uncurry λ s₁ s₂ → (Position C₁ s₁) S.⊎ (Position C₂ s₂)
 
-  to-_×_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X → ⟦ _×_ ⟧ X
+  to-_×_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ _×_ ⟧ A
   to-_×_ ((s₁ , f₁) , (s₂ , f₂)) = ((s₁ , s₂) , [ f₁ , f₂ ]′)
 
-  from-_×_ : ∀ {x} {X : Set x} → ⟦ _×_ ⟧ X → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X
+  from-_×_ : ∀ {a} {A : Set a} → ⟦ _×_ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
   from-_×_ ((s₁ , s₂) , f) = ((s₁ , f F.∘ S.inj₁) , (s₂ , f F.∘ S.inj₂))
 
 -- Indexed product.
@@ -86,10 +86,10 @@ module _ {i s p} (I : Set i) (Cᵢ : I → Container s p) where
   Π .Shape    = ∀ i → Shape (Cᵢ i)
   Π .Position = λ s → ∃ λ i → Position (Cᵢ i) (s i)
 
-  to-Π : ∀ {x} {X : Set x} → (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π ⟧ X
+  to-Π : ∀ {a} {A : Set a} → (∀ i → ⟦ Cᵢ i ⟧ A) → ⟦ Π ⟧ A
   to-Π f = (proj₁ F.∘ f , P.uncurry (proj₂ F.∘ f))
 
-  from-Π : ∀ {x} {X : Set x} → ⟦ Π ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
+  from-Π : ∀ {a} {A : Set a} → ⟦ Π ⟧ A → ∀ i → ⟦ Cᵢ i ⟧ A
   from-Π (s , f) = λ i → (s i , λ p → f (i , p))
 
 -- Constant exponentiation. (Note that this is a special case of
@@ -98,7 +98,7 @@ module _ {i s p} (I : Set i) (Cᵢ : I → Container s p) where
 infix 0 const[_]⟶_
 
 const[_]⟶_ : ∀ {i s p} → Set i → Container s p → Container (i ⊔ s) (i ⊔ p)
-const[ X ]⟶ C = Π X (F.const C)
+const[ A ]⟶ C = Π A (F.const C)
 
 -- Sum. (Note that, up to isomorphism, this is a special case of
 -- indexed sum.)
@@ -111,10 +111,10 @@ module _ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
   _⊎_ .Shape    = (Shape C₁ S.⊎ Shape C₂)
   _⊎_ .Position = [ Position C₁ , Position C₂ ]′
 
-  to-_⊎_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X → ⟦ _⊎_ ⟧ X
+  to-_⊎_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ _⊎_ ⟧ A
   to-_⊎_ = [ P.map S.inj₁ F.id , P.map S.inj₂ F.id ]′
 
-  from-_⊎_ : ∀ {x} {X : Set x} → ⟦ _⊎_ ⟧ X → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X
+  from-_⊎_ : ∀ {a} {A : Set a} → ⟦ _⊎_ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
   from-_⊎_ (S.inj₁ s₁ , f) = S.inj₁ (s₁ , f)
   from-_⊎_ (S.inj₂ s₂ , f) = S.inj₂ (s₂ , f)
 
@@ -126,8 +126,8 @@ module _ {i s p} (I : Set i) (C : I → Container s p) where
   Σ .Shape    = ∃ λ i → Shape (C i)
   Σ .Position = λ s → Position (C (proj₁ s)) (proj₂ s)
 
-  to-Σ : ∀ {x} {X : Set x} → (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ ⟧ X
+  to-Σ : ∀ {a} {A : Set a} → (∃ λ i → ⟦ C i ⟧ A) → ⟦ Σ ⟧ A
   to-Σ (i , (s , f)) = ((i , s) , f)
 
-  from-Σ : ∀ {x} {X : Set x} → ⟦ Σ ⟧ X → ∃ λ i → ⟦ C i ⟧ X
+  from-Σ : ∀ {a} {A : Set a} → ⟦ Σ ⟧ A → ∃ λ i → ⟦ C i ⟧ A
   from-Σ ((i , s) , f) = (i , (s , f))

--- a/src/Data/Container/Combinator.agda
+++ b/src/Data/Container/Combinator.agda
@@ -8,9 +8,9 @@
 
 module Data.Container.Combinator where
 
-open import Level using (Level; _⊔_)
-open import Data.Empty.Polymorphic using (⊥)
-open import Data.Product as P using (_,_; proj₁; proj₂; ∃)
+open import Level using (Level; _⊔_; lower)
+open import Data.Empty.Polymorphic using (⊥; ⊥-elim)
+open import Data.Product as P using (_,_; <_,_>; proj₁; proj₂; ∃)
 open import Data.Sum.Base as S using ([_,_]′)
 open import Data.Unit.Polymorphic.Base using (⊤)
 import Function as F
@@ -29,36 +29,68 @@ module _ {s p : Level} where
   id .Shape    = ⊤
   id .Position = F.const ⊤
 
+  to-id : ∀ {x} {X : Set x} → F.id X → ⟦ id ⟧ X
+  to-id x = (_ , λ _ → x)
+
+  from-id : ∀ {x} {X : Set x} → ⟦ id ⟧ X → F.id X
+  from-id xs = proj₂ xs _
+
 -- Constant.
 
   const : Set s → Container s p
   const X .Shape    = X
   const X .Position = F.const ⊥
 
+  to-const : ∀ {y} (X : Set s) {Y : Set y} → X → ⟦ const X ⟧ Y
+  to-const _ = _, ⊥-elim {Whatever = F.const _}
+
+  from-const : ∀ {y} (X : Set s) {Y : Set y} → ⟦ const X ⟧ Y → X
+  from-const _ = proj₁
+
+module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
+
 -- Composition.
 
-infixr 9 _∘_
+  infixr 9 _∘_
 
-_∘_ : ∀ {s₁ s₂ p₁ p₂} → Container s₁ p₁ → Container s₂ p₂ →
-      Container (s₁ ⊔ s₂ ⊔ p₁) (p₁ ⊔ p₂)
-(C₁ ∘ C₂) .Shape    = ⟦ C₁ ⟧ (Shape C₂)
-(C₁ ∘ C₂) .Position = ◇ C₁ (Position C₂)
+  _∘_ : Container (s₁ ⊔ s₂ ⊔ p₁) (p₁ ⊔ p₂)
+  _∘_ .Shape    = ⟦ C₁ ⟧ (Shape C₂)
+  _∘_ .Position = ◇ C₁ (Position C₂)
+
+  to-_∘_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ _∘_ ⟧ X
+  to-_∘_ (s , f) = ((s , proj₁ F.∘ f) , P.uncurry (proj₂ F.∘ f) F.∘′ ◇.proof)
+
+  from-_∘_ : ∀ {x} {X : Set x} → ⟦ _∘_ ⟧ X → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)
+  from-_∘_ ((s , f) , g) = (s , < f , P.curry (g F.∘′ any) >)
 
 -- Product. (Note that, up to isomorphism, this is a special case of
 -- indexed product.)
 
-infixr 2 _×_
+  infixr 2 _×_
 
-_×_ : ∀ {s₁ s₂ p₁ p₂} → Container s₁ p₁ → Container s₂ p₂ →
-      Container (s₁ ⊔ s₂) (p₁ ⊔ p₂)
-(C₁ × C₂) .Shape    = Shape C₁ P.× Shape C₂
-(C₁ × C₂) .Position = P.uncurry λ s₁ s₂ → (Position C₁ s₁) S.⊎ (Position C₂ s₂)
+  _×_ : Container (s₁ ⊔ s₂) (p₁ ⊔ p₂)
+  _×_ .Shape    = Shape C₁ P.× Shape C₂
+  _×_ .Position = P.uncurry λ s₁ s₂ → (Position C₁ s₁) S.⊎ (Position C₂ s₂)
+
+  to-_×_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X → ⟦ _×_ ⟧ X
+  to-_×_ ((s₁ , f₁) , (s₂ , f₂)) = ((s₁ , s₂) , [ f₁ , f₂ ]′)
+
+  from-_×_ : ∀ {x} {X : Set x} → ⟦ _×_ ⟧ X → ⟦ C₁ ⟧ X P.× ⟦ C₂ ⟧ X
+  from-_×_ ((s₁ , s₂) , f) = ((s₁ , f F.∘ S.inj₁) , (s₂ , f F.∘ S.inj₂))
 
 -- Indexed product.
 
-Π : ∀ {i s p} (I : Set i) → (I → Container s p) → Container (i ⊔ s) (i ⊔ p)
-Π I C .Shape    = ∀ i → Shape (C i)
-Π I C .Position = λ s → ∃ λ i → Position (C i) (s i)
+module _ {i s p} (I : Set i) (Cᵢ : I → Container s p) where
+
+  Π : Container (i ⊔ s) (i ⊔ p)
+  Π .Shape    = ∀ i → Shape (Cᵢ i)
+  Π .Position = λ s → ∃ λ i → Position (Cᵢ i) (s i)
+
+  to-Π : ∀ {x} {X : Set x} → (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π ⟧ X
+  to-Π f = (proj₁ F.∘ f , P.uncurry (proj₂ F.∘ f))
+
+  from-Π : ∀ {x} {X : Set x} → ⟦ Π ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
+  from-Π (s , f) = λ i → (s i , λ p → f (i , p))
 
 -- Constant exponentiation. (Note that this is a special case of
 -- indexed product.)
@@ -71,14 +103,31 @@ const[ X ]⟶ C = Π X (F.const C)
 -- Sum. (Note that, up to isomorphism, this is a special case of
 -- indexed sum.)
 
-infixr 1 _⊎_
+module _ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
+  
+  infixr 1 _⊎_
 
-_⊎_ : ∀ {s₁ s₂ p} → Container s₁ p → Container s₂ p → Container (s₁ ⊔ s₂) p
-(C₁ ⊎ C₂) .Shape    = (Shape C₁ S.⊎ Shape C₂)
-(C₁ ⊎ C₂) .Position = [ Position C₁ , Position C₂ ]′
+  _⊎_ : Container (s₁ ⊔ s₂) p
+  _⊎_ .Shape    = (Shape C₁ S.⊎ Shape C₂)
+  _⊎_ .Position = [ Position C₁ , Position C₂ ]′
+
+  to-_⊎_ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X → ⟦ _⊎_ ⟧ X
+  to-_⊎_ = [ P.map S.inj₁ F.id , P.map S.inj₂ F.id ]′
+
+  from-_⊎_ : ∀ {x} {X : Set x} → ⟦ _⊎_ ⟧ X → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X
+  from-_⊎_ (S.inj₁ s₁ , f) = S.inj₁ (s₁ , f)
+  from-_⊎_ (S.inj₂ s₂ , f) = S.inj₂ (s₂ , f)
 
 -- Indexed sum.
 
-Σ : ∀ {i s p} (I : Set i) → (I → Container s p) → Container (i ⊔ s) p
-Σ I C .Shape    = ∃ λ i → Shape (C i)
-Σ I C .Position = λ s → Position (C (proj₁ s)) (proj₂ s)
+module _ {i s p} (I : Set i) (C : I → Container s p) where
+
+  Σ : Container (i ⊔ s) p
+  Σ .Shape    = ∃ λ i → Shape (C i)
+  Σ .Position = λ s → Position (C (proj₁ s)) (proj₂ s)
+
+  to-Σ : ∀ {x} {X : Set x} → (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ ⟧ X
+  to-Σ (i , (s , f)) = ((i , s) , f)
+
+  from-Σ : ∀ {x} {X : Set x} → ⟦ Σ ⟧ X → ∃ λ i → ⟦ C i ⟧ X
+  from-Σ ((i , s) , f) = (i , (s , f))

--- a/src/Data/Container/Combinator.agda
+++ b/src/Data/Container/Combinator.agda
@@ -57,11 +57,11 @@ module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s�
   _∘_ .Shape    = ⟦ C₁ ⟧ (Shape C₂)
   _∘_ .Position = ◇ C₁ (Position C₂)
 
-  to-_∘_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ _∘_ ⟧ A
-  to-_∘_ (s , f) = ((s , proj₁ F.∘ f) , P.uncurry (proj₂ F.∘ f) F.∘′ ◇.proof)
+  to-∘ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A) → ⟦ _∘_ ⟧ A
+  to-∘ (s , f) = ((s , proj₁ F.∘ f) , P.uncurry (proj₂ F.∘ f) F.∘′ ◇.proof)
 
-  from-_∘_ : ∀ {a} {A : Set a} → ⟦ _∘_ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
-  from-_∘_ ((s , f) , g) = (s , < f , P.curry (g F.∘′ any) >)
+  from-∘ : ∀ {a} {A : Set a} → ⟦ _∘_ ⟧ A → ⟦ C₁ ⟧ (⟦ C₂ ⟧ A)
+  from-∘ ((s , f) , g) = (s , < f , P.curry (g F.∘′ any) >)
 
 -- Product. (Note that, up to isomorphism, this is a special case of
 -- indexed product.)
@@ -72,11 +72,11 @@ module _ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s�
   _×_ .Shape    = Shape C₁ P.× Shape C₂
   _×_ .Position = P.uncurry λ s₁ s₂ → (Position C₁ s₁) S.⊎ (Position C₂ s₂)
 
-  to-_×_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ _×_ ⟧ A
-  to-_×_ ((s₁ , f₁) , (s₂ , f₂)) = ((s₁ , s₂) , [ f₁ , f₂ ]′)
+  to-× : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A → ⟦ _×_ ⟧ A
+  to-× ((s₁ , f₁) , (s₂ , f₂)) = ((s₁ , s₂) , [ f₁ , f₂ ]′)
 
-  from-_×_ : ∀ {a} {A : Set a} → ⟦ _×_ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
-  from-_×_ ((s₁ , s₂) , f) = ((s₁ , f F.∘ S.inj₁) , (s₂ , f F.∘ S.inj₂))
+  from-× : ∀ {a} {A : Set a} → ⟦ _×_ ⟧ A → ⟦ C₁ ⟧ A P.× ⟦ C₂ ⟧ A
+  from-× ((s₁ , s₂) , f) = ((s₁ , f F.∘ S.inj₁) , (s₂ , f F.∘ S.inj₂))
 
 -- Indexed product.
 
@@ -111,12 +111,12 @@ module _ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
   _⊎_ .Shape    = (Shape C₁ S.⊎ Shape C₂)
   _⊎_ .Position = [ Position C₁ , Position C₂ ]′
 
-  to-_⊎_ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ _⊎_ ⟧ A
-  to-_⊎_ = [ P.map S.inj₁ F.id , P.map S.inj₂ F.id ]′
+  to-⊎ : ∀ {a} {A : Set a} → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A → ⟦ _⊎_ ⟧ A
+  to-⊎ = [ P.map S.inj₁ F.id , P.map S.inj₂ F.id ]′
 
-  from-_⊎_ : ∀ {a} {A : Set a} → ⟦ _⊎_ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
-  from-_⊎_ (S.inj₁ s₁ , f) = S.inj₁ (s₁ , f)
-  from-_⊎_ (S.inj₂ s₂ , f) = S.inj₂ (s₂ , f)
+  from-⊎ : ∀ {a} {A : Set a} → ⟦ _⊎_ ⟧ A → ⟦ C₁ ⟧ A S.⊎ ⟦ C₂ ⟧ A
+  from-⊎ (S.inj₁ s₁ , f) = S.inj₁ (s₁ , f)
+  from-⊎ (S.inj₂ s₂ , f) = S.inj₂ (s₂ , f)
 
 -- Indexed sum.
 

--- a/src/Data/Container/Combinator.agda
+++ b/src/Data/Container/Combinator.agda
@@ -104,7 +104,7 @@ const[ X ]⟶ C = Π X (F.const C)
 -- indexed sum.)
 
 module _ {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
-  
+
   infixr 1 _⊎_
 
   _⊎_ : Container (s₁ ⊔ s₂) p

--- a/src/Data/Container/Combinator/Properties.agda
+++ b/src/Data/Container/Combinator/Properties.agda
@@ -40,15 +40,15 @@ module Constant (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′) where
 module Composition {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
   correct : ∀ {x} {X : Set x} → ⟦ C₁ ∘ C₂ ⟧ X ↔ (⟦ C₁ ⟧ F.∘ ⟦ C₂ ⟧) X
-  correct {X = X} = inverse (from- C₁ ∘ C₂) (to- C₁ ∘ C₂) (λ _ → P.refl) (λ _ → P.refl)
+  correct {X = X} = inverse (from-∘ C₁ C₂) (to-∘ C₁ C₂) (λ _ → P.refl) (λ _ → P.refl)
 
 module Product (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′)
        {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
   correct : ∀ {x} {X : Set x} →  ⟦ C₁ × C₂ ⟧ X ↔ (⟦ C₁ ⟧ X Prod.× ⟦ C₂ ⟧ X)
-  correct {X = X} = inverse (from- C₁ × C₂) (to- C₁ × C₂) from∘to (λ _ → P.refl)
+  correct {X = X} = inverse (from-× C₁ C₂) (to-× C₁ C₂) from∘to (λ _ → P.refl)
     where
-    from∘to : (to- C₁ × C₂) F.∘ (from- C₁ × C₂) ≗ F.id
+    from∘to : (to-× C₁ C₂) F.∘ (from-× C₁ C₂) ≗ F.id
     from∘to (s , f) =
       P.cong (s ,_) (ext [ (λ _ → P.refl) , (λ _ → P.refl) ])
 
@@ -60,13 +60,13 @@ module IndexedProduct {i s p} {I : Set i} (Cᵢ : I → Container s p) where
 module Sum {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
 
   correct : ∀ {x} {X : Set x} → ⟦ C₁ ⊎ C₂ ⟧ X ↔ (⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X)
-  correct {X = X} = inverse (from- C₁ ⊎ C₂) (to- C₁ ⊎ C₂) from∘to to∘from
+  correct {X = X} = inverse (from-⊎ C₁ C₂) (to-⊎ C₁ C₂) from∘to to∘from
     where
-    from∘to : (to- C₁ ⊎ C₂) F.∘ (from- C₁ ⊎ C₂) ≗ F.id
+    from∘to : (to-⊎ C₁ C₂) F.∘ (from-⊎ C₁ C₂) ≗ F.id
     from∘to (inj₁ s₁ , f) = P.refl
     from∘to (inj₂ s₂ , f) = P.refl
 
-    to∘from : (from- C₁ ⊎ C₂) F.∘ (to- C₁ ⊎ C₂) ≗ F.id
+    to∘from : (from-⊎ C₁ C₂) F.∘ (to-⊎ C₁ C₂) ≗ F.id
     to∘from = [ (λ _ → P.refl) , (λ _ → P.refl) ]
 
 module IndexedSum {i s p} {I : Set i} (C : I → Container s p) where

--- a/src/Data/Container/Combinator/Properties.agda
+++ b/src/Data/Container/Combinator/Properties.agda
@@ -27,93 +27,52 @@ open import Relation.Binary.PropositionalEquality as P using (_≡_; _≗_)
 module Identity where
 
   correct : ∀ {s p x} {X : Set x} → ⟦ id {s} {p} ⟧ X ↔ F.id X
-  correct {X = X} = inverse to from (λ _ → P.refl) (λ _ → P.refl)
-    where
-    to : ⟦ id ⟧ X → F.id X
-    to xs = proj₂ xs _
-
-    from : F.id X → ⟦ id ⟧ X
-    from x = (_ , λ _ → x)
+  correct {X = X} = inverse from-id to-id (λ _ → P.refl) (λ _ → P.refl)
 
 module Constant (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′) where
 
   correct : ∀ {x p y} (X : Set x) {Y : Set y} → ⟦ const {x} {p ⊔ y} X ⟧ Y ↔ F.const X Y
-  correct {x} {y} X {Y} = inverse proj₁ from from∘to λ _ → P.refl
-
+  correct {x} {y} X {Y} = inverse (from-const X) (to-const X) from∘to λ _ → P.refl
     where
-    from : X → ⟦ const X ⟧ Y
-    from = < F.id , F.const (⊥-elim ∘′ lower) >
-
-    from∘to : (x : ⟦ const X ⟧ Y) → from (proj₁ x) ≡ x
+    from∘to : (x : ⟦ const X ⟧ Y) → to-const X (proj₁ x) ≡ x
     from∘to xs = P.cong (proj₁ xs ,_) (ext (λ x → ⊥-elim (lower x)))
 
 module Composition {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
   correct : ∀ {x} {X : Set x} → ⟦ C₁ ∘ C₂ ⟧ X ↔ (⟦ C₁ ⟧ F.∘ ⟦ C₂ ⟧) X
-  correct {X = X} = inverse to from (λ _ → P.refl) (λ _ → P.refl)
-    where
-    to : ⟦ C₁ ∘ C₂ ⟧ X → ⟦ C₁ ⟧ (⟦ C₂ ⟧ X)
-    to ((s , f) , g) = (s , < f , curry (g ∘′ any) >)
-
-    from : ⟦ C₁ ⟧ (⟦ C₂ ⟧ X) → ⟦ C₁ ∘ C₂ ⟧ X
-    from (s , f) = ((s , proj₁ F.∘ f) , uncurry (proj₂ F.∘ f) ∘′ ◇.proof)
+  correct {X = X} = inverse (from- C₁ ∘ C₂) (to- C₁ ∘ C₂) (λ _ → P.refl) (λ _ → P.refl)
 
 module Product (ext : ∀ {ℓ ℓ′} → Extensionality ℓ ℓ′)
        {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Container s₂ p₂) where
 
   correct : ∀ {x} {X : Set x} →  ⟦ C₁ × C₂ ⟧ X ↔ (⟦ C₁ ⟧ X Prod.× ⟦ C₂ ⟧ X)
-  correct {X = X} = inverse to from from∘to (λ _ → P.refl)
+  correct {X = X} = inverse (from- C₁ × C₂) (to- C₁ × C₂) from∘to (λ _ → P.refl)
     where
-    to : ⟦ C₁ × C₂ ⟧ X → ⟦ C₁ ⟧ X Prod.× ⟦ C₂ ⟧ X
-    to ((s₁ , s₂) , f) = ((s₁ , f F.∘ inj₁) , (s₂ , f F.∘ inj₂))
-
-    from : ⟦ C₁ ⟧ X Prod.× ⟦ C₂ ⟧ X → ⟦ C₁ × C₂ ⟧ X
-    from ((s₁ , f₁) , (s₂ , f₂)) = ((s₁ , s₂) , [ f₁ , f₂ ]′)
-
-    from∘to : from F.∘ to ≗ F.id
+    from∘to : (to- C₁ × C₂) F.∘ (from- C₁ × C₂) ≗ F.id
     from∘to (s , f) =
       P.cong (s ,_) (ext [ (λ _ → P.refl) , (λ _ → P.refl) ])
 
 module IndexedProduct {i s p} {I : Set i} (Cᵢ : I → Container s p) where
 
   correct : ∀ {x} {X : Set x} → ⟦ Π I Cᵢ ⟧ X ↔ (∀ i → ⟦ Cᵢ i ⟧ X)
-  correct {X = X} = inverse to from (λ _ → P.refl) (λ _ → P.refl)
-    where
-    to : ⟦ Π I Cᵢ ⟧ X → ∀ i → ⟦ Cᵢ i ⟧ X
-    to (s , f) = λ i → (s i , λ p → f (i , p))
-
-    from : (∀ i → ⟦ Cᵢ i ⟧ X) → ⟦ Π I Cᵢ ⟧ X
-    from f = (proj₁ F.∘ f , uncurry (proj₂ F.∘ f))
+  correct {X = X} = inverse (from-Π I Cᵢ) (to-Π I Cᵢ) (λ _ → P.refl) (λ _ → P.refl)
 
 module Sum {s₁ s₂ p} (C₁ : Container s₁ p) (C₂ : Container s₂ p) where
 
   correct : ∀ {x} {X : Set x} → ⟦ C₁ ⊎ C₂ ⟧ X ↔ (⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X)
-  correct {X = X} = inverse to from from∘to to∘from
+  correct {X = X} = inverse (from- C₁ ⊎ C₂) (to- C₁ ⊎ C₂) from∘to to∘from
     where
-    to : ⟦ C₁ ⊎ C₂ ⟧ X → ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X
-    to (inj₁ s₁ , f) = inj₁ (s₁ , f)
-    to (inj₂ s₂ , f) = inj₂ (s₂ , f)
-
-    from : ⟦ C₁ ⟧ X S.⊎ ⟦ C₂ ⟧ X → ⟦ C₁ ⊎ C₂ ⟧ X
-    from = [ Prod.map inj₁ F.id , Prod.map inj₂ F.id ]′
-
-    from∘to : from F.∘ to ≗ F.id
+    from∘to : (to- C₁ ⊎ C₂) F.∘ (from- C₁ ⊎ C₂) ≗ F.id
     from∘to (inj₁ s₁ , f) = P.refl
     from∘to (inj₂ s₂ , f) = P.refl
 
-    to∘from : to F.∘ from ≗ F.id
+    to∘from : (from- C₁ ⊎ C₂) F.∘ (to- C₁ ⊎ C₂) ≗ F.id
     to∘from = [ (λ _ → P.refl) , (λ _ → P.refl) ]
 
 module IndexedSum {i s p} {I : Set i} (C : I → Container s p) where
 
   correct : ∀ {x} {X : Set x} → ⟦ Σ I C ⟧ X ↔ (∃ λ i → ⟦ C i ⟧ X)
-  correct {X = X} = inverse to from (λ _ → P.refl) (λ _ → P.refl)
-    where
-    to : ⟦ Σ I C ⟧ X → ∃ λ i → ⟦ C i ⟧ X
-    to ((i , s) , f) = (i , (s , f))
-
-    from : (∃ λ i → ⟦ C i ⟧ X) → ⟦ Σ I C ⟧ X
-    from (i , (s , f)) = ((i , s) , f)
+  correct {X = X} = inverse (from-Σ I C) (to-Σ I C) (λ _ → P.refl) (λ _ → P.refl)
 
 module ConstantExponentiation {i s p} {I : Set i} (C : Container s p) where
 


### PR DESCRIPTION
Exposed container combinator conversion functions from `Data.Container.Combinator.Properties` separate from their correctness proofs in `Data.Container.Combinator`. Functions are named same as combinators prefixed with `to-` (to combinator) and `from-` (from combinator). Explicit arguments (besides the last one - value being converted) correspond to combinators' arguments.