### PR TITLE
Fixed "installation" with GHC 9.4.4.

### DIFF
--- a/agda-stdlib-utils.cabal
+++ b/agda-stdlib-utils.cabal
@@ -1,5 +1,5 @@
 name:            agda-stdlib-utils
-version:         1.7.1
+version:         1.7.2
 cabal-version:   >= 1.10
 build-type:      Simple
 description:     Helper programs.
@@ -12,7 +12,7 @@ tested-with:     GHC == 8.0.2
                  GHC == 8.10.7
                  GHC == 9.0.2
                  GHC == 9.2.1
-                 GHC == 9.4.2
+                 GHC == 9.4.4
 
 executable GenerateEverything
   hs-source-dirs:   .
@@ -31,4 +31,4 @@ executable AllNonAsciiChars
   default-language: Haskell2010
   build-depends:      base      >= 4.9.0.0 && < 4.18
                     , filemanip >= 0.3.6.2 && < 0.4
-                    , text      >= 1.2.3.0 && < 1.3
+                    , text      >= 1.2.3.0 && < 2.1


### PR DESCRIPTION
@MatthewDaggitt, I couldn't test the `release-v1.7.2` branch with Agda 2.6.3 (see [error](https://github.com/agda/agda/actions/runs/3991533650/jobs/6846675894)). This PR fixes the problem.