### PR TITLE
initial+terminal algebras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -605,6 +605,8 @@ Non-backwards compatible changes
 
 * New modules:
   ```
+  Algebra.Construct.Initial
+  Algebra.Construct.Terminal
   Data.List.Effectful.Transformer
   Data.List.NonEmpty.Effectful.Transformer
   Data.Maybe.Effectful.Transformer
@@ -869,6 +871,14 @@ Deprecated modules
 
 Deprecated names
 ----------------
+
+* In `Algebra.Construct.Zero`:
+  ```agda
+  rawMagma   ↦  Algebra.Construct.Terminal.rawMagma
+  magma      ↦  Algebra.Construct.Terminal.magma
+  semigroup  ↦  Algebra.Construct.Terminal.semigroup
+  band       ↦  Algebra.Construct.Terminal.band
+  ```
 
 * In `Codata.Guarded.Stream.Properties`:
   ```agda

--- a/src/Algebra/Construct/Initial.agda
+++ b/src/Algebra/Construct/Initial.agda
@@ -26,13 +26,13 @@ open import Relation.Binary using (Rel; Reflexive; Symmetric; Transitive; IsEqui
 
 
 ------------------------------------------------------------------------
--- re-export those algebras which are also terminal
+-- Re-export those algebras which are also terminal
 
 open import Algebra.Construct.Terminal {c} {ℓ} public
   hiding (rawMagma; magma; semigroup; band)
 
 ------------------------------------------------------------------------
--- gather all the functionality in one place
+-- Gather all the functionality in one place
 
 private module ℤero where
 

--- a/src/Algebra/Construct/Initial.agda
+++ b/src/Algebra/Construct/Initial.agda
@@ -34,7 +34,7 @@ open import Algebra.Construct.Terminal {c} {ℓ} public
 ------------------------------------------------------------------------
 -- Gather all the functionality in one place
 
-private module ℤero where
+module ℤero where
 
   infixl 7 _∙_
   infix  4 _≈_
@@ -66,13 +66,13 @@ open ℤero
 -- Raw bundles
 
 rawMagma : RawMagma c ℓ
-rawMagma = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ }
+rawMagma = record { ℤero }
 
 ------------------------------------------------------------------------
 -- Structures
 
 isEquivalence : IsEquivalence _≈_
-isEquivalence = record { refl = refl ; sym = sym ; trans = trans }
+isEquivalence = record { ℤero }
 
 isMagma : IsMagma _≈_ _∙_
 isMagma = record { isEquivalence = isEquivalence ; ∙-cong = ∙-cong }

--- a/src/Algebra/Construct/Initial.agda
+++ b/src/Algebra/Construct/Initial.agda
@@ -1,0 +1,92 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Instances of algebraic structures where the carrier is ⊥.
+-- In mathematics, this is usually called 0.
+--
+-- From monoids up, these are zero-objects – i.e, the initial
+-- object is the terminal object in the relevant category.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Level using (Level)
+
+module Algebra.Construct.Initial {c ℓ : Level} where
+
+open import Algebra.Bundles
+  using (Magma; Semigroup; Band)
+open import Algebra.Bundles.Raw
+  using (RawMagma)
+open import Algebra.Core using (Op₂)
+open import Algebra.Definitions using (Congruent₂)
+open import Algebra.Structures using (IsMagma; IsSemigroup; IsBand)
+open import Data.Empty.Polymorphic
+open import Relation.Binary using (Rel; Reflexive; Symmetric; Transitive; IsEquivalence)
+
+
+------------------------------------------------------------------------
+-- re-export those algebras which are also terminal
+
+open import Algebra.Construct.Terminal {c} {ℓ} public
+  hiding (rawMagma; magma; semigroup; band)
+
+------------------------------------------------------------------------
+-- gather all the functionality in one place
+
+private module ℤero where
+
+  infixl 7 _∙_
+  infix  4 _≈_
+  Carrier : Set c
+  _≈_     : Rel Carrier ℓ
+  _∙_     : Op₂ Carrier
+
+  Carrier = ⊥
+  _≈_ ()
+  _∙_ ()
+
+  refl : Reflexive _≈_
+  refl {x = ()}
+
+  sym : Symmetric _≈_
+  sym {x = ()}
+
+  trans : Transitive _≈_
+  trans {i = ()}
+
+  isEquivalence : IsEquivalence _≈_
+  isEquivalence = record { refl = refl ; sym = sym ; trans = trans }
+
+  ∙-cong : Congruent₂ _≈_ _∙_
+  ∙-cong {x = ()}
+
+  isMagma : IsMagma _≈_ _∙_
+  isMagma = record { isEquivalence = isEquivalence ; ∙-cong = ∙-cong }
+
+  isSemigroup : IsSemigroup _≈_ _∙_
+  isSemigroup = record { isMagma = isMagma ; assoc = λ () }
+
+  isBand : IsBand _≈_ _∙_
+  isBand = record { isSemigroup = isSemigroup ; idem = λ () }
+
+open ℤero
+
+------------------------------------------------------------------------
+-- Raw bundles
+
+rawMagma : RawMagma c ℓ
+rawMagma = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ }
+
+------------------------------------------------------------------------
+-- Bundles
+
+magma : Magma c ℓ
+magma = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isMagma = isMagma }
+
+semigroup : Semigroup c ℓ
+semigroup = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isSemigroup = isSemigroup }
+
+band : Band c ℓ
+band = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isBand = isBand }
+

--- a/src/Algebra/Construct/Initial.agda
+++ b/src/Algebra/Construct/Initial.agda
@@ -38,12 +38,14 @@ private module ℤero where
 
   infixl 7 _∙_
   infix  4 _≈_
-  Carrier : Set c
-  _≈_     : Rel Carrier ℓ
-  _∙_     : Op₂ Carrier
 
+  Carrier : Set c
   Carrier = ⊥
+
+  _≈_     : Rel Carrier ℓ
   _≈_ ()
+
+  _∙_     : Op₂ Carrier
   _∙_ ()
 
   refl : Reflexive _≈_
@@ -55,20 +57,8 @@ private module ℤero where
   trans : Transitive _≈_
   trans {i = ()}
 
-  isEquivalence : IsEquivalence _≈_
-  isEquivalence = record { refl = refl ; sym = sym ; trans = trans }
-
   ∙-cong : Congruent₂ _≈_ _∙_
   ∙-cong {x = ()}
-
-  isMagma : IsMagma _≈_ _∙_
-  isMagma = record { isEquivalence = isEquivalence ; ∙-cong = ∙-cong }
-
-  isSemigroup : IsSemigroup _≈_ _∙_
-  isSemigroup = record { isMagma = isMagma ; assoc = λ () }
-
-  isBand : IsBand _≈_ _∙_
-  isBand = record { isSemigroup = isSemigroup ; idem = λ () }
 
 open ℤero
 
@@ -79,14 +69,29 @@ rawMagma : RawMagma c ℓ
 rawMagma = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ }
 
 ------------------------------------------------------------------------
+-- Structures
+
+isEquivalence : IsEquivalence _≈_
+isEquivalence = record { refl = refl ; sym = sym ; trans = trans }
+
+isMagma : IsMagma _≈_ _∙_
+isMagma = record { isEquivalence = isEquivalence ; ∙-cong = ∙-cong }
+
+isSemigroup : IsSemigroup _≈_ _∙_
+isSemigroup = record { isMagma = isMagma ; assoc = λ () }
+
+isBand : IsBand _≈_ _∙_
+isBand = record { isSemigroup = isSemigroup ; idem = λ () }
+
+------------------------------------------------------------------------
 -- Bundles
 
 magma : Magma c ℓ
-magma = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isMagma = isMagma }
+magma = record { isMagma = isMagma }
 
 semigroup : Semigroup c ℓ
-semigroup = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isSemigroup = isSemigroup }
+semigroup = record { isSemigroup = isSemigroup }
 
 band : Band c ℓ
-band = record { Carrier = Carrier ; _≈_ = _≈_ ; _∙_ = _∙_ ; isBand = isBand }
+band = record { isBand = isBand }
 

--- a/src/Algebra/Construct/Terminal.agda
+++ b/src/Algebra/Construct/Terminal.agda
@@ -19,15 +19,15 @@ open import Data.Unit.Polymorphic
 open import Relation.Binary.Core using (Rel)
 
 ------------------------------------------------------------------------
--- gather all the functionality in one place
+-- Gather all the functionality in one place
 
 private module 𝕆ne where
 
   infix  4 _≈_
   Carrier : Set c
-  _≈_     : Rel Carrier ℓ
-
   Carrier = ⊤
+  
+  _≈_     : Rel Carrier ℓ
   _ ≈ _ = ⊤
 
 open 𝕆ne

--- a/src/Algebra/Construct/Terminal.agda
+++ b/src/Algebra/Construct/Terminal.agda
@@ -26,7 +26,7 @@ private module 𝕆ne where
   infix  4 _≈_
   Carrier : Set c
   Carrier = ⊤
-  
+
   _≈_     : Rel Carrier ℓ
   _ ≈ _ = ⊤
 

--- a/src/Algebra/Construct/Terminal.agda
+++ b/src/Algebra/Construct/Terminal.agda
@@ -18,6 +18,9 @@ open import Algebra.Bundles
 open import Data.Unit.Polymorphic
 open import Relation.Binary.Core using (Rel)
 
+------------------------------------------------------------------------
+-- gather all the functionality in one place
+
 private module 𝕆ne where
 
   infix  4 _≈_

--- a/src/Algebra/Construct/Terminal.agda
+++ b/src/Algebra/Construct/Terminal.agda
@@ -21,7 +21,7 @@ open import Relation.Binary.Core using (Rel)
 ------------------------------------------------------------------------
 -- Gather all the functionality in one place
 
-private module 𝕆ne where
+module 𝕆ne where
 
   infix  4 _≈_
   Carrier : Set c
@@ -30,59 +30,57 @@ private module 𝕆ne where
   _≈_     : Rel Carrier ℓ
   _ ≈ _ = ⊤
 
-open 𝕆ne
-
 ------------------------------------------------------------------------
 -- Raw bundles
 
 rawMagma : RawMagma c ℓ
-rawMagma = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawMagma = record { 𝕆ne }
 
 rawMonoid : RawMonoid c ℓ
-rawMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawMonoid = record { 𝕆ne }
 
 rawGroup : RawGroup c ℓ
-rawGroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawGroup = record { 𝕆ne }
 
 rawSemiring : RawSemiring c ℓ
-rawSemiring = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawSemiring = record { 𝕆ne }
 
 rawRing : RawRing c ℓ
-rawRing = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawRing = record { 𝕆ne }
 
 ------------------------------------------------------------------------
 -- Bundles
 
 magma : Magma c ℓ
-magma = record { Carrier = Carrier ; _≈_ = _≈_ }
+magma = record { 𝕆ne }
 
 semigroup : Semigroup c ℓ
-semigroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+semigroup = record { 𝕆ne }
 
 band : Band c ℓ
-band = record { Carrier = Carrier ; _≈_ = _≈_ }
+band = record { 𝕆ne }
 
 commutativeSemigroup : CommutativeSemigroup c ℓ
-commutativeSemigroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+commutativeSemigroup = record { 𝕆ne }
 
 monoid : Monoid c ℓ
-monoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+monoid = record { 𝕆ne }
 
 commutativeMonoid : CommutativeMonoid c ℓ
-commutativeMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+commutativeMonoid = record { 𝕆ne }
 
 idempotentCommutativeMonoid : IdempotentCommutativeMonoid c ℓ
-idempotentCommutativeMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+idempotentCommutativeMonoid = record { 𝕆ne }
 
 group : Group c ℓ
-group = record { Carrier = Carrier ; _≈_ = _≈_ }
+group = record { 𝕆ne }
 
 abelianGroup : AbelianGroup c ℓ
-abelianGroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+abelianGroup = record { 𝕆ne }
 
 semiring : Semiring c ℓ
-semiring = record { Carrier = Carrier ; _≈_ = _≈_ }
+semiring = record { 𝕆ne }
 
 ring : Ring c ℓ
-ring = record { Carrier = Carrier ; _≈_ = _≈_ }
+ring = record { 𝕆ne }
 

--- a/src/Algebra/Construct/Terminal.agda
+++ b/src/Algebra/Construct/Terminal.agda
@@ -1,0 +1,85 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Instances of algebraic structures where the carrier is ⊤.
+-- In mathematics, this is usually called 0 (1 in the case of Group).
+--
+-- From monoids up, these are zero-objects – i.e, both the initial
+-- and the terminal object in the relevant category.
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Level using (Level)
+
+module Algebra.Construct.Terminal {c ℓ : Level} where
+
+open import Algebra.Bundles
+open import Data.Unit.Polymorphic
+open import Relation.Binary.Core using (Rel)
+
+private module 𝕆ne where
+
+  infix  4 _≈_
+  Carrier : Set c
+  _≈_     : Rel Carrier ℓ
+
+  Carrier = ⊤
+  _ ≈ _ = ⊤
+
+open 𝕆ne
+
+------------------------------------------------------------------------
+-- Raw bundles
+
+rawMagma : RawMagma c ℓ
+rawMagma = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+rawMonoid : RawMonoid c ℓ
+rawMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+rawGroup : RawGroup c ℓ
+rawGroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+rawSemiring : RawSemiring c ℓ
+rawSemiring = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+rawRing : RawRing c ℓ
+rawRing = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+------------------------------------------------------------------------
+-- Bundles
+
+magma : Magma c ℓ
+magma = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+semigroup : Semigroup c ℓ
+semigroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+band : Band c ℓ
+band = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+commutativeSemigroup : CommutativeSemigroup c ℓ
+commutativeSemigroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+monoid : Monoid c ℓ
+monoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+commutativeMonoid : CommutativeMonoid c ℓ
+commutativeMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+idempotentCommutativeMonoid : IdempotentCommutativeMonoid c ℓ
+idempotentCommutativeMonoid = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+group : Group c ℓ
+group = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+abelianGroup : AbelianGroup c ℓ
+abelianGroup = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+semiring : Semiring c ℓ
+semiring = record { Carrier = Carrier ; _≈_ = _≈_ }
+
+ring : Ring c ℓ
+ring = record { Carrier = Carrier ; _≈_ = _≈_ }
+

--- a/src/Algebra/Construct/Zero.agda
+++ b/src/Algebra/Construct/Zero.agda
@@ -23,6 +23,10 @@ open import Algebra.Bundles.Raw
   using (RawMagma)
 open import Algebra.Bundles
   using (Magma; Semigroup; Band)
+
+------------------------------------------------------------------------
+-- re-export those algebras which are both initial and terminal
+
 open import Algebra.Construct.Terminal public
   hiding (rawMagma; magma; semigroup; band)
 

--- a/src/Algebra/Construct/Zero.agda
+++ b/src/Algebra/Construct/Zero.agda
@@ -2,13 +2,15 @@
 -- The Agda standard library
 --
 -- Instances of algebraic structures where the carrier is ⊤.
--- In mathematics, this is usually called 0.
+-- In mathematics, this is usually called 0 (1 in the case of Group).
 --
 -- From monoids up, these are are zero-objects – i.e, both the initial
 -- and the terminal object in the relevant category.
--- For structures without an identity element, we can't necessarily
--- produce a homomorphism out of 0, because there is an instance of such
--- a structure with an empty Carrier.
+--
+-- For structures without an identity element, the terminal algebra is
+-- *not*  initial, because there is an instance of such a structure
+-- with an empty Carrier. Accordingly, such definitions are now deprecated
+-- in favour of those defined in `Algebra.Construct.Terminal`.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -17,47 +19,53 @@ open import Level using (Level)
 
 module Algebra.Construct.Zero {c ℓ : Level} where
 
+open import Algebra.Bundles.Raw
+  using (RawMagma)
 open import Algebra.Bundles
-open import Data.Unit.Polymorphic
+  using (Magma; Semigroup; Band)
+open import Algebra.Construct.Terminal public
+  hiding (rawMagma; magma; semigroup; band)
+
+------------------------------------------------------------------------
+-- DEPRECATED
+------------------------------------------------------------------------
+-- Please use the new definitions re-exported from
+-- `Algebra.Construct.Terminal` as continuing support for the below is
+-- not guaranteed.
+
+-- Version 2.0
 
 ------------------------------------------------------------------------
 -- Raw bundles
 
 rawMagma : RawMagma c ℓ
-rawMagma = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
+rawMagma = Algebra.Construct.Terminal.rawMagma
 
-rawMonoid : RawMonoid c ℓ
-rawMonoid = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-rawGroup : RawGroup c ℓ
-rawGroup = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
+{-# WARNING_ON_USAGE rawMagma
+"Warning: rawMagma was deprecated in v2.0.
+Please use Algebra.Construct.Terminal.rawMagma instead."
+#-}
 
 ------------------------------------------------------------------------
 -- Bundles
 
 magma : Magma c ℓ
-magma = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
+magma = Algebra.Construct.Terminal.magma
+{-# WARNING_ON_USAGE magma
+"Warning: magma was deprecated in v2.0.
+Please use Algebra.Construct.Terminal.magma instead."
+#-}
 
 semigroup : Semigroup c ℓ
-semigroup = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
+semigroup = Algebra.Construct.Terminal.semigroup
+{-# WARNING_ON_USAGE semigroup
+"Warning: semigroup was deprecated in v2.0.
+Please use Algebra.Construct.Terminal.semigroup instead."
+#-}
 
 band : Band c ℓ
-band = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-commutativeSemigroup : CommutativeSemigroup c ℓ
-commutativeSemigroup = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-monoid : Monoid c ℓ
-monoid = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-commutativeMonoid : CommutativeMonoid c ℓ
-commutativeMonoid = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-idempotentCommutativeMonoid : IdempotentCommutativeMonoid c ℓ
-idempotentCommutativeMonoid = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-group : Group c ℓ
-group = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
-
-abelianGroup : AbelianGroup c ℓ
-abelianGroup = record { Carrier = ⊤ ; _≈_ = λ _ _ → ⊤ }
+band = Algebra.Construct.Terminal.band
+{-# WARNING_ON_USAGE semigroup
+"Warning: semigroup was deprecated in v2.0.
+Please use Algebra.Construct.Terminal.semigroup instead."
+#-}

--- a/src/Algebra/Construct/Zero.agda
+++ b/src/Algebra/Construct/Zero.agda
@@ -25,7 +25,7 @@ open import Algebra.Bundles
   using (Magma; Semigroup; Band)
 
 ------------------------------------------------------------------------
--- re-export those algebras which are both initial and terminal
+-- Re-export those algebras which are both initial and terminal
 
 open import Algebra.Construct.Terminal public
   hiding (rawMagma; magma; semigroup; band)

--- a/src/Algebra/Construct/Zero.agda
+++ b/src/Algebra/Construct/Zero.agda
@@ -35,9 +35,6 @@ open import Algebra.Construct.Terminal public
 
 -- Version 2.0
 
-------------------------------------------------------------------------
--- Raw bundles
-
 rawMagma : RawMagma c ℓ
 rawMagma = Algebra.Construct.Terminal.rawMagma
 
@@ -45,9 +42,6 @@ rawMagma = Algebra.Construct.Terminal.rawMagma
 "Warning: rawMagma was deprecated in v2.0.
 Please use Algebra.Construct.Terminal.rawMagma instead."
 #-}
-
-------------------------------------------------------------------------
--- Bundles
 
 magma : Magma c ℓ
 magma = Algebra.Construct.Terminal.magma

--- a/src/Algebra/Module/Construct/Zero.agda
+++ b/src/Algebra/Module/Construct/Zero.agda
@@ -26,14 +26,14 @@ private
 ------------------------------------------------------------------------
 -- gather all the functionality in one place
 
-private module ℤero where
+module ℤero where
 
-  infix  4 _≈_
-  Carrier : Set c
-  Carrier = ⊤
+  infix  4 _≈ᴹ_
+  Carrierᴹ : Set c
+  Carrierᴹ = ⊤
 
-  _≈_     : Rel Carrier ℓ
-  _ ≈ _ = ⊤
+  _≈ᴹ_     : Rel Carrierᴹ ℓ
+  _ ≈ᴹ _ = ⊤
 
 open ℤero
 
@@ -41,32 +41,32 @@ open ℤero
 -- Raw bundles NOT YET IMPLEMENTED issue #1828
 {-
 rawModule : RawModule c ℓ
-rawModule = record { Carrier = Carrier ; _≈_ = _≈_ }
+rawModule = record { ℤero }
 -}
 ------------------------------------------------------------------------
 -- Bundles
 
 leftSemimodule : {R : Semiring r ℓr} → LeftSemimodule R c ℓ
-leftSemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+leftSemimodule = record { ℤero }
 
 rightSemimodule : {S : Semiring s ℓs} → RightSemimodule S c ℓ
-rightSemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+rightSemimodule = record { ℤero }
 
 bisemimodule :
   {R : Semiring r ℓr} {S : Semiring s ℓs} → Bisemimodule R S c ℓ
-bisemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+bisemimodule = record { ℤero }
 
 semimodule : {R : CommutativeSemiring r ℓr} → Semimodule R c ℓ
-semimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+semimodule = record { ℤero }
 
 leftModule : {R : Ring r ℓr} → LeftModule R c ℓ
-leftModule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+leftModule = record { ℤero }
 
 rightModule : {S : Ring s ℓs} → RightModule S c ℓ
-rightModule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+rightModule = record { ℤero }
 
 bimodule : {R : Ring r ℓr} {S : Ring s ℓs} → Bimodule R S c ℓ
-bimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+bimodule = record { ℤero }
 
 ⟨module⟩ : {R : CommutativeRing r ℓr} → Module R c ℓ
-⟨module⟩ = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
+⟨module⟩ = record { ℤero }

--- a/src/Algebra/Module/Construct/Zero.agda
+++ b/src/Algebra/Module/Construct/Zero.agda
@@ -17,56 +17,44 @@ module Algebra.Module.Construct.Zero {c ℓ : Level} where
 open import Algebra.Bundles
 open import Algebra.Module.Bundles
 open import Data.Unit.Polymorphic
+open import Relation.Binary.Core using (Rel)
 
 private
   variable
     r s ℓr ℓs : Level
 
+private module ℤero where
+
+  infix  4 _≈_
+  Carrier : Set c
+  _≈_     : Rel Carrier ℓ
+
+  Carrier = ⊤
+  _ ≈ _ = ⊤
+
+open ℤero
+
 leftSemimodule : {R : Semiring r ℓr} → LeftSemimodule R c ℓ
-leftSemimodule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+leftSemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 rightSemimodule : {S : Semiring s ℓs} → RightSemimodule S c ℓ
-rightSemimodule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+rightSemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 bisemimodule :
   {R : Semiring r ℓr} {S : Semiring s ℓs} → Bisemimodule R S c ℓ
-bisemimodule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+bisemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 semimodule : {R : CommutativeSemiring r ℓr} → Semimodule R c ℓ
-semimodule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+semimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 leftModule : {R : Ring r ℓr} → LeftModule R c ℓ
-leftModule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+leftModule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 rightModule : {S : Ring s ℓs} → RightModule S c ℓ
-rightModule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+rightModule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 bimodule : {R : Ring r ℓr} {S : Ring s ℓs} → Bimodule R S c ℓ
-bimodule = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+bimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }
 
 ⟨module⟩ : {R : CommutativeRing r ℓr} → Module R c ℓ
-⟨module⟩ = record
-  { Carrierᴹ = ⊤
-  ; _≈ᴹ_ = λ _ _ → ⊤
-  }
+⟨module⟩ = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }

--- a/src/Algebra/Module/Construct/Zero.agda
+++ b/src/Algebra/Module/Construct/Zero.agda
@@ -23,6 +23,9 @@ private
   variable
     r s ℓr ℓs : Level
 
+------------------------------------------------------------------------
+-- gather all the functionality in one place
+
 private module ℤero where
 
   infix  4 _≈_
@@ -33,6 +36,15 @@ private module ℤero where
   _ ≈ _ = ⊤
 
 open ℤero
+
+------------------------------------------------------------------------
+-- Raw bundles NOT YET IMPLEMENTED issue #1828
+{-
+rawModule : RawModule c ℓ
+rawModule = record { Carrier = Carrier ; _≈_ = _≈_ }
+-}
+------------------------------------------------------------------------
+-- Bundles
 
 leftSemimodule : {R : Semiring r ℓr} → LeftSemimodule R c ℓ
 leftSemimodule = record { Carrierᴹ = Carrier ; _≈ᴹ_ = _≈_ }

--- a/src/Algebra/Module/Construct/Zero.agda
+++ b/src/Algebra/Module/Construct/Zero.agda
@@ -30,9 +30,9 @@ private module ℤero where
 
   infix  4 _≈_
   Carrier : Set c
-  _≈_     : Rel Carrier ℓ
-
   Carrier = ⊤
+
+  _≈_     : Rel Carrier ℓ
   _ ≈ _ = ⊤
 
 open ℤero

--- a/src/Data/Unit.agda
+++ b/src/Data/Unit.agda
@@ -8,8 +8,6 @@
 
 module Data.Unit where
 
-import Relation.Binary.PropositionalEquality as PropEq
-
 ------------------------------------------------------------------------
 -- Re-export contents of base module
 

--- a/src/Data/Unit/Base.agda
+++ b/src/Data/Unit/Base.agda
@@ -6,8 +6,6 @@
 
 {-# OPTIONS --without-K --safe #-}
 
-open import Agda.Builtin.Equality using (_≡_)
-
 module Data.Unit.Base where
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
Refactored `Algebra.Construct.Zero` into
- [x] `Algebra.Construct.Initial`
- [x] `Algebra.Construct.Terminal`

and fixed up the public (re-)imports of the second into `Algebra.Construct.Zero` (for backwards compatibility), while deprecating the occurrences of the non-initial terminal algebras in favour of their counterparts in `Algebra.Construct.Terminal`. 

Also: amended `Algebra.Module.Construct.Zero` with commented-out hooks for the various `Raw` bundles associated with module-like algebras, pending the resolution of issue #1828 

One wrinkle: I wanted to abstract out all the common structure, so i did that in each module via an additional private module, that nevertheless is `open`ed into order to make the definitions (transparently) visible. But I may have got my `private`/`public` modifiers a bit mixed up. My concern is whether by making the internal modules `private`, I somehow fail to transparently export the definitions inside the publicly exported (raw) bundles, so that no actually reasoning is possible with them. But barring this wrinkle (fixable by removing the `private` modifiers), I think this one is now ready to go. 
