### PR TITLE
Adds `setoid` export to `Algebra.Bundles.SemiringWithoutOne` (possible solution to #1917)

### DIFF
--- a/src/Algebra/Bundles.agda
+++ b/src/Algebra/Bundles.agda
@@ -504,7 +504,7 @@ record SemiringWithoutOne c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open NearSemiring nearSemiring public
     using
-    ( _≉_; +-rawMagma; +-magma; +-unitalMagma; +-semigroup
+    ( +-rawMagma; +-magma; +-unitalMagma; +-semigroup
     ; +-rawMonoid; +-monoid
     ; *-rawMagma; *-magma; *-semigroup
     ; rawNearSemiring
@@ -542,7 +542,7 @@ record CommutativeSemiringWithoutOne c ℓ : Set (suc (c ⊔ ℓ)) where
 
   open SemiringWithoutOne semiringWithoutOne public
     using
-    ( _≉_; +-rawMagma; +-magma; +-unitalMagma; +-semigroup; +-commutativeSemigroup
+    ( +-rawMagma; +-magma; +-unitalMagma; +-semigroup; +-commutativeSemigroup
     ; *-rawMagma; *-magma; *-semigroup
     ; +-rawMonoid; +-monoid; +-commutativeMonoid
     ; nearSemiring; rawNearSemiring

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -358,13 +358,15 @@ record IsSemiringWithoutOne (+ * : Op₂ A) (0# : A) : Set (a ⊔ ℓ) where
     zero                  : Zero 0# *
 
   open IsCommutativeMonoid +-isCommutativeMonoid public
-    using (isEquivalence)
+    using (setoid)
     renaming
     ( comm                   to +-comm
     ; isMonoid               to +-isMonoid
     ; isCommutativeMagma     to +-isCommutativeMagma
     ; isCommutativeSemigroup to +-isCommutativeSemigroup
     )
+
+  open Setoid setoid public
 
   *-isMagma : IsMagma *
   *-isMagma = record


### PR DESCRIPTION
What I don't understand is why/how this solution is to be preferred over others (such as?), or whether this may break anything subsequently... nor how this problem came about in the first place... nor what, if any, `CHANGELOG` entry might be suitable to account for the fix.  