### PR TITLE
removed redundant `import`s from `Data.Bool.Base` in `Data.List.NonEmpty.Base`

### DIFF
--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -9,8 +9,7 @@
 module Data.List.NonEmpty.Base where
 
 open import Level using (Level)
-open import Data.Bool.Base using (Bool; false; true; not; T)
-open import Data.Bool.Properties using (T?)
+open import Data.Bool.Base using (Bool; false; true)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.Maybe.Base using (Maybe ; nothing; just)
 open import Data.Nat.Base as ℕ


### PR DESCRIPTION
No `CHANGELOG` required