### PR TITLE
Monus `_∸_` is right adjoint to addition `_+_` across usual `_≤_` preorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2044,7 +2044,6 @@ Other minor changes
   <⇒<′ : m < n → m <′ n
   <′⇒< : m <′ n → m < n
 
-  m≤n⇒[1+m]∸n≡1+[m∸n] : m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
   m+n≤p⇒m≤p∸n         : m + n ≤ p → m ≤ p ∸ n
   m≤p∸n⇒m+n≤p         : n ≤ p → m ≤ p ∸ n → m + n ≤ p
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2044,6 +2044,10 @@ Other minor changes
   <⇒<′ : m < n → m <′ n
   <′⇒< : m <′ n → m < n
 
+  m≤n⇒[1+m]∸n≡1+[m∸n] : m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+  m+n≤p⇒m≤p∸n         : m + n ≤ p → m ≤ p ∸ n
+  m≤p∸n⇒m+n≤p         : n ≤ p → m ≤ p ∸ n → m + n ≤ p
+
   1≤n!    : 1 ≤ n !
   _!≢0    : NonZero (n !)
   _!*_!≢0 : NonZero (m ! * n !)

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -123,7 +123,7 @@ instance
 -- Arithmetic
 
 open import Agda.Builtin.Nat public
-  using (_+_; _*_) renaming (_-_ to _∸_)
+  using (_+_; _*_) renaming (_-_ to _∸_) 
 
 open import Agda.Builtin.Nat
   using (div-helper; mod-helper)

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -123,7 +123,7 @@ instance
 -- Arithmetic
 
 open import Agda.Builtin.Nat public
-  using (_+_; _*_) renaming (_-_ to _∸_) 
+  using (_+_; _*_) renaming (_-_ to _∸_)
 
 open import Agda.Builtin.Nat
   using (div-helper; mod-helper)

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1464,10 +1464,6 @@ n∸n≡0 : ∀ n → n ∸ n ≡ 0
 n∸n≡0 zero    = refl
 n∸n≡0 (suc n) = n∸n≡0 n
 
-m≤n⇒[1+m]∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                     = refl
-m≤n⇒[1+m]∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]∸n≡1+[m∸n] le = refl
-
 ------------------------------------------------------------------------
 -- Properties of _∸_ and pred
 
@@ -1479,15 +1475,6 @@ pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 
 ------------------------------------------------------------------------
 -- Properties of _∸_ and _≤_/_<_
-
-m+n≤o⇒m≤o∸n : ∀ m n o → m + n ≤ o → m ≤ o ∸ n
-m+n≤o⇒m≤o∸n zero    n o       le               = z≤n
-m+n≤o⇒m≤o∸n (suc m) n (suc o) (s≤s le)
-  rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤o⇒m≤o∸n m n o le)
-
-m≤o∸n⇒m+n≤o : ∀ m {n o} (n≤o : n ≤ o) → m ≤ o ∸ n → m + n ≤ o
-m≤o∸n⇒m+n≤o m         z≤n       le rewrite +-identityʳ m = le
-m≤o∸n⇒m+n≤o m {suc n} (s≤s n≤o) le rewrite +-suc m n = s≤s (m≤o∸n⇒m+n≤o m n≤o le)
 
 m∸n≤m : ∀ m n → m ∸ n ≤ m
 m∸n≤m n       zero    = ≤-refl
@@ -1585,6 +1572,15 @@ m≤n⇒n∸m≤n (s≤s m≤n) = m≤n⇒m≤1+n (m≤n⇒n∸m≤n m≤n)
   suc (m + n) ∸ suc o  ≡⟨⟩
   (m + n) ∸ o          ≡⟨ +-∸-assoc m o≤n ⟩
   m + (n ∸ o)          ∎
+
+m+n≤o⇒m≤o∸n : ∀ m n o → m + n ≤ o → m ≤ o ∸ n
+m+n≤o⇒m≤o∸n zero    n o       le       = z≤n
+m+n≤o⇒m≤o∸n (suc m) n (suc o) (s≤s le)
+  rewrite +-∸-assoc 1 (m+n≤o⇒n≤o m le) = s≤s (m+n≤o⇒m≤o∸n m n o le)
+
+m≤o∸n⇒m+n≤o : ∀ m {n o} (n≤o : n ≤ o) → m ≤ o ∸ n → m + n ≤ o
+m≤o∸n⇒m+n≤o m         z≤n       le rewrite +-identityʳ m = le
+m≤o∸n⇒m+n≤o m {suc n} (s≤s n≤o) le rewrite +-suc m n = s≤s (m≤o∸n⇒m+n≤o m n≤o le)
 
 m≤n+m∸n : ∀ m n → m ≤ n + (m ∸ n)
 m≤n+m∸n zero    n       = z≤n

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1465,7 +1465,7 @@ n∸n≡0 zero    = refl
 n∸n≡0 (suc n) = n∸n≡0 n
 
 m≤n⇒[1+m]∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                      = refl
+m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                     = refl
 m≤n⇒[1+m]∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]∸n≡1+[m∸n] le = refl
 
 ------------------------------------------------------------------------
@@ -1481,7 +1481,7 @@ pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 -- Properties of _∸_ and _≤_/_<_
 
 m+n≤p⇒m≤p∸n : ∀ m n p → m + n ≤ p → m ≤ p ∸ n
-m+n≤p⇒m≤p∸n zero    n p       le                 = z≤n
+m+n≤p⇒m≤p∸n zero    n p       le               = z≤n
 m+n≤p⇒m≤p∸n (suc m) n (suc p) (s≤s le)
   rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
 

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1464,6 +1464,10 @@ n∸n≡0 : ∀ n → n ∸ n ≡ 0
 n∸n≡0 zero    = refl
 n∸n≡0 (suc n) = n∸n≡0 n
 
+m≤n⇒[1+m]∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                      = refl
+m≤n⇒[1+m]∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]∸n≡1+[m∸n] le = refl
+
 ------------------------------------------------------------------------
 -- Properties of _∸_ and pred
 
@@ -1472,17 +1476,6 @@ pred[m∸n]≡m∸[1+n] zero    zero    = refl
 pred[m∸n]≡m∸[1+n] (suc m) zero    = refl
 pred[m∸n]≡m∸[1+n] zero (suc n)    = refl
 pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
-
-------------------------------------------------------------------------
--- Properties of _∸_ and zero, suc
-
-0∸n≡n :  ∀ n → 0 ∸ n ≡ 0
-0∸n≡n zero    = refl
-0∸n≡n (suc _) = refl
-
-m≤n⇒[1+m]∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                       = refl
-m≤n⇒[1+m]∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]∸n≡1+[m∸n] le = refl
 
 ------------------------------------------------------------------------
 -- Properties of _∸_ and _≤_/_<_

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1474,11 +1474,15 @@ pred[m∸n]≡m∸[1+n] zero (suc n)    = refl
 pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 
 ------------------------------------------------------------------------
--- Properties of _∸_ and suc
+-- Properties of _∸_ and zero, suc
 
-m≤n⇒[1+m]m∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
-m≤n⇒[1+m]m∸n≡1+[m∸n] z≤n                                       = refl
-m≤n⇒[1+m]m∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]m∸n≡1+[m∸n] le = refl
+0∸n≡n :  ∀ n → 0 ∸ n ≡ 0
+0∸n≡n zero    = refl
+0∸n≡n (suc _) = refl
+
+m≤n⇒[1+m]∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+m≤n⇒[1+m]∸n≡1+[m∸n] z≤n                                       = refl
+m≤n⇒[1+m]∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]∸n≡1+[m∸n] le = refl
 
 ------------------------------------------------------------------------
 -- Properties of _∸_ and _≤_/_<_
@@ -1486,7 +1490,11 @@ m≤n⇒[1+m]m∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]m∸n≡1+[m∸n]
 m+n≤p⇒m≤p∸n : ∀ m n p → m + n ≤ p → m ≤ p ∸ n
 m+n≤p⇒m≤p∸n zero    n p       le                 = z≤n 
 m+n≤p⇒m≤p∸n (suc m) n (suc p) (s≤s le)
-  rewrite m≤n⇒[1+m]m∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
+  rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
+
+m≤p∸n⇒m+n≤p : ∀ m {n p} (n≤p : n ≤ p) → m ≤ p ∸ n → m + n ≤ p
+m≤p∸n⇒m+n≤p m         z≤n       le rewrite +-identityʳ m = le
+m≤p∸n⇒m+n≤p m {suc n} (s≤s n≤p) le rewrite +-suc m n = s≤s (m≤p∸n⇒m+n≤p m n≤p le)
 
 m∸n≤m : ∀ m n → m ∸ n ≤ m
 m∸n≤m n       zero    = ≤-refl

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1481,7 +1481,7 @@ pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 -- Properties of _∸_ and _≤_/_<_
 
 m+n≤p⇒m≤p∸n : ∀ m n p → m + n ≤ p → m ≤ p ∸ n
-m+n≤p⇒m≤p∸n zero    n p       le                 = z≤n 
+m+n≤p⇒m≤p∸n zero    n p       le                 = z≤n
 m+n≤p⇒m≤p∸n (suc m) n (suc p) (s≤s le)
   rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
 

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1474,7 +1474,19 @@ pred[m∸n]≡m∸[1+n] zero (suc n)    = refl
 pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 
 ------------------------------------------------------------------------
+-- Properties of _∸_ and suc
+
+m≤n⇒[1+m]m∸n≡1+[m∸n] : ∀ {m n} → m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
+m≤n⇒[1+m]m∸n≡1+[m∸n] z≤n                                       = refl
+m≤n⇒[1+m]m∸n≡1+[m∸n] (s≤s le) rewrite m≤n⇒[1+m]m∸n≡1+[m∸n] le = refl
+
+------------------------------------------------------------------------
 -- Properties of _∸_ and _≤_/_<_
+
+m+n≤p⇒m≤p∸n : ∀ m n p → m + n ≤ p → m ≤ p ∸ n
+m+n≤p⇒m≤p∸n zero    n p       le                 = z≤n 
+m+n≤p⇒m≤p∸n (suc m) n (suc p) (s≤s le)
+  rewrite m≤n⇒[1+m]m∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
 
 m∸n≤m : ∀ m n → m ∸ n ≤ m
 m∸n≤m n       zero    = ≤-refl

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -1480,14 +1480,14 @@ pred[m∸n]≡m∸[1+n] (suc m) (suc n) = pred[m∸n]≡m∸[1+n] m n
 ------------------------------------------------------------------------
 -- Properties of _∸_ and _≤_/_<_
 
-m+n≤p⇒m≤p∸n : ∀ m n p → m + n ≤ p → m ≤ p ∸ n
-m+n≤p⇒m≤p∸n zero    n p       le               = z≤n
-m+n≤p⇒m≤p∸n (suc m) n (suc p) (s≤s le)
-  rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤p⇒m≤p∸n m n p le)
+m+n≤o⇒m≤o∸n : ∀ m n o → m + n ≤ o → m ≤ o ∸ n
+m+n≤o⇒m≤o∸n zero    n o       le               = z≤n
+m+n≤o⇒m≤o∸n (suc m) n (suc o) (s≤s le)
+  rewrite m≤n⇒[1+m]∸n≡1+[m∸n] (m+n≤o⇒n≤o m le) = s≤s (m+n≤o⇒m≤o∸n m n o le)
 
-m≤p∸n⇒m+n≤p : ∀ m {n p} (n≤p : n ≤ p) → m ≤ p ∸ n → m + n ≤ p
-m≤p∸n⇒m+n≤p m         z≤n       le rewrite +-identityʳ m = le
-m≤p∸n⇒m+n≤p m {suc n} (s≤s n≤p) le rewrite +-suc m n = s≤s (m≤p∸n⇒m+n≤p m n≤p le)
+m≤o∸n⇒m+n≤o : ∀ m {n o} (n≤o : n ≤ o) → m ≤ o ∸ n → m + n ≤ o
+m≤o∸n⇒m+n≤o m         z≤n       le rewrite +-identityʳ m = le
+m≤o∸n⇒m+n≤o m {suc n} (s≤s n≤o) le rewrite +-suc m n = s≤s (m≤o∸n⇒m+n≤o m n≤o le)
 
 m∸n≤m : ∀ m n → m ∸ n ≤ m
 m∸n≤m n       zero    = ≤-refl


### PR DESCRIPTION
Surprised that these properties are not already there; they *may* induce downstream a number of simplification to proofs of properties of monus. But not for this PR!

Separately, in view of the right->left direction of the adjunction: monus is defined as a *total* function `_-_` in `Agda.Builtin.Nat`, and reimported as `_∸_`... why don't we define an alternative function `n ∸ m` only on those arguments satisfying `m ≤ n` (by an easy recursion on the inductive definition of that relation; alternatively with an irrelevant instance argument of that type, and then simply definitionally equal to `Agda.Builtin.Nat._-_`) and then prove the two definitions extensionally equal? The fact that `_-_`  has certain properties provable outright, without further ordering assumptions here or there, seems moot: the only ones which matter are those restricted to the partial domain... but our library setup doesn't typically take account for that. A case of strict(er) specification, but (more) permissive implementation?