### PR TITLE
Refactor some lookup and truncation lemmas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1428,7 +1428,7 @@ Deprecated names
 
   take-drop-id ↦ take++drop≡id
 
-  lookup-inject≤-take ↦ lookup-take-inject≤
+  lookup-inject≤-take ↦ lookup-take-inject≤′
   ```
   and the type of the proof `zipWith-comm` has been generalised from:
   ```
@@ -2719,6 +2719,9 @@ Additions to existing modules
   cast-fromList : cast _ (fromList xs) ≡ fromList ys
   fromList-map  : cast _ (fromList (List.map f xs)) ≡ map f (fromList xs)
   fromList-++   : cast _ (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
+
+  lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
+                        lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2723,7 +2723,6 @@ Additions to existing modules
 
   lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
                         lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
-  take≤               : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2155,6 +2155,9 @@ Additions to existing modules
   cast-trans    : cast eq₂ (cast eq₁ k) ≡ cast (trans eq₁ eq₂) k
 
   fromℕ≢inject₁      : {i : Fin n} → fromℕ n ≢ inject₁ i
+
+  inject≤-trans      : inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i (≤-trans m≤n n≤o)
+  inject≤-irrelevant : inject≤ i m≤n ≡ inject≤ i m≤n′
   ```
 
 * Added new functions in `Data.Integer.Base`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2723,6 +2723,9 @@ Additions to existing modules
 
   lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
                         lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
+  take≤               : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
+  take≤-irrelevant    : (xs : Vec A n) → take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs 
+  take≤-unfold        : (xs : Vec A (m + n)) → take≤ (m≤m+n m n) xs ≡ take m xs
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2700,7 +2700,7 @@ Additions to existing modules
 
   cast-is-id    : cast eq xs ≡ xs
   subst-is-cast : subst (Vec A) eq xs ≡ cast eq xs
-  cast-sym      : ys ≡ cast eq xs → xs ≡ cast (sym eq) ys
+  cast-sym      : cast eq xs ≡ ys → cast (sym eq) ys ≡ xs
   cast-trans    : cast eq₂ (cast eq₁ xs) ≡ cast (trans eq₁ eq₂) xs
   map-cast      : map f (cast eq xs) ≡ cast eq (map f xs)
   lookup-cast   : lookup (cast eq xs) (Fin.cast eq i) ≡ lookup xs i

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2721,7 +2721,9 @@ Additions to existing modules
   fromList-map  : cast _ (fromList (List.map f xs)) ≡ map f (fromList xs)
   fromList-++   : cast _ (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
 
-  lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
+  lookup-take-inject≤ : (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
+                        lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
+  lookup-take         : (xs : Vec A (m + n)) (i : Fin m) →
                         lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
   take≤               : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
   take≤-irrelevant    : (xs : Vec A n) → take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2700,12 +2700,13 @@ Additions to existing modules
 
   cast-is-id    : cast eq xs ≡ xs
   subst-is-cast : subst (Vec A) eq xs ≡ cast eq xs
+  cast-sym      : ys ≡ cast eq xs → xs ≡ cast (sym eq) ys
   cast-trans    : cast eq₂ (cast eq₁ xs) ≡ cast (trans eq₁ eq₂) xs
   map-cast      : map f (cast eq xs) ≡ cast eq (map f xs)
   lookup-cast   : lookup (cast eq xs) (Fin.cast eq i) ≡ lookup xs i
   lookup-cast₁  : lookup (cast eq xs) i ≡ lookup xs (Fin.cast (sym eq) i)
   lookup-cast₂  : lookup xs (Fin.cast eq i) ≡ lookup (cast (sym eq) xs) i
-  cast-reverse : cast eq ∘ reverse ≗ reverse ∘ cast eq
+  cast-reverse  : cast eq ∘ reverse ≗ reverse ∘ cast eq
 
   zipwith-++ : zipWith f (xs ++ ys) (xs' ++ ys') ≡ zipWith f xs xs' ++ zipWith f ys ys'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2722,6 +2722,7 @@ Additions to existing modules
 
   lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
                         lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
+  take≤               : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1427,6 +1427,8 @@ Deprecated names
   sum-++-commute  ↦ sum-++
 
   take-drop-id ↦ take++drop≡id
+
+  lookup-inject≤-take ↦ lookup-take-inject≤
   ```
   and the type of the proof `zipWith-comm` has been generalised from:
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2721,13 +2721,10 @@ Additions to existing modules
   fromList-map  : cast _ (fromList (List.map f xs)) ≡ map f (fromList xs)
   fromList-++   : cast _ (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
 
-  lookup-take-inject≤ : (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
-                        lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
-  lookup-take         : (xs : Vec A (m + n)) (i : Fin m) →
-                        lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
-  take≤               : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
-  take≤-irrelevant    : (xs : Vec A n) → take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs 
-  take≤-unfold        : (xs : Vec A (m + n)) → take≤ (m≤m+n m n) xs ≡ take m xs
+  truncate≡take       : .(eq : n ≡ m + o) → truncate m≤n xs ≡ take m (cast eq xs)
+  take≡truncate       : take m xs ≡ truncate (m≤m+n m n) xs
+  lookup-truncate     : lookup (truncate m≤n xs) i ≡ lookup xs (Fin.inject≤ i m≤n)
+  lookup-take-inject≤ : lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1428,7 +1428,7 @@ Deprecated names
 
   take-drop-id ↦ take++drop≡id
 
-  lookup-inject≤-take ↦ lookup-take-inject≤′
+  lookup-inject≤-take ↦ lookup-take-inject≤
   ```
   and the type of the proof `zipWith-comm` has been generalised from:
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2724,7 +2724,7 @@ Additions to existing modules
   truncate≡take       : .(eq : n ≡ m + o) → truncate m≤n xs ≡ take m (cast eq xs)
   take≡truncate       : take m xs ≡ truncate (m≤m+n m n) xs
   lookup-truncate     : lookup (truncate m≤n xs) i ≡ lookup xs (Fin.inject≤ i m≤n)
-  lookup-take-inject≤ : lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
+  lookup-take-inject≤ : lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
   ```
 
 * Added new proofs in `Data.Vec.Membership.Propositional.Properties`:

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -12,7 +12,6 @@
 module Data.Fin.Base where
 
 open import Data.Bool.Base using (Bool; true; false; T; not)
-open import Data.Empty using (⊥-elim)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; z≤n; s≤s; z<s; s<s; _^_)
 open import Data.Product.Base as Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
@@ -121,7 +120,7 @@ inject≤ {_} {suc n} (suc i) (s≤s m≤n) = suc (inject≤ i m≤n)
 -- lower₁ "i" _ = "i".
 
 lower₁ : ∀ (i : Fin (suc n)) → n ≢ toℕ i → Fin n
-lower₁ {zero}  zero    ne = ⊥-elim (ne refl)
+lower₁ {zero}  zero    ne = contradiction refl ne
 lower₁ {suc n} zero    _  = zero
 lower₁ {suc n} (suc i) ne = suc (lower₁ i (ne ∘ cong suc))
 
@@ -252,7 +251,7 @@ opposite {suc n} (suc i) = inject₁ (opposite i)
 -- McBride's "First-order unification by structural recursion".
 
 punchOut : ∀ {i j : Fin (suc n)} → i ≢ j → Fin n
-punchOut {_}     {zero}   {zero}  i≢j = ⊥-elim (i≢j refl)
+punchOut {_}     {zero}   {zero}  i≢j = contradiction refl i≢j
 punchOut {_}     {zero}   {suc j} _   = j
 punchOut {suc _} {suc i}  {zero}  _   = zero
 punchOut {suc _} {suc i}  {suc j} i≢j = suc (punchOut (i≢j ∘ cong suc))

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -114,7 +114,7 @@ inject₁ zero    = zero
 inject₁ (suc i) = suc (inject₁ i)
 
 inject≤ : Fin m → m ℕ.≤ n → Fin n
-inject≤ {_} {suc n} zero    _        = zero
+inject≤ {_} {suc n} zero    _         =  zero
 inject≤ {_} {suc n} (suc i) (s≤s m≤n) = suc (inject≤ i m≤n)
 
 -- lower₁ "i" _ = "i".

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -547,11 +547,20 @@ inject≤-idempotent {_} {suc n} {suc o} zero    _   _   _ = refl
 inject≤-idempotent {_} {suc n} {suc o} (suc i) (s≤s m≤n) (s≤s n≤o) (s≤s m≤o) =
   cong suc (inject≤-idempotent i m≤n n≤o m≤o)
 
+inject≤-trans : ∀ (i : Fin m) (m≤n : m ℕ.≤ n) (n≤o : n ℕ.≤ o) →
+                inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i (ℕₚ.≤-trans m≤n n≤o)
+inject≤-trans i m≤n n≤o = inject≤-idempotent i m≤n n≤o _             
+
 inject≤-injective : ∀ (m≤n m≤n′ : m ℕ.≤ n) i j →
                     inject≤ i m≤n ≡ inject≤ j m≤n′ → i ≡ j
 inject≤-injective (s≤s p) (s≤s q) zero    zero    eq = refl
 inject≤-injective (s≤s p) (s≤s q) (suc i) (suc j) eq =
   cong suc (inject≤-injective p q i j (suc-injective eq))
+
+inject≤-irrelevant : ∀ (m≤n m≤n′ : m ℕ.≤ n) i →
+                    inject≤ i m≤n ≡ inject≤ i m≤n′
+inject≤-irrelevant (s≤s p) (s≤s q) zero    = refl
+inject≤-irrelevant (s≤s p) (s≤s q) (suc i) = cong suc (inject≤-irrelevant p q i)
 
 ------------------------------------------------------------------------
 -- pred

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -549,7 +549,7 @@ inject≤-idempotent {_} {suc n} {suc o} (suc i) (s≤s m≤n) (s≤s n≤o) (s�
 
 inject≤-trans : ∀ (i : Fin m) (m≤n : m ℕ.≤ n) (n≤o : n ℕ.≤ o) →
                 inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i (ℕₚ.≤-trans m≤n n≤o)
-inject≤-trans i m≤n n≤o = inject≤-idempotent i m≤n n≤o _             
+inject≤-trans i m≤n n≤o = inject≤-idempotent i m≤n n≤o _
 
 inject≤-injective : ∀ (m≤n m≤n′ : m ℕ.≤ n) i j →
                     inject≤ i m≤n ≡ inject≤ j m≤n′ → i ≡ j

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -559,8 +559,7 @@ inject≤-injective (s≤s p) (s≤s q) (suc i) (suc j) eq =
 
 inject≤-irrelevant : ∀ (m≤n m≤n′ : m ℕ.≤ n) i →
                     inject≤ i m≤n ≡ inject≤ i m≤n′
-inject≤-irrelevant (s≤s p) (s≤s q) zero    = refl
-inject≤-irrelevant (s≤s p) (s≤s q) (suc i) = cong suc (inject≤-irrelevant p q i)
+inject≤-irrelevant m≤n m≤n′ i rewrite ℕₚ.≤-irrelevant m≤n m≤n′ = refl
 
 ------------------------------------------------------------------------
 -- pred

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -559,7 +559,7 @@ inject≤-injective (s≤s p) (s≤s q) (suc i) (suc j) eq =
 
 inject≤-irrelevant : ∀ (m≤n m≤n′ : m ℕ.≤ n) i →
                     inject≤ i m≤n ≡ inject≤ i m≤n′
-inject≤-irrelevant m≤n m≤n′ i rewrite ℕₚ.≤-irrelevant m≤n m≤n′ = refl
+inject≤-irrelevant m≤n m≤n′ i =  cong (inject≤ i) (ℕₚ.≤-irrelevant m≤n m≤n′)
 
 ------------------------------------------------------------------------
 -- pred

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -290,7 +290,7 @@ uncons (x ∷ xs) = x , xs
 
 -- Take the first 'm' elements of a vector.
 truncate : ∀ {m n} → m ≤ n → Vec A n → Vec A m
-truncate z≤n      _        = []
+truncate {m = zero} _ _    = []
 truncate (s≤s le) (x ∷ xs) = x ∷ (truncate le xs)
 
 -- Pad out a vector with extra elements.

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -272,7 +272,7 @@ drop m xs = proj₁ (proj₂ (splitAt m xs))
 group : ∀ n k (xs : Vec A (n * k)) →
         ∃ λ (xss : Vec (Vec A k) n) → xs ≡ concat xss
 group zero    k []                  = ([] , refl)
-group (suc n) k xs  = 
+group (suc n) k xs  =
   let ys , zs , eq-split = splitAt k xs in
   let zss , eq-group     = group n k zs in
    (ys ∷ zss) , trans eq-split (cong (ys ++_) eq-group)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -365,12 +365,12 @@ cast-is-id eq (x ∷ xs) = cong (x ∷_) (cast-is-id (suc-injective eq) xs)
 subst-is-cast : (eq : m ≡ n) (xs : Vec A m) → subst (Vec A) eq xs ≡ cast eq xs
 subst-is-cast refl xs = sym (cast-is-id refl xs)
 
-cast-sym : (eq : m ≡ n) {xs : Vec A m} {ys : Vec A n} →
+cast-sym : .(eq : m ≡ n) {xs : Vec A m} {ys : Vec A n} →
            ys ≡ cast eq xs → xs ≡ cast (sym eq) ys
 cast-sym eq {xs = []}     {ys = []}     _ = refl
-cast-sym eq {xs = x ∷ xs} {ys = y ∷ ys} xxs≡[eq]yys
-  with x≡y , xs≡[eq]ys ← ∷-injective xxs≡[eq]yys
-  = cong₂ _∷_ (sym x≡y) (cast-sym (suc-injective eq) xs≡[eq]ys)
+cast-sym eq {xs = x ∷ xs} {ys = y ∷ ys} xxs≡[eq]yys =
+  let x≡y , xs≡[eq]ys = ∷-injective xxs≡[eq]yys
+  in cong₂ _∷_ (sym x≡y) (cast-sym (suc-injective eq) xs≡[eq]ys)
 
 cast-trans : .(eq₁ : m ≡ n) .(eq₂ : n ≡ o) (xs : Vec A m) →
              cast eq₂ (cast eq₁ xs) ≡ cast (trans eq₁ eq₂) xs

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -15,7 +15,7 @@ open import Data.List.Base as List using (List)
 import Data.List.Properties as Listₚ
 open import Data.Nat.Base
 open import Data.Nat.Properties
-  using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; suc-injective; +-comm; +-suc)
+  using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; ≤⇒≤″; suc-injective; +-comm; +-suc)
 open import Data.Product.Base as Prod
   using (_×_; _,_; proj₁; proj₂; <_,_>; uncurry)
 open import Data.Sum.Base using ([_,_]′)
@@ -179,6 +179,17 @@ lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
 lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
 
+-- provisional definition
+
+take≤ : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
+take≤ {m} m≤n xs = let less-than-or-equal {k} eq = ≤⇒≤″ m≤n in take m (cast (sym eq) xs)
+{-
+lookup-take : (m≤n : m ≤ n) (i : Fin m) →
+              let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
+              (xs : Vec A (m + k)) →
+              lookup (take m xs) i ≡ lookup (cast ? xs) (Fin.inject≤ i m≤n)
+lookup-take m≤n i xs = ?
+-}
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -15,7 +15,7 @@ open import Data.List.Base as List using (List)
 import Data.List.Properties as Listₚ
 open import Data.Nat.Base
 open import Data.Nat.Properties
-  using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; ≤⇒≤″; suc-injective; +-comm; +-suc)
+  using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; ≤-irrelevant; ≤⇒≤″; suc-injective; +-comm; +-suc)
 open import Data.Product.Base as Prod
   using (_×_; _,_; proj₁; proj₂; <_,_>; uncurry)
 open import Data.Sum.Base using ([_,_]′)
@@ -178,6 +178,20 @@ lookup-take-inject≤′ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject
 lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
 lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
+
+------------------------------------------------------------------------
+-- take≤: provisional definition: where should this go?
+
+take≤ : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
+take≤ {m = m} m≤n xs = let less-than-or-equal eq = ≤⇒≤″ m≤n in take m (cast (sym eq) xs)
+
+take≤-irrelevant : (m≤n₁ m≤n₂ : m ≤ n) (xs : Vec A n) →
+                   take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs 
+take≤-irrelevant m≤n₁ m≤n₂ xs with refl ← ≤-irrelevant m≤n₁ m≤n₂ = refl
+
+take≤-unfold : (xs : Vec A (m + n)) → take≤ (m≤m+n m n) xs ≡ take m xs
+take≤-unfold {m = zero}  _        = refl
+take≤-unfold {m = suc m} (x ∷ xs) = cong (x ∷_) (take≤-unfold xs)
 
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -179,17 +179,6 @@ lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
 lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
 
--- provisional definition
-
-take≤ : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
-take≤ {m} m≤n xs = let less-than-or-equal {k} eq = ≤⇒≤″ m≤n in take m (cast (sym eq) xs)
-{-
-lookup-take : (m≤n : m ≤ n) (i : Fin m) →
-              let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
-              (xs : Vec A (m + k)) →
-              lookup (take m xs) i ≡ lookup (cast ? xs) (Fin.inject≤ i m≤n)
-lookup-take m≤n i xs = ?
--}
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
 
@@ -361,6 +350,13 @@ cast-is-id eq (x ∷ xs) = cong (x ∷_) (cast-is-id (suc-injective eq) xs)
 
 subst-is-cast : (eq : m ≡ n) (xs : Vec A m) → subst (Vec A) eq xs ≡ cast eq xs
 subst-is-cast refl xs = sym (cast-is-id refl xs)
+
+cast-sym : (eq : m ≡ n) {xs : Vec A m} {ys : Vec A n} →
+           ys ≡ cast eq xs → xs ≡ cast (sym eq) ys
+cast-sym eq {xs = []}     {ys = []}     _ = refl
+cast-sym eq {xs = x ∷ xs} {ys = y ∷ ys} xxs≡[eq]yys
+  with x≡y , xs≡[eq]ys ← ∷-injective xxs≡[eq]yys
+  = cong₂ _∷_ (sym x≡y) (cast-sym (suc-injective eq) xs≡[eq]ys)
 
 cast-trans : .(eq₁ : m ≡ n) .(eq₂ : n ≡ o) (xs : Vec A m) →
              cast eq₂ (cast eq₁ xs) ≡ cast (trans eq₁ eq₂) xs

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -1311,6 +1311,6 @@ lookup-inject≤-take m m≤m+n i xs = sym (begin
     ∎) where open ≡-Reasoning
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
-Please use lookup-take-inject≤ instead."
+Please use lookup-take-inject≤ or lookup-truncate, take≡truncate instead."
 #-}
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -11,6 +11,7 @@ module Data.Vec.Properties where
 open import Algebra.Definitions
 open import Data.Bool.Base using (true; false)
 open import Data.Fin.Base as Fin using (Fin; zero; suc; toℕ; fromℕ<; _↑ˡ_; _↑ʳ_)
+open import Data.Fin.Properties as Fin using (inject≤-irrelevant)
 open import Data.List.Base as List using (List)
 import Data.List.Properties as Listₚ
 open import Data.Nat.Base
@@ -189,18 +190,15 @@ lookup-truncate : (m≤n : m ≤ n) (xs : Vec A n) (i : Fin m) →
 lookup-truncate (s≤s m≤m+n) (_ ∷ _)  zero    = refl
 lookup-truncate (s≤s m≤m+n) (_ ∷ xs) (suc i) = lookup-truncate m≤m+n xs i
 
-lookup-take-inject≤ : (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
-                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
-lookup-take-inject≤ {m = m} m≤m+n xs i = begin
-  lookup (take m xs) i
+lookup-take-inject≤ : (xs : Vec A (m + n)) (i : Fin m) →
+                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
+lookup-take-inject≤ {m = m} {n = n} xs i = begin
+  lookup (take _ xs) i
     ≡⟨ cong (λ ys → lookup ys i) (take≡truncate m xs) ⟩
   lookup (truncate _ xs) i
-    ≡⟨ cong (λ ys → lookup ys i) (truncate-irrelevant _ _ xs) ⟩
-  lookup (truncate m≤m+n xs) i
-    ≡⟨ lookup-truncate m≤m+n xs i ⟩
-  lookup xs (Fin.inject≤ i m≤m+n)
-    ∎
- where open ≡-Reasoning
+    ≡⟨ lookup-truncate (m≤m+n m n) xs i ⟩
+  lookup xs (Fin.inject≤ i (m≤m+n m n))
+    ∎ where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
@@ -1305,7 +1303,13 @@ Please use drop-map instead."
 #-}
 lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤ m≤m+n xs i)
+lookup-inject≤-take m m≤m+n i xs = sym (begin
+  lookup (take m xs) i
+    ≡⟨ lookup-take-inject≤ xs i ⟩
+  lookup xs (Fin.inject≤ i _)
+    ≡⟨ cong (lookup xs) (inject≤-irrelevant _ _ i) ⟩
+  lookup xs (Fin.inject≤ i m≤m+n)
+    ∎) where open ≡-Reasoning
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
 Please use lookup-take-inject≤ instead."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -170,16 +170,17 @@ lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) zero    refl = refl
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) (suc i) p    = []=⇒lookup∘lookup⇒[]= xs i p
 
-lookup-take-inject≤ : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
-                      lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-take-inject≤ (suc m) m≤m+n zero (x ∷ xs) = refl
-lookup-take-inject≤ (suc m) (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m m≤m+n i xs
-
-lookup-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
-                      lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-take (suc m) m≤m+n zero (x ∷ xs) = refl
-lookup-take (suc m) (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m m≤m+n i xs
-
+lookup-take-inject≤ : ∀ (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
+lookup-take-inject≤ m≤m+n zero (x ∷ xs) = refl
+lookup-take-inject≤ (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m≤m+n i xs
+{-
+lookup-take : (m≤n : m ≤ n) (i : Fin m) →
+              let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
+              (xs : Vec A (m + k)) →
+              lookup (take m xs) i ≡ lookup (cast ? xs) (Fin.inject≤ i m≤n)
+lookup-take m≤n i xs = ?
+-}
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
 
@@ -1278,7 +1279,7 @@ Please use drop-map instead."
 #-}
 lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take m m≤m+n i xs = lookup-take-inject≤ m m≤m+n i xs
+lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤ m≤m+n i xs)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
 Please use lookup-take-inject≤ instead."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -1299,6 +1299,6 @@ lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m
 lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤ m≤m+n xs i)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
-Please use lookup-take-inject≤′ instead."
+Please use lookup-take-inject≤ instead."
 #-}
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -23,7 +23,7 @@ open import Data.Sum.Base using ([_,_]′)
 open import Data.Sum.Properties using ([,]-map)
 open import Data.Vec.Base
 open import Function.Base
-open import Function.Bundles using (_↔_; mk↔′)
+open import Function.Bundles using (_↔_; mk↔ₛ′)
 open import Level using (Level)
 open import Relation.Binary.Definitions using (DecidableEquality)
 open import Relation.Binary.PropositionalEquality

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -186,7 +186,7 @@ take≤ : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
 take≤ {m = m} m≤n xs = let less-than-or-equal eq = ≤⇒≤″ m≤n in take m (cast (sym eq) xs)
 
 take≤-irrelevant : (m≤n₁ m≤n₂ : m ≤ n) (xs : Vec A n) →
-                   take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs 
+                   take≤ m≤n₁ xs ≡ take≤ m≤n₂ xs
 take≤-irrelevant m≤n₁ m≤n₂ xs with refl ← ≤-irrelevant m≤n₁ m≤n₂ = refl
 
 take≤-unfold : (xs : Vec A (m + n)) → take≤ (m≤m+n m n) xs ≡ take m xs
@@ -366,11 +366,11 @@ subst-is-cast : (eq : m ≡ n) (xs : Vec A m) → subst (Vec A) eq xs ≡ cast e
 subst-is-cast refl xs = sym (cast-is-id refl xs)
 
 cast-sym : .(eq : m ≡ n) {xs : Vec A m} {ys : Vec A n} →
-           ys ≡ cast eq xs → xs ≡ cast (sym eq) ys
+           cast eq xs ≡ ys → cast (sym eq) ys ≡ xs
 cast-sym eq {xs = []}     {ys = []}     _ = refl
-cast-sym eq {xs = x ∷ xs} {ys = y ∷ ys} xxs≡[eq]yys =
-  let x≡y , xs≡[eq]ys = ∷-injective xxs≡[eq]yys
-  in cong₂ _∷_ (sym x≡y) (cast-sym (suc-injective eq) xs≡[eq]ys)
+cast-sym eq {xs = x ∷ xs} {ys = y ∷ ys} xxs[eq]≡yys =
+  let x≡y , xs[eq]≡ys = ∷-injective xxs[eq]≡yys
+  in cong₂ _∷_ (sym x≡y) (cast-sym (suc-injective eq) xs[eq]≡ys)
 
 cast-trans : .(eq₁ : m ≡ n) .(eq₂ : n ≡ o) (xs : Vec A m) →
              cast eq₂ (cast eq₁ xs) ≡ cast (trans eq₁ eq₂) xs

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -178,13 +178,7 @@ lookup-take-inject≤′ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject
 lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
 lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
-{-
-lookup-take : (m≤n : m ≤ n) (i : Fin m) →
-              let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
-              (xs : Vec A (m + k)) →
-              lookup (take m xs) i ≡ lookup (cast ? xs) (Fin.inject≤ i m≤n)
-lookup-take m≤n i xs = ?
--}
+
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
 
@@ -1254,13 +1248,11 @@ sum-++-commute = sum-++
 "Warning: sum-++-commute was deprecated in v2.0.
 Please use sum-++ instead."
 #-}
-
 take-drop-id = take++drop≡id
 {-# WARNING_ON_USAGE take-drop-id
 "Warning: take-drop-id was deprecated in v2.0.
 Please use take++drop≡id instead."
 #-}
-
 take-distr-zipWith = take-zipWith
 {-# WARNING_ON_USAGE take-distr-zipWith
 "Warning: take-distr-zipWith was deprecated in v2.0.
@@ -1286,6 +1278,6 @@ lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m
 lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤′ m≤m+n xs i)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
-Please use lookup-take-inject≤ instead."
+Please use lookup-take-inject≤′ instead."
 #-}
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -170,10 +170,10 @@ lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) zero    refl = refl
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) (suc i) p    = []=⇒lookup∘lookup⇒[]= xs i p
 
-lookup-take-inject≤ : ∀ (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+lookup-take-inject≤′ : ∀ (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
-lookup-take-inject≤ m≤m+n zero (x ∷ xs) = refl
-lookup-take-inject≤ (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m≤m+n i xs
+lookup-take-inject≤′ _           zero    (_ ∷ _)  = refl
+lookup-take-inject≤′ (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤′ m≤m+n i xs
 {-
 lookup-take : (m≤n : m ≤ n) (i : Fin m) →
               let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
@@ -1279,7 +1279,7 @@ Please use drop-map instead."
 #-}
 lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤ m≤m+n i xs)
+lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤′ m≤m+n i xs)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
 Please use lookup-take-inject≤ instead."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -170,10 +170,14 @@ lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) zero    refl = refl
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) (suc i) p    = []=⇒lookup∘lookup⇒[]= xs i p
 
-lookup-take-inject≤′ : ∀ (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+lookup-take-inject≤′ : ∀ (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
-lookup-take-inject≤′ _           zero    (_ ∷ _)  = refl
-lookup-take-inject≤′ (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤′ m≤m+n i xs
+lookup-take-inject≤′ _           (_ ∷ _)  zero    = refl
+lookup-take-inject≤′ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject≤′ m≤m+n xs i
+
+lookup-take-inject≤ : ∀ m (xs : Vec A (m + n)) (i : Fin m) →
+                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i ?)
+lookup-take-inject≤ m xs i = lookup-take-inject≤′ ? xs i
 {-
 lookup-take : (m≤n : m ≤ n) (i : Fin m) →
               let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in
@@ -1279,7 +1283,7 @@ Please use drop-map instead."
 #-}
 lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤′ m≤m+n i xs)
+lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤′ m≤m+n xs i)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
 Please use lookup-take-inject≤ instead."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -15,7 +15,7 @@ open import Data.List.Base as List using (List)
 import Data.List.Properties as Listₚ
 open import Data.Nat.Base
 open import Data.Nat.Properties
-  using (+-assoc; m≤n⇒m≤1+n; ≤-refl; ≤-trans; suc-injective; +-comm; +-suc)
+  using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; suc-injective; +-comm; +-suc)
 open import Data.Product.Base as Prod
   using (_×_; _,_; proj₁; proj₂; <_,_>; uncurry)
 open import Data.Sum.Base using ([_,_]′)
@@ -175,9 +175,9 @@ lookup-take-inject≤′ : ∀ (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i :
 lookup-take-inject≤′ _           (_ ∷ _)  zero    = refl
 lookup-take-inject≤′ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject≤′ m≤m+n xs i
 
-lookup-take-inject≤ : ∀ m (xs : Vec A (m + n)) (i : Fin m) →
-                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i ?)
-lookup-take-inject≤ m xs i = lookup-take-inject≤′ ? xs i
+lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
+                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
+lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
 {-
 lookup-take : (m≤n : m ≤ n) (i : Fin m) →
               let less-than-or-equal {k} refl = ≤⇒≤″ m≤n in

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -22,15 +22,14 @@ open import Data.Sum.Base using ([_,_]′)
 open import Data.Sum.Properties using ([,]-map)
 open import Data.Vec.Base
 open import Function.Base
--- open import Function.Inverse using (_↔_; inverse)
 open import Function.Bundles using (_↔_; mk↔′)
 open import Level using (Level)
 open import Relation.Binary.Definitions using (DecidableEquality)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; _≗_; refl; sym; trans; cong; cong₂; subst; module ≡-Reasoning)
 open import Relation.Unary using (Pred; Decidable)
-open import Relation.Nullary.Decidable using (Dec; does; yes; no; _×-dec_; map′)
-open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Nullary.Decidable.Core using (Dec; does; yes; no; _×-dec_; map′)
+open import Relation.Nullary.Negation.Core using (contradiction)
 
 open ≡-Reasoning
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -170,10 +170,15 @@ lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) zero    refl = refl
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) (suc i) p    = []=⇒lookup∘lookup⇒[]= xs i p
 
-lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+lookup-take-inject≤ : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take (suc m) m≤m+n zero (x ∷ xs) = refl
-lookup-inject≤-take (suc m) (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-inject≤-take m m≤m+n i xs
+lookup-take-inject≤ (suc m) m≤m+n zero (x ∷ xs) = refl
+lookup-take-inject≤ (suc m) (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m m≤m+n i xs
+
+lookup-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+                      lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
+lookup-take (suc m) m≤m+n zero (x ∷ xs) = refl
+lookup-take (suc m) (s≤s m≤m+n) (suc i) (x ∷ xs) = lookup-take-inject≤ m m≤m+n i xs
 
 ------------------------------------------------------------------------
 -- updateAt (_[_]%=_)
@@ -1271,3 +1276,11 @@ drop-distr-map = drop-map
 "Warning: drop-distr-map was deprecated in v2.0.
 Please use drop-map instead."
 #-}
+lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
+                      lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
+lookup-inject≤-take m m≤m+n i xs = lookup-take-inject≤ m m≤m+n i xs
+{-# WARNING_ON_USAGE lookup-inject≤-take
+"Warning: lookup-inject≤-take was deprecated in v2.0.
+Please use lookup-take-inject≤ instead."
+#-}
+

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -170,14 +170,14 @@ lookup⇒[]= (suc i) (_ ∷ xs) p    = there (lookup⇒[]= i xs p)
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) zero    refl = refl
   []=⇒lookup∘lookup⇒[]= (x ∷ xs) (suc i) p    = []=⇒lookup∘lookup⇒[]= xs i p
 
-lookup-take-inject≤′ : ∀ (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
+lookup-take-inject≤ : (m≤m+n : m ≤ m + n) (xs : Vec A (m + n)) (i : Fin m) →
                       lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i m≤m+n)
-lookup-take-inject≤′ _           (_ ∷ _)  zero    = refl
-lookup-take-inject≤′ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject≤′ m≤m+n xs i
+lookup-take-inject≤ _           (_ ∷ _)  zero    = refl
+lookup-take-inject≤ (s≤s m≤m+n) (x ∷ xs) (suc i) = lookup-take-inject≤ m≤m+n xs i
 
-lookup-take-inject≤ : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
-                      lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
-lookup-take-inject≤ m xs i = lookup-take-inject≤′ (m≤m+n m _) xs i
+lookup-take : ∀ m {n} (xs : Vec A (m + n)) (i : Fin m) →
+              lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
+lookup-take m xs i = lookup-take-inject≤ (m≤m+n m _) xs i
 
 ------------------------------------------------------------------------
 -- take≤: provisional definition: where should this go?
@@ -1296,7 +1296,7 @@ Please use drop-map instead."
 #-}
 lookup-inject≤-take : ∀ m (m≤m+n : m ≤ m + n) (i : Fin m) (xs : Vec A (m + n)) →
                       lookup xs (Fin.inject≤ i m≤m+n) ≡ lookup (take m xs) i
-lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤′ m≤m+n xs i)
+lookup-inject≤-take m m≤m+n i xs = sym (lookup-take-inject≤ m≤m+n xs i)
 {-# WARNING_ON_USAGE lookup-inject≤-take
 "Warning: lookup-inject≤-take was deprecated in v2.0.
 Please use lookup-take-inject≤′ instead."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -10,8 +10,8 @@ module Data.Vec.Properties where
 
 open import Algebra.Definitions
 open import Data.Bool.Base using (true; false)
-open import Data.Fin.Base as Fin using (Fin; zero; suc; toℕ; fromℕ<; _↑ˡ_; _↑ʳ_)
-open import Data.Fin.Properties as Fin using (inject≤-irrelevant)
+open import Data.Fin.Base as Fin
+  using (Fin; zero; suc; toℕ; fromℕ<; _↑ˡ_; _↑ʳ_)
 open import Data.List.Base as List using (List)
 import Data.List.Properties as Listₚ
 open import Data.Nat.Base
@@ -123,8 +123,7 @@ truncate-trans z≤n       n≤p       xs = refl
 truncate-trans (s≤s m≤n) (s≤s n≤p) (x ∷ xs) = cong (x ∷_) (truncate-trans m≤n n≤p xs)
 
 truncate-irrelevant : (m≤n₁ m≤n₂ : m ≤ n) → truncate {A = A} m≤n₁ ≗ truncate m≤n₂
-truncate-irrelevant {m = zero}  m≤n₁ m≤n₂ _        = refl
-truncate-irrelevant (s≤s m≤n₁) (s≤s m≤n₂) (x ∷ xs) = cong (x ∷_) (truncate-irrelevant m≤n₁ m≤n₂ xs)
+truncate-irrelevant m≤n₁ m≤n₂ xs rewrite ≤-irrelevant m≤n₁ m≤n₂ = refl
 
 truncate≡take : (m≤n : m ≤ n) (xs : Vec A n) .(eq : n ≡ m + o) →
                 truncate m≤n xs ≡ take m (cast eq xs)
@@ -430,9 +429,9 @@ map-updateAt (x ∷ xs) (suc i) eq = cong (_ ∷_) (map-updateAt xs i eq)
 
 map-insert : ∀ (f : A → B) (x : A) (xs : Vec A n) (i : Fin (suc n)) →
              map f (insert xs i x) ≡ insert (map f xs) i (f x)
-map-insert f _ []        Fin.zero = refl
-map-insert f _ (x' ∷ xs) Fin.zero = refl
-map-insert f x (x' ∷ xs) (Fin.suc i) = cong (_ ∷_) (map-insert f x xs i)
+map-insert f _ []        zero    = refl
+map-insert f _ (x' ∷ xs) zero    = refl
+map-insert f x (x' ∷ xs) (suc i) = cong (_ ∷_) (map-insert f x xs i)
 
 map-[]≔ : ∀ (f : A → B) (xs : Vec A n) (i : Fin n) →
           map f (xs [ i ]≔ x) ≡ map f xs [ i ]≔ f x
@@ -1307,7 +1306,7 @@ lookup-inject≤-take m m≤m+n i xs = sym (begin
   lookup (take m xs) i
     ≡⟨ lookup-take-inject≤ xs i ⟩
   lookup xs (Fin.inject≤ i _)
-    ≡⟨ cong (lookup xs) (inject≤-irrelevant _ _ i) ⟩
+    ≡⟨ cong ((lookup xs) ∘ (Fin.inject≤ i)) (≤-irrelevant _ _) ⟩
   lookup xs (Fin.inject≤ i m≤m+n)
     ∎) where open ≡-Reasoning
 {-# WARNING_ON_USAGE lookup-inject≤-take

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -123,7 +123,7 @@ truncate-trans z≤n       n≤p       xs = refl
 truncate-trans (s≤s m≤n) (s≤s n≤p) (x ∷ xs) = cong (x ∷_) (truncate-trans m≤n n≤p xs)
 
 truncate-irrelevant : (m≤n₁ m≤n₂ : m ≤ n) → truncate {A = A} m≤n₁ ≗ truncate m≤n₂
-truncate-irrelevant m≤n₁ m≤n₂ xs rewrite ≤-irrelevant m≤n₁ m≤n₂ = refl
+truncate-irrelevant m≤n₁ m≤n₂ xs = cong (λ m≤n → truncate m≤n xs) (≤-irrelevant m≤n₁ m≤n₂)
 
 truncate≡take : (m≤n : m ≤ n) (xs : Vec A n) .(eq : n ≡ m + o) →
                 truncate m≤n xs ≡ take m (cast eq xs)


### PR DESCRIPTION
~~Most of the way there, but I would like to introduce a definition of~~
Refactored to take advantage of:
```agda
truncate : (m≤n : m ≤ n) (xs : Vec A n) → Vec A m
```
and add: ~~a version of (itself refactored by this PR... ;-))~~
```agda
lookup-take-inject≤ : lookup (take m xs) i ≡ lookup xs (Fin.inject≤ i (m≤m+n m n))
```
~~which then makes use of it. But currently in `cast` hell... cf. #2057~~
UPDATED: Ugh! RTFL... The follies of ignorance... and there being rather scant properties of the function `truncate` already defined in `Data.Vec.Base`. 

Moving to draft status while I sort out the signal from the noise... NOW DONE. And with no plans to add to this PR further. 