### PR TITLE
`SelfInverse` operations on `Algebra`s and their properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1567,7 +1567,7 @@ Other minor changes
 
 * Added new proofs to `Algebra.Consequences.Base`:
   ```agda
-  reflexive+selfinverse⇒involutive : Reflexive _≈_ →
+  reflexive+selfInverse⇒involutive : Reflexive _≈_ →
                                      SelfInverse _≈_ f →
                                      Involutive _≈_ f
   ```
@@ -1575,12 +1575,12 @@ Other minor changes
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
   involutive⇒surjective  : Involutive f  → Surjective f
-  selfinverse⇒involutive : SelfInverse f → Involutive f
-  selfinverse⇒congruent  : SelfInverse f → Congruent f
-  selfinverse⇒inverseᵇ   : SelfInverse f → Inverseᵇ f f
-  selfinverse⇒surjective : SelfInverse f → Surjective f
-  selfinverse⇒injective  : SelfInverse f → Injective f
-  selfinverse⇒bijective  : SelfInverse f → Bijective f
+  selfInverse⇒involutive : SelfInverse f → Involutive f
+  selfInverse⇒congruent  : SelfInverse f → Congruent f
+  selfInverse⇒inverseᵇ   : SelfInverse f → Inverseᵇ f f
+  selfInverse⇒surjective : SelfInverse f → Surjective f
+  selfInverse⇒injective  : SelfInverse f → Injective f
+  selfInverse⇒bijective  : SelfInverse f → Bijective f
 
   comm+idˡ⇒id              : Commutative _•_ → LeftIdentity  e _•_ → Identity e _•_
   comm+idʳ⇒id              : Commutative _•_ → RightIdentity e _•_ → Identity e _•_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1565,8 +1565,22 @@ Other minor changes
   ```
   and their corresponding algebraic subbundles.
 
+* Added new proofs to `Algebra.Consequences.Base`:
+  ```agda
+  reflexive+selfinverse⇒involutive : Reflexive _≈_ →
+                                     SelfInverse _≈_ f →
+                                     Involutive _≈_ f
+  ```
+
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
+  involutive⇒surjective  : Involutive f  → Surjective f
+  selfinverse⇒congruent  : SelfInverse f → Congruent f
+  selfinverse⇒inverseᵇ   : SelfInverse f → Inverseᵇ f f
+  selfinverse⇒surjective : SelfInverse f → Surjective f
+  selfinverse⇒injective  : SelfInverse f → Injective f
+  selfinverse⇒bijective  : SelfInverse f → Bijective f
+
   comm+idˡ⇒id              : Commutative _•_ → LeftIdentity  e _•_ → Identity e _•_
   comm+idʳ⇒id              : Commutative _•_ → RightIdentity e _•_ → Identity e _•_
   comm+zeˡ⇒ze              : Commutative _•_ → LeftZero      e _•_ → Zero     e _•_
@@ -1622,6 +1636,8 @@ Other minor changes
 
 * Added new definition to `Algebra.Definitions`:
   ```agda
+  SelfInverse : Op₁ A → Set _
+  
   LeftDividesˡ  : Op₂ A → Op₂ A → Set _
   LeftDividesʳ  : Op₂ A → Op₂ A → Set _
   RightDividesˡ : Op₂ A → Op₂ A → Set _

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1575,6 +1575,7 @@ Other minor changes
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
   involutive⇒surjective  : Involutive f  → Surjective f
+  selfinverse⇒involutive : SelfInverse f → Involutive f
   selfinverse⇒congruent  : SelfInverse f → Congruent f
   selfinverse⇒inverseᵇ   : SelfInverse f → Inverseᵇ f f
   selfinverse⇒surjective : SelfInverse f → Surjective f

--- a/src/Algebra/Consequences/Base.agda
+++ b/src/Algebra/Consequences/Base.agda
@@ -2,7 +2,7 @@
 -- The Agda standard library
 --
 -- Lemmas relating algebraic definitions (such as associativity and
--- commutativity) that don't the equality relation to be a setoid.
+-- commutativity) that don't require the equality relation to be a setoid.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
@@ -14,9 +14,19 @@ open import Algebra.Core
 open import Algebra.Definitions
 open import Data.Sum.Base
 open import Relation.Binary.Core
+open import Relation.Binary.Definitions using (Reflexive)
 
-sel⇒idem : ∀ {ℓ} {_•_ : Op₂ A} (_≈_ : Rel A ℓ) →
-           Selective _≈_ _•_ → Idempotent _≈_ _•_
-sel⇒idem _ sel x with sel x x
-... | inj₁ x•x≈x = x•x≈x
-... | inj₂ x•x≈x = x•x≈x
+module _ {ℓ} {_•_ : Op₂ A} (_≈_ : Rel A ℓ) where
+
+  sel⇒idem : Selective _≈_ _•_ → Idempotent _≈_ _•_
+  sel⇒idem sel x with sel x x
+  ... | inj₁ x•x≈x = x•x≈x
+  ... | inj₂ x•x≈x = x•x≈x
+
+module _ {ℓ} {f : Op₁ A} (_≈_ : Rel A ℓ) where
+
+  reflexive+selfinverse⇒involutive : Reflexive _≈_ →
+                                     SelfInverse _≈_ f →
+                                     Involutive _≈_ f
+  reflexive+selfinverse⇒involutive refl inv _ = inv refl
+

--- a/src/Algebra/Consequences/Base.agda
+++ b/src/Algebra/Consequences/Base.agda
@@ -25,8 +25,8 @@ module _ {ℓ} {_•_ : Op₂ A} (_≈_ : Rel A ℓ) where
 
 module _ {ℓ} {f : Op₁ A} (_≈_ : Rel A ℓ) where
 
-  reflexive+selfinverse⇒involutive : Reflexive _≈_ →
+  reflexive+selfInverse⇒involutive : Reflexive _≈_ →
                                      SelfInverse _≈_ f →
                                      Involutive _≈_ f
-  reflexive+selfinverse⇒involutive refl inv _ = inv refl
+  reflexive+selfInverse⇒involutive refl inv _ = inv refl
 

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -41,35 +41,35 @@ module _ {f : Op₁ A} (inv : Involutive f) where
 
 module _ {f : Op₁ A} (self : SelfInverse f) where
 
-  selfinverse⇒involutive : Involutive f
-  selfinverse⇒involutive = reflexive+selfinverse⇒involutive _≈_ refl self
+  selfInverse⇒involutive : Involutive f
+  selfInverse⇒involutive = reflexive+selfInverse⇒involutive _≈_ refl self
 
   private
 
-    inv = selfinverse⇒involutive
+    inv = selfInverse⇒involutive
 
   open FunDefs _≈_ _≈_
 
-  selfinverse⇒congruent : Congruent f
-  selfinverse⇒congruent {x} {y} x≈y = sym (self (begin
+  selfInverse⇒congruent : Congruent f
+  selfInverse⇒congruent {x} {y} x≈y = sym (self (begin
     f (f x) ≈⟨ inv x ⟩
     x       ≈⟨ x≈y ⟩
     y       ∎))
 
-  selfinverse⇒inverseᵇ : Inverseᵇ f f
-  selfinverse⇒inverseᵇ = inv , inv
+  selfInverse⇒inverseᵇ : Inverseᵇ f f
+  selfInverse⇒inverseᵇ = inv , inv
 
-  selfinverse⇒surjective : Surjective f
-  selfinverse⇒surjective = involutive⇒surjective inv
+  selfInverse⇒surjective : Surjective f
+  selfInverse⇒surjective = involutive⇒surjective inv
 
-  selfinverse⇒injective : Injective f
-  selfinverse⇒injective {x} {y} x≈y = begin
+  selfInverse⇒injective : Injective f
+  selfInverse⇒injective {x} {y} x≈y = begin
     x       ≈˘⟨ self x≈y ⟩
     f (f y) ≈⟨ inv y ⟩
     y       ∎
 
-  selfinverse⇒bijective : Bijective f
-  selfinverse⇒bijective = selfinverse⇒injective , selfinverse⇒surjective
+  selfInverse⇒bijective : Bijective f
+  selfInverse⇒bijective = selfInverse⇒injective , selfInverse⇒surjective
 
 ------------------------------------------------------------------------
 -- Magma-like structures

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -41,8 +41,12 @@ module _ {f : Op₁ A} (inv : Involutive f) where
 
 module _ {f : Op₁ A} (self : SelfInverse f) where
 
-  inv : Involutive f
-  inv = reflexive+selfinverse⇒involutive _≈_ refl self
+  selfinverse⇒involutive : Involutive f
+  selfinverse⇒involutive = reflexive+selfinverse⇒involutive _≈_ refl self
+
+  private
+
+    inv = selfinverse⇒involutive
 
   open FunDefs _≈_ _≈_
 

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -17,6 +17,7 @@ open import Algebra.Definitions _≈_
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Data.Product using (_,_)
 open import Function.Base using (_$_)
+import Function.Definitions as FunDefs
 import Relation.Binary.Consequences as Bin
 open import Relation.Binary.Reasoning.Setoid S
 open import Relation.Unary using (Pred)
@@ -27,6 +28,44 @@ open import Relation.Unary using (Pred)
 -- Export base lemmas that don't require the setoid
 
 open import Algebra.Consequences.Base public
+
+------------------------------------------------------------------------
+-- Involutive/SelfInverse functions
+
+module _ {f : Op₁ A} (inv : Involutive f) where
+
+  open FunDefs _≈_ _≈_
+
+  involutive⇒surjective : Surjective f
+  involutive⇒surjective y = f y , inv y
+
+module _ {f : Op₁ A} (self : SelfInverse f) where
+
+  inv : Involutive f
+  inv = reflexive+selfinverse⇒involutive _≈_ refl self
+
+  open FunDefs _≈_ _≈_
+
+  selfinverse⇒congruent : Congruent f
+  selfinverse⇒congruent {x} {y} x≈y = sym (self (begin
+    f (f x) ≈⟨ inv x ⟩
+    x       ≈⟨ x≈y ⟩
+    y       ∎))
+
+  selfinverse⇒inverseᵇ : Inverseᵇ f f
+  selfinverse⇒inverseᵇ = inv , inv
+
+  selfinverse⇒surjective : Surjective f
+  selfinverse⇒surjective = involutive⇒surjective inv
+
+  selfinverse⇒injective : Injective f
+  selfinverse⇒injective {x} {y} x≈y = begin
+    x       ≈˘⟨ self x≈y ⟩
+    f (f y) ≈⟨ inv y ⟩
+    y       ∎
+
+  selfinverse⇒bijective : Bijective f
+  selfinverse⇒bijective = selfinverse⇒injective , selfinverse⇒surjective
 
 ------------------------------------------------------------------------
 -- Magma-like structures

--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -126,6 +126,9 @@ _∙_ Absorbs _∘_ = ∀ x y → (x ∙ (x ∘ y)) ≈ x
 Absorptive : Op₂ A → Op₂ A → Set _
 Absorptive ∙ ∘ = (∙ Absorbs ∘) × (∘ Absorbs ∙)
 
+SelfInverse : Op₁ A → Set _
+SelfInverse f = ∀ {x y} → f x ≈ y → f y ≈ x
+
 Involutive : Op₁ A → Set _
 Involutive f = ∀ x → f (f x) ≈ x
 

--- a/src/Data/Parity/Properties.agda
+++ b/src/Data/Parity/Properties.agda
@@ -25,8 +25,8 @@ open import Relation.Nullary using (yes; no)
 
 open import Algebra.Structures {A = Parity} _≡_
 open import Algebra.Definitions {A = Parity} _≡_
-
-open import Algebra.Consequences.Propositional using (comm+distrˡ⇒distrʳ)
+open import Algebra.Consequences.Propositional
+  using (selfinverse⇒involutive; selfinverse⇒injective; comm+distrˡ⇒distrʳ)
 open import Algebra.Morphism.Structures
 
 ------------------------------------------------------------------------
@@ -52,22 +52,24 @@ _≟_ : DecidableEquality Parity
 ------------------------------------------------------------------------
 -- _⁻¹
 
+-- Algebraic properties of _⁻¹
+
+⁻¹-self-inverse : SelfInverse _⁻¹
+⁻¹-self-inverse { 1ℙ } { 0ℙ } refl = refl
+⁻¹-self-inverse { 0ℙ } { 1ℙ } refl = refl
+
+⁻¹-involutive : Involutive _⁻¹
+⁻¹-involutive = selfinverse⇒involutive ⁻¹-self-inverse
+
+⁻¹-injective : Injective _≡_ _≡_ _⁻¹
+⁻¹-injective = selfinverse⇒injective ⁻¹-self-inverse
+
+------------------------------------------------------------------------
+-- other properties of _⁻¹
+
 p≢p⁻¹ : ∀ p → p ≢ p ⁻¹
 p≢p⁻¹ 1ℙ ()
 p≢p⁻¹ 0ℙ ()
-
-⁻¹-inverts : ∀ {p q} → p ⁻¹ ≡ q → q ⁻¹ ≡ p
-⁻¹-inverts { 1ℙ } { 0ℙ } refl = refl
-⁻¹-inverts { 0ℙ } { 1ℙ } refl = refl
-
-⁻¹-involutive : ∀ p → (p ⁻¹) ⁻¹ ≡ p
-⁻¹-involutive p = ⁻¹-inverts refl
-
-⁻¹-injective : ∀ {p q} → p ⁻¹ ≡ q ⁻¹ → p ≡ q
-⁻¹-injective {p} {q} eq = begin
-  p         ≡⟨ sym (⁻¹-inverts eq) ⟩
-  (q ⁻¹) ⁻¹ ≡⟨ ⁻¹-involutive q ⟩
-  q         ∎ where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- ⁻¹ and _+_
@@ -480,7 +482,7 @@ toSign-isGroupIsomorphism = record
 
 suc-homo-⁻¹ : ∀ n → (parity (suc n)) ⁻¹ ≡ parity n
 suc-homo-⁻¹ zero    = refl
-suc-homo-⁻¹ (suc n) = ⁻¹-inverts (suc-homo-⁻¹ n)
+suc-homo-⁻¹ (suc n) = ⁻¹-self-inverse (suc-homo-⁻¹ n)
 
 -- parity is a _+_ homomorphism
 

--- a/src/Data/Parity/Properties.agda
+++ b/src/Data/Parity/Properties.agda
@@ -26,7 +26,7 @@ open import Relation.Nullary using (yes; no)
 open import Algebra.Structures {A = Parity} _≡_
 open import Algebra.Definitions {A = Parity} _≡_
 open import Algebra.Consequences.Propositional
-  using (selfinverse⇒involutive; selfinverse⇒injective; comm+distrˡ⇒distrʳ)
+  using (selfInverse⇒involutive; selfInverse⇒injective; comm+distrˡ⇒distrʳ)
 open import Algebra.Morphism.Structures
 
 ------------------------------------------------------------------------
@@ -54,15 +54,15 @@ _≟_ : DecidableEquality Parity
 
 -- Algebraic properties of _⁻¹
 
-⁻¹-self-inverse : SelfInverse _⁻¹
-⁻¹-self-inverse { 1ℙ } { 0ℙ } refl = refl
-⁻¹-self-inverse { 0ℙ } { 1ℙ } refl = refl
+⁻¹-selfInverse : SelfInverse _⁻¹
+⁻¹-selfInverse { 1ℙ } { 0ℙ } refl = refl
+⁻¹-selfInverse { 0ℙ } { 1ℙ } refl = refl
 
 ⁻¹-involutive : Involutive _⁻¹
-⁻¹-involutive = selfinverse⇒involutive ⁻¹-self-inverse
+⁻¹-involutive = selfInverse⇒involutive ⁻¹-selfInverse
 
 ⁻¹-injective : Injective _≡_ _≡_ _⁻¹
-⁻¹-injective = selfinverse⇒injective ⁻¹-self-inverse
+⁻¹-injective = selfInverse⇒injective ⁻¹-selfInverse
 
 ------------------------------------------------------------------------
 -- other properties of _⁻¹
@@ -482,7 +482,7 @@ toSign-isGroupIsomorphism = record
 
 suc-homo-⁻¹ : ∀ n → (parity (suc n)) ⁻¹ ≡ parity n
 suc-homo-⁻¹ zero    = refl
-suc-homo-⁻¹ (suc n) = ⁻¹-self-inverse (suc-homo-⁻¹ n)
+suc-homo-⁻¹ (suc n) = ⁻¹-selfInverse (suc-homo-⁻¹ n)
 
 -- parity is a _+_ homomorphism
 

--- a/src/Data/Sign/Properties.agda
+++ b/src/Data/Sign/Properties.agda
@@ -22,7 +22,7 @@ open import Relation.Nullary.Decidable using (yes; no)
 open import Algebra.Structures {A = Sign} _≡_
 open import Algebra.Definitions {A = Sign} _≡_
 open import Algebra.Consequences.Propositional
-  using (selfinverse⇒involutive; selfinverse⇒injective)
+  using (selfInverse⇒involutive; selfInverse⇒injective)
 
 ------------------------------------------------------------------------
 -- Equality
@@ -49,15 +49,15 @@ _≟_ : DecidableEquality Sign
 
 -- Algebraic properties of opposite
 
-opposite-self-inverse : SelfInverse opposite
-opposite-self-inverse { - } { + } refl = refl
-opposite-self-inverse { + } { - } refl = refl
+opposite-selfInverse : SelfInverse opposite
+opposite-selfInverse { - } { + } refl = refl
+opposite-selfInverse { + } { - } refl = refl
 
 opposite-involutive : Involutive opposite
-opposite-involutive = selfinverse⇒involutive opposite-self-inverse
+opposite-involutive = selfInverse⇒involutive opposite-selfInverse
 
 opposite-injective : Injective _≡_ _≡_ opposite
-opposite-injective = selfinverse⇒injective opposite-self-inverse
+opposite-injective = selfInverse⇒injective opposite-selfInverse
 
 
 ------------------------------------------------------------------------

--- a/src/Data/Sign/Properties.agda
+++ b/src/Data/Sign/Properties.agda
@@ -21,6 +21,8 @@ open import Relation.Nullary.Decidable using (yes; no)
 
 open import Algebra.Structures {A = Sign} _≡_
 open import Algebra.Definitions {A = Sign} _≡_
+open import Algebra.Consequences.Propositional
+  using (selfinverse⇒involutive; selfinverse⇒injective)
 
 ------------------------------------------------------------------------
 -- Equality
@@ -45,13 +47,25 @@ _≟_ : DecidableEquality Sign
 ------------------------------------------------------------------------
 -- opposite
 
+-- Algebraic properties of opposite
+
+opposite-self-inverse : SelfInverse opposite
+opposite-self-inverse { - } { + } refl = refl
+opposite-self-inverse { + } { - } refl = refl
+
+opposite-involutive : Involutive opposite
+opposite-involutive = selfinverse⇒involutive opposite-self-inverse
+
+opposite-injective : Injective _≡_ _≡_ opposite
+opposite-injective = selfinverse⇒injective opposite-self-inverse
+
+
+------------------------------------------------------------------------
+-- other properties of opposite
+
 s≢opposite[s] : ∀ s → s ≢ opposite s
 s≢opposite[s] - ()
 s≢opposite[s] + ()
-
-opposite-injective : ∀ {s t} → opposite s ≡ opposite t → s ≡ t
-opposite-injective { - } { - } refl = refl
-opposite-injective { + } { + } refl = refl
 
 ------------------------------------------------------------------------
 -- _*_


### PR DESCRIPTION
Reviewing my contribution of `Data.Parity` and friends, I found myself annoyed about repeated proofs of properties of the self-inverse functions `_⁻¹` and corresponding `opposite` on `Data.Sign`...
... and was surprised that being `SelfInverse` didn't seem to be in either the `Function` or `Algebra` hierarchies. 

Now, with this PR, I've chosen to put these things in the `Algebra` hierarchy, because that is where `Involutive` is defined, and self-inverse operations are involutive in the presence of reflexivity (one of the properties I needed/used/defined). 

But it seems that I could have put these definitions under `Function`, and certainly some of the `Consequences.Setoid` for self-inverse operations are really about their behaviour as `Function`s... so some advice on where these properties should properly go would be welcome. 

An argument I am open to is that, *qua* functions, they belong under `Function`; but as operations which are *automorphisms* of the corresponding `Algebra` structure, then they belong under `Algebra`. 

It's not obvious to me that we systematically observe such distinctions. One thing that does jump out, cf. issue #1544, is that `Algebra.Definitions` defines `Congruent₁` and `Congruent₂`, while `Function.Definitions` defines `Congruent`, so (t)here's another failure of systematisation: ... I prove that self-inverse operations are `Congruent`, rather than `Congruent₁`... but which should I have done?

~~TODO~~DONE: refactor to use the new definitions/proofs
- [x] `Data.Sign.Properties`
- [x] `Data.Parity.Properties`