### PR TITLE
`WellFounded` proofs for transitive closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2933,14 +2933,6 @@ Other minor changes
   ```
   accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
   wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
-  ```
-  as instances of the corresponding proofs in `Induction.WellFounded.Subrelation`,
-  together with a refactoring of the former proof
-  ```
-  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
-  ```
-  in terms of a new proof:
-  ```
   accessible : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2929,6 +2929,18 @@ Other minor changes
                     f Preserves₂ ≈₁ ⟶ ≈₁ ⟶ ≈₂
   ```
 
+* Added new proofs to `Relation.Binary.Construct.Closure.Transitive`:
+  ```
+  accessible⁺ : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
+  accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
+  wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
+  ```
+  together with a refactoring of the former proof
+  ```
+  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
+  ```
+  along these lines. 
+
 * Added new operations in `Relation.Binary.PropositionalEquality.Properties`:
   ```
   J       : (B : (y : A) → x ≡ y → Set b) (p : x ≡ y) → B x refl → B y p

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2931,15 +2931,18 @@ Other minor changes
 
 * Added new proofs to `Relation.Binary.Construct.Closure.Transitive`:
   ```
-  accessible⁺ : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
   accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
   wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
   ```
+  as instances of the corresponding proofs in `Induction.WellFounded.Subrelation`,
   together with a refactoring of the former proof
   ```
   wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
   ```
-  along these lines. 
+  in terms of a new proof:
+  ```
+  accessible : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
+  ```
 
 * Added new operations in `Relation.Binary.PropositionalEquality.Properties`:
   ```

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -71,10 +71,10 @@ module _ (_∼_ : Rel A ℓ) where
   transitive = _++_
 
   accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
-  accessible⁻ = accessible where open ∼⊆∼⁺
+  accessible⁻ = ∼⊆∼⁺.accessible
 
   wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
-  wellFounded⁻ = wellFounded where open ∼⊆∼⁺
+  wellFounded⁻ = ∼⊆∼⁺.wellFounded
 
   accessible : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
   accessible acc[x] = acc (wf-acc acc[x])

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -78,7 +78,7 @@ module _ (_∼_ : Rel A ℓ) where
 
   wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
   wellFounded wf x = accessible⁺ (wf x)
- 
+
   accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
   accessible⁻ acc[x] = acc (wf-acc⁻ acc[x])
     where

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -58,6 +58,7 @@ module _ {_∼_ : Rel A ℓ} where
 module _ (_∼_ : Rel A ℓ) where
   private
     _∼⁺_ = TransClosure _∼_
+    module ∼⊆∼⁺ = Subrelation {_<₂_ = _∼⁺_} [_]
 
   reflexive : Reflexive _∼_ → Reflexive _∼⁺_
   reflexive refl = [ refl ]
@@ -69,24 +70,21 @@ module _ (_∼_ : Rel A ℓ) where
   transitive : Transitive _∼⁺_
   transitive = _++_
 
-  accessible⁺ : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
-  accessible⁺ acc[x] = acc (wf-acc⁺ acc[x])
-    where
-    wf-acc⁺ : ∀ {x} → Acc _∼_ x → WfRec _∼⁺_ (Acc _∼⁺_) x
-    wf-acc⁺ (acc rec) _ [ y∼x ]   = acc (wf-acc⁺ (rec _ y∼x))
-    wf-acc⁺ acc[x] _ (y∼z ∷ z∼⁺x) = acc-inverse (wf-acc⁺ acc[x] _ z∼⁺x) _ [ y∼z ]
-
-  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
-  wellFounded wf x = accessible⁺ (wf x)
-
   accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
-  accessible⁻ acc[x] = acc (wf-acc⁻ acc[x])
-    where
-    wf-acc⁻ : ∀ {x} → Acc _∼⁺_ x → WfRec _∼_ (Acc _∼_) x
-    wf-acc⁻ (acc rec) _ y∼x = acc (wf-acc⁻ (rec _ [ y∼x ]))
+  accessible⁻ = accessible where open ∼⊆∼⁺
 
   wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
-  wellFounded⁻ wf x = accessible⁻ (wf x)
+  wellFounded⁻ = wellFounded where open ∼⊆∼⁺
+
+  accessible : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
+  accessible acc[x] = acc (wf-acc acc[x])
+    where
+    wf-acc : ∀ {x} → Acc _∼_ x → WfRec _∼⁺_ (Acc _∼⁺_) x
+    wf-acc (acc rec) _ [ y∼x ]   = acc (wf-acc (rec _ y∼x))
+    wf-acc acc[x] _ (y∼z ∷ z∼⁺x) = acc-inverse (wf-acc acc[x] _ z∼⁺x) _ [ y∼z ]
+
+  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
+  wellFounded wf x = accessible (wf x)
 
 
 ------------------------------------------------------------------------

--- a/src/Relation/Binary/Construct/Closure/Transitive.agda
+++ b/src/Relation/Binary/Construct/Closure/Transitive.agda
@@ -69,17 +69,24 @@ module _ (_∼_ : Rel A ℓ) where
   transitive : Transitive _∼⁺_
   transitive = _++_
 
-  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
-  wellFounded wf = λ x → acc (accessible′ (wf x))
+  accessible⁺ : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x
+  accessible⁺ acc[x] = acc (wf-acc⁺ acc[x])
     where
-    downwardsClosed : ∀ {x y} → Acc _∼⁺_ y → x ∼ y → Acc _∼⁺_ x
-    downwardsClosed (acc rec) x∼y = acc (λ z z∼x → rec z (z∼x ∷ʳ x∼y))
+    wf-acc⁺ : ∀ {x} → Acc _∼_ x → WfRec _∼⁺_ (Acc _∼⁺_) x
+    wf-acc⁺ (acc rec) _ [ y∼x ]   = acc (wf-acc⁺ (rec _ y∼x))
+    wf-acc⁺ acc[x] _ (y∼z ∷ z∼⁺x) = acc-inverse (wf-acc⁺ acc[x] _ z∼⁺x) _ [ y∼z ]
 
-    accessible′ : ∀ {x} → Acc _∼_ x → WfRec _∼⁺_ (Acc _∼⁺_) x
-    accessible′ (acc rec) y [ y∼x ]      = acc (accessible′ (rec y y∼x))
-    accessible′ acc[x]    y (y∼z ∷ z∼⁺x) =
-      downwardsClosed (accessible′ acc[x] _ z∼⁺x) y∼z
+  wellFounded : WellFounded _∼_ → WellFounded _∼⁺_
+  wellFounded wf x = accessible⁺ (wf x)
+ 
+  accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x
+  accessible⁻ acc[x] = acc (wf-acc⁻ acc[x])
+    where
+    wf-acc⁻ : ∀ {x} → Acc _∼⁺_ x → WfRec _∼_ (Acc _∼_) x
+    wf-acc⁻ (acc rec) _ y∼x = acc (wf-acc⁻ (rec _ [ y∼x ]))
 
+  wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_
+  wellFounded⁻ wf x = accessible⁻ (wf x)
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds the following new proofs [UPDATED]:
- [x] `accessible⁻ : ∀ {x} → Acc _∼⁺_ x → Acc _∼_ x`
- [x] `wellFounded⁻ : WellFounded _∼⁺_ → WellFounded _∼_`

which are instances of the corresponding proofs for ` module ∼⊆∼⁺ = Subrelation {_<₂_ = _∼⁺_} [_]`, together with
- [x] `accessible : ∀ {x} → Acc _∼_ x → Acc _∼⁺_ x`

which then permits refactoring the old proof `Relation.Binary.Construct.Closure.Transitive.wellFounded`, to streamline it using `accessible` (and removing unnecessary detours via the shadow reimplementation `downwardsClosed` of `Induction.WellFounded.acc-inverse`).

~~Possible candidate deprecation opportunity: to deprecate the old name in favour of `wellFounded⁺`, for the sake of uniformity of the above naming scheme, which is, of course, up for discussion/debate (an alternative uniformity might be to call `accessible⁺` simply `accessible`, for example)~~
