### PR TITLE
[ admin ] fix sorting logic

### DIFF
--- a/travis/landing.sh
+++ b/travis/landing.sh
@@ -7,8 +7,9 @@ cat landing-top.html >> landing.html
 
 find html/ -name "index.html" \
   | grep -v "master\|experimental" \
+  | sed 's|html/\([^\/]*\)/index.html|\1|g' \
   | sort -r \
-  | sed 's|html/\([^\/]*\)/index.html|        <li><a href="\1">\1</a></li>|g' \
+  | sed 's|^\(.*\)$|        <li><a href="\1">\1</a></li>|g' \
   >> landing.html
 
 cat landing-bottom.html >> landing.html


### PR DESCRIPTION
With the previous script we were sorting entries of the form html/vX.Y.Z/index.html but the order is such that vX.Y/ < vX.Y.Z/ and so we were ending up with v1.7 coming after v1.7.3.

This fixes that by using sed to get rid of the html/ prefix and the /index.html suffix before the sorting phase.