### PR TITLE
Fix Float libraries w.r.t. toWord in newer Agda versions

### DIFF
--- a/src/Data/Float/Base.agda
+++ b/src/Data/Float/Base.agda
@@ -10,6 +10,7 @@ module Data.Float.Base where
 
 open import Relation.Binary.Core using (Rel)
 import Data.Word.Base as Word
+import Data.Maybe.Relation.Binary.Pointwise as Maybe
 open import Function.Base using (_on_)
 open import Agda.Builtin.Equality
 
@@ -65,4 +66,4 @@ open import Agda.Builtin.Float public
   )
 
 _≈_ : Rel Float _
-_≈_ = Word._≈_ on toWord
+_≈_ = Maybe.Pointwise Word._≈_ on toWord

--- a/src/Data/Float/Properties.agda
+++ b/src/Data/Float/Properties.agda
@@ -10,6 +10,7 @@ module Data.Float.Properties where
 
 open import Data.Bool.Base as Bool using (Bool)
 open import Data.Float.Base
+import Data.Maybe.Relation.Binary.Pointwise as Maybe
 import Data.Word.Base as Word
 import Data.Word.Properties as Wₚ
 open import Relation.Nullary.Decidable as RN using (map′)
@@ -28,26 +29,26 @@ open import Agda.Builtin.Float.Properties
 -- Properties of _≈_
 
 ≈⇒≡ : _≈_ ⇒ _≡_
-≈⇒≡ eq = toWord-injective _ _  (Wₚ.≈⇒≡ eq)
+≈⇒≡ eq = toWord-injective _ _ (Maybe.injective Wₚ.≈⇒≡ eq)
 
 ≈-reflexive : _≡_ ⇒ _≈_
-≈-reflexive eq = Wₚ.≈-reflexive (cong toWord eq)
+≈-reflexive eq = Maybe.reflexive Wₚ.≈-reflexive (cong toWord eq)
 
 ≈-refl : Reflexive _≈_
-≈-refl = refl
+≈-refl = Maybe.refl refl
 
 ≈-sym : Symmetric _≈_
-≈-sym = sym
+≈-sym = Maybe.sym sym
 
 ≈-trans : Transitive _≈_
-≈-trans = trans
+≈-trans = Maybe.trans trans
 
 ≈-subst : ∀ {ℓ} → Substitutive _≈_ ℓ
 ≈-subst P x≈y p = subst P (≈⇒≡ x≈y) p
 
 infix 4 _≈?_
 _≈?_ : Decidable _≈_
-_≈?_ = On.decidable toWord Word._≈_ Wₚ._≈?_
+_≈?_ = On.decidable toWord (Maybe.Pointwise Word._≈_) (Maybe.dec Wₚ._≈?_)
 
 ≈-isEquivalence : IsEquivalence _≈_
 ≈-isEquivalence = record

--- a/src/Data/Maybe/Relation/Binary/Pointwise.agda
+++ b/src/Data/Maybe/Relation/Binary/Pointwise.agda
@@ -55,6 +55,10 @@ module _ {a r} {A : Set a} {R : Rel A r} where
   reflexive : _≡_ ⇒ R → _≡_ ⇒ Pointwise R
   reflexive reflexive P.refl = refl (reflexive P.refl)
 
+  injective : R ⇒ _≡_ → Pointwise R ⇒ _≡_
+  injective R-inj (just e) = P.cong just (R-inj e)
+  injective R-inj nothing  = P.refl
+
 module _ {a b r₁ r₂} {A : Set a} {B : Set b}
          {R : REL A B r₁} {S : REL B A r₂} where
 


### PR DESCRIPTION
Using a recent development Agda, I got errors in the `Float` modules (which are dependencies of e.g. `Reflection`) due to `toWord` now returning a `Maybe`. This fixes up the issues.

I imagine this breaks the same libraries relative to released versions of Agda, so it should only be merged when that is acceptable.