### PR TITLE
Add proofs in Algebra.Properties.<Ring/Semigroup> 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1130,6 +1130,7 @@ Other minor changes
   ```
   leftAlternative : LeftAlternative _∙_
   rightAlternative : RightAlternative _∙_
+  alternative : Alternative _∙_
   flexible : Flexible _∙_
   ```
 
@@ -1150,7 +1151,7 @@ Other minor changes
   record IsQuasiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ)
   record IsNearring (+ * : Op₂ A) (0# 1# : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ)
   record IsIdempotentMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)
-  record IsAlternateMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)
+  record IsAlternativeMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)
   record IsFlexibleMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)
   record IsMedialMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)
   record IsSemimedialMagma (∙ : Op₂ A) : Set (a ⊔ ℓ)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1135,10 +1135,7 @@ Other minor changes
 
 * Added new proofs to `Algebra.Properties.Ring`:
   ```
-  0x≈0 : ∀ x → 0# * x ≈ 0#
-  x0≈0 : ∀ x → x * 0# ≈ 0#
-  -1*x≈x : ∀ x → - 1# * x ≈ - x
-  -‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
+  -1*x≈-x : ∀ x → - 1# * x ≈ - x
   ```
 
 * Added new definitions to `Algebra.Structures`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1133,6 +1133,14 @@ Other minor changes
   flexible : Flexible _∙_
   ```
 
+* Added new proofs to `Algebra.Properties.Ring`:
+  ```
+  0x≈0 : ∀ x → 0# * x ≈ 0#
+  x0≈0 : ∀ x → x * 0# ≈ 0#
+  -1*x≈x : ∀ x → - 1# * x ≈ - x
+  -‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
+  ```
+
 * Added new definitions to `Algebra.Structures`:
   ```agda
   record IsUnitalMagma (_∙_ : Op₂ A) (ε : A) : Set (a ⊔ ℓ)

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -72,3 +72,13 @@ x0≈0 x = zeroʳ x
   - 1# * x  ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
   - (1# * x) ≈⟨ -‿cong ( *-identityˡ x ) ⟩
   - x ∎
+
+-‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
+-‿distrib-+ x y = begin
+  - (x + y) ≈⟨ sym (*-identityˡ _) ⟩
+  1# * - (x + y) ≈⟨ sym ( -‿distribʳ-* _ _) ⟩
+  - (1# * (x + y) ) ≈⟨ -‿distribˡ-* _ _ ⟩
+  (- 1#) * (x + y) ≈⟨ (distribˡ _ _ _) ⟩
+  (- 1# * x) + (- 1# * y) ≈⟨ +-cong (-1*x≈x _) (-1*x≈x _) ⟩
+  - x + (- y) ∎
+

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -65,10 +65,10 @@ open AbelianGroupProperties +-abelianGroup public
 0x≈0 x = zeroˡ x
 
 x0≈0 : ∀ x → x * 0# ≈ 0#
-x0≈0 x = zeroʳ x 
+x0≈0 x = zeroʳ x
 
--1*x≈x : ∀ x → - 1# * x ≈ - x 
--1*x≈x x = begin 
+-1*x≈x : ∀ x → - 1# * x ≈ - x
+-1*x≈x x = begin
   - 1# * x  ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
   - (1# * x) ≈⟨ -‿cong ( *-identityˡ x ) ⟩
   - x ∎

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -61,24 +61,9 @@ open AbelianGroupProperties +-abelianGroup public
   - (x * y) + 0#                 ≈⟨ +-identityʳ _ ⟩
   - (x * y)                      ∎
 
-0x≈0 : ∀ x → 0# * x ≈ 0#
-0x≈0 x = zeroˡ x
-
-x0≈0 : ∀ x → x * 0# ≈ 0#
-x0≈0 x = zeroʳ x
-
--1*x≈x : ∀ x → - 1# * x ≈ - x
--1*x≈x x = begin
+-1*x≈-x : ∀ x → - 1# * x ≈ - x
+-1*x≈-x x = begin
   - 1# * x    ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
   - (1# * x)  ≈⟨ -‿cong ( *-identityˡ x ) ⟩
   - x         ∎
-
--‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
--‿distrib-+ x y = begin
-  - (x + y)                ≈⟨ sym (*-identityˡ _) ⟩
-  1# * - (x + y)           ≈⟨ sym ( -‿distribʳ-* _ _) ⟩
-  - (1# * (x + y) )        ≈⟨ -‿distribˡ-* _ _ ⟩
-  (- 1#) * (x + y)         ≈⟨ (distribˡ _ _ _) ⟩
-  (- 1# * x) + (- 1# * y)  ≈⟨ +-cong (-1*x≈x _) (-1*x≈x _) ⟩
-  - x + (- y)              ∎
 

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -69,9 +69,9 @@ x0≈0 x = zeroʳ x
 
 -1*x≈x : ∀ x → - 1# * x ≈ - x
 -1*x≈x x = begin
-  - 1# * x  ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
-  - (1# * x) ≈⟨ -‿cong ( *-identityˡ x ) ⟩
-  - x ∎
+  - 1# * x    ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
+  - (1# * x)  ≈⟨ -‿cong ( *-identityˡ x ) ⟩
+  - x         ∎
 
 -‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
 -‿distrib-+ x y = begin
@@ -80,5 +80,5 @@ x0≈0 x = zeroʳ x
   - (1# * (x + y) )        ≈⟨ -‿distribˡ-* _ _ ⟩
   (- 1#) * (x + y)         ≈⟨ (distribˡ _ _ _) ⟩
   (- 1# * x) + (- 1# * y)  ≈⟨ +-cong (-1*x≈x _) (-1*x≈x _) ⟩
-  - x + (- y) ∎
+  - x + (- y)              ∎
 

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -60,3 +60,15 @@ open AbelianGroupProperties +-abelianGroup public
   - (x * y) + x * 0#             ≈⟨ +-congˡ $ zeroʳ _ ⟩
   - (x * y) + 0#                 ≈⟨ +-identityʳ _ ⟩
   - (x * y)                      ∎
+
+0x≈0 : ∀ x → 0# * x ≈ 0#
+0x≈0 x = zeroˡ x
+
+x0≈0 : ∀ x → x * 0# ≈ 0#
+x0≈0 x = zeroʳ x 
+
+-1*x≈x : ∀ x → - 1# * x ≈ - x 
+-1*x≈x x = begin 
+  - 1# * x  ≈⟨ sym (-‿distribˡ-* 1# x ) ⟩
+  - (1# * x) ≈⟨ -‿cong ( *-identityˡ x ) ⟩
+  - x ∎

--- a/src/Algebra/Properties/Ring.agda
+++ b/src/Algebra/Properties/Ring.agda
@@ -75,10 +75,10 @@ x0≈0 x = zeroʳ x
 
 -‿distrib-+ : ∀ x y → - (x + y) ≈ - x + (- y)
 -‿distrib-+ x y = begin
-  - (x + y) ≈⟨ sym (*-identityˡ _) ⟩
-  1# * - (x + y) ≈⟨ sym ( -‿distribʳ-* _ _) ⟩
-  - (1# * (x + y) ) ≈⟨ -‿distribˡ-* _ _ ⟩
-  (- 1#) * (x + y) ≈⟨ (distribˡ _ _ _) ⟩
-  (- 1# * x) + (- 1# * y) ≈⟨ +-cong (-1*x≈x _) (-1*x≈x _) ⟩
+  - (x + y)                ≈⟨ sym (*-identityˡ _) ⟩
+  1# * - (x + y)           ≈⟨ sym ( -‿distribʳ-* _ _) ⟩
+  - (1# * (x + y) )        ≈⟨ -‿distribˡ-* _ _ ⟩
+  (- 1#) * (x + y)         ≈⟨ (distribˡ _ _ _) ⟩
+  (- 1# * x) + (- 1# * y)  ≈⟨ +-cong (-1*x≈x _) (-1*x≈x _) ⟩
   - x + (- y) ∎
 

--- a/src/Algebra/Properties/Semigroup.agda
+++ b/src/Algebra/Properties/Semigroup.agda
@@ -12,6 +12,7 @@ module Algebra.Properties.Semigroup {a ℓ} (S : Semigroup a ℓ) where
 
 open Semigroup S
 open import Algebra.Definitions _≈_
+open import Data.Product
 
 x∙yz≈xy∙z : ∀ x y z → x ∙ (y ∙ z) ≈ (x ∙ y) ∙ z
 x∙yz≈xy∙z x y z = sym (assoc x y z)
@@ -21,6 +22,9 @@ leftAlternative x y = assoc x x y
 
 rightAlternative : RightAlternative _∙_
 rightAlternative x y = sym (assoc x y y)
+
+alternative : Alternative _∙_
+alternative = leftAlternative , rightAlternative
 
 flexible : Flexible _∙_
 flexible x y = assoc x y x


### PR DESCRIPTION
In this PR following proofs are added 
  `-1*x≈x : ∀ x → - 1# * x ≈ - x`
`alternative : Alternative _∙_`
