### PR TITLE
ghc 9.8

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.4
+# version: 0.17.20230824
 #
-# REGENDATA ("0.16.4",["github","--no-cabal-check","agda-stdlib-utils.cabal"])
+# REGENDATA ("0.17.20230824",["github","--no-cabal-check","agda-stdlib-utils.cabal"])
 #
 name: Haskell-CI
 on:
@@ -44,14 +44,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.8.0.20230822
+            compilerKind: ghc
+            compilerVersion: 9.8.0.20230822
+            setup-method: ghcup
+            allow-failure: true
           - compiler: ghc-9.6.2
             compilerKind: ghc
             compilerVersion: 9.6.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.4.5
+          - compiler: ghc-9.4.6
             compilerKind: ghc
-            compilerVersion: 9.4.5
+            compilerVersion: 9.4.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.8
@@ -87,8 +92,9 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
@@ -96,8 +102,9 @@ jobs:
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.19.5/x86_64-linux-ghcup-0.1.19.5 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
+            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
@@ -112,10 +119,12 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
             echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
@@ -129,7 +138,7 @@ jobs:
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90800)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -158,6 +167,18 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
+          EOF
+          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -209,6 +230,9 @@ jobs:
           echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(agda-stdlib-utils)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/AllNonAsciiChars.hs
+++ b/AllNonAsciiChars.hs
@@ -4,7 +4,8 @@
 
 module Main where
 
-import qualified Data.List as L (sortBy, group, sort)
+import qualified Data.List as List (sortBy, sort)
+import qualified Data.List.NonEmpty as List1 (group, head)
 import Data.Char (isAscii, ord)
 import Data.Function (on)
 import Numeric (showHex)
@@ -27,9 +28,9 @@ main = do
   nonAsciiChars <-
     filter (not . isAscii) . T.unpack . T.concat <$> mapM readUTF8File agdaFiles
   let table :: [(Char, Int)]
-      table = L.sortBy (flip compare `on` snd) $
-              map (\cs -> (head cs, length cs)) $
-              L.group $ L.sort $ nonAsciiChars
+      table = List.sortBy (flip compare `on` snd) $
+              map (\cs -> (List1.head cs, length cs)) $
+              List1.group $ List.sort $ nonAsciiChars
 
   let codePoint :: Char -> T.Text
       codePoint c = T.pack $ showHex (ord c) ""

--- a/agda-stdlib-utils.cabal
+++ b/agda-stdlib-utils.cabal
@@ -6,8 +6,9 @@ description:     Helper programs for setting up the Agda standard library.
 license:         MIT
 
 tested-with:
+  GHC == 9.8.0
   GHC == 9.6.2
-  GHC == 9.4.5
+  GHC == 9.4.6
   GHC == 9.2.8
   GHC == 9.0.2
   GHC == 8.10.7
@@ -22,7 +23,7 @@ common common-build-parameters
     PatternSynonyms
 
   build-depends:
-      base          >= 4.12.0.0 && < 4.19
+      base          >= 4.12.0.0 && < 4.20
     , filemanip     >= 0.3.6.2  && < 0.4
 
 executable GenerateEverything
@@ -41,4 +42,4 @@ executable AllNonAsciiChars
   main-is:          AllNonAsciiChars.hs
 
   build-depends:
-      text          >= 1.2.3.1  && < 2.1
+      text          >= 1.2.3.1  && < 2.2

--- a/stack-9.4.5.yaml
+++ b/stack-9.4.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-21.0
+resolver: lts-21.7
 compiler: ghc-9.4.5
 compiler-check: match-exact
 

--- a/stack-9.6.2.yaml
+++ b/stack-9.6.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2023-06-23
+resolver: nightly-2023-08-27
 compiler: ghc-9.6.2
 compiler-check: match-exact
 


### PR DESCRIPTION
Build the agda-stdlib-utils with GHC 9.8.1 alpha3.
- agda-stdlib-utils/AllNonAsciiChars: use List1.head instead of List.head
- Bump resolvers in stack-{9.4.5,9.6.2}.yaml
- Bump Haskell CI to GHC 9.8.0 and 9.4.6; allow text-2.1
