### PR TITLE
Fix doc typo in README.Data.List.Membership

### DIFF
--- a/README/Data/List/Membership.agda
+++ b/README/Data/List/Membership.agda
@@ -30,7 +30,7 @@ import Data.List.Membership.Propositional as PropMembership
 import Data.List.Membership.DecPropositional as DecPropMembership
 
 -- For example if we want to reason about membership for `List ℕ`
--- then you would use the `DecSetoidMembership` as we use
+-- then you would use the `DecPropMembership` as we use
 -- propositional equality over `ℕ` and it is also decidable. Therefore
 -- the module `DecPropMembership` should be opened as follows:
 


### PR DESCRIPTION
The documentation reads
> For example if we want to reason about membership for `List ℕ`
> then you would use the `DecSetoidMembership` as we use ...

but then the passage later says:
> the module `DecPropMembership` should be opened as follows:

I am guessing that these are meant to both be `DecPropMembership`, as equality of `ℕ` is propositional and decidable.