### PR TITLE
middle four exchange law in a `Setoid`: definition and consequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1603,6 +1603,15 @@ Other minor changes
 
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
+  cong+comm+assoc⇒middleFour : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →
+                                _•_ MiddleFourExchange _•_
+  cong+identity+middleFour⇒assoc : Congruent₂ _•_ → Identity e _•_ →
+                                    _•_ MiddleFourExchange _•_ →
+                                    Associative _•_
+  cong+identity+middleFour⇒comm : Congruent₂ _•_ → Identity e _+_ →
+                                   _•_ MiddleFourExchange _+_ →
+                                   Commutative _•_
+
   involutive⇒surjective  : Involutive f  → Surjective f
   selfInverse⇒involutive : SelfInverse f → Involutive f
   selfInverse⇒congruent  : SelfInverse f → Congruent f
@@ -1666,6 +1675,8 @@ Other minor changes
 
 * Added new definition to `Algebra.Definitions`:
   ```agda
+  _MiddleFourExchange_ : Op₂ A → Op₂ A → Set _
+
   SelfInverse : Op₁ A → Set _
   
   LeftDividesˡ  : Op₂ A → Op₂ A → Set _

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1603,24 +1603,25 @@ Other minor changes
 
 * Added new proofs to `Algebra.Consequences.Propositional`:
   ```agda
-  comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
-                           _•_ MiddleFourExchange _•_
+  comm+assoc⇒middleFour     : Commutative _•_ →
+                              Associative _•_ →
+                              _•_ MiddleFourExchange _•_
   identity+middleFour⇒assoc : Identity e _•_ →
-                               _•_ MiddleFourExchange _•_ →
-                               Associative _•_
-  identity+middleFour⇒comm : Identity e _+_ →
+                              _•_ MiddleFourExchange _•_ →
+                              Associative _•_
+  identity+middleFour⇒comm  : Identity e _+_ →
                               _•_ MiddleFourExchange _+_ →
                               Commutative _•_
   ```
 
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
-  comm+assoc⇒middleFour : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →
-                           _•_ MiddleFourExchange _•_
+  comm+assoc⇒middleFour     : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →
+                              _•_ MiddleFourExchange _•_
   identity+middleFour⇒assoc : Congruent₂ _•_ → Identity e _•_ →
-                               _•_ MiddleFourExchange _•_ →
-                               Associative _•_
-  identity+middleFour⇒comm : Congruent₂ _•_ → Identity e _+_ →
+                              _•_ MiddleFourExchange _•_ →
+                              Associative _•_
+  identity+middleFour⇒comm  : Congruent₂ _•_ → Identity e _+_ →
                               _•_ MiddleFourExchange _+_ →
                               Commutative _•_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1603,14 +1603,14 @@ Other minor changes
 
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
-  cong+comm+assoc⇒middleFour : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →
-                                _•_ MiddleFourExchange _•_
-  cong+identity+middleFour⇒assoc : Congruent₂ _•_ → Identity e _•_ →
-                                    _•_ MiddleFourExchange _•_ →
-                                    Associative _•_
-  cong+identity+middleFour⇒comm : Congruent₂ _•_ → Identity e _+_ →
-                                   _•_ MiddleFourExchange _+_ →
-                                   Commutative _•_
+  comm+assoc⇒middleFour : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →
+                           _•_ MiddleFourExchange _•_
+  identity+middleFour⇒assoc : Congruent₂ _•_ → Identity e _•_ →
+                               _•_ MiddleFourExchange _•_ →
+                               Associative _•_
+  identity+middleFour⇒comm : Congruent₂ _•_ → Identity e _+_ →
+                              _•_ MiddleFourExchange _+_ →
+                              Commutative _•_
 
   involutive⇒surjective  : Involutive f  → Surjective f
   selfInverse⇒involutive : SelfInverse f → Involutive f

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1601,6 +1601,18 @@ Other minor changes
                                      Involutive _≈_ f
   ```
 
+* Added new proofs to `Algebra.Consequences.Propositional`:
+  ```agda
+  comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
+                           _•_ MiddleFourExchange _•_
+  identity+middleFour⇒assoc : Identity e _•_ →
+                               _•_ MiddleFourExchange _•_ →
+                               Associative _•_
+  identity+middleFour⇒comm : Identity e _+_ →
+                              _•_ MiddleFourExchange _+_ →
+                              Commutative _•_
+  ```
+
 * Added new proofs to `Algebra.Consequences.Setoid`:
   ```agda
   comm+assoc⇒middleFour : Congruent₂ _•_ → Commutative _•_ → Associative _•_ →

--- a/src/Algebra/Consequences/Propositional.agda
+++ b/src/Algebra/Consequences/Propositional.agda
@@ -24,7 +24,10 @@ import Algebra.Consequences.Setoid (setoid A) as Base
 
 open Base public
   hiding
-  ( assoc+distribʳ+idʳ+invʳ⇒zeˡ
+  ( cong+comm+assoc⇒middleFour
+  ; cong+identity+middleFour⇒assoc
+  ; cong+identity+middleFour⇒comm
+  ; assoc+distribʳ+idʳ+invʳ⇒zeˡ
   ; assoc+distribˡ+idʳ+invʳ⇒zeʳ
   ; assoc+id+invʳ⇒invˡ-unique
   ; assoc+id+invˡ⇒invʳ-unique
@@ -83,12 +86,26 @@ module _ {_•_ _◦_ : Op₂ A} (•-comm : Commutative _•_) where
   comm⇒sym[distribˡ] = Base.comm⇒sym[distribˡ] (cong₂ _◦_) •-comm
 
 ------------------------------------------------------------------------
--- Selectivity
+-- Selectivity and Middle-Four Exchange
 
 module _ {_•_ : Op₂ A} where
 
   sel⇒idem : Selective _•_ → Idempotent _•_
   sel⇒idem = Base.sel⇒idem _≡_
+
+  comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
+                           _•_ MiddleFourExchange _•_
+  comm+assoc⇒middleFour = Base.cong+comm+assoc⇒middleFour (cong₂ _•_)
+
+  identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
+                               _•_ MiddleFourExchange _•_ →
+                               Associative _•_
+  identity+middleFour⇒assoc = Base.cong+identity+middleFour⇒assoc (cong₂ _•_)
+
+  identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
+                              _•_ MiddleFourExchange _+_ →
+                              Commutative _•_
+  identity+middleFour⇒comm = Base.cong+identity+middleFour⇒comm (cong₂ _•_)
 
 ------------------------------------------------------------------------
 -- Without Loss of Generality

--- a/src/Algebra/Consequences/Propositional.agda
+++ b/src/Algebra/Consequences/Propositional.agda
@@ -99,17 +99,17 @@ module _ {_•_ : Op₂ A} where
 module _ {_•_ : Op₂ A} where
 
   comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
-                           _•_ MiddleFourExchange _•_
+                          _•_ MiddleFourExchange _•_
   comm+assoc⇒middleFour = Base.comm+assoc⇒middleFour (cong₂ _•_)
 
   identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
-                               _•_ MiddleFourExchange _•_ →
-                               Associative _•_
+                              _•_ MiddleFourExchange _•_ →
+                              Associative _•_
   identity+middleFour⇒assoc = Base.identity+middleFour⇒assoc (cong₂ _•_)
 
   identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
-                              _•_ MiddleFourExchange _+_ →
-                              Commutative _•_
+                             _•_ MiddleFourExchange _+_ →
+                             Commutative _•_
   identity+middleFour⇒comm = Base.identity+middleFour⇒comm (cong₂ _•_)
 
 ------------------------------------------------------------------------

--- a/src/Algebra/Consequences/Propositional.agda
+++ b/src/Algebra/Consequences/Propositional.agda
@@ -24,9 +24,9 @@ import Algebra.Consequences.Setoid (setoid A) as Base
 
 open Base public
   hiding
-  ( cong+comm+assoc⇒middleFour
-  ; cong+identity+middleFour⇒assoc
-  ; cong+identity+middleFour⇒comm
+  ( comm+assoc⇒middleFour
+  ; identity+middleFour⇒assoc
+  ; identity+middleFour⇒comm
   ; assoc+distribʳ+idʳ+invʳ⇒zeˡ
   ; assoc+distribˡ+idʳ+invʳ⇒zeʳ
   ; assoc+id+invʳ⇒invˡ-unique
@@ -95,17 +95,17 @@ module _ {_•_ : Op₂ A} where
 
   comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
                            _•_ MiddleFourExchange _•_
-  comm+assoc⇒middleFour = Base.cong+comm+assoc⇒middleFour (cong₂ _•_)
+  comm+assoc⇒middleFour = Base.comm+assoc⇒middleFour (cong₂ _•_)
 
   identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
                                _•_ MiddleFourExchange _•_ →
                                Associative _•_
-  identity+middleFour⇒assoc = Base.cong+identity+middleFour⇒assoc (cong₂ _•_)
+  identity+middleFour⇒assoc = Base.identity+middleFour⇒assoc (cong₂ _•_)
 
   identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
                               _•_ MiddleFourExchange _+_ →
                               Commutative _•_
-  identity+middleFour⇒comm = Base.cong+identity+middleFour⇒comm (cong₂ _•_)
+  identity+middleFour⇒comm = Base.identity+middleFour⇒comm (cong₂ _•_)
 
 ------------------------------------------------------------------------
 -- Without Loss of Generality

--- a/src/Algebra/Consequences/Propositional.agda
+++ b/src/Algebra/Consequences/Propositional.agda
@@ -86,12 +86,17 @@ module _ {_•_ _◦_ : Op₂ A} (•-comm : Commutative _•_) where
   comm⇒sym[distribˡ] = Base.comm⇒sym[distribˡ] (cong₂ _◦_) •-comm
 
 ------------------------------------------------------------------------
--- Selectivity and Middle-Four Exchange
+-- Selectivity
 
 module _ {_•_ : Op₂ A} where
 
   sel⇒idem : Selective _•_ → Idempotent _•_
   sel⇒idem = Base.sel⇒idem _≡_
+
+------------------------------------------------------------------------
+-- Middle-Four Exchange
+
+module _ {_•_ : Op₂ A} where
 
   comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
                            _•_ MiddleFourExchange _•_

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -51,7 +51,7 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     (x • y) • z       ≈⟨ cong refl (sym (identityˡ z)) ⟩
     (x • y) • (e • z) ≈⟨ middleFour x y e z ⟩
     (x • e) • (y • z) ≈⟨ cong (identityʳ x) refl ⟩
-    x • (y • z) ∎
+    x • (y • z)       ∎
 
   identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
                               _•_ MiddleFourExchange _+_ →

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -34,9 +34,9 @@ open import Algebra.Consequences.Base public
 
 module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
 
-  cong+comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
+  comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
                                 _•_ MiddleFourExchange _•_
-  cong+comm+assoc⇒middleFour comm assoc w x y z = begin
+  comm+assoc⇒middleFour comm assoc w x y z = begin
     (w • x) • (y • z) ≈⟨ assoc w x (y • z) ⟩
     w • (x • (y • z)) ≈⟨ cong refl (sym (assoc x y z)) ⟩
     w • ((x • y) • z) ≈⟨ cong refl (cong (comm x y) refl) ⟩
@@ -44,19 +44,19 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     w • (y • (x • z)) ≈⟨ sym (assoc w y (x • z)) ⟩
     (w • y) • (x • z) ∎
 
-  cong+identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
+  identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
                                     _•_ MiddleFourExchange _•_ →
                                     Associative _•_
-  cong+identity+middleFour⇒assoc {e} (identityˡ , identityʳ) middleFour x y z = begin
+  identity+middleFour⇒assoc {e} (identityˡ , identityʳ) middleFour x y z = begin
     (x • y) • z       ≈⟨ cong refl (sym (identityˡ z)) ⟩
     (x • y) • (e • z) ≈⟨ middleFour x y e z ⟩
     (x • e) • (y • z) ≈⟨ cong (identityʳ x) refl ⟩
     x • (y • z) ∎
 
-  cong+identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
+  identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
                                    _•_ MiddleFourExchange _+_ →
                                    Commutative _•_
-  cong+identity+middleFour⇒comm {_+_} {e} (identityˡ , identityʳ) middleFour x y
+  identity+middleFour⇒comm {_+_} {e} (identityˡ , identityʳ) middleFour x y
     = begin
     x • y             ≈⟨ sym (cong (identityˡ x) (identityʳ y)) ⟩
     (e + x) • (y + e) ≈⟨ middleFour e x y e ⟩

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -30,7 +30,7 @@ open import Relation.Unary using (Pred)
 open import Algebra.Consequences.Base public
 
 ------------------------------------------------------------------------
--- Congruence and MiddleFourExchange
+-- MiddleFourExchange
 
 module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
 

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -35,7 +35,7 @@ open import Algebra.Consequences.Base public
 module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
 
   comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
-                           _•_ MiddleFourExchange _•_
+                          _•_ MiddleFourExchange _•_
   comm+assoc⇒middleFour comm assoc w x y z = begin
     (w • x) • (y • z) ≈⟨ assoc w x (y • z) ⟩
     w • (x • (y • z)) ≈⟨ cong refl (sym (assoc x y z)) ⟩
@@ -45,8 +45,8 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     (w • y) • (x • z) ∎
 
   identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
-                               _•_ MiddleFourExchange _•_ →
-                               Associative _•_
+                              _•_ MiddleFourExchange _•_ →
+                              Associative _•_
   identity+middleFour⇒assoc {e} (identityˡ , identityʳ) middleFour x y z = begin
     (x • y) • z       ≈⟨ cong refl (sym (identityˡ z)) ⟩
     (x • y) • (e • z) ≈⟨ middleFour x y e z ⟩
@@ -54,8 +54,8 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     x • (y • z)       ∎
 
   identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
-                              _•_ MiddleFourExchange _+_ →
-                              Commutative _•_
+                             _•_ MiddleFourExchange _+_ →
+                             Commutative _•_
   identity+middleFour⇒comm {_+_} {e} (identityˡ , identityʳ) middleFour x y
     = begin
     x • y             ≈⟨ sym (cong (identityˡ x) (identityʳ y)) ⟩

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -30,6 +30,40 @@ open import Relation.Unary using (Pred)
 open import Algebra.Consequences.Base public
 
 ------------------------------------------------------------------------
+-- Congruence and MiddleFourExchange
+
+module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
+
+  cong+comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
+                                _•_ MiddleFourExchange _•_
+  cong+comm+assoc⇒middleFour comm assoc w x y z = begin
+    (w • x) • (y • z) ≈⟨ assoc w x (y • z) ⟩
+    w • (x • (y • z)) ≈⟨ cong refl (sym (assoc x y z)) ⟩
+    w • ((x • y) • z) ≈⟨ cong refl (cong (comm x y) refl) ⟩
+    w • ((y • x) • z) ≈⟨ cong refl (assoc y x z) ⟩
+    w • (y • (x • z)) ≈⟨ sym (assoc w y (x • z)) ⟩
+    (w • y) • (x • z) ∎
+
+  cong+identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
+                                    _•_ MiddleFourExchange _•_ →
+                                    Associative _•_
+  cong+identity+middleFour⇒assoc {e} (identityˡ , identityʳ) middleFour x y z = begin
+    (x • y) • z       ≈⟨ cong refl (sym (identityˡ z)) ⟩
+    (x • y) • (e • z) ≈⟨ middleFour x y e z ⟩
+    (x • e) • (y • z) ≈⟨ cong (identityʳ x) refl ⟩
+    x • (y • z) ∎
+
+  cong+identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
+                                   _•_ MiddleFourExchange _+_ →
+                                   Commutative _•_
+  cong+identity+middleFour⇒comm {_+_} {e} (identityˡ , identityʳ) middleFour x y
+    = begin
+    x • y             ≈⟨ sym (cong (identityˡ x) (identityʳ y)) ⟩
+    (e + x) • (y + e) ≈⟨ middleFour e x y e ⟩
+    (e + y) • (x + e) ≈⟨ cong (identityˡ y) (identityʳ x) ⟩
+    y • x             ∎
+
+------------------------------------------------------------------------
 -- Involutive/SelfInverse functions
 
 module _ {f : Op₁ A} (inv : Involutive f) where

--- a/src/Algebra/Consequences/Setoid.agda
+++ b/src/Algebra/Consequences/Setoid.agda
@@ -35,7 +35,7 @@ open import Algebra.Consequences.Base public
 module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
 
   comm+assoc⇒middleFour : Commutative _•_ → Associative _•_ →
-                                _•_ MiddleFourExchange _•_
+                           _•_ MiddleFourExchange _•_
   comm+assoc⇒middleFour comm assoc w x y z = begin
     (w • x) • (y • z) ≈⟨ assoc w x (y • z) ⟩
     w • (x • (y • z)) ≈⟨ cong refl (sym (assoc x y z)) ⟩
@@ -45,8 +45,8 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     (w • y) • (x • z) ∎
 
   identity+middleFour⇒assoc : {e : A} → Identity e _•_ →
-                                    _•_ MiddleFourExchange _•_ →
-                                    Associative _•_
+                               _•_ MiddleFourExchange _•_ →
+                               Associative _•_
   identity+middleFour⇒assoc {e} (identityˡ , identityʳ) middleFour x y z = begin
     (x • y) • z       ≈⟨ cong refl (sym (identityˡ z)) ⟩
     (x • y) • (e • z) ≈⟨ middleFour x y e z ⟩
@@ -54,8 +54,8 @@ module _ {_•_ : Op₂ A} (cong : Congruent₂ _•_) where
     x • (y • z) ∎
 
   identity+middleFour⇒comm : {_+_ : Op₂ A} {e : A} → Identity e _+_ →
-                                   _•_ MiddleFourExchange _+_ →
-                                   Commutative _•_
+                              _•_ MiddleFourExchange _+_ →
+                              Commutative _•_
   identity+middleFour⇒comm {_+_} {e} (identityˡ , identityʳ) middleFour x y
     = begin
     x • y             ≈⟨ sym (cong (identityˡ x) (identityʳ y)) ⟩

--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -108,6 +108,10 @@ _*_ DistributesOverʳ _+_ =
 _DistributesOver_ : Op₂ A → Op₂ A → Set _
 * DistributesOver + = (* DistributesOverˡ +) × (* DistributesOverʳ +)
 
+_MiddleFourExchange_ : Op₂ A → Op₂ A → Set _
+_*_ MiddleFourExchange _+_ = 
+  ∀ w x y z → ((w + x) * (y + z)) ≈ ((w + y) * (x + z))
+
 _IdempotentOn_ : Op₂ A → A → Set _
 _∙_ IdempotentOn x = (x ∙ x) ≈ x
 


### PR DESCRIPTION
```agda
_MiddleFourExchange_ : Op₂ A → Op₂ A → Set _
_*_ MiddleFourExchange _+_ =  ∀ w x y z → ((w + x) * (y + z)) ≈ ((w + y) * (x + z))
```

UPDATED: hmmm... naming conventions between `Algebra.Consequences.Setoid` and  `Algebra.Consequences.Propositional`: may wish to remove `cong+` prefixes? DONE.