### PR TITLE
Be a little tighter with imports

### DIFF
--- a/src/Data/Nat/Binary/Base.agda
+++ b/src/Data/Nat/Binary/Base.agda
@@ -15,12 +15,11 @@ module Data.Nat.Binary.Base where
 open import Algebra.Core using (Op₂)
 open import Data.Bool.Base using (if_then_else_)
 open import Data.Nat.Base as ℕ using (ℕ)
-open import Data.Nat.DivMod using (_%_ ; _/_)
 open import Data.Sum.Base using (_⊎_)
 open import Function.Base using (_on_)
 open import Level using (0ℓ)
 open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.PropositionalEquality using (_≡_)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_)
 open import Relation.Nullary using (¬_)
 
 ------------------------------------------------------------------------
@@ -120,9 +119,9 @@ fromℕ n = helper n n
   helper : ℕ → ℕ → ℕᵇ
   helper 0 _ = zero
   helper (ℕ.suc n) (ℕ.suc w) =
-    if (n % 2 ℕ.≡ᵇ 0)
-      then 1+[2 helper (n / 2) w ]
-      else 2[1+ helper (n / 2) w ]
+    if (n ℕ.% 2 ℕ.≡ᵇ 0)
+      then 1+[2 helper (n ℕ./ 2) w ]
+      else 2[1+ helper (n ℕ./ 2) w ]
   -- Impossible case
   helper _ 0 = zero
 

--- a/src/Effect/Applicative/Indexed.agda
+++ b/src/Effect/Applicative/Indexed.agda
@@ -13,9 +13,9 @@ module Effect.Applicative.Indexed where
 
 open import Effect.Functor using (RawFunctor)
 open import Data.Product using (_×_; _,_)
-open import Function hiding (Morphism)
+open import Function.Base
 open import Level
-open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
 
 private
   variable

--- a/src/Effect/Functor.agda
+++ b/src/Effect/Functor.agda
@@ -10,10 +10,10 @@
 
 module Effect.Functor where
 
-open import Function hiding (Morphism)
+open import Function.Base
 open import Level
 
-open import Relation.Binary.PropositionalEquality
+open import Relation.Binary.PropositionalEquality.Core
 
 private
   variable

--- a/src/Effect/Monad.agda
+++ b/src/Effect/Monad.agda
@@ -10,9 +10,8 @@
 
 module Effect.Monad where
 
-open import Function
 open import Effect.Monad.Indexed
-open import Data.Unit
+open import Data.Unit.Base
 open import Level
 
 private

--- a/src/Effect/Monad/Indexed.agda
+++ b/src/Effect/Monad/Indexed.agda
@@ -11,7 +11,7 @@
 module Effect.Monad.Indexed where
 
 open import Effect.Applicative.Indexed
-open import Function
+open import Function.Base
 open import Level
 
 private

--- a/src/Function/Bundles.agda
+++ b/src/Function/Bundles.agda
@@ -25,8 +25,9 @@ import Function.Structures as FunctionStructures
 open import Level using (Level; _⊔_; suc)
 open import Data.Product using (_,_; proj₁; proj₂)
 open import Relation.Binary hiding (_⇔_)
-open import Relation.Binary.PropositionalEquality as ≡
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_)
+import Relation.Binary.PropositionalEquality.Properties as ≡
 open Setoid using (isEquivalence)
 
 private

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -12,12 +12,11 @@ open import Level using (Level)
 open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
 open import Function.Base
-open import Function.Equality    using (_⟨$⟩_; module Π)
-open import Function using (Injection; module Injection; module Equivalence; _⇔_; _↔_; mk↔′)
+open import Function.Bundles using (Injection; module Injection; module Equivalence; _⇔_; _↔_; mk↔′)
 open import Relation.Binary      using (Setoid; module Setoid; Decidable)
 open import Relation.Nullary
 open import Relation.Nullary.Reflects using (invert)
-open import Relation.Binary.PropositionalEquality using (cong′)
+open import Relation.Binary.PropositionalEquality.Core using (cong′)
 
 private
   variable

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -13,7 +13,7 @@ open import Data.Bool.Base using (Bool; false; true; if_then_else_; not)
 open import Data.Empty
 open import Data.Product as Prod
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_])
-open import Function
+open import Function.Base
 open import Level
 open import Relation.Nullary
 open import Relation.Nullary.Decidable


### PR DESCRIPTION
This was prompted by me noticing that building `Data.Nat.Binary.Base` was pulling in `Algebra`. This change reduces its dependency graph by quite a lot.