### PR TITLE
[discussion] a view-based analysis of `punchOut`, `punchIn` and `pinch` from `Data.Fin`

### DIFF
--- a/README/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/README/Data/Fin/Relation/Ternary/Pinch.agda
@@ -1,0 +1,53 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Example use of the 'Pinch' view of Fin
+--
+-- This is an example of a view of a function defined over a datatype,
+-- such that the recursion and call-pattern(s) of the function are
+-- precisely mirrored in the constructors of the view type
+--
+-- Using this view, we can exhibit the corresponding properties of
+-- the function `punchIn` defined in `Data.Fin.Properties`
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module README.Data.Fin.Relation.Ternary.Pinch where
+
+open import Data.Nat.Base as Nat using (ℕ; suc; ∣_-_∣)
+open import Data.Fin.Base using (Fin; zero; suc; toℕ; _≤_; _<_; pinch)
+open import Data.Fin.Relation.Ternary.Pinch
+open import Data.Product using (_,_; ∃)
+open import Function.Definitions.Core2 using (Surjective)
+open import Relation.Binary.Core
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
+
+private
+  variable
+    n : ℕ
+
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+pinch-surjective : ∀ (i : Fin n) → Surjective _≡_ (pinch i)
+pinch-surjective i k
+  with j , v ← view-surjective i k
+  with refl ← view-complete v = j , refl
+
+pinch-injective : ∀ {i : Fin n} {j k : Fin (ℕ.suc n)} →
+                  suc i ≢ j → suc i ≢ k → pinch i j ≡ pinch i k → j ≡ k
+pinch-injective {n = n} {i} {j} {k} = view-injective (view i j) (view i k)
+
+pinch-mono-≤ : ∀ (i : Fin n) → (pinch i) Preserves _≤_ ⟶ _≤_
+pinch-mono-≤ i {j} {k} = view-mono-≤ (view i j) (view i k)
+
+pinch-cancel-< : ∀ (i : Fin (suc n)) {j k} →
+                (pinch i j < pinch i k) → j < k
+pinch-cancel-< i {j} {k} = view-cancel-< (view i j) (view i k)
+
+pinch-≡⇒∣j-k∣≤1 : ∀ (i : Fin n) {j k} →
+                  (pinch i j ≡ pinch i k) → ∣ (toℕ j) - (toℕ k) ∣ Nat.≤ 1
+pinch-≡⇒∣j-k∣≤1 i {j} {k} = view-j≡view-k⇒∣j-k∣≤1 (view i j) (view i k)
+

--- a/README/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/README/Data/Fin/Relation/Ternary/Pinch.agda
@@ -11,7 +11,7 @@
 -- the function `punchIn` defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module README.Data.Fin.Relation.Ternary.Pinch where
 

--- a/README/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -11,7 +11,7 @@
 -- the function `punchIn` defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module README.Data.Fin.Relation.Ternary.PunchIn where
 

--- a/README/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -1,0 +1,44 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Example use of the 'PunchIn' view of Fin
+--
+-- This is an example of a view of a function defined over a datatype,
+-- such that the recursion and call-pattern(s) of the function are
+-- precisely mirrored inthe ocnstructors of the view type
+--
+-- Using this view, we can exhibit the corresponding properties of the function
+-- deifned in `Data.Fin.Properties`
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module README.Data.Fin.Relation.Ternary.PunchInView where
+
+open import Data.Nat.Base using (ℕ; suc)
+open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchIn)
+open import Data.Fin.Relation.Ternary.PunchIn
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
+
+private
+  variable
+    n : ℕ
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+punchInᵢ≢i : ∀ i (j : Fin n) → punchIn i j ≢ i
+punchInᵢ≢i i j = view-codomain (view i j)
+
+punchIn-injective : ∀ i (j k : Fin n) →
+                    punchIn i j ≡ punchIn i k → j ≡ k
+punchIn-injective i j k = view-injective (view i j) (view i k)
+
+punchIn-mono≤ : ∀ (i : Fin (suc n)) {j k} →
+                j ≤ k → punchIn i j ≤ punchIn i k
+punchIn-mono≤ i {j} {k} = view-mono-≤ (view i j) (view i k)
+
+punchIn-cancel≤ : ∀ (i : Fin (suc n)) {j k} →
+                  (punchIn i j ≤ punchIn i k) → j ≤ k
+punchIn-cancel≤ i {j} {k} = view-cancel-≤ (view i j) (view i k)
+

--- a/README/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -7,8 +7,8 @@
 -- such that the recursion and call-pattern(s) of the function are
 -- precisely mirrored in the constructors of the view type
 --
--- Using this view, we can exhibit the corresponding properties of the function
--- defined in `Data.Fin.Properties`
+-- Using this view, we can exhibit the corresponding properties of
+-- the function `punchIn` defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}

--- a/README/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -5,15 +5,15 @@
 --
 -- This is an example of a view of a function defined over a datatype,
 -- such that the recursion and call-pattern(s) of the function are
--- precisely mirrored inthe ocnstructors of the view type
+-- precisely mirrored in the constructors of the view type
 --
 -- Using this view, we can exhibit the corresponding properties of the function
--- deifned in `Data.Fin.Properties`
+-- defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
-module README.Data.Fin.Relation.Ternary.PunchInView where
+module README.Data.Fin.Relation.Ternary.PunchIn where
 
 open import Data.Nat.Base using (ℕ; suc)
 open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchIn)

--- a/README/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -18,6 +18,8 @@ module README.Data.Fin.Relation.Ternary.PunchIn where
 open import Data.Nat.Base using (ℕ; suc)
 open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchIn)
 open import Data.Fin.Relation.Ternary.PunchIn
+open import Function.Definitions using (Injective)
+open import Relation.Binary.Core
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_)
 
 private
@@ -30,15 +32,13 @@ private
 punchInᵢ≢i : ∀ i (j : Fin n) → punchIn i j ≢ i
 punchInᵢ≢i i j = view-codomain (view i j)
 
-punchIn-injective : ∀ i (j k : Fin n) →
-                    punchIn i j ≡ punchIn i k → j ≡ k
-punchIn-injective i j k = view-injective (view i j) (view i k)
+punchIn-injective : ∀ (i : Fin (suc n)) → Injective _≡_ _≡_ (punchIn i)
+punchIn-injective i {j} {k} = view-injective (view i j) (view i k)
 
-punchIn-mono≤ : ∀ (i : Fin (suc n)) {j k} →
-                j ≤ k → punchIn i j ≤ punchIn i k
-punchIn-mono≤ i {j} {k} = view-mono-≤ (view i j) (view i k)
+punchIn-mono-≤ : ∀ (i : Fin (suc n)) → (punchIn i) Preserves _≤_ ⟶ _≤_
+punchIn-mono-≤ i {j} {k} = view-mono-≤ (view i j) (view i k)
 
-punchIn-cancel≤ : ∀ (i : Fin (suc n)) {j k} →
+punchIn-cancel-≤ : ∀ (i : Fin (suc n)) {j k} →
                   (punchIn i j ≤ punchIn i k) → j ≤ k
-punchIn-cancel≤ i {j} {k} = view-cancel-≤ (view i j) (view i k)
+punchIn-cancel-≤ i {j} {k} = view-cancel-≤ (view i j) (view i k)
 

--- a/README/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -1,0 +1,59 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Example use of the 'PunchOut' view of Fin
+--
+-- This is an example of a view of a function defined over a datatype,
+-- such that the recursion and call-pattern(s) of the function are
+-- precisely mirrored in the constructors of the view type
+--
+-- Using this view, we can exhibit the corresponding properties of
+-- the function `punchIn` defined in `Data.Fin.Properties`
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module README.Data.Fin.Relation.Ternary.PunchOut where
+
+open import Data.Nat.Base using (ℕ; suc)
+open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchIn; punchOut)
+open import Data.Fin.Properties using (punchInᵢ≢i)
+open import Data.Fin.Relation.Ternary.PunchIn as PunchIn using ()
+open import Data.Fin.Relation.Ternary.PunchOut
+open import Function.Base using (_∘_)
+open import Relation.Binary.Core
+open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; sym)
+
+private
+  variable
+    n : ℕ
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+punchOut-injective : ∀ {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
+                    punchOut i≢j ≡ punchOut i≢k → j ≡ k
+punchOut-injective i≢j i≢k = view-injective (view i≢j) (view i≢k)
+
+punchOut-cong : ∀ (i : Fin (suc n)) {j k} {i≢j : i ≢ j} {i≢k : i ≢ k} →
+                j ≡ k → punchOut i≢j ≡ punchOut i≢k
+punchOut-cong i {i≢j = i≢j} {i≢k = i≢k} = view-cong (view i≢j) (view i≢k)
+
+punchOut-mono-≤ : ∀ {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
+                j ≤ k → punchOut i≢j ≤ punchOut i≢k
+punchOut-mono-≤ i≢j i≢k = view-mono-≤ (view i≢j) (view i≢k)
+
+punchOut-cancel-≤ : ∀ {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
+                  (punchOut i≢j ≤ punchOut i≢k) → j ≤ k
+punchOut-cancel-≤ i≢j i≢k = view-cancel-≤ (view i≢j) (view i≢k)
+
+-- punchOut and punchIn are mutual inverses,
+-- because their corresponding View s are converses
+
+punchIn-punchOut : ∀ {i j : Fin (suc n)} (i≢j : i ≢ j) →
+                   punchIn i (punchOut i≢j) ≡ j
+punchIn-punchOut = PunchIn.view-complete ∘ view-view⁻¹ ∘ view
+
+punchOut-punchIn : ∀ i {j : Fin n} →
+                   punchOut {i = i} {j = punchIn i j} (punchInᵢ≢i i j ∘ sym) ≡ j
+punchOut-punchIn i {j} = view-complete (view⁻¹-view (PunchIn.view i j))

--- a/README/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -11,7 +11,7 @@
 -- the function `punchOut` defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module README.Data.Fin.Relation.Ternary.PunchOut where
 

--- a/README/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/README/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -8,7 +8,7 @@
 -- precisely mirrored in the constructors of the view type
 --
 -- Using this view, we can exhibit the corresponding properties of
--- the function `punchIn` defined in `Data.Fin.Properties`
+-- the function `punchOut` defined in `Data.Fin.Properties`
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -33,6 +33,16 @@ private
 -- function definition; recursive calls are represented by inductive premises
 
 data View : ∀ {n} (i : Fin n) (j : Fin (suc n)) (k : Fin n) → Set where
+{-
+
+-- `pinch` is the function f(i,j) such that f(i,j) = if j≤i then j else j-1
+
+pinch : Fin n → Fin (suc n) → Fin n
+pinch {suc n} _       zero    = zero
+pinch {suc n} zero    (suc j) = j
+pinch {suc n} (suc i) (suc j) = suc (pinch i j)
+
+-}
 
   any-zero : ∀ {n} (i : Fin (suc n))             → View i zero zero
   zero-suc : ∀ {n} (j : Fin (suc n))             → View zero (suc j) j

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -3,9 +3,11 @@
 --
 -- The '`Pinch` view' of the function `pinch` defined on finite sets
 ------------------------------------------------------------------------
-
--- This example of a "view of a function via its graph relation" is inspired
--- by Nathan van Doorn's recent PR#1913.
+--
+-- This is an example of a view of a function defined over a datatype,
+-- such that the recursion and call-pattern(s) of the function are
+-- precisely mirrored in the constructors of the view type,
+-- ie that we 'view the function via its graph relation'
 
 {-# OPTIONS --without-K --safe #-}
 

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -29,6 +29,9 @@ private
 ------------------------------------------------------------------------
 -- The View, considered as a ternary relation
 
+-- Each constructor corresponds to a particular call-pattern in the original
+-- function definition; recursive calls are represented by inductive premises
+
 data View : ∀ {n} (i : Fin n) (j : Fin (suc n)) (k : Fin n) → Set where
 
   any-zero : ∀ {n} (i : Fin (suc n))             → View i zero zero
@@ -37,14 +40,24 @@ data View : ∀ {n} (i : Fin n) (j : Fin (suc n)) (k : Fin n) → Set where
 
 -- The View is sound, ie covers all telescopes (satisfying the always-true precondition)
 
+-- The recursion/pattern analysis of the original definition of `pinch`
+-- (which is responsible for showing termination in the first place)
+-- is then exactly replicated in the definition of the covering function `view`;
+-- thus that definitional pattern analysis is encapsulated once and for all
+
 view : ∀ {n} i j → View {n} i j (pinch i j)
 view {suc _} i zero    = any-zero i
 view   zero    (suc j) = zero-suc j
 view   (suc i) (suc j) = suc-suc (view i j)
 
+-- Interpretation of the view: the original function itself
+
+⟦_⟧ : ∀ {i j} {k} .(v : View {n} i j k) → Fin n
+⟦_⟧ {n = n} {i} {j} {k} _ = pinch i j
+
 -- The View is complete
 
-view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → pinch i j ≡ k
+view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → ⟦ v ⟧ ≡ k
 view-complete (any-zero i) = refl
 view-complete (zero-suc j) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -1,0 +1,86 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The 'punchOut view' of the function `punchOut` defined on finite sets
+------------------------------------------------------------------------
+
+-- This example of a "view of a function via its graph relation" is inspired
+-- by Nathan van Doorn's recent PR#1913.
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Fin.Relation.Ternary.Pinch where
+
+open import Data.Fin.Base using (Fin; zero; suc; toℕ; _≤_; _<_; pinch)
+open import Data.Fin.Properties using (suc-injective)
+open import Data.Nat.Base as Nat using (ℕ; zero; suc; z≤n; s≤s; z<s; s<s; ∣_-_∣)
+open import Data.Nat.Properties using (≤-refl; <⇒≤; ∣n-n∣≡0)
+open import Function.Base using (id; _∘_)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
+
+------------------------------------------------------------------------
+-- The View, considered as a ternary relation
+
+data View : ∀ {n} (i : Fin n) (j : Fin (suc n)) (k : Fin n) → Set where
+
+  any-zero : ∀ {n} (i : Fin (suc n))             → View i zero zero
+  zero-suc : ∀ {n} (j : Fin (suc n))             → View zero (suc j) j
+  suc-suc  : ∀ {n} {i} {j} {k} → View {n} i j k → View (suc i) (suc j) (suc k)
+
+-- The View is sound, ie covers all telescopes (satisfying the always-true precondition)
+
+view : ∀ {n} i j → View {n} i j (pinch i j)
+view {suc _} i zero    = any-zero i
+view   zero    (suc j) = zero-suc j
+view   (suc i) (suc j) = suc-suc (view i j)
+
+-- The View is complete
+
+view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → k ≡ pinch i j
+view-complete (any-zero i) = refl
+view-complete (zero-suc j) = refl
+view-complete (suc-suc v)  = cong suc (view-complete v)
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+{- pinch-mono≤ -}
+j≤k⇒view-j≤view-k : ∀ {n} {i} {j k} {p q} → View {n} i j p → View {n} i k q →
+                     j ≤ k → p ≤ q
+j≤k⇒view-j≤view-k (any-zero _) _            _         = z≤n
+j≤k⇒view-j≤view-k (zero-suc _) (zero-suc _) (s≤s j≤k) = j≤k
+j≤k⇒view-j≤view-k (suc-suc v)  (suc-suc w)  (s≤s j≤k) = s≤s (j≤k⇒view-j≤view-k v w j≤k)
+
+pinch-mono≤ : ∀ {n} (i : Fin n) {j k} →
+                j ≤ k → pinch i j ≤ pinch i k
+pinch-mono≤ i {j} {k} = j≤k⇒view-j≤view-k (view i j) (view i k)
+
+{- pinch-cancel< -}
+view-j<view-k⇒j<k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                     p < q → j < k
+view-j<view-k⇒j<k (any-zero _) (zero-suc _) _         = z<s
+view-j<view-k⇒j<k (any-zero _) (suc-suc _)  _         = z<s
+view-j<view-k⇒j<k (zero-suc _) (zero-suc _) p<q       = s<s p<q
+view-j<view-k⇒j<k (suc-suc v)  (suc-suc w)  (s<s p<q) = s<s (view-j<view-k⇒j<k v w p<q)
+
+pinch-cancel< : ∀ {n} (i : Fin (suc n)) {j k} →
+                  (pinch i j < pinch i k) → j < k
+pinch-cancel< i {j} {k} = view-j<view-k⇒j<k (view i j) (view i k)
+
+{- pinch-cancel≡ -}
+view-j≡view-k⇒∣j-k∣≤1 : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                        p ≡ q → ∣ (toℕ j) - (toℕ k)∣ Nat.≤ 1
+view-j≡view-k⇒∣j-k∣≤1 v w refl = helper v w
+  where
+    helper : ∀ {n} {i j k} {r} → View {n} i j r → View {n} i k r →
+             ∣ (toℕ j) - (toℕ k) ∣ Nat.≤ 1
+    helper (any-zero _)    (any-zero _)    = z≤n
+    helper (any-zero zero) (zero-suc zero) = ≤-refl
+    helper (zero-suc zero) (any-zero zero) = ≤-refl
+    helper (zero-suc j)    (zero-suc j) rewrite ∣n-n∣≡0 (toℕ j) = z≤n
+    helper (suc-suc v)     (suc-suc w) = helper v w
+
+pinch-cancel≡ : ∀ {n} (i : Fin n) {j k} →
+                (pinch i j ≡ pinch i k) → ∣ (toℕ j) - (toℕ k) ∣ Nat.≤ 1
+pinch-cancel≡ i {j} {k} = view-j≡view-k⇒∣j-k∣≤1 (view i j) (view i k)
+

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The 'punchOut view' of the function `punchOut` defined on finite sets
+-- The '`Pinch` view' of the function `pinch` defined on finite sets
 ------------------------------------------------------------------------
 
 -- This example of a "view of a function via its graph relation" is inspired

--- a/src/Data/Fin/Relation/Ternary/Pinch.agda
+++ b/src/Data/Fin/Relation/Ternary/Pinch.agda
@@ -9,7 +9,7 @@
 -- precisely mirrored in the constructors of the view type,
 -- ie that we 'view the function via its graph relation'
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module Data.Fin.Relation.Ternary.Pinch where
 

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The 'punchOut view' of the function `punchOut` defined on finite sets
+-- The '`PunchIn` view' of the function `punchIn` defined on finite sets
 ------------------------------------------------------------------------
 
 -- This example of a "view of a function via its graph relation" is inspired

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -31,7 +31,16 @@ private
 -- function definition; recursive calls are represented by inductive premises
 
 data View : ∀ {n} (i : Fin (suc n)) (j : Fin n) (k : Fin (suc n)) → Set where
+{-
 
+-- `punchIn` is the function f(i,j) = if j≥i then j+1 else j
+
+punchIn : Fin (suc n) → Fin n → Fin (suc n)
+punchIn zero    j       = suc j
+punchIn (suc i) zero    = zero
+punchIn (suc i) (suc j) = suc (punchIn i j)
+
+-}
   zero-suc : ∀ {n} (j : Fin n)                   → View zero j (suc j)
   suc-zero : ∀ {n} (i : Fin (suc n))             → View (suc i) zero zero
   suc-suc  : ∀ {n} {i} {j} {k} → View {n} i j k → View (suc i) (suc j) (suc k)

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -9,7 +9,7 @@
 -- precisely mirrored in the constructors of the view type,
 -- ie that we 'view the function via its graph relation'
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module Data.Fin.Relation.Ternary.PunchIn where
 

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -50,7 +50,7 @@ view (suc i) (suc j) = suc-suc (view i j)
 
 -- The View is complete
 
-view-complete : ∀ {i j} {k} (v : View {n} i j k) → k ≡ punchIn i j
+view-complete : ∀ {i j} {k} (v : View {n} i j k) → punchIn i j ≡ k
 view-complete (zero-suc j) = refl
 view-complete (suc-zero i) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -17,6 +17,11 @@ open import Data.Nat.Base using (ℕ; zero; suc; z≤n; s≤s)
 open import Function.Base using (id; _∘_)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
 
+private
+  variable
+    n : ℕ
+
+
 ------------------------------------------------------------------------
 -- The View, considered as a ternary relation
 
@@ -28,48 +33,46 @@ data View : ∀ {n} (i : Fin (suc n)) (j : Fin n) (k : Fin (suc n)) → Set wher
 
 -- The View enforces the codomain postcondition
 
-Codomain : ∀ {n} (i : Fin (suc n)) (j : Fin n) → Set
+Codomain : ∀ (i : Fin (suc n)) (j : Fin n) → Set
 Codomain i j = punchIn i j ≢ i
 
-view-codomain : ∀ {n} {i} {j} {k} → View {n} i j k → Codomain i j
+view-codomain : ∀ {i} {j} {k} → View {n} i j k → Codomain i j
 view-codomain (suc-suc v) = (view-codomain v) ∘ suc-injective
 
 -- The View is sound, ie covers all telescopes (satisfying the always-true precondition)
 
-view : ∀ {n} i j → View {n} i j (punchIn i j)
+view : ∀ i j → View {n} i j (punchIn i j)
 view zero         j  = zero-suc j
 view (suc i) zero    = suc-zero i
 view (suc i) (suc j) = suc-suc (view i j)
 
 -- The View is complete
 
-view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → k ≡ punchIn i j
+view-complete : ∀ {i j} {k} (v : View {n} i j k) → k ≡ punchIn i j
 view-complete (zero-suc j) = refl
 view-complete (suc-zero i) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)
 
 ------------------------------------------------------------------------
--- Properties of the function, derived from properties of the View
+-- Properties of the View
 
-{- punchIn-mono≤ -}
-j≤k⇒view-j≤view-k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
-                     j ≤ k → p ≤ q
-j≤k⇒view-j≤view-k (zero-suc _) (zero-suc _)  j≤k     = s≤s j≤k
-j≤k⇒view-j≤view-k (suc-zero i) _             _       = z≤n
-j≤k⇒view-j≤view-k (suc-suc v)  (suc-suc w) (s≤s j≤k) = s≤s (j≤k⇒view-j≤view-k v w j≤k)
+view-injective : ∀ {i j k} {p q} →
+                 View {n} i j p → View {n} i k q → p ≡ q → j ≡ k
+view-injective v w refl = aux v w where
+  aux : ∀ {i j k} {r} → View {n} i j r → View {n} i k r → j ≡ k
+  aux (zero-suc _) (zero-suc _) = refl
+  aux (suc-zero i) (suc-zero i) = refl
+  aux (suc-suc v) (suc-suc w)   = cong suc (aux v w)
 
-punchIn-mono≤ : ∀ {n} (i : Fin (suc n)) {j k} →
-                j ≤ k → punchIn i j ≤ punchIn i k
-punchIn-mono≤ i {j} {k} = j≤k⇒view-j≤view-k (view i j) (view i k)
+view-mono-≤ : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+              j ≤ k → p ≤ q
+view-mono-≤ (zero-suc _) (zero-suc _)  j≤k     = s≤s j≤k
+view-mono-≤ (suc-zero i) _             _       = z≤n
+view-mono-≤ (suc-suc v)  (suc-suc w) (s≤s j≤k) = s≤s (view-mono-≤ v w j≤k)
 
-{- punchIn-cancel≤ -}
-view-j≤view-k⇒j≤k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
-                     p ≤ q → j ≤ k
-view-j≤view-k⇒j≤k (zero-suc _) (zero-suc _) (s≤s p≤q) = p≤q
-view-j≤view-k⇒j≤k (suc-zero i) _            _         = z≤n
-view-j≤view-k⇒j≤k (suc-suc v)  (suc-suc w)  (s≤s p≤q) = s≤s (view-j≤view-k⇒j≤k v w p≤q)
-
-punchIn-cancel≤ : ∀ {n} (i : Fin (suc n)) {j k} →
-                  (punchIn i j ≤ punchIn i k) → j ≤ k
-punchIn-cancel≤ i {j} {k} = view-j≤view-k⇒j≤k (view i j) (view i k)
+view-cancel-≤ : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+                p ≤ q → j ≤ k
+view-cancel-≤ (zero-suc _) (zero-suc _) (s≤s p≤q) = p≤q
+view-cancel-≤ (suc-zero i) _            _         = z≤n
+view-cancel-≤ (suc-suc v)  (suc-suc w)  (s≤s p≤q) = s≤s (view-cancel-≤ v w p≤q)
 

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -27,6 +27,9 @@ private
 ------------------------------------------------------------------------
 -- The View, considered as a ternary relation
 
+-- Each constructor corresponds to a particular call-pattern in the original
+-- function definition; recursive calls are represented by inductive premises
+
 data View : ∀ {n} (i : Fin (suc n)) (j : Fin n) (k : Fin (suc n)) → Set where
 
   zero-suc : ∀ {n} (j : Fin n)                   → View zero j (suc j)
@@ -43,14 +46,24 @@ view-codomain (suc-suc v) = (view-codomain v) ∘ suc-injective
 
 -- The View is sound, ie covers all telescopes (satisfying the always-true precondition)
 
+-- The recursion/pattern analysis of the original definition of `punchIn`
+-- (which is responsible for showing termination in the first place)
+-- is then exactly replicated in the definition of the covering function `view`;
+-- thus that definitional pattern analysis is encapsulated once and for all
+
 view : ∀ i j → View {n} i j (punchIn i j)
 view zero         j  = zero-suc j
 view (suc i) zero    = suc-zero i
 view (suc i) (suc j) = suc-suc (view i j)
 
+-- Interpretation of the view: the original function itself
+
+⟦_⟧ : ∀ {i} {j} {k} .(v : View {n} i j k) → Fin (suc n)
+⟦_⟧ {n = n} {i} {j} {k} _ = punchIn i j
+
 -- The View is complete
 
-view-complete : ∀ {i j} {k} (v : View {n} i j k) → punchIn i j ≡ k
+view-complete : ∀ {i j} {k} (v : View {n} i j k) → ⟦ v ⟧ ≡ k
 view-complete (zero-suc j) = refl
 view-complete (suc-zero i) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -3,9 +3,11 @@
 --
 -- The '`PunchIn` view' of the function `punchIn` defined on finite sets
 ------------------------------------------------------------------------
-
--- This example of a "view of a function via its graph relation" is inspired
--- by Nathan van Doorn's recent PR#1913.
+--
+-- This is an example of a view of a function defined over a datatype,
+-- such that the recursion and call-pattern(s) of the function are
+-- precisely mirrored in the constructors of the view type,
+-- ie that we 'view the function via its graph relation'
 
 {-# OPTIONS --without-K --safe #-}
 

--- a/src/Data/Fin/Relation/Ternary/PunchIn.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchIn.agda
@@ -1,0 +1,75 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The 'punchOut view' of the function `punchOut` defined on finite sets
+------------------------------------------------------------------------
+
+-- This example of a "view of a function via its graph relation" is inspired
+-- by Nathan van Doorn's recent PR#1913.
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Fin.Relation.Ternary.PunchIn where
+
+open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchIn)
+open import Data.Fin.Properties using (suc-injective)
+open import Data.Nat.Base using (ℕ; zero; suc; z≤n; s≤s)
+open import Function.Base using (id; _∘_)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
+
+------------------------------------------------------------------------
+-- The View, considered as a ternary relation
+
+data View : ∀ {n} (i : Fin (suc n)) (j : Fin n) (k : Fin (suc n)) → Set where
+
+  zero-suc : ∀ {n} (j : Fin n)                   → View zero j (suc j)
+  suc-zero : ∀ {n} (i : Fin (suc n))             → View (suc i) zero zero
+  suc-suc  : ∀ {n} {i} {j} {k} → View {n} i j k → View (suc i) (suc j) (suc k)
+
+-- The View enforces the codomain postcondition
+
+Codomain : ∀ {n} (i : Fin (suc n)) (j : Fin n) → Set
+Codomain i j = punchIn i j ≢ i
+
+view-codomain : ∀ {n} {i} {j} {k} → View {n} i j k → Codomain i j
+view-codomain (suc-suc v) = (view-codomain v) ∘ suc-injective
+
+-- The View is sound, ie covers all telescopes (satisfying the always-true precondition)
+
+view : ∀ {n} i j → View {n} i j (punchIn i j)
+view zero         j  = zero-suc j
+view (suc i) zero    = suc-zero i
+view (suc i) (suc j) = suc-suc (view i j)
+
+-- The View is complete
+
+view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → k ≡ punchIn i j
+view-complete (zero-suc j) = refl
+view-complete (suc-zero i) = refl
+view-complete (suc-suc v)  = cong suc (view-complete v)
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+{- punchIn-mono≤ -}
+j≤k⇒view-j≤view-k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                     j ≤ k → p ≤ q
+j≤k⇒view-j≤view-k (zero-suc _) (zero-suc _)  j≤k     = s≤s j≤k
+j≤k⇒view-j≤view-k (suc-zero i) _             _       = z≤n
+j≤k⇒view-j≤view-k (suc-suc v)  (suc-suc w) (s≤s j≤k) = s≤s (j≤k⇒view-j≤view-k v w j≤k)
+
+punchIn-mono≤ : ∀ {n} (i : Fin (suc n)) {j k} →
+                j ≤ k → punchIn i j ≤ punchIn i k
+punchIn-mono≤ i {j} {k} = j≤k⇒view-j≤view-k (view i j) (view i k)
+
+{- punchIn-cancel≤ -}
+view-j≤view-k⇒j≤k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                     p ≤ q → j ≤ k
+view-j≤view-k⇒j≤k (zero-suc _) (zero-suc _) (s≤s p≤q) = p≤q
+view-j≤view-k⇒j≤k (suc-zero i) _            _         = z≤n
+view-j≤view-k⇒j≤k (suc-suc v)  (suc-suc w)  (s≤s p≤q) = s≤s (view-j≤view-k⇒j≤k v w p≤q)
+
+punchIn-cancel≤ : ∀ {n} (i : Fin (suc n)) {j k} →
+                  (punchIn i j ≤ punchIn i k) → j ≤ k
+punchIn-cancel≤ i {j} {k} = view-j≤view-k⇒j≤k (view i j) (view i k)
+

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -1,10 +1,10 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The '`PunchOut` view' of the function `punchOut` defined on finite sets
+-- The '`PunchOut` view of the function `punchOut` defined on finite sets
 ------------------------------------------------------------------------
 
--- This example of a "view of a function via its graph relation" is inspired
+-- This example of a 'view of a function via its graph relation' is inspired
 -- by Nathan van Doorn's recent PR#1913.
 
 {-# OPTIONS --without-K --safe #-}
@@ -17,6 +17,11 @@ open import Data.Nat.Base using (ℕ; zero; suc; z≤n; s≤s)
 open import Function.Base using (_∘_)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
 
+private
+  variable
+    n : ℕ
+
+
 ------------------------------------------------------------------------
 -- The View, considered as a ternary relation
 
@@ -28,10 +33,10 @@ data View : ∀ {n} (i j : Fin (suc n)) (k : Fin n) → Set where
 
 -- The View enforces the precondition given by a Domain predicate
 
-Domain : ∀ {n} (i j : Fin (suc n)) → Set
+Domain : ∀ (i j : Fin (suc n)) → Set
 Domain i j = i ≢ j
 
-view-domain : ∀ {n} {i j} {k} → View {n} i j k → Domain i j
+view-domain : ∀ {i j} {k} → View {n} i j k → Domain i j
 view-domain (suc-suc v) = (view-domain v) ∘ suc-injective
 
 -- The View is sound, ie covers all telescopes satisfying that precondition
@@ -44,7 +49,7 @@ view {n = suc _} {i = suc i} {j = suc j} d = suc-suc (view (d ∘ (cong suc)))
 
 -- The View is complete
 
-view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → k ≡ punchOut (view-domain v)
+view-complete : ∀ {i j} {k} (v : View {n} i j k) → k ≡ punchOut (view-domain v)
 view-complete (zero-suc j) = refl
 view-complete (suc-zero i) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)
@@ -52,25 +57,15 @@ view-complete (suc-suc v)  = cong suc (view-complete v)
 ------------------------------------------------------------------------
 -- Properties of the function, derived from properties of the View
 
-{- punchOut-mono≤ -}
-j≤k⇒view-j≤view-k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
-                     j ≤ k → p ≤ q
-j≤k⇒view-j≤view-k (zero-suc j) (zero-suc k)  (s≤s j≤k) = j≤k
-j≤k⇒view-j≤view-k (suc-zero i) _             _         = z≤n
-j≤k⇒view-j≤view-k (suc-suc vj) (suc-suc vk)  (s≤s j≤k) = s≤s (j≤k⇒view-j≤view-k vj vk j≤k)
+view-mono-≤ : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+              j ≤ k → p ≤ q
+view-mono-≤ (zero-suc j) (zero-suc k)  (s≤s j≤k) = j≤k
+view-mono-≤ (suc-zero i) _             _         = z≤n
+view-mono-≤ (suc-suc vj) (suc-suc vk)  (s≤s j≤k) = s≤s (view-mono-≤ vj vk j≤k)
 
-punchOut-mono≤ : ∀ {n} {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
-                 j ≤ k → punchOut i≢j ≤ punchOut i≢k
-punchOut-mono≤ i≢j i≢k = j≤k⇒view-j≤view-k (view i≢j) (view i≢k)
-
-{- punchOut-cancel≤ -}
-view-j≤view-k⇒j≤k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
-                     p ≤ q → j ≤ k
-view-j≤view-k⇒j≤k (zero-suc j) (zero-suc k)  p≤q       = s≤s p≤q
-view-j≤view-k⇒j≤k (suc-zero i) _             _         = z≤n
-view-j≤view-k⇒j≤k (suc-suc vj) (suc-suc vk)  (s≤s p≤q) = s≤s (view-j≤view-k⇒j≤k vj vk p≤q)
-
-punchOut-cancel≤ : ∀ {n} {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
-                   (p≤q : punchOut i≢j ≤ punchOut i≢k) →  j ≤ k
-punchOut-cancel≤ i≢j i≢k = view-j≤view-k⇒j≤k (view i≢j) (view i≢k)
+view-cancel-≤ : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+                p ≤ q → j ≤ k
+view-cancel-≤ (zero-suc j) (zero-suc k)  p≤q       = s≤s p≤q
+view-cancel-≤ (suc-zero i) _             _         = z≤n
+view-cancel-≤ (suc-suc vj) (suc-suc vk)  (s≤s p≤q) = s≤s (view-cancel-≤ vj vk p≤q)
 

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The 'punchOut view' of the function `punchOut` defined on finite sets
+-- The '`PunchOut` view' of the function `punchOut` defined on finite sets
 ------------------------------------------------------------------------
 
 -- This example of a "view of a function via its graph relation" is inspired

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -28,6 +28,9 @@ private
 ------------------------------------------------------------------------
 -- The View, considered as a ternary relation
 
+-- Each constructor corresponds to a particular call-pattern in the original
+-- function definition; recursive calls are represented by inductive premises
+
 data View : ∀ {n} (i j : Fin (suc n)) (k : Fin n) → Set where
 
   zero-suc : ∀ {n} (j : Fin n)                   → View zero (suc j) j
@@ -44,15 +47,25 @@ view-domain (suc-suc v) = (view-domain v) ∘ suc-injective
 
 -- The View is sound, ie covers all telescopes satisfying that precondition
 
+-- The recursion/pattern analysis of the original definition of `punchOut`
+-- (which is responsible for showing termination in the first place)
+-- is then exactly replicated in the definition of the covering function `view`;
+-- thus that definitional pattern analysis is encapsulated once and for all
+
 view : ∀ {n} {i j} (d : Domain i j) → View {n} i j (punchOut d)
 view             {i = zero}  {j = zero}  d with () ← d refl
 view             {i = zero}  {j = suc j} d = zero-suc j
 view {n = suc _} {i = suc i} {j = zero}  d = suc-zero i
 view {n = suc _} {i = suc i} {j = suc j} d = suc-suc (view (d ∘ (cong suc)))
 
+-- Interpretation of the view: the original function itself
+
+⟦_⟧ : ∀ {i j} {k} (v : View {n} i j k) → Fin n
+⟦ v ⟧ = punchOut (view-domain v)
+
 -- The View is complete
 
-view-complete : ∀ {i j} {k} (v : View {n} i j k) → punchOut (view-domain v) ≡ k
+view-complete : ∀ {i j} {k} (v : View {n} i j k) → ⟦ v ⟧ ≡ k
 view-complete (zero-suc j) = refl
 view-complete (suc-zero i) = refl
 view-complete (suc-suc v)  = cong suc (view-complete v)

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -9,7 +9,7 @@
 -- precisely mirrored in the constructors of the view type,
 -- ie that we 'view the function via its graph relation'
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --cubical-compatible --safe #-}
 
 module Data.Fin.Relation.Ternary.PunchOut where
 

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -32,7 +32,17 @@ private
 -- function definition; recursive calls are represented by inductive premises
 
 data View : ∀ {n} (i j : Fin (suc n)) (k : Fin n) → Set where
+{-
 
+-- `punchOut` is the function f(i,j) = if j>i then j-1 else j
+
+punchOut : ∀ {i j : Fin (suc n)} → i ≢ j → Fin n
+punchOut {_}     {zero}   {zero}  i≢j = ⊥-elim (i≢j refl)
+punchOut {_}     {zero}   {suc j} _   = j
+punchOut {suc _} {suc i}  {zero}  _   = zero
+punchOut {suc _} {suc i}  {suc j} i≢j = suc (punchOut (i≢j ∘ cong suc))
+
+-}
   zero-suc : ∀ {n} (j : Fin n)                   → View zero (suc j) j
   suc-zero : ∀ {n} (i : Fin (suc n))             → View (suc i) zero zero
   suc-suc  : ∀ {n} {i} {j} {k} → View {n} i j k → View (suc i) (suc j) (suc k)
@@ -73,16 +83,16 @@ view-complete (suc-suc v)  = cong suc (view-complete v)
 ------------------------------------------------------------------------
 -- Properties of the function, derived from properties of the View
 
-view-cong : ∀ {i j k} {p q} →
-                 View {n} i j p → View {n} i k q → j ≡ k → p ≡ q
+view-cong : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+            j ≡ k → p ≡ q
 view-cong v w refl = aux v w where
   aux : ∀ {i j} {p q} → View {n} i j p → View {n} i j q → p ≡ q
   aux (zero-suc _) (zero-suc _) = refl
   aux (suc-zero i) (suc-zero i) = refl
   aux (suc-suc v)  (suc-suc w)  = cong suc (aux v w)
 
-view-injective : ∀ {i j k} {p q} →
-                 View {n} i j p → View {n} i k q → p ≡ q → j ≡ k
+view-injective : ∀ {i j k} {p q} → View {n} i j p → View {n} i k q →
+                 p ≡ q → j ≡ k
 view-injective v w refl = aux v w where
   aux : ∀ {i j k} {r} → View {n} i j r → View {n} i k r → j ≡ k
   aux (zero-suc _) (zero-suc _) = refl

--- a/src/Data/Fin/Relation/Ternary/PunchOut.agda
+++ b/src/Data/Fin/Relation/Ternary/PunchOut.agda
@@ -1,0 +1,76 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The 'punchOut view' of the function `punchOut` defined on finite sets
+------------------------------------------------------------------------
+
+-- This example of a "view of a function via its graph relation" is inspired
+-- by Nathan van Doorn's recent PR#1913.
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.Fin.Relation.Ternary.PunchOut where
+
+open import Data.Fin.Base using (Fin; zero; suc; _≤_; punchOut)
+open import Data.Fin.Properties using (suc-injective)
+open import Data.Nat.Base using (ℕ; zero; suc; z≤n; s≤s)
+open import Function.Base using (_∘_)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
+
+------------------------------------------------------------------------
+-- The View, considered as a ternary relation
+
+data View : ∀ {n} (i j : Fin (suc n)) (k : Fin n) → Set where
+
+  zero-suc : ∀ {n} (j : Fin n)                   → View zero (suc j) j
+  suc-zero : ∀ {n} (i : Fin (suc n))             → View (suc i) zero zero
+  suc-suc  : ∀ {n} {i} {j} {k} → View {n} i j k → View (suc i) (suc j) (suc k)
+
+-- The View enforces the precondition given by a Domain predicate
+
+Domain : ∀ {n} (i j : Fin (suc n)) → Set
+Domain i j = i ≢ j
+
+view-domain : ∀ {n} {i j} {k} → View {n} i j k → Domain i j
+view-domain (suc-suc v) = (view-domain v) ∘ suc-injective
+
+-- The View is sound, ie covers all telescopes satisfying that precondition
+
+view : ∀ {n} {i j} (d : Domain i j) → View {n} i j (punchOut d)
+view             {i = zero}  {j = zero}  d with () ← d refl
+view             {i = zero}  {j = suc j} d = zero-suc j
+view {n = suc _} {i = suc i} {j = zero}  d = suc-zero i
+view {n = suc _} {i = suc i} {j = suc j} d = suc-suc (view (d ∘ (cong suc)))
+
+-- The View is complete
+
+view-complete : ∀ {n} {i j} {k} (v : View {n} i j k) → k ≡ punchOut (view-domain v)
+view-complete (zero-suc j) = refl
+view-complete (suc-zero i) = refl
+view-complete (suc-suc v)  = cong suc (view-complete v)
+
+------------------------------------------------------------------------
+-- Properties of the function, derived from properties of the View
+
+{- punchOut-mono≤ -}
+j≤k⇒view-j≤view-k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                     j ≤ k → p ≤ q
+j≤k⇒view-j≤view-k (zero-suc j) (zero-suc k)  (s≤s j≤k) = j≤k
+j≤k⇒view-j≤view-k (suc-zero i) _             _         = z≤n
+j≤k⇒view-j≤view-k (suc-suc vj) (suc-suc vk)  (s≤s j≤k) = s≤s (j≤k⇒view-j≤view-k vj vk j≤k)
+
+punchOut-mono≤ : ∀ {n} {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
+                 j ≤ k → punchOut i≢j ≤ punchOut i≢k
+punchOut-mono≤ i≢j i≢k = j≤k⇒view-j≤view-k (view i≢j) (view i≢k)
+
+{- punchOut-cancel≤ -}
+view-j≤view-k⇒j≤k : ∀ {n} {i j k} {p q} → View {n} i j p → View {n} i k q →
+                     p ≤ q → j ≤ k
+view-j≤view-k⇒j≤k (zero-suc j) (zero-suc k)  p≤q       = s≤s p≤q
+view-j≤view-k⇒j≤k (suc-zero i) _             _         = z≤n
+view-j≤view-k⇒j≤k (suc-suc vj) (suc-suc vk)  (s≤s p≤q) = s≤s (view-j≤view-k⇒j≤k vj vk p≤q)
+
+punchOut-cancel≤ : ∀ {n} {i j k : Fin (suc n)} (i≢j : i ≢ j) (i≢k : i ≢ k) →
+                   (p≤q : punchOut i≢j ≤ punchOut i≢k) →  j ≤ k
+punchOut-cancel≤ i≢j i≢k = view-j≤view-k⇒j≤k (view i≢j) (view i≢k)
+


### PR DESCRIPTION
Currently lodged in `Data.Fin.Relation.Ternary`, but if I were to add more of these (see also PR #1901), I'd be strongly tempted to have a separate category, rather than something (of potentially arbitrary arity) under `Relation.*`... I'd suggest under `View.*`. Thoughts welcome. 

This is an obvious duplicate/competitor to PR #1913 but founded on a slightly different basis. 

No `CHANGELOG` at this stage: for discussion only. 