### PR TITLE
addresses #2075: removes symmetry assumption from lexicographic well-foundedness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,6 +781,28 @@ Non-backwards compatible changes
   properties about the orderings themselves the second index must be provided
   explicitly.
 
+* Issue #2075 (Johannes Waldmann): wellfoundedness of the lexicographic ordering
+  on products, defined in `Data.Product.Relation.Binary.Lex.Strict`, no longer
+  requires the assumption of symmetry for the first equality relation `_≈₁_`,
+  and so the type of the auxiliary proof `×-wellFounded'` now reads:
+  ```agda
+  ×-wellFounded' : Transitive _≈₁_ →
+                   _<₁_ Respectsʳ _≈₁_ →
+                   WellFounded _<₁_ →
+                   WellFounded _<₂_ →
+                   WellFounded _<ₗₑₓ_
+  ```
+  leading to:
+  upstream requirement for a new lemma in `Induction.WellFounded` with weaker assumptions;
+  downstream consequence for `Data.Vec.Relation.Binary.Lex.Strict.<-wellFounded`,
+  with change of type to:
+  ```agda
+  <-wellFounded : (≈-trans : Transitive _≈_) →
+	          (≺-respʳ : _≺_ Respectsʳ _≈_ ) →
+	          (≺-wf : WellFounded _≺_) →
+                  ∀ {n} → WellFounded (_<_ {n})
+  ```
+
 * The operation `SymClosure` on relations in
   `Relation.Binary.Construct.Closure.Symmetric` has been reimplemented
   as a data type `SymClosure _⟶_ a b` that is parameterized by the
@@ -3352,6 +3374,11 @@ This is a full list of proofs that have changed form to use irrelevant instance 
   ```agda
   ⊆-mergeˡ : ∀ xs ys → xs ⊆ merge _≤?_ xs ys
   ⊆-mergeʳ : ∀ xs ys → ys ⊆ merge _≤?_ xs ys
+  ```
+
+* Added new proof to `Induction.WellFounded`
+  ```agda
+  Acc-resp-flip-≈ : _<_ Respectsʳ (flip _≈_) → (Acc _<_) Respects _≈_
   ```
 
 * Added new file `Relation.Binary.Reasoning.Base.Apartness`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -784,24 +784,8 @@ Non-backwards compatible changes
 * Issue #2075 (Johannes Waldmann): wellfoundedness of the lexicographic ordering
   on products, defined in `Data.Product.Relation.Binary.Lex.Strict`, no longer
   requires the assumption of symmetry for the first equality relation `_≈₁_`,
-  and so the type of the auxiliary proof `×-wellFounded'` now reads:
-  ```agda
-  ×-wellFounded' : Transitive _≈₁_ →
-                   _<₁_ Respectsʳ _≈₁_ →
-                   WellFounded _<₁_ →
-                   WellFounded _<₂_ →
-                   WellFounded _<ₗₑₓ_
-  ```
-  leading to:
-  upstream requirement for a new lemma in `Induction.WellFounded` with weaker assumptions;
-  downstream consequence for `Data.Vec.Relation.Binary.Lex.Strict.<-wellFounded`,
-  with change of type to:
-  ```agda
-  <-wellFounded : (≈-trans : Transitive _≈_) →
-	          (≺-respʳ : _≺_ Respectsʳ _≈_ ) →
-	          (≺-wf : WellFounded _≺_) →
-                  ∀ {n} → WellFounded (_<_ {n})
-  ```
+  leading to a new lemma `Induction.WellFounded.Acc-resp-flip-≈`, and refactoring
+  of the previous proof `Induction.WellFounded.Acc-resp-≈`.
 
 * The operation `SymClosure` on relations in
   `Relation.Binary.Construct.Closure.Symmetric` has been reimplemented
@@ -2535,13 +2519,13 @@ Other minor changes
   ×-≡,≡←≡ : p₁ ≡ p₂ → (proj₁ p₁ ≡ proj₁ p₂ × proj₂ p₁ ≡ proj₂ p₂)
   ```
 
-* Added new proof to `Data.Product.Relation.Binary.Lex.Strict`
+* Added new proofs to `Data.Product.Relation.Binary.Lex.Strict`
   ```agda
   ×-respectsʳ : Transitive _≈₁_ →
                 _<₁_ Respectsʳ _≈₁_ → _<₂_ Respectsʳ _≈₂_ → _<ₗₑₓ_ Respectsʳ _≋_
   ×-respectsˡ : Symmetric _≈₁_ → Transitive _≈₁_ →
                  _<₁_ Respectsˡ _≈₁_ → _<₂_ Respectsˡ _≈₂_ → _<ₗₑₓ_ Respectsˡ _≋_
-  ×-wellFounded' : Symmetric  _≈₁_ → Transitive _≈₁_ → _<₁_ Respectsʳ _≈₁_ →
+  ×-wellFounded' : Transitive _≈₁_ → _<₁_ Respectsʳ _≈₁_ →
                    WellFounded _<₁_ → WellFounded _<₂_ → WellFounded _<ₗₑₓ_
   ```
 
@@ -2706,7 +2690,7 @@ Other minor changes
                 ∀ {m n} → _Respectsˡ_ (_<_ {m} {n}) _≋_
   <-respectsʳ : IsPartialEquivalence _≈_ → _≺_ Respectsʳ _≈_ →
                 ∀ {m n} → _Respectsʳ_ (_<_ {m} {n}) _≋_
-  <-wellFounded : Symmetric _≈_ →  Transitive _≈_ → _≺_ Respectsʳ _≈_ → WellFounded _≺_ →
+  <-wellFounded : Transitive _≈_ → _≺_ Respectsʳ _≈_ → WellFounded _≺_ →
                   ∀ {n} → WellFounded (_<_ {n})
 ```
 

--- a/src/Data/Product/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Product/Relation/Binary/Lex/Strict.agda
@@ -22,7 +22,7 @@ open import Level
 open import Relation.Nullary.Decidable
 open import Relation.Binary
 open import Relation.Binary.Consequences
-open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_; refl)
+open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 
 private
   variable
@@ -198,10 +198,10 @@ module _ {_≈₁_ : Rel A ℓ₁} {_<₁_ : Rel A ℓ₂} {_<₂_ : Rel B ℓ�
             WfRec _<ₗₑₓ_ (Acc _<ₗₑₓ_) (x , y)
     ×-acc (acc rec₁) acc₂ (u , v) (inj₁ u<x)
       = acc (×-acc (rec₁ u u<x) (wf₂ v))
-    ×-acc {x₁} acc₁ (acc rec₂) (u , v) (inj₂ (u≈x , v<y))
+    ×-acc acc₁ (acc rec₂) (u , v) (inj₂ (u≈x , v<y))
       = Acc-resp-flip-≈
-        (×-respectsʳ {_<₁_ = _<₁_} {_<₂_ = _<₂_} trans resp  (≡.respʳ   _<₂_) )
-        (u≈x , _≡_.refl)
+        (×-respectsʳ {_<₁_ = _<₁_} {_<₂_ = _<₂_} trans resp (≡.respʳ _<₂_))
+        (u≈x , ≡.refl)
         (acc (×-acc acc₁ (rec₂ v v<y)))
 
 

--- a/src/Data/Product/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Product/Relation/Binary/Lex/Strict.agda
@@ -186,12 +186,12 @@ module _ {_≈₁_ : Rel A ℓ₁} {_<₁_ : Rel A ℓ₂} {_<₂_ : Rel B ℓ�
   private
     _<ₗₑₓ_ = ×-Lex _≈₁_ _<₁_ _<₂_
 
-  ×-wellFounded' : Symmetric _≈₁_ → Transitive _≈₁_ →
+  ×-wellFounded' : Transitive _≈₁_ →
                    _<₁_ Respectsʳ _≈₁_ →
                    WellFounded _<₁_ →
                    WellFounded _<₂_ →
                    WellFounded _<ₗₑₓ_
-  ×-wellFounded' sym trans resp wf₁ wf₂ (x , y) = acc (×-acc (wf₁ x) (wf₂ y))
+  ×-wellFounded' trans resp wf₁ wf₂ (x , y) = acc (×-acc (wf₁ x) (wf₂ y))
     where
     ×-acc : ∀ {x y} →
             Acc _<₁_ x → Acc _<₂_ y →
@@ -199,10 +199,11 @@ module _ {_≈₁_ : Rel A ℓ₁} {_<₁_ : Rel A ℓ₂} {_<₂_ : Rel B ℓ�
     ×-acc (acc rec₁) acc₂ (u , v) (inj₁ u<x)
       = acc (×-acc (rec₁ u u<x) (wf₂ v))
     ×-acc {x₁} acc₁ (acc rec₂) (u , v) (inj₂ (u≈x , v<y))
-      = Acc-resp-≈ (Pointwise.×-symmetric {_∼₁_ = _≈₁_} {_∼₂_ = _≡_ } sym ≡.sym)
-                   (×-respectsʳ {_<₁_ = _<₁_} {_<₂_ = _<₂_} trans resp (≡.respʳ _<₂_))
-                   (sym u≈x , _≡_.refl)
-                   (acc (×-acc acc₁ (rec₂ v v<y)))
+      = Acc-resp-flip-≈
+        (×-respectsʳ {_<₁_ = _<₁_} {_<₂_ = _<₂_} trans resp  (≡.respʳ   _<₂_) )
+        (u≈x , _≡_.refl)
+        (acc (×-acc acc₁ (rec₂ v v<y)))
+
 
 module _ {_<₁_ : Rel A ℓ₁} {_<₂_ : Rel B ℓ₂} where
 
@@ -212,7 +213,7 @@ module _ {_<₁_ : Rel A ℓ₁} {_<₂_ : Rel B ℓ₂} where
   ×-wellFounded : WellFounded _<₁_ →
                   WellFounded _<₂_ →
                   WellFounded _<ₗₑₓ_
-  ×-wellFounded = ×-wellFounded' ≡.sym ≡.trans (≡.respʳ _<₁_)
+  ×-wellFounded = ×-wellFounded' ≡.trans (≡.respʳ _<₁_)
 
 ------------------------------------------------------------------------
 -- Collections of properties which are preserved by ×-Lex.

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -124,7 +124,7 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
                  ∀ {m n} → Irrelevant (_<_ {m} {n})
   <-irrelevant = Core.irrelevant (λ ())
 
-  module _ (≈-sym : Symmetric _≈_) (≈-trans : Transitive _≈_) (≺-respʳ : _≺_ Respectsʳ _≈_ ) (≺-wf : WellFounded _≺_)
+  module _ (≈-trans : Transitive _≈_) (≺-respʳ : _≺_ Respectsʳ _≈_ ) (≺-wf : WellFounded _≺_)
     where
 
     <-wellFounded : ∀ {n} → WellFounded (_<_ {n})
@@ -136,7 +136,7 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
         <⇒uncons-Lex {x ∷ xs} {y ∷ ys} (next x≈y xs<ys) = inj₂ (x≈y , xs<ys)
 
         uncons-Lex-wellFounded : WellFounded (×-Lex _≈_ _≺_ _<_ on uncons)
-        uncons-Lex-wellFounded = On.wellFounded uncons (×-wellFounded' ≈-sym ≈-trans ≺-respʳ ≺-wf <-wellFounded)
+        uncons-Lex-wellFounded = On.wellFounded uncons (×-wellFounded' ≈-trans ≺-respʳ ≺-wf <-wellFounded)
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -9,7 +9,7 @@
 module Induction.WellFounded where
 
 open import Data.Product.Base using (Σ; _,_; proj₁)
-open import Function.Base using (_on_)
+open import Function.Base using (_∘_; flip; _on_)
 open import Induction
 open import Level using (Level; _⊔_)
 open import Relation.Binary.Core using (Rel)
@@ -54,10 +54,13 @@ acc-inverse : ∀ {_<_ : Rel A ℓ} {x : A} (q : Acc _<_ x) →
               (y : A) → y < x → Acc _<_ y
 acc-inverse (acc rs) y y<x = rs y y<x
 
-Acc-resp-≈ : {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} → Symmetric _≈_ →
-             _<_ Respectsʳ _≈_ → (Acc _<_) Respects _≈_
-Acc-resp-≈ sym respʳ x≈y (acc rec) =
-  acc (λ z z<y → rec z (respʳ (sym x≈y) z<y))
+module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
+
+  Acc-resp-flip-≈ : _<_ Respectsʳ (flip _≈_) → (Acc _<_) Respects _≈_
+  Acc-resp-flip-≈ respʳ x≈y (acc rec) = acc (λ z z<y → rec z (respʳ (x≈y) z<y))
+
+  Acc-resp-≈ : Symmetric _≈_ → _<_ Respectsʳ _≈_ → (Acc _<_) Respects _≈_
+  Acc-resp-≈ sym respʳ x≈y wf = Acc-resp-flip-≈ (respʳ ∘ sym) x≈y wf
 
 ------------------------------------------------------------------------
 -- Well-founded induction for the subset of accessible elements:

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -57,7 +57,7 @@ acc-inverse (acc rs) y y<x = rs y y<x
 module _ {_≈_ : Rel A ℓ₁} {_<_ : Rel A ℓ₂} where
 
   Acc-resp-flip-≈ : _<_ Respectsʳ (flip _≈_) → (Acc _<_) Respects _≈_
-  Acc-resp-flip-≈ respʳ x≈y (acc rec) = acc (λ z z<y → rec z (respʳ (x≈y) z<y))
+  Acc-resp-flip-≈ respʳ x≈y (acc rec) = acc λ z z<y → rec z (respʳ x≈y z<y)
 
   Acc-resp-≈ : Symmetric _≈_ → _<_ Respectsʳ _≈_ → (Acc _<_) Respects _≈_
   Acc-resp-≈ sym respʳ x≈y wf = Acc-resp-flip-≈ (respʳ ∘ sym) x≈y wf
@@ -123,7 +123,7 @@ module Subrelation {_<₁_ : Rel A ℓ₁} {_<₂_ : Rel A ℓ₂}
                    (<₁⇒<₂ : ∀ {x y} → x <₁ y → x <₂ y) where
 
   accessible : Acc _<₂_ ⊆ Acc _<₁_
-  accessible (acc rs) = acc (λ y y<x → accessible (rs y (<₁⇒<₂ y<x)))
+  accessible (acc rs) = acc λ y y<x → accessible (rs y (<₁⇒<₂ y<x))
 
   wellFounded : WellFounded _<₂_ → WellFounded _<₁_
   wellFounded wf = λ x → accessible (wf x)
@@ -134,7 +134,7 @@ module Subrelation {_<₁_ : Rel A ℓ₁} {_<₂_ : Rel A ℓ₂}
 module InverseImage {_<_ : Rel B ℓ} (f : A → B) where
 
   accessible : ∀ {x} → Acc _<_ (f x) → Acc (_<_ on f) x
-  accessible (acc rs) = acc (λ y fy<fx → accessible (rs (f y) fy<fx))
+  accessible (acc rs) = acc λ y fy<fx → accessible (rs (f y) fy<fx)
 
   wellFounded : WellFounded _<_ → WellFounded (_<_ on f)
   wellFounded wf = λ x → accessible (wf (f x))
@@ -161,7 +161,7 @@ module TransitiveClosure {A : Set a} (_<_ : Rel A ℓ) where
     trans : ∀ {x y z} (x<y : x <⁺ y) (y<z : y <⁺ z) → x <⁺ z
 
   downwardsClosed : ∀ {x y} → Acc _<⁺_ y → x <⁺ y → Acc _<⁺_ x
-  downwardsClosed (acc rs) x<y = acc (λ z z<x → rs z (trans z<x x<y))
+  downwardsClosed (acc rs) x<y = acc λ z z<x → rs z (trans z<x x<y)
 
   mutual
 


### PR DESCRIPTION
This addresses a minimal fragment of Johannes Waldmann's issue #2075 . There may be useful/desirable further consequences of this re-factoring, but they have not been pursued here. [UPDATED: but see also #2082 #2083 #2084]

This is NOT a breaking change, so there are no deprecation warnings, as changes are only to proofs added in the v2.0 development cycle...

No remaining knock-on consequences for `stdlib` dependent modules; external v2.0-compatible client code may break, but that will force the desired/desirable change to remove a redundant assumption at such call-sites.