### PR TITLE
Wellfounded proof for vec lexicographic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2239,7 +2239,13 @@ Other minor changes
 * Added new proofs in `Data.Vec.Relation.Binary.Lex.Strict`:
   ```agda
   xs≮[] : ∀ {n} (xs : Vec A n) → ¬ xs < []
-  ```
+  <-respectsˡ : IsPartialEquivalence _≈_ → _≺_ Respectsˡ _≈_ →
+                ∀ {m n} → _Respectsˡ_ (_<_ {m} {n}) _≋_
+  <-respectsʳ : IsPartialEquivalence _≈_ → _≺_ Respectsʳ _≈_ →
+                ∀ {m n} → _Respectsʳ_ (_<_ {m} {n}) _≋_
+  <-wellFounded : Symmetric _≈_ →  Transitive _≈_ → _≺_ Respectsʳ _≈_ → WellFounded _≺_ → 
+                  ∀ {n} → WellFounded (_<_ {n})
+```
 
 * Added new functions in `Data.Vec.Relation.Unary.Any`:
   ```

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -26,7 +26,7 @@ open import Induction.WellFounded
 open import Relation.Nullary using (yes; no; ¬_)
 open import Relation.Binary
 open import Relation.Binary.Consequences
-open import Relation.Binary.Construct.On as On using ()
+open import Relation.Binary.Construct.On as On using (wellFounded)
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Level using (Level; _⊔_)
 
@@ -133,9 +133,11 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
       where
         f : Vec A (suc n) → A × Vec A n
         f (x ∷ xs) = x , xs
+
         foo : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on f) xs ys
         foo {x ∷ xs} {y ∷ ys} (this x<y _) = inj₁ x<y
         foo {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
+
         bar : WellFounded (×-Lex _≈_ _≺_ _<_ on f)
         bar = On.wellFounded f (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
 

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -18,7 +18,7 @@ open import Data.Nat.Base using (ℕ; suc)
 open import Data.Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Product.Relation.Binary.Lex.Strict
 open import Data.Sum.Base using (inj₁; inj₂)
-open import Data.Vec.Base using (Vec; []; _∷_)
+open import Data.Vec.Base using (Vec; []; _∷_; uncons)
 open import Data.Vec.Relation.Binary.Pointwise.Inductive as Pointwise
   using (Pointwise; []; _∷_; head; tail)
 open import Function.Base using (id; _on_; _∘_)
@@ -131,15 +131,12 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
     <-wellFounded {0}     [] = acc λ ys ys<[] → ⊥-elim (xs≮[] ys ys<[])
     <-wellFounded {suc n} xs = Subrelation.wellFounded foo bar xs
       where
-        f : Vec A (suc n) → A × Vec A n
-        f (x ∷ xs) = x , xs
-
-        foo : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on f) xs ys
+        foo : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on uncons) xs ys
         foo {x ∷ xs} {y ∷ ys} (this x<y _) = inj₁ x<y
         foo {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
 
-        bar : WellFounded (×-Lex _≈_ _≺_ _<_ on f)
-        bar = On.wellFounded f (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
+        bar : WellFounded (×-Lex _≈_ _≺_ _<_ on uncons)
+        bar = On.wellFounded uncons (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
 
 ----------------------------------------------------------------------
 -- Structures

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -14,16 +14,19 @@ module Data.Vec.Relation.Binary.Lex.Strict where
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Unit.Base using (⊤; tt)
 open import Data.Unit.Properties using (⊤-irrelevant)
-open import Data.Nat.Base using (ℕ)
-open import Data.Product using (proj₁; proj₂)
+open import Data.Nat.Base using (ℕ; suc)
+open import Data.Product using (_×_; _,_; proj₁; proj₂)
+open import Data.Product.Relation.Binary.Lex.Strict
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Data.Vec.Base using (Vec; []; _∷_)
 open import Data.Vec.Relation.Binary.Pointwise.Inductive as Pointwise
   using (Pointwise; []; _∷_; head; tail)
-open import Function.Base using (id; _∘_)
+open import Function.Base using (id; _on_; _∘_)
+open import Induction.WellFounded
 open import Relation.Nullary using (yes; no; ¬_)
 open import Relation.Binary
 open import Relation.Binary.Consequences
+open import Relation.Binary.Construct.On as On using ()
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
 open import Level using (Level; _⊔_)
 
@@ -105,6 +108,14 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
                 ∀ {m n} → Decidable (_<_ {m} {n})
   <-decidable = Core.decidable (no id)
 
+  <-respectsˡ : IsPartialEquivalence _≈_ → _≺_ Respectsˡ _≈_ →
+                ∀ {m n} → _Respectsˡ_ (_<_ {m} {n}) _≋_
+  <-respectsˡ = Core.respectsˡ
+
+  <-respectsʳ : IsPartialEquivalence _≈_ → _≺_ Respectsʳ _≈_ →
+                ∀ {m n} → _Respectsʳ_ (_<_ {m} {n}) _≋_
+  <-respectsʳ = Core.respectsʳ
+
   <-respects₂ : IsPartialEquivalence _≈_ → _≺_ Respects₂ _≈_ →
                 ∀ {n} → _Respects₂_ (_<_ {n} {n}) _≋_
   <-respects₂ = Core.respects₂
@@ -112,6 +123,21 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
   <-irrelevant : Irrelevant _≈_ → Irrelevant _≺_ → Irreflexive _≈_ _≺_ →
                  ∀ {m n} → Irrelevant (_<_ {m} {n})
   <-irrelevant = Core.irrelevant (λ ())
+
+  module _ (≈-sym : Symmetric _≈_) (≈-trans : Transitive _≈_) (≺-respʳ : _≺_ Respectsʳ _≈_ ) (≺-wf : WellFounded _≺_)
+    where
+
+    <-wellFounded : ∀ {n} → WellFounded (_<_ {n})
+    <-wellFounded {0}     [] = acc λ ys ys<[] → ⊥-elim (xs≮[] ys ys<[])
+    <-wellFounded {suc n} xs = Subrelation.wellFounded foo bar xs
+      where
+        f : Vec A (suc n) → A × Vec A n
+        f (x ∷ xs) = x , xs
+        foo : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on f) xs ys
+        foo {x ∷ xs} {y ∷ ys} (this x<y _) = inj₁ x<y
+        foo {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
+        bar : WellFounded (×-Lex _≈_ _≺_ _<_ on f)
+        bar = On.wellFounded f (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
 
 ----------------------------------------------------------------------
 -- Structures

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -129,14 +129,14 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
 
     <-wellFounded : ∀ {n} → WellFounded (_<_ {n})
     <-wellFounded {0}     [] = acc λ ys ys<[] → ⊥-elim (xs≮[] ys ys<[])
-    <-wellFounded {suc n} xs = Subrelation.wellFounded foo bar xs
+    <-wellFounded {suc n} xs = Subrelation.wellFounded <⇒uncons-Lex uncons-Lex-wellFounded xs
       where
-        foo : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on uncons) xs ys
-        foo {x ∷ xs} {y ∷ ys} (this x<y _) = inj₁ x<y
-        foo {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
+        <⇒uncons-Lex : {xs ys : Vec A (suc n)} → xs < ys → (×-Lex _≈_ _≺_ _<_ on uncons) xs ys
+        <⇒uncons-Lex {x ∷ xs} {y ∷ ys} (this x<y _) = inj₁ x<y
+        <⇒uncons-Lex {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
 
-        bar : WellFounded (×-Lex _≈_ _≺_ _<_ on uncons)
-        bar = On.wellFounded uncons (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
+        uncons-Lex-wellFounded : WellFounded (×-Lex _≈_ _≺_ _<_ on uncons)
+        uncons-Lex-wellFounded = On.wellFounded uncons (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
 
 ----------------------------------------------------------------------
 -- Structures


### PR DESCRIPTION
This is a draft as `foo` and `bar` are not very good names for helpers functions.

It will also close issue #1738