### PR TITLE
Add missing direct products and proof 0⋆≈1 in Kleene Algebra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1409,12 +1409,17 @@ New modules
 * Properties of Loop
   ```
   Algebra.Properties.Loop
+  ```
 
 * Some n-ary functions manipulating lists
   ```
   Data.List.Nary.NonDependent
   ```
 
+* Properties of KleeneAlgebra
+  ```
+  Algebra.Properties.KleeneAlgebra
+  ```
 Other minor changes
 -------------------
 
@@ -1508,6 +1513,10 @@ Other minor changes
   semimedialMagma : SemimedialMagma a ℓ₁ → SemimedialMagma b ℓ₂ →
                     SemimedialMagma (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
   kleeneAlgebra : KleeneAlgebra a ℓ₁ → KleeneAlgebra b ℓ₂ → KleeneAlgebra (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  leftBolLoop : LeftBolLoop a ℓ₁ → LeftBolLoop b ℓ₂ → LeftBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  rightBolLoop : RightBolLoop a ℓ₁ → RightBolLoop b ℓ₂ → RightBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  middleBolLoop : MiddleBolLoop a ℓ₁ → MiddleBolLoop b ℓ₂ → MiddleBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+  moufangLoop : MoufangLoop a ℓ₁ → MoufangLoop b ℓ₂ → MoufangLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
  ```
 
 * Added new definition to `Algebra.Definitions`:

--- a/src/Algebra/Construct/DirectProduct.agda
+++ b/src/Algebra/Construct/DirectProduct.agda
@@ -366,3 +366,37 @@ loop M N = record
                , (M.identityʳ , N.identityʳ <*>_)
     }
   } where module M = Loop M; module N = Loop N
+
+
+leftBolLoop : LeftBolLoop a ℓ₁ → LeftBolLoop b ℓ₂ → LeftBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+leftBolLoop M N = record
+  { isLeftBolLoop = record
+    { isLoop = Loop.isLoop (loop M.loop N.loop)
+    ; leftBol = λ x y z → M.leftBol , N.leftBol <*> x <*> y <*> z
+    }
+  } where module M = LeftBolLoop M; module N = LeftBolLoop N
+
+rightBolLoop : RightBolLoop a ℓ₁ → RightBolLoop b ℓ₂ → RightBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+rightBolLoop M N = record
+  { isRightBolLoop = record
+    { isLoop = Loop.isLoop (loop M.loop N.loop)
+    ; rightBol = λ x y z → M.rightBol , N.rightBol <*> x <*> y <*> z
+    }
+  } where module M = RightBolLoop M; module N = RightBolLoop N
+
+middleBolLoop : MiddleBolLoop a ℓ₁ → MiddleBolLoop b ℓ₂ → MiddleBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+middleBolLoop M N = record
+  { isMiddleBolLoop = record
+    { isLoop = Loop.isLoop (loop M.loop N.loop)
+    ; middleBol = λ x y z → M.middleBol , N.middleBol <*> x <*> y <*> z
+    }
+  } where module M = MiddleBolLoop M; module N = MiddleBolLoop N
+
+moufangLoop : MoufangLoop a ℓ₁ → MoufangLoop b ℓ₂ → MoufangLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
+moufangLoop M N = record
+  { isMoufangLoop = record
+    { isLeftBolLoop = LeftBolLoop.isLeftBolLoop (leftBolLoop M.leftBolLoop N.leftBolLoop)
+    ; rightBol = λ x y z → M.rightBol , N.rightBol <*> x <*> y <*> z
+    ; identical = λ x y z → M.identical , N.identical <*> x <*> y <*> z
+    }
+  } where module M = MoufangLoop M; module N = MoufangLoop N

--- a/src/Algebra/Construct/DirectProduct.agda
+++ b/src/Algebra/Construct/DirectProduct.agda
@@ -367,7 +367,6 @@ loop M N = record
     }
   } where module M = Loop M; module N = Loop N
 
-
 leftBolLoop : LeftBolLoop a ℓ₁ → LeftBolLoop b ℓ₂ → LeftBolLoop (a ⊔ b) (ℓ₁ ⊔ ℓ₂)
 leftBolLoop M N = record
   { isLeftBolLoop = record

--- a/src/Algebra/Properties/KleeneAlgebra.agda
+++ b/src/Algebra/Properties/KleeneAlgebra.agda
@@ -17,8 +17,8 @@ open import Function
 open import Data.Product
 
 0⋆≈1 : 0# ⋆ ≈ 1#
-0⋆≈1 = begin 
-  0# ⋆ ≈⟨ sym (starExpansiveˡ 0#) ⟩ 
+0⋆≈1 = begin
+  0# ⋆           ≈⟨ sym (starExpansiveˡ 0#) ⟩
   1# + 0# ⋆ * 0# ≈⟨ +-congˡ ( zeroʳ (0# ⋆)) ⟩
-  1# + 0# ≈⟨ +-identityʳ 1# ⟩
-  1# ∎
+  1# + 0#        ≈⟨ +-identityʳ 1# ⟩
+  1#             ∎

--- a/src/Algebra/Properties/KleeneAlgebra.agda
+++ b/src/Algebra/Properties/KleeneAlgebra.agda
@@ -13,8 +13,6 @@ module Algebra.Properties.KleeneAlgebra {k₁ k₂} (K : KleeneAlgebra k₁ k₂
 open KleeneAlgebra K
 open import Algebra.Definitions _≈_
 open import Relation.Binary.Reasoning.Setoid setoid
-open import Function
-open import Data.Product
 
 0⋆≈1 : 0# ⋆ ≈ 1#
 0⋆≈1 = begin


### PR DESCRIPTION
In this PR add direct product for  leftBolLoop, rightBolLoop, middleBolLoop and moufangLoop 
Prove  0⋆≈1 in Kleene Algebra
