### PR TITLE
[resolves #1333] writer transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -591,6 +591,15 @@ Non-backwards compatible changes
   This is needed because `MonadState S M` does not pack a `Monad M` instance anymore
   and so we cannot define `modify f` as `get >>= λ s → put (f s)`.
 
+* `MonadWriter 𝕎 M` is defined similarly:
+   ```agda
+   writer : W × A → M A
+   listen : M A → M (W × A)
+   pass   : M ((W → W) × A) → M A
+   ```
+   with `tell` defined as a derived notion.
+   Note that `𝕎` is a `RawMonoid`, not a `Set` and `W` is the carrier of the monoid.
+
 * New modules:
   ```
   Data.List.Effectful.Transformer
@@ -613,6 +622,11 @@ Non-backwards compatible changes
   Effect.Monad.State.Instances
   Effect.Monad.State.Transformer
   Effect.Monad.State.Transformer.Base
+  Effect.Monad.Writer
+  Effect.Monad.Writer.Indexed
+  Effect.Monad.Writer.Instances
+  Effect.Monad.Writer.Transformer
+  Effect.Monad.Writer.Transformer.Base
   IO.Effectful
   IO.Instances
   ```

--- a/src/Effect/Monad/Error/Transformer.agda
+++ b/src/Effect/Monad/Error/Transformer.agda
@@ -21,14 +21,14 @@ private
   variable
     f ℓ : Level
     A B : Set ℓ
-    M : Set f → Set f
+    M : Set f → Set ℓ
 
 ------------------------------------------------------------------------
 -- Error monad operations
 
 record RawMonadError
-       (M : Set (e ⊔ a) → Set (e ⊔ a))
-       : Set (suc (e ⊔ a)) where
+       (M : Set (e ⊔ a) → Set ℓ)
+       : Set (suc (e ⊔ a) ⊔ ℓ) where
   field
     throw : E → M A
     catch : M A → (E → M A) → M A

--- a/src/Effect/Monad/IO.agda
+++ b/src/Effect/Monad/IO.agda
@@ -32,7 +32,7 @@ record RawMonadIO
     liftIO : IO A → M A
 
 ------------------------------------------------------------------------
--- Reader monad specifics
+-- IO monad specifics
 
 monadIO : RawMonadIO {f} IO
 monadIO = record { liftIO = id }
@@ -50,3 +50,10 @@ liftReaderT : ∀ {R} → RawMonadIO M → RawMonadIO (ReaderT R M)
 liftReaderT MIO = record
   { liftIO = λ io → mkReaderT (λ r → liftIO io)
   } where open RawMonadIO MIO
+
+open import Effect.Monad.Writer.Transformer.Base using (WriterT; mkWriterT)
+
+liftWriterT : ∀ {f 𝕎} → RawFunctor M → RawMonadIO M → RawMonadIO (WriterT {f = f} 𝕎 M)
+liftWriterT M MIO = record
+  { liftIO = λ io → mkWriterT (λ w → (w ,_) <$> liftIO io)
+  } where open RawFunctor M; open RawMonadIO MIO

--- a/src/Effect/Monad/IO/Instances.agda
+++ b/src/Effect/Monad/IO/Instances.agda
@@ -14,3 +14,4 @@ instance
   ioMonadIO = monadIO
   stateTMonadIO = λ {s} {S} {M} {{m}} {{mio}} → liftStateT {s} {S} {M} m mio
   readerTMonadIO = λ {r} {R} {M} {{mio}} → liftReaderT  {r} {R} {M} mio
+  writerTMonadIO = λ {f} {w} {W} {M} {{m}} {{mio}} → liftWriterT {f} {w} {W} {M} m mio

--- a/src/Effect/Monad/Reader/Instances.agda
+++ b/src/Effect/Monad/Reader/Instances.agda
@@ -22,6 +22,7 @@ instance
   readerTMonadPlus = λ {s} {S} {f} {M} {{mpl}} → monadPlus {s} {S} {f} {M} mpl
   readerTMonadT = λ {s} {S} {f} {M} {{mon}} → monadT {s} {S} {f} {M} mon
   readerTMonadReader = λ {s} {S} {f} {M} {{mon}} → monadReader {s} {S} {f} {M} mon
-  readerTLiftStateT = λ {s} {S₁} {S₂} {f} {M} {{mon}} {{ms}} → liftStateT {s} {S₁} {S₂} {f} {M} mon ms
+  readerTLiftWriterT = λ {s} {S₁} {S₂} {f} {M} {{mo}} {{fun}} {{mr}} → liftWriterT {s} {S₁} {S₂} {f} {M} mo fun mr
+  readerTLiftStateT = λ {s} {S₁} {S₂} {f} {M} {{fun}} {{mr}} → liftStateT {s} {S₁} {S₂} {f} {M} fun mr
   -- the following instance conflicts with readerTMonadReader so we don't include it
   -- readerTLiftReaderT = λ {R} {s} {S} {f} {M} {{ms}} → liftReaderT {R} {s} {S} {f} {M} ms

--- a/src/Effect/Monad/Reader/Transformer.agda
+++ b/src/Effect/Monad/Reader/Transformer.agda
@@ -9,6 +9,7 @@
 
 module Effect.Monad.Reader.Transformer where
 
+open import Algebra using (RawMonoid)
 open import Effect.Choice
 open import Effect.Empty
 open import Effect.Functor
@@ -115,7 +116,20 @@ liftReaderT MRead = record
   ; local = λ f mx → mkReaderT (λ r₂ → local f (runReaderT mx r₂))
   } where open RawMonadReader MRead
 
-open import Data.Product using (_,_)
+open import Data.Product using (_×_; _,_)
+open import Effect.Monad.Writer.Transformer.Base
+
+liftWriterT : (MR : RawMonoid r g) →
+              RawFunctor M →
+              RawMonadReader R M →
+              RawMonadReader R (WriterT MR M)
+liftWriterT MR M MRead = record
+  { reader = λ k → mkWriterT λ w → ((w ,_) <$> reader k)
+  ; local = λ f mx → mkWriterT λ w → (local f (runWriterT mx w))
+  } where open RawMonadReader MRead
+          open RawFunctor M
+          open RawMonoid MR
+
 open import Effect.Monad.State.Transformer.Base
 
 liftStateT : RawFunctor M →

--- a/src/Effect/Monad/Reader/Transformer.agda
+++ b/src/Effect/Monad/Reader/Transformer.agda
@@ -128,7 +128,6 @@ liftWriterT MR M MRead = record
   ; local = λ f mx → mkWriterT λ w → (local f (runWriterT mx w))
   } where open RawMonadReader MRead
           open RawFunctor M
-          open RawMonoid MR
 
 open import Effect.Monad.State.Transformer.Base
 

--- a/src/Effect/Monad/State/Instances.agda
+++ b/src/Effect/Monad/State/Instances.agda
@@ -22,6 +22,7 @@ instance
   stateTMonadPlus = λ {s} {S} {f} {M} {{mpl}} → monadPlus {s} {S} {f} {M} mpl
   stateTMonadT = λ {s} {S} {f} {M} {{mon}} → monadT {s} {S} {f} {M} mon
   stateTMonadState = λ {s} {S} {f} {M} {{mon}} → monadState {s} {S} {f} {M} mon
-  -- the following instance conflicts with stateTMonadState so we don't include it
-  -- stateTLiftStateT = λ {s} {S₁} {S₂} {f} {M} {{mon}} {{ms}} → liftStateT {s} {S₁} {S₂} {f} {M} mon ms
   stateTLiftReaderT = λ {R} {s} {S} {f} {M} {{ms}} → liftReaderT {R} {s} {S} {f} {M} ms
+  stateTLiftWriterT = λ {R} {s} {S} {f} {M} {{fun}} {{mo}} {{ms}} → liftWriterT {R} {s} {S} {f} {M} mo fun ms
+  -- the following instances conflicts with stateTMonadState so we don't include it
+  -- stateTLiftStateT = λ {s} {S₁} {S₂} {f} {M} {{mon}} {{ms}} → liftStateT {s} {S₁} {S₂} {f} {M} mon ms

--- a/src/Effect/Monad/State/Transformer.agda
+++ b/src/Effect/Monad/State/Transformer.agda
@@ -10,6 +10,7 @@ open import Level using (Level; suc; _⊔_)
 
 module Effect.Monad.State.Transformer where
 
+open import Algebra using (RawMonoid)
 open import Data.Product using (_×_; _,_; map₂; proj₁; proj₂)
 open import Data.Unit.Polymorphic.Base
 open import Effect.Choice
@@ -136,3 +137,16 @@ liftReaderT Mon = record
   { gets   = λ f → mkReaderT (const (gets f))
   ; modify = λ f → mkReaderT (const (modify f))
   } where open RawMonadState Mon
+
+open import Effect.Monad.Writer.Transformer.Base
+
+liftWriterT : (MS : RawMonoid s f) →
+              RawFunctor M →
+              RawMonadState S M →
+              RawMonadState S (WriterT MS M)
+liftWriterT MS M Mon = record
+  { gets   = λ f → mkWriterT λ w → (gets ((w ,_) ∘′ f))
+  ; modify = λ f → mkWriterT λ w → (const (w , tt) <$> modify f)
+  } where open RawMonadState Mon
+          open RawFunctor M
+          open RawMonoid MS

--- a/src/Effect/Monad/State/Transformer.agda
+++ b/src/Effect/Monad/State/Transformer.agda
@@ -149,4 +149,3 @@ liftWriterT MS M Mon = record
   ; modify = λ f → mkWriterT λ w → (const (w , tt) <$> modify f)
   } where open RawMonadState Mon
           open RawFunctor M
-          open RawMonoid MS

--- a/src/Effect/Monad/Writer.agda
+++ b/src/Effect/Monad/Writer.agda
@@ -1,0 +1,62 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The writer monad
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Effect.Monad.Writer where
+
+open import Algebra using (RawMonoid)
+open import Data.Product using (_×_)
+open import Effect.Applicative
+open import Effect.Choice
+open import Effect.Empty
+open import Effect.Functor
+open import Effect.Monad
+open import Effect.Monad.Identity as Id using (Identity; runIdentity)
+open import Function.Base using (_∘′_)
+open import Level using (Level)
+
+import Effect.Monad.Writer.Transformer as Trans
+
+private
+  variable
+    w ℓ : Level
+    A : Set w
+    𝕎 : RawMonoid w ℓ
+
+------------------------------------------------------------------------
+-- Re-export the monad writer operations
+
+open Trans public
+  using (RawMonadWriter)
+
+------------------------------------------------------------------------
+-- Writer monad
+
+Writer : (𝕎 : RawMonoid w ℓ) (A : Set w) → Set w
+Writer 𝕎 = Trans.WriterT 𝕎 Identity
+
+functor : RawFunctor (Writer 𝕎)
+functor = Trans.functor Id.functor
+
+module _ {𝕎 : RawMonoid w ℓ} where
+
+  open RawMonoid 𝕎 renaming (Carrier to W)
+
+  runWriter : Writer 𝕎 A → W × A
+  runWriter ma = runIdentity (Trans.runWriterT ma ε)
+
+  applicative : RawApplicative (Writer 𝕎)
+  applicative = Trans.applicative Id.applicative
+
+  monad : RawMonad (Writer 𝕎)
+  monad = Trans.monad Id.monad
+
+  ----------------------------------------------------------------------
+  -- Writer monad specifics
+
+  monadWriter : RawMonadWriter 𝕎 (Writer 𝕎)
+  monadWriter = Trans.monadWriter Id.monad

--- a/src/Effect/Monad/Writer/Indexed.agda
+++ b/src/Effect/Monad/Writer/Indexed.agda
@@ -1,0 +1,122 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The indexed writer monad
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Level
+
+module Effect.Monad.Writer.Indexed (a : Level) where
+
+open import Algebra using (RawMonoid)
+open import Data.Product using (_×_; _,_; map₁)
+open import Data.Unit.Polymorphic
+open import Effect.Applicative.Indexed
+open import Effect.Monad
+open import Effect.Monad.Indexed
+open import Function
+open import Function.Identity.Effectful as Id using (Identity)
+
+private
+  variable
+    w ℓ : Level
+    A B I : Set ℓ
+
+------------------------------------------------------------------------
+-- Indexed writer
+
+IWriterT : (𝕎 : RawMonoid w ℓ) → IFun I (w ⊔ a) → IFun I (w ⊔ a)
+IWriterT 𝕎 M i j A = M i j (RawMonoid.Carrier 𝕎 × A)
+
+module _ {M : IFun I (w ⊔ a)} {𝕎 : RawMonoid w ℓ} where
+
+  open RawMonoid 𝕎 renaming (Carrier to W)
+
+  ------------------------------------------------------------------------
+  -- Indexed writer applicative
+
+  WriterTIApplicative : RawIApplicative M → RawIApplicative (IWriterT 𝕎 M)
+  WriterTIApplicative App = record
+    { pure = λ x → pure (ε , x)
+    ; _⊛_ = λ m n → go <$> m ⊛ n
+    } where
+        open RawIApplicative App
+        go : W × (A → B) → W × A → W × B
+        go (w₁ , f) (w₂ , x) = w₁ ∙ w₂ , f x
+
+  WriterTIApplicativeZero : RawIApplicativeZero M →
+                            RawIApplicativeZero (IWriterT 𝕎 M)
+  WriterTIApplicativeZero App = record
+    { applicative = WriterTIApplicative applicative
+    ; ∅ = ∅
+    } where open RawIApplicativeZero App
+
+  WriterTIAlternative : RawIAlternative M → RawIAlternative (IWriterT 𝕎 M)
+  WriterTIAlternative Alt = record
+    { applicativeZero = WriterTIApplicativeZero applicativeZero
+    ; _∣_ = _∣_
+    } where open RawIAlternative Alt
+
+  ------------------------------------------------------------------------
+  -- Indexed writer monad
+
+  WriterTIMonad : RawIMonad M → RawIMonad (IWriterT 𝕎 M)
+  WriterTIMonad Mon = record
+    { return = λ x → return (ε , x)
+    ; _>>=_ = λ m f → do
+        w₁ , x  ← m
+        w₂ , fx ← f x
+        return (w₁ ∙ w₂ , fx)
+    } where open RawIMonad Mon
+
+  WriterTIMonadZero : RawIMonadZero M → RawIMonadZero (IWriterT 𝕎 M)
+  WriterTIMonadZero Mon = record
+    { monad = WriterTIMonad monad
+    ; applicativeZero = WriterTIApplicativeZero applicativeZero
+    } where open RawIMonadZero Mon
+
+  WriterTIMonadPlus : RawIMonadPlus M → RawIMonadPlus (IWriterT 𝕎 M)
+  WriterTIMonadPlus Mon = record
+    { monad = WriterTIMonad monad
+    ; alternative = WriterTIAlternative alternative
+    } where open RawIMonadPlus Mon
+
+------------------------------------------------------------------------
+-- Writer monad operations
+
+record RawIMonadWriter {I : Set ℓ} (𝕎 : RawMonoid w ℓ) (M : IFun I (w ⊔ a))
+                       : Set (ℓ ⊔ suc (w ⊔ a)) where
+  open RawMonoid 𝕎 renaming (Carrier to W)
+  field
+    monad  : RawIMonad M
+    writer : ∀ {i} → (W × A) → M i i A
+    listen : ∀ {i j} → M i j A → M i j (W × A)
+    pass   : ∀ {i j} → M i j ((W → W) × A) → M i j A
+
+  open RawIMonad monad public
+
+  tell : ∀ {i} → W → M i i ⊤
+  tell = writer ∘′ (_, tt)
+
+  listens : ∀ {i j} {Z : Set w} → (W → Z) → M i j A → M i j (Z × A)
+  listens f m = listen m >>= return ∘′ map₁ f
+
+  censor : ∀ {i j} → (W → W) → M i j A → M i j A
+  censor f m = pass (m >>= return ∘′ (f ,_))
+
+
+WriterTIMonadWriter : {I : Set ℓ} {𝕎 : RawMonoid w ℓ} {M : IFun I (w ⊔ a)} →
+                      RawIMonad M → RawIMonadWriter 𝕎 (IWriterT 𝕎 M)
+WriterTIMonadWriter {𝕎 = 𝕎} Mon = record
+  { monad = WriterTIMonad {𝕎 = 𝕎} Mon
+  ; writer = return
+  ; listen = λ m → do
+      w , a ← m
+      return (w , w , a)
+  ; pass = λ m → do
+      w , f , a ← m
+      return (f w , a)
+  } where open RawIMonad Mon
+          open RawMonoid 𝕎 renaming (Carrier to W)

--- a/src/Effect/Monad/Writer/Instances.agda
+++ b/src/Effect/Monad/Writer/Instances.agda
@@ -1,0 +1,26 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Instances for the writer monad
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Effect.Monad.Writer.Instances where
+
+open import Effect.Monad.Writer.Transformer
+
+instance
+  writerTFunctor = λ {s} {S} {f} {M} {{fun}} {{mo}} → functor {s} {S} {f} {M} {mo} fun
+  writerTApplicative = λ {s} {S} {f} {M} {{mo}} {{mon}} → applicative {s} {S} {f} {M} {mo} mon
+  writerTEmpty = λ {s} {S} {f} {M} {{e}} {{mo}} → empty {s} {S} {f} {M} {mo} e
+  writerTChoice = λ {s} {S} {f} {M} {{ch}} {{mo}} → choice {s} {S} {f} {M} {mo} ch
+  writerTApplicativeZero = λ {s} {S} {f} {M} {{mo}} {{mon}} → applicativeZero {s} {S} {f} {M} {mo} mon
+  writerTAlternative = λ {s} {S} {f} {M} {{mo}} {{mpl}} → alternative {s} {S} {f} {M} {mo} mpl
+  writerTMonad = λ {s} {S} {f} {M} {{mo}} {{mon}} → monad {s} {S} {f} {M} {mo} mon
+  writerTMonadZero = λ {s} {S} {f} {M} {{mo}} {{mz}} → monadZero {s} {S} {f} {M} {mo} mz
+  writerTMonadPlus = λ {s} {S} {f} {M} {{mo}} {{mpl}} → monadPlus {s} {S} {f} {M} {mo} mpl
+  writerTMonadT = λ {s} {S} {f} {M} {{mo}} {{mon}} → monadT {s} {S} {f} {M} {mo} mon
+  writerTMonadWriter = λ {s} {S} {f} {M} {{mo}} {{mon}} → monadWriter {s} {S} {f} {M} {mo} mon
+  writerTLiftReaderT = λ {s} {S₁} {S₂} {f} {g} {M} {{fun}} {{mw}} → liftReaderT {s} {S₁} {S₂} {f} {g} {M} fun mw
+  writerTLiftStateT = λ {s} {S₁} {S₂} {f} {g} {M} {{fun}} {{mw}} → liftStateT {s} {S₁} {S₂} {f} {g} {M} fun mw

--- a/src/Effect/Monad/Writer/Transformer.agda
+++ b/src/Effect/Monad/Writer/Transformer.agda
@@ -1,0 +1,169 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The writer monad transformer
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+
+module Effect.Monad.Writer.Transformer where
+
+open import Algebra using (RawMonoid)
+open import Data.Product using (_×_; _,_; proj₂; map₂)
+open import Effect.Applicative
+open import Effect.Choice
+open import Effect.Empty
+open import Effect.Functor
+open import Effect.Monad
+open import Function.Base using (_∘′_; const; _$_)
+open import Level using (Level; _⊔_; suc)
+
+private
+  variable
+    w g g₁ g₂ : Level
+    A B : Set w
+    M : Set w → Set g
+    𝕎 : RawMonoid w g
+
+------------------------------------------------------------------------
+-- Re-export the basic type definitions
+
+open import Effect.Monad.Writer.Transformer.Base public
+  using ( RawMonadWriter
+        ; WriterT
+        ; mkWriterT
+        ; runWriterT
+        )
+
+------------------------------------------------------------------------
+-- Structure
+
+functor : RawFunctor M → RawFunctor (WriterT 𝕎 M)
+functor M = record
+  { _<$>_ = λ f ma → mkWriterT λ w → map₂ f <$> runWriterT ma w
+  } where open RawFunctor M
+
+empty : RawEmpty M → RawEmpty (WriterT 𝕎 M)
+empty M = record
+  { empty = mkWriterT (const (RawEmpty.empty M))
+  }
+
+choice : RawChoice M → RawChoice (WriterT 𝕎 M)
+choice M = record
+  { _<|>_ = λ ma₁ ma₂ → mkWriterT λ w →
+            WriterT.runWriterT ma₁ w
+            <|> WriterT.runWriterT ma₂ w
+  } where open RawChoice M
+
+module _ {𝕎 : RawMonoid w g} where
+
+  open RawMonoid 𝕎 renaming (Carrier to W)
+
+  applicative : RawApplicative M → RawApplicative (WriterT 𝕎 M)
+  applicative M = record
+    { rawFunctor = functor rawFunctor
+    ; pure = λ a → mkWriterT (pure ∘′ (_, a))
+    ; _<*>_ = λ mf mx → mkWriterT $ λ w →
+              (go <$> runWriterT mf w) <*> runWriterT mx ε
+    } where
+        open RawApplicative M
+        go : W × (A → B) → W × A → W × B
+        go (w₁ , f) (w₂ , x) = w₁ ∙ w₂ , f x
+
+  applicativeZero : RawApplicativeZero M → RawApplicativeZero (WriterT 𝕎 M)
+  applicativeZero M = record
+    { rawApplicative = applicative rawApplicative
+    ; rawEmpty = empty rawEmpty
+    } where open RawApplicativeZero M using (rawApplicative; rawEmpty)
+
+  alternative : RawAlternative M → RawAlternative (WriterT 𝕎 M)
+  alternative M = record
+    { rawApplicativeZero = applicativeZero rawApplicativeZero
+    ; rawChoice = choice rawChoice
+    } where open RawAlternative M
+
+  monad : RawMonad M → RawMonad (WriterT 𝕎 M)
+  monad M = record
+    { rawApplicative = applicative rawApplicative
+    ; _>>=_ = λ ma f → mkWriterT λ w → do
+        w₁ , a  ← runWriterT ma w
+        runWriterT (f a) w₁
+    } where open RawMonad M
+
+  monadZero : RawMonadZero M → RawMonadZero (WriterT 𝕎 M)
+  monadZero M = record
+    { rawMonad = monad (RawMonadZero.rawMonad M)
+    ; rawEmpty = empty (RawMonadZero.rawEmpty M)
+    }
+
+  monadPlus : RawMonadPlus M → RawMonadPlus (WriterT 𝕎 M)
+  monadPlus M = record
+    { rawMonadZero = monadZero rawMonadZero
+    ; rawChoice = choice rawChoice
+    } where open RawMonadPlus M
+
+  ----------------------------------------------------------------------
+  -- Monad writer transformer specifics
+
+  monadT : RawMonadT {g₁ = g₁} {g₂ = _} (WriterT 𝕎)
+  monadT M = record
+    { lift = mkWriterT ∘′ λ ma w → (w ,_) <$> ma
+    ; rawMonad = monad M
+    } where open RawMonad M
+
+  monadWriter : RawMonad M → RawMonadWriter 𝕎 (WriterT 𝕎 M)
+  monadWriter M = record
+    { writer = mkWriterT ∘′ λ (w' , a) w → pure (w ∙ w' , a)
+    ; listen = λ ma → mkWriterT λ w → do
+             w , a ← runWriterT ma w
+             pure (w , w , a)
+    ; pass = λ mx → mkWriterT λ w → do
+           w , f , a ← runWriterT mx w
+           pure (f w , a)
+    } where open RawMonad M
+
+module _ {𝕎₁ : RawMonoid w g₁} where
+
+  open RawMonoid 𝕎₁ renaming (Carrier to W₁)
+
+  liftWriterT : (𝕎₂ : RawMonoid w g₂) →
+                RawFunctor M →
+                RawMonadWriter 𝕎₁ M →
+                RawMonadWriter 𝕎₁ (WriterT 𝕎₂ M)
+  liftWriterT 𝕎₂ M MWrite = record
+    { writer = λ (w , a) → mkWriterT λ w' → (writer (w , w' , a ))
+    ; listen = λ mx → mkWriterT λ w' → ((λ (w₁ , w₂ , a) → w₂ , w₁ , a) <$> listen (runWriterT mx w'))
+    ; pass = λ mx → mkWriterT λ w' → (pass ((λ (w , f , a) → f , w , a) <$> runWriterT mx w'))
+    } where open RawMonadWriter MWrite
+            open RawFunctor M
+
+  private
+    variable
+      W₂ : Set g₂
+
+  open import Effect.Monad.Reader.Transformer.Base
+
+  liftReaderT : RawFunctor M →
+                RawMonadWriter 𝕎₁ M →
+                RawMonadWriter 𝕎₁ (ReaderT W₂ M)
+  liftReaderT M MWrite = record
+    { writer = mkReaderT ∘′ const ∘′ writer
+    ; listen = λ ma → mkReaderT (listen ∘′ runReaderT ma)
+    ; pass = λ ma → mkReaderT (pass ∘′ runReaderT ma)
+    } where open RawMonadWriter MWrite
+
+  open import Effect.Monad.State.Transformer.Base
+
+  liftStateT : RawFunctor M →
+               RawMonadWriter 𝕎₁ M →
+               RawMonadWriter 𝕎₁ (StateT W₂ M)
+  liftStateT M MWrite = record
+    { writer = λ x → mkStateT λ w₂ → (w₂ ,_) <$>
+                 writer x
+    ; listen = λ mx → mkStateT λ w₂ → (w₂ ,_) <$>
+                 listen (proj₂ <$> runStateT mx w₂)
+    ; pass = λ mx → mkStateT λ w₂ → (w₂ ,_) <$>
+               pass ((λ (_ , f , a) → f , a) <$> runStateT mx w₂)
+    } where open RawMonadWriter MWrite
+            open RawFunctor M

--- a/src/Effect/Monad/Writer/Transformer/Base.agda
+++ b/src/Effect/Monad/Writer/Transformer/Base.agda
@@ -1,0 +1,65 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Basic type and definition of the writer monad transformer
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Effect.Monad.Writer.Transformer.Base where
+
+open import Algebra using (RawMonoid)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Unit.Polymorphic using (⊤; tt)
+open import Function.Base using (id; _∘′_)
+open import Level using (Level; suc; _⊔_)
+
+open import Effect.Functor using (RawFunctor)
+
+private
+  variable
+    w f g : Level
+    A : Set g
+    M : Set w → Set g
+    𝕎 : RawMonoid w g
+
+------------------------------------------------------------------------
+-- Writer monad operations
+
+record RawMonadWriter
+       (𝕎 : RawMonoid w f)
+       (M : Set w → Set g)
+       : Set (suc w ⊔ g) where
+  open RawMonoid 𝕎 renaming (Carrier to W)
+  field
+    writer : W × A → M A
+    listen : M A → M (W × A)
+    pass   : M ((W → W) × A) → M A
+
+  tell : W → M ⊤
+  tell w = writer (w , tt)
+
+------------------------------------------------------------------------
+-- Writer monad transformer (CPS-encoded)
+
+record WriterT
+       (𝕎 : RawMonoid w f)
+       (M : Set w → Set g)
+       (A : Set w)
+       : Set (w ⊔ g) where
+  constructor mkWriterT
+  open RawMonoid 𝕎 renaming (Carrier to W)
+  field runWriterT : W → M (W × A)
+open WriterT public
+
+module _ {𝕎 : RawMonoid w f} where
+
+  open RawMonoid 𝕎 renaming (Carrier to W)
+
+  evalWriterT : RawFunctor M → WriterT 𝕎 M A → M A
+  evalWriterT M ma = proj₂ <$> runWriterT ma ε
+    where open RawFunctor M
+
+  execWriterT : RawFunctor M → WriterT 𝕎 M A → M W
+  execWriterT M ma = proj₁ <$> runWriterT ma ε
+    where open RawFunctor M


### PR DESCRIPTION
I'm aware of `Data.Sum.Effectful.*` but it didn't help me much, I have no idea how to properly organize all the stuff about ExceptT reusing those modules.

I'm also asking for tips about improving the current code. First of all I couldn't come up with a really indexed construction for ExceptT because short-circuiting computations mess with the indices. Exceptions can be modeled with `Effect.Monad.Continuation` but is it a good definition for stdlib? Also there's no standard definition of categories in this library so indexed writer as in Bob Atkey's paper is out of reach.