### PR TITLE
binomial lemmas for *-commuting elements in a `Semiring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1692,7 +1692,7 @@ Other minor changes
 
 * Added new proof to `Algebra.Properties.Monoid.Sum`:
   ```agda
-  sum-init : ∀ {n} (t : Vector _ (suc n)) → sum t ≈ sum (init t) + last t
+  sum-init-last : ∀ {n} (t : Vector _ (suc n)) → sum t ≈ sum (init t) + last t
   ```
 
 * Added new proofs to `Algebra.Properties.Semigroup`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1685,7 +1685,7 @@ Other minor changes
   middleSemimedial : ∀ x y z → (x ∙ y) ∙ (z ∙ x) ≈ (x ∙ z) ∙ (y ∙ x)
   semimedial : Semimedial _∙_
   ```
-* Added new proofs to `Algebra.Properties.Monoid`:
+* Added new proof to `Algebra.Properties.Monoid.Sum`:
   ```agda
   sum-init : ∀ {n} (t : Vector _ (suc n)) → sum t ≈ sum (init t) + last t
   ```
@@ -1701,6 +1701,13 @@ Other minor changes
 * Added new proof to `Algebra.Properties.Semiring.Exp`:
   ```agda
   y*x^m*y^n≈x^m*y^[n+1] : (x * y ≈ y * x) → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
+  ```
+
+* Added new proofs to `Algebra.Properties.Semiring.Mult`:
+  ```agda
+  1×-identityʳ : 1 × x ≈ x
+  ×-comm-*     : x * (n × y) ≈ n × (x * y)
+  ×-assoc-*    : (n × x) * y ≈ n × (x * y)
   ```
 
 * Added new proofs to `Algebra.Properties.Ring`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1694,6 +1694,11 @@ Other minor changes
   flexible : Flexible _∙_
   ```
 
+* Added new proof to `Algebra.Properties.Semiring.Exp`:
+  ```agda
+  y*x^m*y^n≈x^m*y^[n+1] : (x * y ≈ y * x) → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
+  ```
+
 * Added new proofs to `Algebra.Properties.Ring`:
   ```agda
   -1*x≈-x : ∀ x → - 1# * x ≈ - x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1685,6 +1685,10 @@ Other minor changes
   middleSemimedial : ∀ x y z → (x ∙ y) ∙ (z ∙ x) ≈ (x ∙ z) ∙ (y ∙ x)
   semimedial : Semimedial _∙_
   ```
+* Added new proofs to `Algebra.Properties.Monoid`:
+  ```agda
+  sum-init : ∀ {n} (t : Vector _ (suc n)) → sum t ≈ sum (init t) + last t
+  ```
 
 * Added new proofs to `Algebra.Properties.Semigroup`:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1685,6 +1685,11 @@ Other minor changes
   middleSemimedial : ∀ x y z → (x ∙ y) ∙ (z ∙ x) ≈ (x ∙ z) ∙ (y ∙ x)
   semimedial : Semimedial _∙_
   ```
+* Added new proof to `Algebra.Properties.Monoid.Mult`:
+  ```agda
+  ×-congˡ : ∀ {x} → (_× x) Preserves _≡_ ⟶ _≈_
+  ```
+
 * Added new proof to `Algebra.Properties.Monoid.Sum`:
   ```agda
   sum-init : ∀ {n} (t : Vector _ (suc n)) → sum t ≈ sum (init t) + last t
@@ -1698,16 +1703,17 @@ Other minor changes
   flexible : Flexible _∙_
   ```
 
-* Added new proof to `Algebra.Properties.Semiring.Exp`:
+* Added new proofs to `Algebra.Properties.Semiring.Exp`:
   ```agda
+  ^-congʳ               : (x ^_) Preserves _≡_ ⟶ _≈_
   y*x^m*y^n≈x^m*y^[n+1] : (x * y ≈ y * x) → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
   ```
 
 * Added new proofs to `Algebra.Properties.Semiring.Mult`:
   ```agda
   1×-identityʳ : 1 × x ≈ x
-  ×-comm-*     : x * (n × y) ≈ n × (x * y)
-  ×-assoc-*    : (n × x) * y ≈ n × (x * y)
+  ×-comm-*    : x * (n × y) ≈ n × (x * y)
+  ×-assoc-*   : (n × x) * y ≈ n × (x * y)
   ```
 
 * Added new proofs to `Algebra.Properties.Ring`:

--- a/src/Algebra/Properties/Monoid/Mult.agda
+++ b/src/Algebra/Properties/Monoid/Mult.agda
@@ -46,6 +46,9 @@ open import Algebra.Definitions.RawMonoid rawMonoid public
 ×-cong : _×_ Preserves₂ _≡_ ⟶ _≈_ ⟶ _≈_
 ×-cong {n} P.refl x≈x′ = ×-congʳ n x≈x′
 
+×-congˡ : ∀ {x} → (_× x) Preserves _≡_ ⟶ _≈_
+×-congˡ m≡n = ×-cong m≡n refl
+
 -- _×_ is homomorphic with respect to _ℕ+_/_+_.
 
 ×-homo-+ : ∀ x m n → (m ℕ.+ n) × x ≈ m × x + n × x

--- a/src/Algebra/Properties/Monoid/Sum.agda
+++ b/src/Algebra/Properties/Monoid/Sum.agda
@@ -31,6 +31,7 @@ open Monoid M
 open import Data.Vec.Functional.Relation.Binary.Equality.Setoid setoid
 open import Algebra.Properties.Monoid.Mult M
 open import Algebra.Definitions _≈_
+open import Relation.Binary.Reasoning.Setoid setoid
 
 ------------------------------------------------------------------------
 -- Definition
@@ -70,3 +71,21 @@ sum-replicate-idem idem n = trans (sum-replicate n) (×-idem idem n)
 sum-replicate-zero : ∀ n → sum {n} (replicate 0#) ≈ 0#
 sum-replicate-zero zero    = refl
 sum-replicate-zero (suc n) = sum-replicate-idem (+-identityˡ 0#) (suc n)
+
+------------------------------------------------------------------------
+-- When summing over a `Vector`, we can pull out last element
+
+sum-init : ∀ {n} (t : Vector Carrier (suc n)) → sum t ≈ sum (init t) + last t
+sum-init {zero} t  = begin
+  t₀ + 0# ≈⟨ +-identityʳ t₀ ⟩
+  t₀      ≈˘⟨ +-identityˡ t₀ ⟩
+  0# + t₀ ∎ where t₀ = t zero
+sum-init {suc n} t = begin
+  t₀ + ∑t             ≈⟨ +-congˡ (sum-init (tail t)) ⟩
+  t₀ + (∑t′ + tₗ)     ≈˘⟨ +-assoc _ _ _ ⟩
+  (t₀ + ∑t′) + tₗ     ∎
+  where
+    t₀ = head t
+    tₗ = last t
+    ∑t = sum (tail t)
+    ∑t′ = sum (tail (init t))

--- a/src/Algebra/Properties/Monoid/Sum.agda
+++ b/src/Algebra/Properties/Monoid/Sum.agda
@@ -72,16 +72,15 @@ sum-replicate-zero : ∀ n → sum {n} (replicate 0#) ≈ 0#
 sum-replicate-zero zero    = refl
 sum-replicate-zero (suc n) = sum-replicate-idem (+-identityˡ 0#) (suc n)
 
-------------------------------------------------------------------------
 -- When summing over a `Vector`, we can pull out last element
 
-sum-init : ∀ {n} (t : Vector Carrier (suc n)) → sum t ≈ sum (init t) + last t
-sum-init {zero} t  = begin
+sum-init-last : ∀ {n} (t : Vector Carrier (suc n)) → sum t ≈ sum (init t) + last t
+sum-init-last {zero} t  = begin
   t₀ + 0# ≈⟨ +-identityʳ t₀ ⟩
   t₀      ≈˘⟨ +-identityˡ t₀ ⟩
   0# + t₀ ∎ where t₀ = t zero
-sum-init {suc n} t = begin
-  t₀ + ∑t             ≈⟨ +-congˡ (sum-init (tail t)) ⟩
+sum-init-last {suc n} t = begin
+  t₀ + ∑t             ≈⟨ +-congˡ (sum-init-last (tail t)) ⟩
   t₀ + (∑t′ + tₗ)     ≈˘⟨ +-assoc _ _ _ ⟩
   (t₀ + ∑t′) + tₗ     ∎
   where

--- a/src/Algebra/Properties/Semiring/Exp.agda
+++ b/src/Algebra/Properties/Semiring/Exp.agda
@@ -48,23 +48,25 @@ open import Algebra.Definitions.RawSemiring rawSemiring public
 ------------------------------------------------------------------------
 -- A lemma using commutativity, needed for the Binomial Theorem
 
-module _ {x} {y} (x*y≈y*x : x * y ≈ y * x) where
-
-  y*x^m*y^n≈x^m*y^[n+1] : ∀ m n → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
-  y*x^m*y^n≈x^m*y^[n+1] zero    n = begin
-    y * (x ^ ℕ.zero * y ^ n)  ≡⟨⟩
-    y * (1# * y ^ n)           ≈⟨ *-congˡ (*-identityˡ (y ^ n)) ⟩
-    y * (y ^ n)                ≡⟨⟩
-    y ^ (suc n)                ≈˘⟨ *-identityˡ (y ^ suc n) ⟩
-    1# * y ^ (suc n)           ≡⟨⟩
-    x ^ ℕ.zero * y ^ (suc n)  ∎
-  y*x^m*y^n≈x^m*y^[n+1] (suc m) n = begin
-    y * (x ^ suc m * y ^ n)    ≡⟨⟩
-    y * ((x * x ^ m) * y ^ n)  ≈⟨ *-congˡ (*-assoc x (x ^ m) (y ^ n)) ⟩
-    y * (x * (x ^ m * y ^ n))  ≈˘⟨ *-assoc y x (x ^ m * y ^ n) ⟩
-    y * x * (x ^ m * y ^ n)    ≈˘⟨ *-congʳ {- here -} x*y≈y*x ⟩
-    x * y * (x ^ m * y ^ n)    ≈⟨ *-assoc x y _ ⟩
-    x * (y * (x ^ m * y ^ n))  ≈⟨ *-congˡ (y*x^m*y^n≈x^m*y^[n+1] m n) ⟩
-    x * (x ^ m * y ^ suc n)    ≈˘⟨ *-assoc x (x ^ m) (y ^ suc n) ⟩
-    (x * x ^ m) * y ^ suc n    ≡⟨⟩
-    x ^ suc m * y ^ suc n      ∎
+y*x^m*y^n≈x^m*y^[n+1] : ∀ {x} {y} (x*y≈y*x : x * y ≈ y * x) →
+                        ∀ m n → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
+y*x^m*y^n≈x^m*y^[n+1] {x} {y} x*y≈y*x = helper
+  where
+    helper : ∀ m n → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
+    helper zero    n = begin
+      y * (x ^ ℕ.zero * y ^ n)  ≡⟨⟩
+      y * (1# * y ^ n)          ≈⟨ *-congˡ (*-identityˡ (y ^ n)) ⟩
+      y * (y ^ n)               ≡⟨⟩
+      y ^ (suc n)               ≈˘⟨ *-identityˡ (y ^ suc n) ⟩
+      1# * y ^ (suc n)          ≡⟨⟩
+      x ^ ℕ.zero * y ^ (suc n)  ∎
+    helper (suc m) n = begin
+      y * (x ^ suc m * y ^ n)    ≡⟨⟩
+      y * ((x * x ^ m) * y ^ n)  ≈⟨ *-congˡ (*-assoc x (x ^ m) (y ^ n)) ⟩
+      y * (x * (x ^ m * y ^ n))  ≈˘⟨ *-assoc y x (x ^ m * y ^ n) ⟩
+      y * x * (x ^ m * y ^ n)    ≈˘⟨ *-congʳ x*y≈y*x ⟩
+      x * y * (x ^ m * y ^ n)    ≈⟨ *-assoc x y _ ⟩
+      x * (y * (x ^ m * y ^ n))  ≈⟨ *-congˡ (helper m n) ⟩
+      x * (x ^ m * y ^ suc n)    ≈˘⟨ *-assoc x (x ^ m) (y ^ suc n) ⟩
+      (x * x ^ m) * y ^ suc n    ≡⟨⟩
+      x ^ suc m * y ^ suc n      ∎

--- a/src/Algebra/Properties/Semiring/Exp.agda
+++ b/src/Algebra/Properties/Semiring/Exp.agda
@@ -41,3 +41,27 @@ open import Algebra.Definitions.RawSemiring rawSemiring public
 -- (xᵐ)ⁿ≈xᵐ*ⁿ
 ^-assocʳ : ∀ x m n → (x ^ m) ^ n ≈ x ^ (m ℕ.* n)
 ^-assocʳ x m n rewrite ℕ.*-comm m n = Mult.×-assocˡ x n m
+
+------------------------------------------------------------------------
+-- A lemma using commutativity, needed for the Binomial Theorem
+
+module _ {x} {y} (x*y≈y*x : x * y ≈ y * x) where
+
+  y*x^m*y^n≈x^m*y^[n+1] : ∀ m n → y * (x ^ m * y ^ n) ≈ x ^ m * y ^ suc n
+  y*x^m*y^n≈x^m*y^[n+1] zero    n = begin
+    y * (x ^ ℕ.zero * y ^ n)  ≡⟨⟩
+    y * (1# * y ^ n)           ≈⟨ *-congˡ (*-identityˡ (y ^ n)) ⟩
+    y * (y ^ n)                ≡⟨⟩
+    y ^ (suc n)                ≈˘⟨ *-identityˡ (y ^ suc n) ⟩
+    1# * y ^ (suc n)           ≡⟨⟩
+    x ^ ℕ.zero * y ^ (suc n)  ∎
+  y*x^m*y^n≈x^m*y^[n+1] (suc m) n = begin
+    y * (x ^ suc m * y ^ n)    ≡⟨⟩
+    y * ((x * x ^ m) * y ^ n)  ≈⟨ *-congˡ (*-assoc x (x ^ m) (y ^ n)) ⟩
+    y * (x * (x ^ m * y ^ n))  ≈˘⟨ *-assoc y x (x ^ m * y ^ n) ⟩
+    y * x * (x ^ m * y ^ n)    ≈˘⟨ *-congʳ {- here -} x*y≈y*x ⟩
+    x * y * (x ^ m * y ^ n)    ≈⟨ *-assoc x y _ ⟩
+    x * (y * (x ^ m * y ^ n))  ≈⟨ *-congˡ (y*x^m*y^n≈x^m*y^[n+1] m n) ⟩
+    x * (x ^ m * y ^ suc n)    ≈˘⟨ *-assoc x (x ^ m) (y ^ suc n) ⟩
+    (x * x ^ m) * y ^ suc n    ≡⟨⟩
+    x ^ suc m * y ^ suc n      ∎

--- a/src/Algebra/Properties/Semiring/Exp.agda
+++ b/src/Algebra/Properties/Semiring/Exp.agda
@@ -15,7 +15,7 @@ import Data.Nat.Properties as ℕ
 module Algebra.Properties.Semiring.Exp
   {a ℓ} (S : Semiring a ℓ) where
 
-open Semiring S renaming (zero to *-zero)
+open Semiring S
 open import Relation.Binary.Reasoning.Setoid setoid
 import Algebra.Properties.Monoid.Mult *-monoid as Mult
 
@@ -33,6 +33,9 @@ open import Algebra.Definitions.RawSemiring rawSemiring public
 
 ^-cong : _^_ Preserves₂ _≈_ ⟶ _≡_ ⟶ _≈_
 ^-cong x≈y u≡v = Mult.×-cong u≡v x≈y
+
+^-congʳ : ∀ x → (x ^_) Preserves _≡_ ⟶ _≈_
+^-congʳ x u≡v = ^-cong refl u≡v
 
 -- xᵐ⁺ⁿ ≈ xᵐxⁿ
 ^-homo-* : ∀ x m n → x ^ (m ℕ.+ n) ≈ (x ^ m) * (x ^ n)

--- a/src/Algebra/Properties/Semiring/Exp.agda
+++ b/src/Algebra/Properties/Semiring/Exp.agda
@@ -35,7 +35,7 @@ open import Algebra.Definitions.RawSemiring rawSemiring public
 ^-cong x≈y u≡v = Mult.×-cong u≡v x≈y
 
 ^-congʳ : ∀ x → (x ^_) Preserves _≡_ ⟶ _≈_
-^-congʳ x u≡v = ^-cong refl u≡v
+^-congʳ x = Mult.×-congˡ
 
 -- xᵐ⁺ⁿ ≈ xᵐxⁿ
 ^-homo-* : ∀ x m n → x ^ (m ℕ.+ n) ≈ (x ^ m) * (x ^ n)

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -33,3 +33,30 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
   n × 1# + (m × 1#) * (n × 1#)        ≈˘⟨ +-congʳ (*-identityˡ _) ⟩
   1# * (n × 1#) + (m × 1#) * (n × 1#) ≈˘⟨ distribʳ (n × 1#) 1# (m × 1#) ⟩
   (1# + m × 1#) * (n × 1#)            ∎
+
+-- (1 ×_) is the identity
+
+1×-identityʳ : ∀ x → 1 × x ≈ x
+1×-identityʳ = +-identityʳ
+
+-- (n ×_) commutes with _*_
+
+×-comm-* : ∀ n x y → x * (n × y) ≈ n × (x * y)
+×-comm-* zero    x y = zeroʳ x
+×-comm-* (suc n) x y = begin
+  x * (suc n × y)       ≡⟨⟩
+  x * (y + n × y)       ≈⟨ distribˡ _ _ _ ⟩
+  x * y + x * (n × y)   ≈⟨ +-congˡ (×-comm-* n _ _) ⟩
+  x * y + n × (x * y)   ≡⟨⟩
+  suc n × (x * y)       ∎
+
+-- (n ×_) associates with _*_
+
+×-assoc-* : ∀ n x y → (n × x) * y ≈ n × (x * y)
+×-assoc-* zero x y = zeroˡ y
+×-assoc-* (suc n) x y = begin
+  (suc n × x) * y       ≡⟨⟩
+  (x + n × x) * y       ≈⟨ distribʳ _ _ _ ⟩
+  x * y + (n × x) * y   ≈⟨ +-congˡ (×-assoc-* n _ _) ⟩
+  x * y + n × (x * y)   ≡⟨⟩
+  suc n × (x * y)       ∎


### PR DESCRIPTION
... on the way to a full proof of the Binomial Theorem PR #1287 / #1928 

Plus a proof of the `sumₜ-init` lemma of the old PR, updated, renamed, and moved to `Algebra.Properties.Monoid.Sum`. 

Plus the proofs of the lemmas concerning the `n ×_` operation in `Algebra.Properties.Semiring.Mult`. 

Plus proof of some useful cosmetic congruence lemmas in `Algebra.Properties.Monoid.Mult` and `Algebra.Properties.Semiring.Exp`