### PR TITLE
Support for GHC 9.4

### DIFF
--- a/agda-stdlib-utils.cabal
+++ b/agda-stdlib-utils.cabal
@@ -12,13 +12,14 @@ tested-with:     GHC == 8.0.2
                  GHC == 8.10.7
                  GHC == 9.0.2
                  GHC == 9.2.1
+                 GHC == 9.4.2
 
 executable GenerateEverything
   hs-source-dirs:   .
   main-is:          GenerateEverything.hs
   default-language: Haskell2010
   default-extensions: PatternGuards, PatternSynonyms
-  build-depends:      base      >= 4.9.0.0 && < 4.17
+  build-depends:      base      >= 4.9.0.0 && < 4.18
                     , directory >= 1.0.0.0 && < 1.4
                     , filemanip >= 0.3.6.2 && < 0.4
                     , filepath  >= 1.4.1.0 && < 1.5
@@ -28,6 +29,6 @@ executable AllNonAsciiChars
   hs-source-dirs:   .
   main-is:          AllNonAsciiChars.hs
   default-language: Haskell2010
-  build-depends:      base      >= 4.9.0.0 && < 4.17
+  build-depends:      base      >= 4.9.0.0 && < 4.18
                     , filemanip >= 0.3.6.2 && < 0.4
                     , text      >= 1.2.3.0 && < 2.1


### PR DESCRIPTION
I tried to fix #1829. I did not find anything in the changelogs related to similar changes to support GHC versions after 8.2.2, so I did not include anything in the changelog.