### PR TITLE
gitignore `_build` correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 .*.swp
 .#*
 \#*
-./_build/*
+_build
 .DS_Store
 .vscode/*
 dist


### PR DESCRIPTION
The `_build` folder is not actually ignored by `git` right now (because of the initial `.`, I think), rather, most of the files inside the `_build` folder are ignored by the following patterns -

https://github.com/agda/agda-stdlib/blob/078d57f98d8c5934de7683e9c70b48b0c74cd678/.gitignore#L3-L6

These patterns are almost always sufficient (hence, the broken ignore was never detected) but cases like `graph.sh` generating a dot file in the `_build` directory breaks this and git ends up not ignoring the dot file.
