### PR TITLE
Turned off the NoEquivWhenSplitting warning

### DIFF
--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -1,2 +1,4 @@
 name: standard-library-2.0
 include: src
+flags:
+  --warning=noNoEquivWhenSplitting


### PR DESCRIPTION
I [plan to](https://github.com/agda/agda/issues/5577) change Agda so that the `NoEquivWhenSplitting` warning is emitted when `--cubical-compatible` is used. To avoid getting lots of noise from the standard library I first want to turn off the warning for the standard library.