### PR TITLE
Get rid of redundant deps in `System.Console.ANSI`

### DIFF
--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -109,7 +109,7 @@ _DistributesOver_ : Op₂ A → Op₂ A → Set _
 * DistributesOver + = (* DistributesOverˡ +) × (* DistributesOverʳ +)
 
 _MiddleFourExchange_ : Op₂ A → Op₂ A → Set _
-_*_ MiddleFourExchange _+_ = 
+_*_ MiddleFourExchange _+_ =
   ∀ w x y z → ((w + x) * (y + z)) ≈ ((w + y) * (x + z))
 
 _IdempotentOn_ : Op₂ A → A → Set _

--- a/src/Data/Nat/Show.agda
+++ b/src/Data/Nat/Show.agda
@@ -17,7 +17,7 @@ open import Data.Maybe.Base as Maybe using (Maybe; nothing; _<∣>_; when)
 import Data.Maybe.Effectful as Maybe
 open import Data.Nat
 open import Data.Product using (proj₁)
-open import Data.String.Base hiding (show)
+open import Data.String.Base using (toList; fromList; String)
 open import Function.Base
 open import Relation.Nullary.Decidable using (True)
 

--- a/src/Data/Nat/Show.agda
+++ b/src/Data/Nat/Show.agda
@@ -17,7 +17,7 @@ open import Data.Maybe.Base as Maybe using (Maybe; nothing; _<∣>_; when)
 import Data.Maybe.Effectful as Maybe
 open import Data.Nat
 open import Data.Product using (proj₁)
-open import Data.String as String using (String)
+open import Data.String.Base hiding (show)
 open import Function.Base
 open import Relation.Nullary.Decidable using (True)
 
@@ -28,7 +28,7 @@ readMaybe : ∀ base {base≤16 : True (base ≤? 16)} → String → Maybe ℕ
 readMaybe _ "" = nothing
 readMaybe base = Maybe.map convert
               ∘′ TraversableA.mapA Maybe.applicative readDigit
-              ∘′ String.toList
+              ∘′ toList
 
   where
 
@@ -62,7 +62,7 @@ toDecimalChars : ℕ → List Char
 toDecimalChars = List.map toDigitChar ∘′ toNatDigits 10
 
 show : ℕ → String
-show = String.fromList ∘ toDecimalChars
+show = fromList ∘ toDecimalChars
 
 -- Arbitrary base betwen 2 & 16.
 -- Warning: when compiled the time complexity of `showInBase b n` is
@@ -81,5 +81,5 @@ showInBase : (base : ℕ)
              {base≥2 : True (2 ≤? base)}
              {base≤16 : True (base ≤? 16)} →
              ℕ → String
-showInBase base {base≥2} {base≤16} = String.fromList
+showInBase base {base≥2} {base≤16} = fromList
                                    ∘ charsInBase base {base≥2} {base≤16}


### PR DESCRIPTION
Closes #1993

See https://github.com/agda/agda-stdlib/issues/1993#issuecomment-1595352224 and https://github.com/agda/agda-stdlib/issues/1993#issuecomment-1595356776

- redundant deps : `Function.HalfAdjointEquivalence`, `Data.Product.Function.Dependent.Propositional`
- replaced `Data.String` import with `Data.String.Base` in `Data.Nat.Show`

