### PR TITLE
Backward compatibility with v1.7.1/2 for the IO Monad

### DIFF
--- a/src/Category/Applicative.agda
+++ b/src/Category/Applicative.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Applicative` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Applicative where
+
+open import Effect.Applicative public
+
+{-# WARNING_ON_IMPORT
+"Category.Applicative was deprecated in v2.0.
+Use Effect.Applicative instead."
+#-}

--- a/src/Category/Applicative/Indexed.agda
+++ b/src/Category/Applicative/Indexed.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Applicative.Indexed` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Applicative.Indexed where
+
+open import Effect.Applicative.Indexed public
+
+{-# WARNING_ON_IMPORT
+"Category.Applicative.Indexed was deprecated in v2.0.
+Use Effect.Applicative.Indexed instead."
+#-}

--- a/src/Category/Applicative/Predicate.agda
+++ b/src/Category/Applicative/Predicate.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Applicative.Predicate` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Applicative.Predicate where
+
+open import Effect.Applicative.Predicate public
+
+{-# WARNING_ON_IMPORT
+"Category.Applicative.Predicate was deprecated in v2.0.
+Use Effect.Applicative.Predicate instead."
+#-}

--- a/src/Category/Comonad.agda
+++ b/src/Category/Comonad.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Comonad` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Comonad where
+
+open import Effect.Comonad public
+
+{-# WARNING_ON_IMPORT
+"Category.Comonad was deprecated in v2.0.
+Use Effect.Comonad instead."
+#-}

--- a/src/Category/Functor.agda
+++ b/src/Category/Functor.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Functor` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Functor where
+
+open import Effect.Functor public
+
+{-# WARNING_ON_IMPORT
+"Category.Functor was deprecated in v2.0.
+Use Effect.Functor instead."
+#-}

--- a/src/Category/Functor/Indexed.agda
+++ b/src/Category/Functor/Indexed.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Functor.Indexed` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Functor.Indexed where
+
+open import Effect.Functor.Indexed public
+
+{-# WARNING_ON_IMPORT
+"Category.Functor.Indexed was deprecated in v2.0.
+Use Effect.Functor.Indexed instead."
+#-}

--- a/src/Category/Functor/Predicate.agda
+++ b/src/Category/Functor/Predicate.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Functor.Predicate` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Functor.Predicate where
+
+open import Effect.Functor.Predicate public
+
+{-# WARNING_ON_IMPORT
+"Category.Functor.Predicate was deprecated in v2.0.
+Use Effect.Functor.Predicate instead."
+#-}

--- a/src/Category/Monad.agda
+++ b/src/Category/Monad.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad where
+
+open import Effect.Monad public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad was deprecated in v2.0.
+Use Effect.Monad instead."
+#-}

--- a/src/Category/Monad/Continuation.agda
+++ b/src/Category/Monad/Continuation.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Continuation` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Continuation where
+
+open import Effect.Monad.Continuation public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Continuation was deprecated in v2.0.
+Use Effect.Monad.Continuation instead."
+#-}

--- a/src/Category/Monad/Indexed.agda
+++ b/src/Category/Monad/Indexed.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Indexed` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Indexed where
+
+open import Effect.Monad.Indexed public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Indexed was deprecated in v2.0.
+Use Effect.Monad.Indexed instead."
+#-}

--- a/src/Category/Monad/Partiality.agda
+++ b/src/Category/Monad/Partiality.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Partiality` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Partiality where
+
+open import Effect.Monad.Partiality public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Partiality was deprecated in v2.0.
+Use Effect.Monad.Partiality instead."
+#-}

--- a/src/Category/Monad/Partiality/All.agda
+++ b/src/Category/Monad/Partiality/All.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Partiality.All` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Partiality.All where
+
+open import Effect.Monad.Partiality.All public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Partiality.All was deprecated in v2.0.
+Use Effect.Monad.Partiality.All instead."
+#-}

--- a/src/Category/Monad/Partiality/Instances.agda
+++ b/src/Category/Monad/Partiality/Instances.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Partiality.Instances` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Partiality.Instances where
+
+open import Effect.Monad.Partiality.Instances public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Partiality.Instances was deprecated in v2.0.
+Use Effect.Monad.Partiality.Instances instead."
+#-}

--- a/src/Category/Monad/Predicate.agda
+++ b/src/Category/Monad/Predicate.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Predicate` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Predicate where
+
+open import Effect.Monad.Predicate public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Predicate was deprecated in v2.0.
+Use Effect.Monad.Predicate instead."
+#-}

--- a/src/Category/Monad/Reader.agda
+++ b/src/Category/Monad/Reader.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.Reader` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.Reader where
+
+open import Effect.Monad.Reader public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.Reader was deprecated in v2.0.
+Use Effect.Monad.Reader instead."
+#-}

--- a/src/Category/Monad/State.agda
+++ b/src/Category/Monad/State.agda
@@ -1,0 +1,17 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- This module is DEPRECATED. Please use
+-- `Effect.Monad.State` instead.
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Category.Monad.State where
+
+open import Effect.Monad.State public
+
+{-# WARNING_ON_IMPORT
+"Category.Monad.State was deprecated in v2.0.
+Use Effect.Monad.State instead."
+#-}

--- a/src/IO/Primitive.agda
+++ b/src/IO/Primitive.agda
@@ -23,12 +23,22 @@ postulate
   pure : ∀ {a} {A : Set a} → A → IO A
   _>>=_  : ∀ {a b} {A : Set a} {B : Set b} → IO A → (A → IO B) → IO B
 
--- Alias 'return' for backwards compatibility.
-
-return : ∀ {a} {A : Set a} → A → IO A
-return = pure
-
 {-# COMPILE GHC pure = \_ _ -> return    #-}
 {-# COMPILE GHC _>>=_  = \_ _ _ _ -> (>>=) #-}
 {-# COMPILE UHC pure = \_ _ x -> UHC.Agda.Builtins.primReturn x #-}
 {-# COMPILE UHC _>>=_  = \_ _ _ _ x y -> UHC.Agda.Builtins.primBind x y #-}
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.0
+
+return : ∀ {a} {A : Set a} → A → IO A
+return = pure
+{-# WARNING_ON_USAGE return
+"Warning: return was deprecated in v2.0.
+Please use pure instead."
+#-}

--- a/src/IO/Primitive.agda
+++ b/src/IO/Primitive.agda
@@ -23,6 +23,11 @@ postulate
   pure : ∀ {a} {A : Set a} → A → IO A
   _>>=_  : ∀ {a b} {A : Set a} {B : Set b} → IO A → (A → IO B) → IO B
 
+-- Alias 'return' for backwards compatibility.
+
+return : ∀ {a} {A : Set a} → A → IO A
+return = pure
+
 {-# COMPILE GHC pure = \_ _ -> return    #-}
 {-# COMPILE GHC _>>=_  = \_ _ _ _ -> (>>=) #-}
 {-# COMPILE UHC pure = \_ _ x -> UHC.Agda.Builtins.primReturn x #-}


### PR DESCRIPTION
- Fix #2124: `IO.Primitive.return` (alias for `pure`) for backwards compat
- Restore Category/* tree of v1.7 as deprected module aliases

These patches allow me to port an Agda development using v1.7.1 to v2.0 (current `master`).  

The code I want to have working with both version uses `do` for the `IO` monad and `mapM`.
```agda
foo = do
   ...
   _ <- mapM f xs
   ...
   return _
   where
   open IOMonad
   open TraversableM record{ IOMonad }
```
So I am using the `module` based technique to bring `>>=` into scope for the `do` notation.

Previously (v1.7), I defined `IOMonad` like this:
```agda
module IOMonad where
  open import IO.Primitive public using (return; _>>=_)

  infixl 1 _>>_

  _>>_  : ∀ {b} {B : Set b} → IO ⊤ → IO B → IO B
  _>>_ = λ m m' → m >>= λ _ → m'

  infixr 1 _=<<_

  _=<<_  : ∀ {a b} {A : Set a} {B : Set b} → (A → IO B) → IO A → IO B
  k =<< m = m >>= k
```
This definition was good enough to form `record {IOMonad}` for the instantiation of `TraversableM`.

With v2.0, forming a `RawMonad` also needs embedded instances of `RawFunctor` and `RawApplicative`.
I managed to make the definition of `IOMonad` compatible with v2.0 by changing it to be the following:
```agda
open import Category.Functor     using (RawFunctor)
open import Category.Applicative using (RawApplicative)

module IOFunctor where
  open import IO.Primitive public using (return; _>>=_)

  infixl 1 _>>_

  _>>_  : ∀ {b} {B : Set b} → IO ⊤ → IO B → IO B
  _>>_ = λ m m' → m >>= λ _ → m'

  infixr 1 _=<<_

  _=<<_  : ∀ {a b} {A : Set a} {B : Set b} → (A → IO B) → IO A → IO B
  k =<< m = m >>= k

  -- The following definition is needed to create the RawFunctor instance.

  infixl 4 _<$>_

  _<$>_ :  ∀ {a b} {A : Set a} {B : Set b} → (A → B) → IO A → IO B
  f <$> m = m >>= λ a -> return (f a)

-- This module is needed to create the RawApplicative instance
-- in a way compatible with both std-lib v1.7.1/2 and v2.0.

module IOApplicative where
  open IOFunctor public

  rawFunctor : ∀{ℓ} → RawFunctor (IO {a = ℓ})
  rawFunctor = record { IOFunctor }

  pure : ∀{a} {A : Set a} → A → IO A
  pure = return

  infixl 4 _<*>_ _⊛_

  _<*>_ : ∀ {a b} {A : Set a} {B : Set b} → IO (A → B) → IO A → IO B
  mf <*> ma = mf >>= λ f → ma >>= λ a → return (f a)

  _⊛_ : ∀ {a b} {A : Set a} {B : Set b} → IO (A → B) → IO A → IO B
  _⊛_ = _<*>_

module IOMonad where
  open IOApplicative public

  -- Field rawApplicative is part of the RawMonad of std-lib v2.0
  -- Thus we have to construct the Applicative implementation
  -- even though we do not use it.
  --
  rawApplicative : ∀{ℓ} → RawApplicative (IO {a = ℓ})
  rawApplicative = record { IOApplicative }
```
This works with 1.7.1/2.  To have it work with 2.0 as well, the present PR is needed, because:
- I need to be able to import `return` from `IO.Primitive`.
- I need to be able to import `Raw*` from `Category.*` (for `*` in {`Functor`, `Applicative`}).
