### PR TITLE
Closes #501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -610,6 +610,7 @@ Non-backwards compatible changes
     lookupₛ : P Respects _≈_ → All P xs → (∀ {x} → x ∈ xs → P x)
     ```
 
+
 Major improvements
 ------------------
 
@@ -806,8 +807,12 @@ Deprecated names
 
   ^-semigroup-morphism ↦ ^-isMagmaHomomorphism
   ^-monoid-morphism    ↦ ^-isMonoidHomomorphism
+  
+  pos-distrib-* ↦ pos-*
+  pos-+-commute ↦ pos-+
+  abs-*-commute ↦ abs-*
   ```
-
+  
 * In `Data.List.Properties`:
   ```agda
   map-id₂         ↦  map-id-local

--- a/src/Data/Integer/Coprimality.agda
+++ b/src/Data/Integer/Coprimality.agda
@@ -35,4 +35,4 @@ coprime? x y = ℕ.coprime? ∣ x ∣ ∣ y ∣
 
 coprime-divisor : ∀ i j k → Coprime i j → i ∣ j * k → i ∣ k
 coprime-divisor i j k c eq =
-  ℕ.coprime-divisor c (subst (∣ i ∣ ℕ.∣_ ) (abs-*-commute j k) eq)
+  ℕ.coprime-divisor c (subst (∣ i ∣ ℕ.∣_ ) (abs-* j k) eq)

--- a/src/Data/Integer/DivMod.agda
+++ b/src/Data/Integer/DivMod.agda
@@ -42,14 +42,14 @@ n%d<d n -[1+ d ] = n%ℕd<d n (ℕ.suc d)
 a≡a%ℕn+[a/ℕn]*n : ∀ n d .{{_ : ℕ.NonZero d}} → n ≡ + (n %ℕ d) + (n /ℕ d) * + d
 a≡a%ℕn+[a/ℕn]*n (+ n) d = let q = n ℕ./ d; r = n ℕ.% d in begin-equality
   + n                ≡⟨ cong +_ (ℕ.m≡m%n+[m/n]*n n d) ⟩
-  + (r ℕ.+ q ℕ.* d)  ≡⟨ pos-+-commute r (q ℕ.* d) ⟩
-  + r + + (q ℕ.* d)  ≡⟨ cong (_+_ (+ r)) (sym (pos-distrib-* q d)) ⟩
+  + (r ℕ.+ q ℕ.* d)  ≡⟨ pos-+ r (q ℕ.* d) ⟩
+  + r + + (q ℕ.* d)  ≡⟨ cong (_+_ (+ r)) (pos-* q d) ⟩
   + r + + q * + d    ∎
 a≡a%ℕn+[a/ℕn]*n n@(-[1+ _ ]) d with ∣ n ∣ ℕ.% d in eq
 ... | ℕ.zero = begin-equality
   n                   ≡⟨ cong (-_ ∘′ +_) (ℕ.m≡m%n+[m/n]*n ∣n∣ d) ⟩
   - + (r ℕ.+ q ℕ.* d) ≡⟨ cong (-_ ∘′ +_) (cong (ℕ._+ q ℕ.* d) eq) ⟩
-  - + (q ℕ.* d)       ≡⟨ cong -_ (sym (pos-distrib-* q d)) ⟩
+  - + (q ℕ.* d)       ≡⟨ cong -_ (pos-* q d) ⟩
   - (+ q * + d)       ≡⟨ neg-distribˡ-* (+ q) (+ d) ⟩
   - (+ q) * + d       ≡⟨ sym (+-identityˡ (- (+ q) * + d)) ⟩
   + 0 + - (+ q) * + d ∎
@@ -58,9 +58,9 @@ a≡a%ℕn+[a/ℕn]*n n@(-[1+ _ ]) d with ∣ n ∣ ℕ.% d in eq
   let ∣n∣ = ∣ n ∣; q = ∣n∣ ℕ./ d; r′ = ∣n∣ ℕ.% d in
   n                                      ≡⟨ cong (-_ ∘′ +_) (ℕ.m≡m%n+[m/n]*n ∣n∣ d) ⟩
   - + (r′ ℕ.+ q ℕ.* d)                   ≡⟨ cong (-_ ∘′ +_) (cong (ℕ._+ q ℕ.* d) eq) ⟩
-  - + (r  ℕ.+ q ℕ.* d)                   ≡⟨ cong -_ (pos-+-commute r (q ℕ.* d)) ⟩
+  - + (r  ℕ.+ q ℕ.* d)                   ≡⟨ cong -_ (pos-+ r (q ℕ.* d)) ⟩
   - (+ r + + (q ℕ.* d))                  ≡⟨ neg-distrib-+ (+ r) (+ (q ℕ.* d)) ⟩
-  - + r - + (q ℕ.* d)                    ≡⟨ cong (_-_ (- + r)) (sym (pos-distrib-* q d)) ⟩
+  - + r - + (q ℕ.* d)                    ≡⟨ cong (_-_ (- + r)) (pos-* q d) ⟩
   - + r - (+ q * + d)                    ≡⟨⟩
   - + r - pred +[1+ q ] * + d            ≡⟨ cong (_-_ (- + r)) (*-distribʳ-+ (+ d) -1ℤ +[1+ q ]) ⟩
   - + r - (-1ℤ * + d + (+[1+ q ] * + d)) ≡⟨ cong (λ v → - + r - (v + (+[1+ q ] * + d))) (-1*i≡-i (+ d))  ⟩

--- a/src/Data/Integer/Divisibility.agda
+++ b/src/Data/Integer/Divisibility.agda
@@ -36,9 +36,9 @@ open ℕᵈ public using (divides)
 
 *-monoʳ-∣ : ∀ k → (k *_) Preserves _∣_ ⟶ _∣_
 *-monoʳ-∣ k {i} {j} i∣j = begin
-  ∣ k * i ∣       ≡⟨ abs-*-commute k i ⟩
+  ∣ k * i ∣       ≡⟨ abs-* k i ⟩
   ∣ k ∣ ℕ.* ∣ i ∣ ∣⟨ ℕᵈ.*-monoʳ-∣ ∣ k ∣ i∣j ⟩
-  ∣ k ∣ ℕ.* ∣ j ∣ ≡⟨ sym (abs-*-commute k j) ⟩
+  ∣ k ∣ ℕ.* ∣ j ∣ ≡⟨ sym (abs-* k j) ⟩
   ∣ k * j ∣       ∎
   where open ℕᵈ.∣-Reasoning
 
@@ -47,9 +47,9 @@ open ℕᵈ public using (divides)
 
 *-cancelˡ-∣ : ∀ k {i j} .{{_ : NonZero k}} → k * i ∣ k * j → i ∣ j
 *-cancelˡ-∣ k {i} {j} k*i∣k*j = ℕᵈ.*-cancelˡ-∣ ∣ k ∣ $ begin
-  ∣ k ∣ ℕ.* ∣ i ∣  ≡⟨ sym (abs-*-commute k i) ⟩
+  ∣ k ∣ ℕ.* ∣ i ∣  ≡⟨ sym (abs-* k i) ⟩
   ∣ k * i ∣        ∣⟨ k*i∣k*j ⟩
-  ∣ k * j ∣        ≡⟨ abs-*-commute k j ⟩
+  ∣ k * j ∣        ≡⟨ abs-* k j ⟩
   ∣ k ∣ ℕ.* ∣ j ∣  ∎
   where open ℕᵈ.∣-Reasoning
 

--- a/src/Data/Integer/Divisibility/Signed.agda
+++ b/src/Data/Integer/Divisibility/Signed.agda
@@ -84,7 +84,7 @@ open _∣_ using (quotient) public
 ∣⇒∣ᵤ : ∀ {k i} → k ∣ i → k ∣ᵤ i
 ∣⇒∣ᵤ {k} {i} (divides q eq) = divides ∣ q ∣ $′ begin
   ∣ i ∣           ≡⟨ cong ∣_∣ eq ⟩
-  ∣ q * k ∣       ≡⟨ abs-*-commute q k ⟩
+  ∣ q * k ∣       ≡⟨ abs-* q k ⟩
   ∣ q ∣ ℕ.* ∣ k ∣ ∎
   where open ≡-Reasoning
 
@@ -189,4 +189,3 @@ m∣∣m∣ = ∣ᵤ⇒∣ ℕ.∣-refl
 
 *-cancelʳ-∣ : ∀ k {i j} .{{_ : NonZero k}} → i * k ∣ j * k → i ∣ j
 *-cancelʳ-∣ k {i} {j} = ∣ᵤ⇒∣ ∘′ Unsigned.*-cancelʳ-∣ k {i} {j} ∘′ ∣⇒∣ᵤ
-

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -986,9 +986,9 @@ distribʳ-⊖-+-neg m n o = begin
 ------------------------------------------------------------------------
 -- Properties of _+_ and +_/-_.
 
-pos-+-commute : ℕtoℤ.Homomorphic₂ +_ ℕ._+_ _+_
-pos-+-commute zero    n = refl
-pos-+-commute (suc m) n = cong sucℤ (pos-+-commute m n)
+pos-+ : ℕtoℤ.Homomorphic₂ +_ ℕ._+_ _+_
+pos-+ zero    n = refl
+pos-+ (suc m) n = cong sucℤ (pos-+ m n)
 
 neg-distrib-+ : ∀ i j → - (i + j) ≡ (- i) + (- j)
 neg-distrib-+ +0        +0        = refl
@@ -1593,8 +1593,8 @@ private
 ------------------------------------------------------------------------
 -- Other properties of _*_ and _≡_
 
-abs-*-commute : ℤtoℕ.Homomorphic₂ ∣_∣ _*_ ℕ._*_
-abs-*-commute i j = abs-◃ _ _
+abs-* : ℤtoℕ.Homomorphic₂ ∣_∣ _*_ ℕ._*_
+abs-* i j = abs-◃ _ _
 
 *-cancelʳ-≡ : ∀ i j k .{{_ : NonZero k}} → i * k ≡ j * k → i ≡ j
 *-cancelʳ-≡ i j k eq with sign-cong′ eq
@@ -1684,10 +1684,10 @@ i^n≡0⇒i≡0 i (suc n) eq = [ id , i^n≡0⇒i≡0 i n ]′ (i*j≡0⇒i≡0�
 ------------------------------------------------------------------------
 -- Properties of _*_ and +_/-_
 
-pos-distrib-* : ∀ m n → (+ m) * (+ n) ≡ + (m ℕ.* n)
-pos-distrib-* zero    n       = refl
-pos-distrib-* (suc m) zero    = pos-distrib-* m zero
-pos-distrib-* (suc m) (suc n) = refl
+pos-* : ℕtoℤ.Homomorphic₂ +_ ℕ._*_ _*_
+pos-* zero    n       = refl
+pos-* (suc m) zero    = pos-* m zero
+pos-* (suc m) (suc n) = refl
 
 neg-distribˡ-* : ∀ i j → - (i * j) ≡ (- i) * j
 neg-distribˡ-* i j = begin
@@ -2348,4 +2348,22 @@ Please use *-monoˡ-≤-nonPos instead."
 {-# WARNING_ON_USAGE *-monoʳ-≤-neg
 "Warning: *-monoʳ-≤-neg was deprecated in v2.0
 Please use *-monoʳ-≤-nonPos instead."
+#-}
+pos-+-commute : ℕtoℤ.Homomorphic₂ +_ ℕ._+_ _+_
+pos-+-commute = pos-+
+{-# WARNING_ON_USAGE pos-+-commute
+"Warning: pos-+-commute was deprecated in v2.0
+Please use pos-+ instead."
+#-}
+abs-*-commute : ℤtoℕ.Homomorphic₂ ∣_∣ _*_ ℕ._*_
+abs-*-commute = abs-*
+{-# WARNING_ON_USAGE abs-*-commute
+"Warning: abs-*-commute was deprecated in v2.0
+Please use abs-* instead."
+#-}
+pos-distrib-* : ∀ m n → (+ m) * (+ n) ≡ + (m ℕ.* n)
+pos-distrib-* m n = sym (pos-* m n)
+{-# WARNING_ON_USAGE pos-distrib-*
+"Warning: pos-distrib-* was deprecated in v2.0
+Please use pos-* instead."
 #-}

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -145,7 +145,7 @@ mkℚ+-pos (suc n) (suc d) = _
     (C.sym (C.recompute c₁)) $
     divides ℤ.∣ n₂ ∣ $ begin
       ℤ.∣ n₁ ℤ.* + suc d₂ ∣  ≡⟨ cong ℤ.∣_∣ eq ⟩
-      ℤ.∣ n₂ ℤ.* + suc d₁ ∣  ≡⟨ ℤ.abs-*-commute n₂ (+ suc d₁) ⟩
+      ℤ.∣ n₂ ℤ.* + suc d₁ ∣  ≡⟨ ℤ.abs-* n₂ (+ suc d₁) ⟩
       ℤ.∣ n₂ ∣ ℕ.* suc d₁    ∎
 
   1+d₂∣1+d₁ : suc d₂ ∣ suc d₁
@@ -153,7 +153,7 @@ mkℚ+-pos (suc n) (suc d) = _
     (C.sym (C.recompute c₂)) $
     divides ℤ.∣ n₁ ∣ (begin
       ℤ.∣ n₂ ℤ.* + suc d₁ ∣  ≡⟨ cong ℤ.∣_∣ (sym eq) ⟩
-      ℤ.∣ n₁ ℤ.* + suc d₂ ∣  ≡⟨ ℤ.abs-*-commute n₁ (+ suc d₂) ⟩
+      ℤ.∣ n₁ ℤ.* + suc d₂ ∣  ≡⟨ ℤ.abs-* n₁ (+ suc d₂) ⟩
       ℤ.∣ n₁ ∣ ℕ.* suc d₂    ∎)
 
   helper : mkℚ n₁ d₁ c₁ ≡ mkℚ n₂ d₂ c₂

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -1151,7 +1151,7 @@ neg-distribʳ-* p@record{} q@record{} =
   (ℤ.+ p ℤ.* q) ℤ.* (↧ (q / r))                   ≡⟨  cong ((ℤ.+ p ℤ.* q) ℤ.*_) (↧[n/d]≡d q r) ⟩
   (ℤ.+ p ℤ.* q) ℤ.* ℤ.+ r                         ≡⟨  xy∙z≈y∙xz (ℤ.+ p) q (ℤ.+ r) ⟩
   (q ℤ.* (ℤ.+ p ℤ.* ℤ.+ r))                       ≡˘⟨ cong (ℤ._* (ℤ.+ p ℤ.* ℤ.+ r)) (↥[n/d]≡n q r) ⟩
-  (↥ (q / r)) ℤ.* (ℤ.+ p ℤ.* ℤ.+ r)               ≡⟨  cong (↥ (q / r) ℤ.*_) (ℤ.pos-distrib-* p r) ⟩
+  (↥ (q / r)) ℤ.* (ℤ.+ p ℤ.* ℤ.+ r)               ≡˘⟨  cong (↥ (q / r) ℤ.*_) (ℤ.pos-* p r) ⟩
   (↥ (q / r)) ℤ.* (ℤ.+ (p ℕ.* r))                 ≡˘⟨ cong (↥ (q / r) ℤ.*_) (↧[n/d]≡d (ℤ.+ p ℤ.* q) (p ℕ.* r)) ⟩
   (↥ (q / r)) ℤ.* (↧ ((ℤ.+ p ℤ.* q) / (p ℕ.* r))) ∎)
   where open ℤ.≤-Reasoning
@@ -1205,9 +1205,9 @@ private
 *-monoˡ-≤-nonNeg : ∀ r .{{_ : NonNegative r}} → (_* r) Preserves _≤_ ⟶ _≤_
 *-monoˡ-≤-nonNeg r@(mkℚᵘ (ℤ.+ n) _) {p@record{}} {q@record{}} (*≤* x<y) = *≤* $ begin
   ↥ p ℤ.* ↥ r ℤ.* (↧ q   ℤ.* ↧ r)  ≡⟨  reorder₂ (↥ p) _ _ _ ⟩
-  l₁          ℤ.* (ℤ.+ n ℤ.* ↧ r)  ≡⟨  cong (l₁ ℤ.*_) (ℤ.pos-distrib-* n _) ⟩
+  l₁          ℤ.* (ℤ.+ n ℤ.* ↧ r)  ≡˘⟨  cong (l₁ ℤ.*_) (ℤ.pos-* n _) ⟩
   l₁          ℤ.* ℤ.+ (n ℕ.* ↧ₙ r) ≤⟨  ℤ.*-monoʳ-≤-nonNeg (ℤ.+ (n ℕ.* ↧ₙ r)) x<y ⟩
-  l₂          ℤ.* ℤ.+ (n ℕ.* ↧ₙ r) ≡˘⟨ cong (l₂ ℤ.*_) (ℤ.pos-distrib-* n _) ⟩
+  l₂          ℤ.* ℤ.+ (n ℕ.* ↧ₙ r) ≡⟨ cong (l₂ ℤ.*_) (ℤ.pos-* n _) ⟩
   l₂          ℤ.* (ℤ.+ n ℤ.* ↧ r)  ≡⟨  reorder₂ (↥ q) _ _ _ ⟩
   ↥ q ℤ.* ↥ r ℤ.* (↧ p   ℤ.* ↧ r)  ∎
   where open ℤ.≤-Reasoning; l₁ = ↥ p ℤ.* ↧ q ; l₂ = ↥ q ℤ.* ↧ p
@@ -1775,7 +1775,7 @@ pos⊔pos⇒pos p q = positive (⊔-mono-< (positive⁻¹ p) (positive⁻¹ q))
     ∣m∣n≡∣mn∣ : ∀ m n → ℤ.+ ℤ.∣ m ∣ ℤ.* ℤ.+ n ≡ ℤ.+ ℤ.∣ m ℤ.* ℤ.+ n ∣
     ∣m∣n≡∣mn∣ m n = begin-equality
       ℤ.+ ℤ.∣ m ∣ ℤ.* ℤ.+ n                        ≡⟨⟩
-      ℤ.+ ℤ.∣ m ∣ ℤ.* ℤ.+ ℤ.∣ ℤ.+ n ∣              ≡⟨ ℤ.pos-distrib-* ℤ.∣ m ∣ ℤ.∣ ℤ.+ n ∣ ⟩
+      ℤ.+ ℤ.∣ m ∣ ℤ.* ℤ.+ ℤ.∣ ℤ.+ n ∣              ≡˘⟨ ℤ.pos-* ℤ.∣ m ∣ ℤ.∣ ℤ.+ n ∣ ⟩
       ℤ.+ (ℤ.∣ m ∣ ℕ.* n)                          ≡⟨⟩
       ℤ.+ (ℤ.∣ m ∣ ℕ.* ℤ.∣ ℤ.+ n ∣)                ≡˘⟨ cong ℤ.+_ (ℤ.∣i*j∣≡∣i∣*∣j∣ m (ℤ.+ n)) ⟩
       ℤ.+ (ℤ.∣ m ℤ.* ℤ.+ n ∣)                      ∎
@@ -1796,7 +1796,7 @@ pos⊔pos⇒pos p q = positive (⊔-mono-< (positive⁻¹ p) (positive⁻¹ q))
   ∣ p * q ∣                                           ≡⟨⟩
   ∣ (↥ p ℤ.* ↥ q) / (↧ₙ p ℕ.* ↧ₙ q) ∣                 ≡⟨⟩
   ℤ.+ ℤ.∣ ↥ p ℤ.* ↥ q ∣ / (↧ₙ p ℕ.* ↧ₙ q)             ≡⟨ cong (λ h → ℤ.+ h / ((↧ₙ p) ℕ.* (↧ₙ q))) (ℤ.∣i*j∣≡∣i∣*∣j∣ (↥ p) (↥ q)) ⟩
-  ℤ.+ (ℤ.∣ ↥ p ∣ ℕ.* ℤ.∣ ↥ q ∣) / (↧ₙ p ℕ.* ↧ₙ q)     ≡˘⟨ cong (_/ (↧ₙ p ℕ.* ↧ₙ q)) (ℤ.pos-distrib-* ℤ.∣ ↥ p ∣ ℤ.∣ ↥ q ∣) ⟩
+  ℤ.+ (ℤ.∣ ↥ p ∣ ℕ.* ℤ.∣ ↥ q ∣) / (↧ₙ p ℕ.* ↧ₙ q)     ≡⟨ cong (_/ (↧ₙ p ℕ.* ↧ₙ q)) (ℤ.pos-* ℤ.∣ ↥ p ∣ ℤ.∣ ↥ q ∣) ⟩
   (ℤ.+ ℤ.∣ ↥ p ∣ ℤ.* ℤ.+ ℤ.∣ ↥ q ∣) / (↧ₙ p ℕ.* ↧ₙ q) ≡⟨⟩
   (ℤ.+ ℤ.∣ ↥ p ∣ / ↧ₙ p) * (ℤ.+ ℤ.∣ ↥ q ∣ / ↧ₙ q)     ≡⟨⟩
   ∣ p ∣ * ∣ q ∣                                       ∎


### PR DESCRIPTION
More specifically:
- Deprecate `pos-distrib-*` in favour of `pos-*`
- Rename `abs-*-commute` to `abs-*` (and deprecate)
- Rename `pos-+-commute` to `pos-+` (and deprecate)
and push through the library.