### PR TITLE
Add proofs for MoufangLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1005,6 +1005,10 @@ New modules
   Algebra.Module.Morphism.ModuleHomomorphism
   Algebra.Module.Properties
   ```
+* Properties of MoufangLoop
+  ```
+  Algebra.Properties.MoufangLoop
+  ```
 
 Other minor changes
 -------------------

--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -187,7 +187,7 @@ Semimedial : Op₂ A → Set _
 Semimedial _∙_ = (LeftSemimedial _∙_) × (RightSemimedial _∙_)
 
 LeftBol : Op₂ A → Set _
-LeftBol _∙_ = ∀ x y z → (x ∙ (y ∙ (x ∙ z))) ≈ ((x ∙ (y ∙ z)) ∙ z )
+LeftBol _∙_ = ∀ x y z → (x ∙ (y ∙ (x ∙ z))) ≈ ((x ∙ (y ∙ x)) ∙ z )
 
 RightBol : Op₂ A → Set _
 RightBol _∙_ = ∀ x y z → (((z ∙ x) ∙ y) ∙ x) ≈ (z ∙ ((x ∙ y) ∙ x))

--- a/src/Algebra/Properties/MoufangLoop.agda
+++ b/src/Algebra/Properties/MoufangLoop.agda
@@ -1,0 +1,39 @@
+{-# OPTIONS --without-K --safe #-}
+
+open import Algebra using (MoufangLoop)
+
+module Algebra.Properties.MoufangLoop {a ℓ} (M : MoufangLoop a ℓ) where
+
+open MoufangLoop M
+open import Algebra.Definitions _≈_
+open import Relation.Binary.Reasoning.Setoid setoid
+open import Data.Product
+
+leftAlternative : LeftBol _∙_ → LeftAlternative _∙_
+leftAlternative eq x y  = begin
+  ((x ∙ x) ∙ y)         ≈⟨ ∙-congʳ (∙-congˡ (sym (identityˡ x))) ⟩
+  ((x ∙ (ε ∙ x)) ∙ y)   ≈⟨ sym (eq x ε y) ⟩
+  (x ∙ (ε ∙ (x ∙ y)))   ≈⟨ ∙-congˡ (identityˡ ((x ∙ y))) ⟩
+  (x ∙ (x ∙ y))         ∎
+
+rightAlternative : RightBol _∙_ → RightAlternative _∙_
+rightAlternative eq x y = begin
+  (x ∙ (y ∙ y))         ≈⟨ ∙-congˡ(∙-congʳ(sym (identityʳ y))) ⟩
+  (x ∙ ((y ∙ ε) ∙ y))   ≈⟨ sym( eq y ε x ) ⟩
+  (((x ∙ y) ∙ ε ) ∙ y)  ≈⟨ ∙-congʳ (identityʳ ((x ∙ y))) ⟩
+  ((x ∙ y) ∙ y)         ∎
+
+alternative : LeftBol _∙_ → RightBol _∙_ → Alternative _∙_
+alternative x y = (leftAlternative x) , rightAlternative y
+
+z∙xzy≈zxz∙y : ∀ x y z → (z ∙ (x ∙ (z ∙ y))) ≈ (((z ∙ x) ∙ z) ∙ y)
+z∙xzy≈zxz∙y x y z = sym (begin
+  (((z ∙ x) ∙ z) ∙ y) ≈⟨ (∙-congʳ (flex z x )) ⟩
+  ((z ∙ (x ∙ z)) ∙ y) ≈⟨ sym (leftBol z x y) ⟩
+  (z ∙ (x ∙ (z ∙ y))) ∎)
+
+x∙zyz≈xzy∙z : ∀ x y z → (x ∙ (z ∙ (y ∙ z))) ≈ (((x ∙ z) ∙ y) ∙ z)
+x∙zyz≈xzy∙z x y z = begin
+  (x ∙ (z ∙ (y ∙ z)))  ≈⟨ (∙-congˡ (sym (flex z y ))) ⟩
+  (x ∙ ((z ∙ y) ∙  z)) ≈⟨ sym (rightBol z y x) ⟩
+  (((x ∙ z) ∙ y) ∙ z)  ∎

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -868,5 +868,6 @@ record IsMoufangLoop (∙ \\ // : Op₂ A) (ε : A) : Set (a ⊔ ℓ) where
   field
     isLeftBolLoop  : IsLeftBolLoop ∙ \\ //  ε
     rightBol       : RightBol ∙
+    flex           : Flexible ∙
 
   open IsLeftBolLoop isLeftBolLoop public


### PR DESCRIPTION
In this PR
- Correct definitions `LeftBol` and `IsMoufangLoop`
Show the following for MoufangLoop
- `leftAlternative : LeftBol _∙_ → LeftAlternative _∙_`
- `rightAlternative : RightBol _∙_ → RightAlternative _∙_`
- `alternative : LeftBol _∙_ → RightBol _∙_ → Alternative _∙_`
- `z∙xzy≈zxz∙y : ∀ x y z → (z ∙ (x ∙ (z ∙ y))) ≈ (((z ∙ x) ∙ z) ∙ y)`
- `x∙zyz≈xzy∙z : ∀ x y z → (x ∙ (z ∙ (y ∙ z))) ≈ (((x ∙ z) ∙ y) ∙ z)`