### PR TITLE
Add citation file to repo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,8 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- name: "The Agda Community"
+title: "Agda Standard Library"
+version: 1.7.2
+date-released: 2023-2-1
+url: "https://github.com/agda/agda-stdlib"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,5 +4,5 @@ authors:
 - name: "The Agda Community"
 title: "Agda Standard Library"
 version: 1.7.2
-date-released: 2023-2-1
+date-released: 2023-02-01
 url: "https://github.com/agda/agda-stdlib"

--- a/notes/release-guide.txt
+++ b/notes/release-guide.txt
@@ -5,15 +5,13 @@ procedure should be followed:
 
 * Update `README.agda` by replacing 'development version' by 'version X.Y' in the title.
 
-* Update `README.md`
-
-* Update `agda-stdlib-utils.cabal` version to `X.Y`.
-
-* Update the version in standard-library.agda-lib to `X.Y`
-
-* Update `notes/installation-guide.txt`
-
-* Update `CHANGELOG.md`.
+* Update the version to `X.Y` in:
+  - `agda-stdlib-utils.cabal`
+  - `standard-library.agda-lib`
+  - `CITATION.cff`
+  - `CHANGELOG.md`
+  - `README.md`
+  - `notes/installation-guide.txt`
 
 * Update the copyright year range in the LICENSE file, if necessary.
 


### PR DESCRIPTION
Fixes #1952. Adds a `Cite this repository` button on the left hand side of the main Github page (as can be seen [here](https://github.com/agda/agda-stdlib/tree/citation)). Any comments by anyone?