### PR TITLE
Make reasoning modular by adding new `Reasoning.Syntax` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Bug-fixes
   in `Function.Construct.Composition` had their arguments in the wrong order. They have
   been flipped so they can actually be used as a composition operator.
 
+* The combinators `_≃⟨_⟩_` and `_≃˘⟨_⟩_` in `Data.Rational.Properties.≤-Reasoning`
+  now correctly accepts proofs of type `_≃_` instead of the previous proofs of type `_≡_`.
+
 * The following operators were missing a fixity declaration, which has now
   been fixed -
   ```
@@ -535,6 +538,10 @@ Non-backwards compatible changes
      terms involving those parameters.
   3. Finally, if the above approaches are not viable then you may be forced to explicitly
      use `cong` combined with a lemma that proves the old reduction behaviour.
+
+* Similarly, in order to prevent reduction, the equality `_≃_` in `Data.Rational.Base` 
+  has been made into a data type with the single constructor `*≡*`. The destructor `drop-*≡*`
+  has been added to `Data.Rational.Properties`.
 
 ### Change to the definition of `LeftCancellative` and `RightCancellative`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2832,6 +2832,7 @@ Additions to existing modules
   ```agda
   ↥ᵘ-toℚᵘ : ↥ᵘ (toℚᵘ p) ≡ ↥ p
   ↧ᵘ-toℚᵘ : ↧ᵘ (toℚᵘ p) ≡ ↧ p
+  ↥p≡↥q≡0⇒p≡q : ↥ p ≡ 0ℤ → ↥ q ≡ 0ℤ → p ≡ q
 
   _≥?_ : Decidable _≥_
   _>?_ : Decidable _>_
@@ -2856,6 +2857,10 @@ Additions to existing modules
 
 * Added new definitions in `Data.Rational.Unnormalised.Properties`:
   ```agda
+  ↥p≡0⇒p≃0 : ↥ p ≡ 0ℤ → p ≃ 0ℚᵘ
+  p≃0⇒↥p≡0 : p ≃ 0ℚᵘ → ↥ p ≡ 0ℤ
+  ↥p≡↥q≡0⇒p≃q : ↥ p ≡ 0ℤ → ↥ q ≡ 0ℤ → p ≃ q
+
   +-*-rawNearSemiring : RawNearSemiring 0ℓ 0ℓ
   +-*-rawSemiring     : RawSemiring 0ℓ 0ℓ
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1182,6 +1182,15 @@ Major improvements
 
 * In `Relation.Binary.Reasoning.Base.Triple`, added a new parameter `<-irrefl : Irreflexive _≈_ _<_`
 
+### More modular design of equational reasoning.
+
+* Have introduced a new module `Relation.Binary.Reasoning.Syntax` which exports 
+  a range of modules containing pre-existing reasoning combinator syntax.
+
+* This makes it possible to add new or rename existing reasoning combinators to a 
+  pre-existing `Reasoning` module in just a couple of lines 
+  (e.g. see `∣-Reasoning` in `Data.Nat.Divisibility`)
+
 Deprecated modules
 ------------------
 
@@ -1753,6 +1762,11 @@ Deprecated names
   sym-↔   ↦   ↔-sym
   ```
 
+* In `Function.Related.Propositional.Reasoning`:
+  ```agda
+  _↔⟨⟩_  ↦  _≡⟨⟩_
+  ```
+  
 * In `Foreign.Haskell.Either` and `Foreign.Haskell.Pair`:
   ```
   toForeign   ↦ Foreign.Haskell.Coerce.coerce
@@ -2640,6 +2654,8 @@ Additions to existing modules
   toℕ-inverseˡ  : Inverseˡ _≡_ _≡_ toℕ fromℕ
   toℕ-inverseʳ  : Inverseʳ _≡_ _≡_ toℕ fromℕ
   toℕ-inverseᵇ  : Inverseᵇ _≡_ _≡_ toℕ fromℕ
+  
+  <-asym : Asymmetric _<_
   ```
 
 * Added a new pattern synonym to `Data.Nat.Divisibility.Core`:

--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -127,10 +127,14 @@ module _ {A : Set a} where
 
 ------------------------------------------------------------------------
 -- Pointwise DSL
+--
 -- A guardedness check does not play well with compositional proofs.
 -- Luckily we can learn from Nils Anders Danielsson's
 -- Beating the Productivity Checker Using Embedded Languages
 -- and design a little compositional DSL to define such proofs
+--
+-- NOTE: also because of the guardedness check we can't use the standard
+-- `Relation.Binary.Reasoning.Syntax` approach.
 
 module pw-Reasoning (S : Setoid a ℓ) where
   private module S = Setoid S

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -34,6 +34,7 @@ import Relation.Binary.Construct.FromRel as Ind
 import Relation.Binary.Reasoning.Preorder as PreR
 import Relation.Binary.Reasoning.PartialOrder as POR
 open import Relation.Binary.PropositionalEquality as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Nullary.Negation
@@ -165,12 +166,11 @@ Any-∈ {P = P} = mk↔ₛ′
 module ⊑-Reasoning {a} {A : Set a} where
   private module Base = POR (⊑-Poset A)
 
-  open Base public
-    hiding (step-<; begin-strict_; step-≤)
+  open Base public hiding (step-<; step-≤)
 
-  infixr 2 step-⊑
-  step-⊑ = Base.step-≤
-  syntax step-⊑ x ys⊑zs xs⊑ys = x ⊑⟨ xs⊑ys ⟩ ys⊑zs
+  open ⊑-syntax _IsRelatedTo_ _IsRelatedTo_ Base.≤-go public
+  open ⊏-syntax _IsRelatedTo_ _IsRelatedTo_ Base.<-go public
+
 
 -- The subset relation forms a preorder.
 
@@ -179,22 +179,22 @@ module ⊑-Reasoning {a} {A : Set a} where
                  (λ xs≈ys → ⊑⇒⊆ (⊑P.reflexive xs≈ys))
   where module ⊑P = Poset (⊑-Poset A)
 
+-- Example uses:
+--
+--    x∈zs : x ∈ zs
+--    x∈zs =
+--      x  ∈⟨ x∈xs ⟩
+--      xs ⊆⟨ xs⊆ys ⟩
+--      ys ≡⟨ ys≡zs ⟩
+--      zs  ∎
 module ⊆-Reasoning {A : Set a} where
   private module Base = PreR (⊆-Preorder A)
 
-  open Base public
-    hiding (step-∼)
+  open Base public hiding (step-∼)
 
-  infixr 2 step-⊆
-  infix  1 step-∈
+  open begin-membership-syntax _IsRelatedTo_ _∈_ (λ x → begin x)
+  open ⊆-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go public
 
-  step-⊆ = Base.step-∼
-
-  step-∈ : ∀ (x : A) {xs ys} → xs IsRelatedTo ys → x ∈ xs → x ∈ ys
-  step-∈ x xs⊆ys x∈xs = (begin xs⊆ys) x∈xs
-
-  syntax step-⊆ xs ys⊆zs xs⊆ys = xs ⊆⟨ xs⊆ys ⟩ ys⊆zs
-  syntax step-∈ x  xs⊆ys x∈xs  = x  ∈⟨ x∈xs  ⟩ xs⊆ys
 
 -- take returns a prefix.
 take-⊑ : ∀ n (xs : Colist A) →

--- a/src/Data/Container/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Container/Relation/Unary/Any/Properties.agda
@@ -26,7 +26,6 @@ open import Relation.Binary.Core using (REL)
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≗_; refl)
 
-open Related.EquationalReasoning hiding (_≡⟨_⟩_)
 private
   module ×⊎ {k ℓ} = CommutativeSemiring (×-⊎-commutativeSemiring k ℓ)
 
@@ -71,6 +70,7 @@ module _ {s p} {C : Container s p} {x} {X : Set x}
     (∃ λ x → x ∈ xs₁ × P₁ x) ∼⟨ Σ.cong ↔-refl (xs₁≈xs₂ ×-cong P₁↔P₂ _) ⟩
     (∃ λ x → x ∈ xs₂ × P₂ x) ↔⟨ SK-sym (↔∈ C) ⟩
     ◇ C P₂ xs₂               ∎
+    where open Related.EquationalReasoning
 
 -- Nested occurrences of ◇ can sometimes be swapped.
 
@@ -95,6 +95,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
     (∃ λ y → y ∈ ys × ∃ λ x → x ∈ xs × P x y)  ↔⟨ Σ.cong ↔-refl (Σ.cong ↔-refl (SK-sym (↔∈ C₁))) ⟩
     (∃ λ y → y ∈ ys × ◇ _ (flip P y) xs)       ↔⟨ SK-sym (↔∈ C₂) ⟩
     ◇ _ (λ y → ◇ _ (flip P y) xs) ys           ∎
+    where open Related.EquationalReasoning
 
 -- Nested occurrences of ◇ can sometimes be flattened.
 
@@ -162,9 +163,10 @@ module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
   map↔∘ : ∀ {xs : ⟦ C ⟧ X} (f : X → Y) → ◇ C P (map f xs) ↔ ◇ C (P ∘′ f) xs
   map↔∘ {xs} f =
    ◇ C P (map f xs)          ↔⟨ ↔Σ C ⟩
-   ∃ (P ∘′ proj₂ (map f xs)) ↔⟨⟩
+   ∃ (P ∘′ proj₂ (map f xs)) ≡⟨⟩
    ∃ (P ∘′ f ∘′ proj₂ xs)    ↔⟨ SK-sym (↔Σ C) ⟩
    ◇ C (P ∘′ f) xs           ∎
+   where open Related.EquationalReasoning
 
 -- Membership in a mapped container can be expressed without reference
 -- to map.
@@ -178,6 +180,7 @@ module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
     y ∈ map f xs               ↔⟨ map↔∘ C (y ≡_) f ⟩
     ◇ C (λ x → y ≡ f x) xs     ↔⟨ ↔∈ C ⟩
     ∃ (λ x → x ∈ xs × y ≡ f x) ∎
+    where open Related.EquationalReasoning
 
 -- map is a congruence for bag and set equality and related preorders.
 
@@ -193,6 +196,7 @@ module _ {s p} (C : Container s p) {x y} {X : Set x} {Y : Set y}
     ◇ C (λ y → x ≡ f₂ y) xs₂ ↔⟨ SK-sym (map↔∘ C (_≡_ x) f₂) ⟩
     x ∈ map f₂ xs₂           ∎
     where
+    open Related.EquationalReasoning
     helper : ∀ y → (x ≡ f₁ y) ↔ (x ≡ f₂ y)
     helper y rewrite f₁≗f₂ y = ↔-refl
 
@@ -205,7 +209,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
   remove-linear {xs} m = mk↔ₛ′ t f t∘f f∘t
     where
     open _≃_
-    open P.≡-Reasoning renaming (_∎ to _∎′)
+    open P.≡-Reasoning
 
     position⊸m : ∀ {s} → Position C₂ (shape⊸ m s) ≃ Position C₁ s
     position⊸m = ↔⇒≃ (position⊸ m)
@@ -259,7 +263,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
 
          P.subst (P ∘ proj₂ xs) P.refl p                        ≡⟨⟩
 
-        p                                                       ∎′)
+        p                                                       ∎)
       )
 
     t∘f : t ∘ f ≗ id
@@ -279,7 +283,7 @@ module _ {s₁ s₂ p₁ p₂} {C₁ : Container s₁ p₁} {C₂ : Container s�
                                                                      (P.trans-symˡ (right-inverse-of position⊸m _)) ⟩
          P.subst (P ∘ proj₂ xs) P.refl p                        ≡⟨⟩
 
-        p                                                       ∎′)
+        p                                                       ∎)
       )
 
 -- Linear endomorphisms are identity functions if bag equality is used.
@@ -290,6 +294,7 @@ module _ {s p} {C : Container s p} {x} {X : Set x} where
   linear-identity {xs} m {x} =
     x ∈ ⟪ m ⟫⊸ xs  ↔⟨ remove-linear (_≡_ x) m ⟩
     x ∈        xs  ∎
+    where open Related.EquationalReasoning
 
 -- If join can be expressed using a linear morphism (in a certain
 -- way), then it can be absorbed by the predicate.
@@ -307,4 +312,6 @@ module _ {s₁ s₂ s₃ p₁ p₂ p₃}
     ◇ C₃ P (⟪ join ⟫⊸ xss′) ↔⟨ remove-linear P join ⟩
     ◇ (C₁ C.∘ C₂) P xss′    ↔⟨ SK-sym $ flatten P xss ⟩
     ◇ C₁ (◇ C₂ P) xss       ∎
-    where xss′ = Inverse.from (Composition.correct C₁ C₂) xss
+    where
+    open Related.EquationalReasoning
+    xss′ = Inverse.from (Composition.correct C₁ C₂) xss

--- a/src/Data/Integer/Divisibility/Signed.agda
+++ b/src/Data/Integer/Divisibility/Signed.agda
@@ -30,6 +30,7 @@ open import Relation.Binary.PropositionalEquality
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 open import Relation.Nullary.Decidable using (yes; no)
 import Relation.Nullary.Decidable as DEC
+open import Relation.Binary.Reasoning.Syntax
 
 ------------------------------------------------------------------------
 -- Type
@@ -118,15 +119,11 @@ open _∣_ using (quotient) public
 -- Divisibility reasoning
 
 module ∣-Reasoning where
-  private
-    module Base = PreorderReasoning ∣-preorder
+  private module Base = PreorderReasoning ∣-preorder
 
-  open Base public
-    hiding (step-∼; step-≈; step-≈˘)
+  open Base public hiding (step-∼; step-≈; step-≈˘)
 
-  infixr 2 step-∣
-  step-∣ = Base.step-∼
-  syntax step-∣ x y∣z x∣y = x ∣⟨ x∣y ⟩ y∣z
+  open ∣-syntax _IsRelatedTo_ _IsRelatedTo_ ∼-go public
 
 ------------------------------------------------------------------------
 -- Other properties of _∣_

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -365,7 +365,7 @@ i≮i = <-irrefl refl
 module ≤-Reasoning where
   open import Relation.Binary.Reasoning.Base.Triple
     ≤-isPreorder
-    <-irrefl
+    <-asym
     <-trans
     (resp₂ _<_)
     <⇒≤

--- a/src/Data/List/Relation/Binary/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/Binary/BagAndSetEquality.agda
@@ -37,11 +37,13 @@ open import Function.Related.TypeIsomorphisms
 open import Function.Properties.Inverse using (↔-sym; ↔-trans; to-from)
 open import Level using (Level)
 open import Relation.Binary.Core using (_⇒_)
+open import Relation.Binary.Definitions using (Trans)
 open import Relation.Binary.Bundles using (Preorder; Setoid)
 import Relation.Binary.Reasoning.Setoid as EqR
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 open import Relation.Binary.PropositionalEquality as P
   using (_≡_; _≢_; _≗_; refl)
+open import Relation.Binary.Reasoning.Syntax
 open import Relation.Nullary
 open import Data.List.Membership.Propositional.Properties
 
@@ -90,29 +92,22 @@ bag-=⇒ xs≈ys = ↔⇒ xs≈ys
 ------------------------------------------------------------------------
 -- "Equational" reasoning for _⊆_ along with an additional relatedness
 
-module ⊆-Reasoning where
-  private
-    module PreOrder {a} {A : Set a} = PreorderReasoning (⊆-preorder A)
+module ⊆-Reasoning {A : Set a} where
+  private module Base = PreorderReasoning (⊆-preorder A)
 
-  open PreOrder public
+  open Base public
     hiding (step-≈; step-≈˘; step-∼)
+    renaming (∼-go to ⊆-go)
 
-  infixr 2 step-∼ step-⊆
-  infix  1 step-∈
+  open begin-membership-syntax _IsRelatedTo_ _∈_ (λ x → begin x) public
+  open ⊆-syntax _IsRelatedTo_ _IsRelatedTo_ ⊆-go public
 
-  step-⊆ = PreOrder.step-∼
+  module _ {k : Related.ForwardKind} where
+    ∼-go : Trans _∼[ ⌊ k ⌋→ ]_ _IsRelatedTo_ _IsRelatedTo_
+    ∼-go eq = ⊆-go (⇒→ eq)
 
-  step-∈ : ∀ x {xs ys : List A} →
-           xs IsRelatedTo ys → x ∈ xs → x ∈ ys
-  step-∈ x xs⊆ys x∈xs = (begin xs⊆ys) x∈xs
+    open ∼-syntax _IsRelatedTo_ _IsRelatedTo_ ∼-go public
 
-  step-∼ : ∀ {k} xs {ys zs : List A} →
-           ys IsRelatedTo zs → xs ∼[ ⌊ k ⌋→ ] ys → xs IsRelatedTo zs
-  step-∼ xs ys⊆zs xs≈ys = step-⊆ xs ys⊆zs (⇒→ xs≈ys)
-
-  syntax step-∈ x  xs⊆ys x∈xs  = x ∈⟨ x∈xs ⟩ xs⊆ys
-  syntax step-∼ xs ys⊆zs xs≈ys = xs ∼⟨ xs≈ys ⟩ ys⊆zs
-  syntax step-⊆ xs ys⊆zs xs⊆ys = xs ⊆⟨ xs⊆ys ⟩ ys⊆zs
 
 ------------------------------------------------------------------------
 -- Congruence lemmas

--- a/src/Data/List/Relation/Binary/Permutation/Propositional.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional.agda
@@ -16,6 +16,7 @@ open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Binary.Definitions using (Reflexive; Transitive)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 import Relation.Binary.Reasoning.Setoid as EqReasoning
+open import Relation.Binary.Reasoning.Syntax
 
 ------------------------------------------------------------------------
 -- An inductive definition of permutation
@@ -73,16 +74,15 @@ data _↭_ : Rel (List A) a where
 
 module PermutationReasoning where
 
-  private
-    module Base = EqReasoning ↭-setoid
+  private module Base = EqReasoning ↭-setoid
 
-  open EqReasoning ↭-setoid public
-    hiding (step-≈; step-≈˘)
+  open Base public hiding (step-≈; step-≈˘)
 
-  infixr 2 step-↭  step-↭˘ step-swap step-prep
+  open ↭-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go ↭-sym public
 
-  step-↭  = Base.step-≈
-  step-↭˘ = Base.step-≈˘
+  -- Some extra combinators that allow us to skip certain elements
+
+  infixr 2 step-swap step-prep
 
   -- Skip reasoning on the first element
   step-prep : ∀ x xs {ys zs : List A} → (x ∷ ys) IsRelatedTo zs →
@@ -94,7 +94,5 @@ module PermutationReasoning where
               xs ↭ ys → (x ∷ y ∷ xs) IsRelatedTo zs
   step-swap x y xs rel xs↭ys = relTo (trans (swap x y xs↭ys) (begin rel))
 
-  syntax step-↭  x y↭z x↭y = x ↭⟨  x↭y ⟩ y↭z
-  syntax step-↭˘ x y↭z y↭x = x ↭˘⟨  y↭x ⟩ y↭z
   syntax step-prep x xs y↭z x↭y = x ∷ xs <⟨ x↭y ⟩ y↭z
   syntax step-swap x y xs y↭z x↭y = x ∷ y ∷ xs <<⟨ x↭y ⟩ y↭z

--- a/src/Data/List/Relation/Binary/Permutation/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Setoid.agda
@@ -6,11 +6,13 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
+open import Function.Base using (_∘′_)
 open import Relation.Binary.Core using (Rel; _⇒_)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Binary.Definitions
   using (Reflexive; Symmetric; Transitive)
+open import Relation.Binary.Reasoning.Syntax
 
 module Data.List.Relation.Binary.Permutation.Setoid
   {a ℓ} (S : Setoid a ℓ) where
@@ -86,24 +88,16 @@ steps (trans xs↭ys ys↭zs) = steps xs↭ys + steps ys↭zs
 
 module PermutationReasoning where
 
-  private
-    module Base = SetoidReasoning ↭-setoid
+  private module Base = SetoidReasoning ↭-setoid
 
-  open SetoidReasoning ↭-setoid public
-    hiding (step-≈; step-≈˘)
+  open Base public hiding (step-≈; step-≈˘)
 
-  infixr 2 step-↭  step-↭˘ step-≋ step-≋˘ step-swap step-prep
+  open ↭-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go ↭-sym public
+  open ≋-syntax _IsRelatedTo_ _IsRelatedTo_ (Base.∼-go ∘′ refl) ≋-sym public
 
-  step-↭  = Base.step-≈
-  step-↭˘ = Base.step-≈˘
+  -- Some extra combinators that allow us to skip certain elements
 
-  -- Step with pointwise list equality
-  step-≋ : ∀ x {y z} → y IsRelatedTo z → x ≋ y → x IsRelatedTo z
-  step-≋ x (relTo y↔z) x≋y = relTo (trans (refl x≋y) y↔z)
-
-  -- Step with flipped pointwise list equality
-  step-≋˘ : ∀ x {y z} → y IsRelatedTo z → y ≋ x → x IsRelatedTo z
-  step-≋˘ x y↭z y≋x = x ≋⟨ ≋-sym y≋x ⟩ y↭z
+  infixr 2 step-swap step-prep
 
   -- Skip reasoning on the first element
   step-prep : ∀ x xs {ys zs : List A} → (x ∷ ys) IsRelatedTo zs →
@@ -115,9 +109,5 @@ module PermutationReasoning where
               xs ↭ ys → (x ∷ y ∷ xs) IsRelatedTo zs
   step-swap x y xs rel xs↭ys = relTo (trans (swap Eq.refl Eq.refl xs↭ys) (begin rel))
 
-  syntax step-↭  x y↭z x↭y = x ↭⟨  x↭y ⟩ y↭z
-  syntax step-↭˘ x y↭z y↭x = x ↭˘⟨  y↭x ⟩ y↭z
-  syntax step-≋  x y↭z x≋y = x ≋⟨  x≋y ⟩ y↭z
-  syntax step-≋˘ x y↭z y≋x = x ≋˘⟨  y≋x ⟩ y↭z
   syntax step-prep x xs y↭z x↭y = x ∷ xs <⟨ x↭y ⟩ y↭z
   syntax step-swap x y xs y↭z x↭y = x ∷ y ∷ xs <<⟨ x↭y ⟩ y↭z

--- a/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Setoid/Properties.agda
@@ -32,6 +32,7 @@ open import Relation.Binary.Definitions
 open import Relation.Binary.Bundles using (Setoid; Preorder)
 open import Relation.Binary.Structures using (IsPreorder)
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
+open import Relation.Binary.Reasoning.Syntax
 
 open Setoid using (Carrier)
 
@@ -112,31 +113,15 @@ module _ (S : Setoid a ℓ) where
 ------------------------------------------------------------------------
 
 module ⊆-Reasoning (S : Setoid a ℓ) where
+  open Membership S using (_∈_)
 
-  open Setoid S renaming (Carrier to A)
-  open Subset S
-  open Membership S
+  private module Base = PreorderReasoning (⊆-preorder S)
 
-  private
-    module Base = PreorderReasoning (⊆-preorder S)
+  open Base public hiding (step-∼; step-≈; step-≈˘)
 
-  open Base public
-    hiding (step-∼; step-≈; step-≈˘)
-
-  infixr 2 step-⊆ step-≋ step-≋˘
-  infix 1 step-∈
-
-  step-∈ : ∀ x {xs ys} → xs IsRelatedTo ys → x ∈ xs → x ∈ ys
-  step-∈ x xs⊆ys x∈xs = (begin xs⊆ys) x∈xs
-
-  step-⊆  = Base.step-∼
-  step-≋  = Base.step-≈
-  step-≋˘ = Base.step-≈˘
-
-  syntax step-∈  x  xs⊆ys x∈xs  = x  ∈⟨  x∈xs  ⟩ xs⊆ys
-  syntax step-⊆  xs ys⊆zs xs⊆ys = xs ⊆⟨  xs⊆ys ⟩ ys⊆zs
-  syntax step-≋  xs ys⊆zs xs≋ys = xs ≋⟨  xs≋ys ⟩ ys⊆zs
-  syntax step-≋˘ xs ys⊆zs xs≋ys = xs ≋˘⟨ xs≋ys ⟩ ys⊆zs
+  open begin-membership-syntax _IsRelatedTo_ _∈_ (λ x → Base.begin x) public
+  open ⊆-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go public
+  open ≋-syntax _IsRelatedTo_ _IsRelatedTo_ Base.≈-go public
 
 ------------------------------------------------------------------------
 -- Relationship with other binary relations

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -27,13 +27,7 @@ open import Function.Base using (_∘_; _$_; id)
 open import Function.Definitions
 open import Function.Consequences.Propositional
 open import Level using (0ℓ)
-open import Relation.Binary.Core using (_⇒_; _Preserves_⟶_; _Preserves₂_⟶_⟶_)
-open import Relation.Binary.Bundles
-  using (Setoid; DecSetoid; StrictPartialOrder; StrictTotalOrder; Preorder; Poset; TotalOrder; DecTotalOrder)
-open import Relation.Binary.Definitions
-  using (Decidable; Irreflexive; Transitive; Reflexive; Antisymmetric; Total; Trichotomous; tri≈; tri<; tri>)
-open import Relation.Binary.Structures
-  using (IsDecEquivalence; IsStrictPartialOrder; IsStrictTotalOrder; IsPreorder; IsPartialOrder; IsTotalOrder; IsDecTotalOrder)
+open import Relation.Binary
 open import Relation.Binary.Consequences
 open import Relation.Binary.Morphism
 import Relation.Binary.Morphism.OrderMonomorphism as OrderMonomorphism
@@ -371,6 +365,9 @@ toℕ-isMonomorphism-< = record
 <-trans (odd<odd x<y) (odd<even (inj₂ refl))   =  odd<even (inj₁ x<y)
 <-trans (odd<odd x<y) (odd<odd y<z)            =  odd<odd (<-trans x<y y<z)
 
+<-asym : Asymmetric _<_
+<-asym {x} {y} = trans∧irr⇒asym refl <-trans <-irrefl {x} {y}
+
 -- Should not be implemented via the morphism `toℕ` in order to
 -- preserve O(log n) time requirement.
 <-cmp : Trichotomous _≡_ _<_
@@ -610,7 +607,7 @@ module ≤-Reasoning where
 
   open import Relation.Binary.Reasoning.Base.Triple
     ≤-isPreorder
-    <-irrefl
+    <-asym
     <-trans
     (resp₂ _<_)
     <⇒≤

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -27,6 +27,7 @@ open import Relation.Binary.Definitions
 import Relation.Binary.Reasoning.Preorder as PreorderReasoning
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl; sym; trans; cong; cong₂; subst)
+open import Relation.Binary.Reasoning.Syntax
 import Relation.Binary.PropositionalEquality.Properties as PropEq
 
 ------------------------------------------------------------------------
@@ -117,15 +118,11 @@ suc n ∣? m      = Dec.map (m%n≡0⇔n∣m m (suc n)) (m % suc n ≟ 0)
 -- A reasoning module for the _∣_ relation
 
 module ∣-Reasoning where
-  private
-    module Base = PreorderReasoning ∣-preorder
+  private module Base = PreorderReasoning ∣-preorder
 
-  open Base public
-    hiding (step-≈; step-≈˘; step-∼)
+  open Base public hiding (step-≈; step-≈˘; step-∼)
 
-  infixr 2 step-∣
-  step-∣ = Base.step-∼
-  syntax step-∣ x y∣z x∣y = x ∣⟨ x∣y ⟩ y∣z
+  open ∣-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go public
 
 ------------------------------------------------------------------------
 -- Simple properties of _∣_

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -496,7 +496,7 @@ m<1+n⇒m≤n (s≤s m≤n) = m≤n
 module ≤-Reasoning where
   open import Relation.Binary.Reasoning.Base.Triple
     ≤-isPreorder
-    <-irrefl
+    <-asym
     <-trans
     (resp₂ _<_)
     <⇒≤

--- a/src/Data/Rational/Base.agda
+++ b/src/Data/Rational/Base.agda
@@ -66,8 +66,11 @@ mkℚ+ n (suc d) coprime = mkℚ (+ n) d coprime
 
 infix 4 _≃_
 
-_≃_ : Rel ℚ 0ℓ
-p ≃ q = (↥ p ℤ.* ↧ q) ≡ (↥ q ℤ.* ↧ p)
+data _≃_ : Rel ℚ 0ℓ where
+  *≡* : ∀ {p q} → (↥ p ℤ.* ↧ q) ≡ (↥ q ℤ.* ↧ p) → p ≃ q
+
+_≄_ : Rel ℚ 0ℓ
+p ≄ q = ¬ (p ≃ q)
 
 ------------------------------------------------------------------------
 -- Ordering of rationals

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -49,13 +49,7 @@ import Data.Sign as S
 open import Function.Base using (_∘_; _∘′_; _∘₂_; _$_; flip)
 open import Function.Definitions using (Injective)
 open import Level using (0ℓ)
-open import Relation.Binary.Core using (_⇒_; _Preserves_⟶_; _Preserves₂_⟶_⟶_)
-open import Relation.Binary.Bundles
-  using (Setoid; DecSetoid; TotalPreorder; DecTotalOrder; StrictPartialOrder; StrictTotalOrder; DenseLinearOrder)
-open import Relation.Binary.Structures
-  using (IsPreorder; IsTotalOrder; IsTotalPreorder; IsPartialOrder; IsDecTotalOrder; IsStrictPartialOrder; IsStrictTotalOrder; IsDenseLinearOrder)
-open import Relation.Binary.Definitions
-  using (DecidableEquality; Reflexive; Transitive; Antisymmetric; Total; Decidable; Irrelevant; Irreflexive; Asymmetric; Dense; Trans; Trichotomous; tri<; tri>; tri≈; _Respectsʳ_; _Respectsˡ_; _Respects₂_)
+open import Relation.Binary
 open import Relation.Binary.PropositionalEquality
 open import Relation.Binary.Morphism.Structures
 import Relation.Binary.Morphism.OrderMonomorphism as OrderMonomorphisms
@@ -738,7 +732,7 @@ _>?_ = flip _<?_
 module ≤-Reasoning where
   import Relation.Binary.Reasoning.Base.Triple
     ≤-isPreorder
-    <-irrefl
+    <-asym
     <-trans
     (resp₂ _<_)
     <⇒≤
@@ -748,14 +742,6 @@ module ≤-Reasoning where
 
   open Triple public
     hiding (step-≈; step-≈˘)
-
-  infixr 2 step-≃ step-≃˘
-
-  step-≃  = Triple.step-≈
-  step-≃˘ = Triple.step-≈˘
-
-  syntax step-≃  x y∼z x≃y = x ≃⟨  x≃y ⟩ y∼z
-  syntax step-≃˘ x y∼z y≃x = x ≃˘⟨ y≃x ⟩ y∼z
 
 ------------------------------------------------------------------------
 -- Properties of Positive/NonPositive/Negative/NonNegative and _≤_/_<_

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -753,7 +753,7 @@ module ≤-Reasoning where
   ≃-go = Triple.≈-go ∘′ ≃⇒≡
   
   open ≃-syntax _IsRelatedTo_ _IsRelatedTo_ ≃-go (λ {x y} → ≃-sym {x} {y}) public
-{-
+
 ------------------------------------------------------------------------
 -- Properties of Positive/NonPositive/Negative/NonNegative and _≤_/_<_
 
@@ -1728,4 +1728,3 @@ Please use neg<pos instead."
 open Data.Rational.Base public
   using (+-rawMagma; +-0-rawGroup; *-rawMagma; +-*-rawNearSemiring; +-*-rawSemiring; +-*-rawRing)
   renaming (+-0-rawMonoid to +-rawMonoid; *-1-rawMonoid to *-rawMonoid)
--}

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -177,6 +177,9 @@ drop-*≡* (*≡* eq) = eq
 p≡0⇒↥p≡0 : ∀ p → p ≡ 0ℚ → ↥ p ≡ 0ℤ
 p≡0⇒↥p≡0 p refl = refl
 
+↥p≡↥q≡0⇒p≡q : ∀ p q → ↥ p ≡ 0ℤ → ↥ q ≡ 0ℤ → p ≡ q
+↥p≡↥q≡0⇒p≡q p q ↥p≡0 ↥q≡0 = trans (↥p≡0⇒p≡0 p ↥p≡0) (sym (↥p≡0⇒p≡0 q ↥q≡0))
+
 ------------------------------------------------------------------------
 -- Basic properties of sign predicates
 ------------------------------------------------------------------------
@@ -846,14 +849,14 @@ toℚᵘ-homo-+ p@record{} q@record{} with +-nf p q ℤ.≟ 0ℤ
   eq : ↥ (p + q) ≡ 0ℤ
   eq rewrite eq2 = cong ↥_ (0/n≡0 (↧ₙ p ℕ.* ↧ₙ q))
 
-... | no  nf[p,q]≢0 = *≡* $ ℤ.*-cancelʳ-≡ _ _ (+-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} $ begin
+... | no  nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (+-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} $ begin
     (↥ᵘ (toℚᵘ (p + q))) ℤ.* ↧+ᵘ p q  ℤ.* +-nf p q ≡⟨ cong (λ v → v ℤ.* ↧+ᵘ p q ℤ.* +-nf p q) (↥ᵘ-toℚᵘ (p + q)) ⟩
     ↥ (p + q) ℤ.* ↧+ᵘ p q ℤ.* +-nf p q            ≡⟨ xy∙z≈xz∙y (↥ (p + q)) _ _ ⟩
     ↥ (p + q) ℤ.* +-nf p q ℤ.* ↧+ᵘ p q            ≡⟨ cong (ℤ._* ↧+ᵘ p q) (↥-+ p q) ⟩
     ↥+ᵘ p q ℤ.* ↧+ᵘ p q                           ≡⟨ cong (↥+ᵘ p q ℤ.*_) (sym (↧-+ p q)) ⟩
     ↥+ᵘ p q ℤ.* (↧ (p + q) ℤ.* +-nf p q)          ≡⟨ x∙yz≈xy∙z (↥+ᵘ p q) _ _ ⟩
     ↥+ᵘ p q ℤ.* ↧ (p + q)  ℤ.* +-nf p q           ≡˘⟨ cong (λ v → ↥+ᵘ p q ℤ.* v ℤ.* +-nf p q) (↧ᵘ-toℚᵘ (p + q)) ⟩
-    ↥+ᵘ p q ℤ.* ↧ᵘ (toℚᵘ (p + q)) ℤ.* +-nf p q    ∎
+    ↥+ᵘ p q ℤ.* ↧ᵘ (toℚᵘ (p + q)) ℤ.* +-nf p q    ∎)
   where open ≡-Reasoning; open CommSemigroupProperties ℤ.*-commutativeSemigroup
 
 toℚᵘ-isMagmaHomomorphism-+ : IsMagmaHomomorphism +-rawMagma ℚᵘ.+-rawMagma toℚᵘ
@@ -1057,14 +1060,14 @@ toℚᵘ-homo-* p@record{} q@record{} with *-nf p q ℤ.≟ 0ℤ
 
   eq : ↥ (p * q) ≡ 0ℤ
   eq rewrite eq2 = cong ↥_ (0/n≡0 (↧ₙ p ℕ.* ↧ₙ q))
-... | no nf[p,q]≢0 = *≡* $ ℤ.*-cancelʳ-≡ _ _ (*-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} $ begin
+... | no nf[p,q]≢0 = *≡* (ℤ.*-cancelʳ-≡ _ _ (*-nf p q) {{ℤ.≢-nonZero nf[p,q]≢0}} $ begin
   ↥ᵘ (toℚᵘ (p * q)) ℤ.* (↧ p ℤ.* ↧ q) ℤ.* *-nf p q     ≡⟨ cong (λ v → v ℤ.* (↧ p ℤ.* ↧ q) ℤ.* *-nf p q) (↥ᵘ-toℚᵘ (p * q)) ⟩
   ↥ (p * q)         ℤ.* (↧ p ℤ.* ↧ q) ℤ.* *-nf p q     ≡⟨ xy∙z≈xz∙y (↥ (p * q)) _ _ ⟩
   ↥ (p * q)         ℤ.* *-nf p q ℤ.* (↧ p ℤ.* ↧ q)     ≡⟨ cong (ℤ._* (↧ p ℤ.* ↧ q)) (↥-* p q) ⟩
   (↥ p ℤ.* ↥ q)     ℤ.* (↧ p ℤ.* ↧ q)                  ≡⟨ cong ((↥ p ℤ.* ↥ q) ℤ.*_) (sym (↧-* p q)) ⟩
   (↥ p ℤ.* ↥ q)     ℤ.* (↧ (p * q) ℤ.* *-nf p q)       ≡⟨ x∙yz≈xy∙z (↥ p ℤ.* ↥ q) _ _ ⟩
   (↥ p ℤ.* ↥ q)     ℤ.* ↧ (p * q)  ℤ.* *-nf p q        ≡˘⟨ cong (λ v → (↥ p ℤ.* ↥ q) ℤ.* v ℤ.* *-nf p q) (↧ᵘ-toℚᵘ (p * q)) ⟩
-  (↥ p ℤ.* ↥ q)     ℤ.* ↧ᵘ (toℚᵘ (p * q)) ℤ.* *-nf p q ∎
+  (↥ p ℤ.* ↥ q)     ℤ.* ↧ᵘ (toℚᵘ (p * q)) ℤ.* *-nf p q ∎)
   where open ≡-Reasoning; open CommSemigroupProperties ℤ.*-commutativeSemigroup
 
 toℚᵘ-homo-1/ : ∀ p .{{_ : NonZero p}} → toℚᵘ (1/ p) ℚᵘ.≃ (ℚᵘ.1/ toℚᵘ p)

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -155,6 +155,19 @@ proj₂ (≄-tight p q) p≃q p≄q = p≄q p≃q
 
 module ≃-Reasoning = SetoidReasoning ≃-setoid
 
+↥p≡0⇒p≃0 : ∀ p → ↥ p ≡ 0ℤ → p ≃ 0ℚᵘ
+↥p≡0⇒p≃0 p ↥p≡0 = *≡* (cong (ℤ._* (↧ 0ℚᵘ)) ↥p≡0)
+
+p≃0⇒↥p≡0 : ∀ p → p ≃ 0ℚᵘ → ↥ p ≡ 0ℤ
+p≃0⇒↥p≡0 p (*≡* eq) = begin
+  ↥ p          ≡˘⟨ ℤ.*-identityʳ (↥ p) ⟩
+  ↥ p ℤ.* 1ℤ  ≡⟨ eq ⟩
+  0ℤ           ∎
+  where open ≡-Reasoning
+  
+↥p≡↥q≡0⇒p≃q : ∀ p q → ↥ p ≡ 0ℤ → ↥ q ≡ 0ℤ → p ≃ q
+↥p≡↥q≡0⇒p≃q p q ↥p≡0 ↥q≡0 = ≃-trans (↥p≡0⇒p≃0 p ↥p≡0) (≃-sym (↥p≡0⇒p≃0 _ ↥q≡0))
+
 ------------------------------------------------------------------------
 -- Properties of -_
 ------------------------------------------------------------------------

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -43,6 +43,7 @@ import Relation.Binary.Consequences as BC
 open import Relation.Binary.PropositionalEquality
 import Relation.Binary.Properties.Poset as PosetProperties
 import Relation.Binary.Reasoning.Setoid as SetoidReasoning
+open import Relation.Binary.Reasoning.Syntax
 
 open import Algebra.Properties.CommutativeSemigroup ℤ.*-commutativeSemigroup
 
@@ -583,7 +584,7 @@ _>?_ = flip _<?_
 module ≤-Reasoning where
   import Relation.Binary.Reasoning.Base.Triple
     ≤-isPreorder
-    <-irrefl
+    <-asym
     <-trans
     <-resp-≃
     <⇒≤
@@ -594,13 +595,7 @@ module ≤-Reasoning where
   open Triple public
     hiding (step-≈; step-≈˘)
 
-  infixr 2 step-≃ step-≃˘
-
-  step-≃  = Triple.step-≈
-  step-≃˘ = Triple.step-≈˘
-
-  syntax step-≃  x y∼z x≃y = x ≃⟨  x≃y ⟩ y∼z
-  syntax step-≃˘ x y∼z y≃x = x ≃˘⟨ y≃x ⟩ y∼z
+  open ≃-syntax _IsRelatedTo_ _IsRelatedTo_  Triple.≈-go ≃-sym public
 
 ------------------------------------------------------------------------
 -- Properties of ↥_/↧_

--- a/src/Data/Vec/Relation/Binary/Lex/NonStrict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/NonStrict.agda
@@ -261,7 +261,7 @@ module ≤-Reasoning  {_≈_ : Rel A ℓ₁} {_≼_ : Rel A ℓ₂}
 
   open import Relation.Binary.Reasoning.Base.Triple
     (≤-isPreorder ≼-po {n})
-    <-irrefl
+    (<-asym isEquivalence ≤-resp-≈ antisym)
     (<-trans ≼-po)
     (<-resp₂ isEquivalence ≤-resp-≈)
     <⇒≤

--- a/src/Data/Vec/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/Vec/Relation/Binary/Lex/Strict.agda
@@ -325,23 +325,21 @@ module _ {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂} where
 -- Equational Reasoning
 ------------------------------------------------------------------------
 
-module ≤-Reasoning {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂}
-                   (≈-isEquivalence : IsEquivalence _≈_)
-                   (≺-irrefl : Irreflexive _≈_ _≺_)
-                   (≺-trans : Transitive _≺_)
-                   (≺-resp-≈ : _≺_ Respects₂ _≈_)
-                   (n : ℕ)
-                   where
+module ≤-Reasoning
+  {_≈_ : Rel A ℓ₁} {_≺_ : Rel A ℓ₂}
+  (≺-isStrictPartialOrder : IsStrictPartialOrder _≈_ _≺_)
+  (n : ℕ)
+  where
 
-  private
-    ≈-isPartialEquivalence = IsEquivalence.isPartialEquivalence ≈-isEquivalence
+  open IsStrictPartialOrder ≺-isStrictPartialOrder
 
   open import Relation.Binary.Reasoning.Base.Triple
-    (≤-isPreorder ≈-isEquivalence ≺-trans ≺-resp-≈)
-    (<-irrefl ≺-irrefl)
-    (<-trans ≈-isPartialEquivalence ≺-resp-≈ ≺-trans)
-    (<-respects₂ ≈-isPartialEquivalence ≺-resp-≈)
+    (≤-isPreorder isEquivalence trans <-resp-≈)
+    (<-asym Eq.sym <-resp-≈ asym)
+    (<-trans Eq.isPartialEquivalence <-resp-≈ trans)
+    (<-respects₂ Eq.isPartialEquivalence <-resp-≈)
     (<⇒≤ {m = n})
-    (<-transˡ ≈-isPartialEquivalence ≺-resp-≈ ≺-trans)
-    (<-transʳ ≈-isPartialEquivalence ≺-resp-≈ ≺-trans)
+    (<-transˡ Eq.isPartialEquivalence <-resp-≈ trans)
+    (<-transʳ Eq.isPartialEquivalence <-resp-≈ trans)
     public
+

--- a/src/Function/Related/Propositional.agda
+++ b/src/Function/Related/Propositional.agda
@@ -10,11 +10,12 @@ module Function.Related.Propositional where
 
 open import Level
 open import Relation.Binary
-  using (Sym; Reflexive; Trans; IsEquivalence; Setoid; IsPreorder; Preorder)
+  using (Rel; REL; Sym; Reflexive; Trans; IsEquivalence; Setoid; IsPreorder; Preorder)
 open import Function.Bundles
 open import Function.Base
 open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
 import Relation.Binary.PropositionalEquality.Properties as P
+open import Relation.Binary.Reasoning.Syntax
 
 open import Function.Properties.Surjection   using (↠⇒↪; ↠⇒⇔)
 open import Function.Properties.RightInverse using (↪⇒↠)
@@ -293,41 +294,39 @@ K-preorder k ℓ = record { isPreorder = K-isPreorder k }
 ------------------------------------------------------------------------
 -- Equational reasoning
 
--- Equational reasoning for related things.
+-- Equational reasoning for related things. Note that we don't use
+-- the `Relation.Binary.Reasoning.Syntax` for this as this relation
+-- is heterogeneous.
 
-module EquationalReasoning where
+module EquationalReasoning {k : Kind} where
 
-  infix  3 _∎
-  infixr 2 _∼⟨_⟩_ _⤖⟨_⟩_ _↔⟨_⟩_ _↔⟨⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_
-  infix  1 begin_
+  -- Combinators with one heterogeneous relation
+  module _ {a b : Level} where
+    open begin-syntax (Related {a} {b} k) id public
+    open ≡-noncomputing-syntax (Related {a} {b} k) public
 
-  begin_ : ∀ {k} → A ∼[ k ] B → A ∼[ k ] B
-  begin_ x∼y = x∼y
+  -- Combinators with two heterogeneous relations
+  module _ {a b c : Level} where
+    private
+      rel1 = Related {b} {c} k
+      rel2 = Related {a} {c} k
 
-  _∼⟨_⟩_ : (A : Set a) → A ∼[ k ] B → B ∼[ k ] C → A ∼[ k ] C
-  _ ∼⟨ A↝B ⟩ B↝C = K-trans A↝B B↝C
+    open ∼-syntax rel1 rel2 K-trans public
+    open ⤖-syntax rel1 rel2 (K-trans ∘′ ↔⇒ ∘′ ⤖⇒↔) Symmetry.⤖-sym public
+    open ↔-syntax rel1 rel2 (K-trans ∘′ ↔⇒) Symmetry.↔-sym public
 
-  -- Isomorphisms and bijections can be combined with any other kind of
-  -- relatedness.
+  -- Combinators with homogeneous relations
+  module _ {a : Level} where
+    open end-syntax (Related {a} k) K-refl public
 
-  _⤖⟨_⟩_ : (A : Set a) → A ⤖ B → B ∼[ k ] C → A ∼[ k ] C
-  A ⤖⟨ A⤖B ⟩ B⇔C = A ∼⟨ ↔⇒ (⤖⇒↔ A⤖B) ⟩ B⇔C
 
-  _↔⟨_⟩_ : (A : Set a) → A ↔ B → B ∼[ k ] C → A ∼[ k ] C
-  A ↔⟨ A↔B ⟩ B⇔C = A ∼⟨ ↔⇒ A↔B ⟩ B⇔C
-
+  infixr 2 _↔⟨⟩_
   _↔⟨⟩_ : (A : Set a) → A ∼[ k ] B → A ∼[ k ] B
   A ↔⟨⟩ A⇔B = A⇔B
-
-  _≡⟨_⟩_ : (A : Set a) → A ≡ B → B ∼[ k ] C → A ∼[ k ] C
-  A ≡⟨ A≡B ⟩ B⇔C = A ∼⟨ ≡⇒ A≡B ⟩ B⇔C
-
-  _≡˘⟨_⟩_ : (A : Set a) → B ≡ A → B ∼[ k ] C → A ∼[ k ] C
-  A ≡˘⟨ B≡A ⟩ B⇔C = A ∼⟨ ≡⇒ (P.sym B≡A) ⟩ B⇔C
-
-  _∎ : (A : Set a) → A ∼[ k ] A
-  A ∎ = K-refl
-
+  {-# WARNING_ON_USAGE _↔⟨⟩_
+  "Warning: _↔⟨⟩_ was deprecated in v2.0.
+  Please use _≡⟨⟩_ instead. "
+  #-}
 
 ------------------------------------------------------------------------
 -- Every unary relation induces a preorder and, for symmetric kinds,

--- a/src/Induction/WellFounded.agda
+++ b/src/Induction/WellFounded.agda
@@ -14,7 +14,7 @@ open import Induction
 open import Level using (Level; _⊔_)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Definitions
-  using (Symmetric; Asymmetric; Irreflexive; _Respects₂_; 
+  using (Symmetric; Asymmetric; Irreflexive; _Respects₂_;
     _Respectsʳ_; _Respects_)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 open import Relation.Binary.Consequences using (asym⇒irr)
@@ -130,7 +130,7 @@ module _ {_<_ : Rel A r} where
   wf⇒asym : WellFounded _<_ → Asymmetric _<_
   wf⇒asym wf = acc⇒asym (wf _)
 
-  wf⇒irrefl : {_≈_ : Rel A ℓ} → _<_ Respects₂ _≈_ → 
+  wf⇒irrefl : {_≈_ : Rel A ℓ} → _<_ Respects₂ _≈_ →
               Symmetric _≈_ → WellFounded _<_ → Irreflexive _≈_ _<_
   wf⇒irrefl r s wf = asym⇒irr r s (wf⇒asym wf)
 

--- a/src/Relation/Binary/Bundles.agda
+++ b/src/Relation/Binary/Bundles.agda
@@ -100,7 +100,7 @@ record Preorder c ℓ₁ ℓ₂ : Set (suc (c ⊔ ℓ₁ ⊔ ℓ₂)) where
   _≳_ = flip _≲_
 
   -- Deprecated.
-  infix 4 _∼_ 
+  infix 4 _∼_
   _∼_ = _≲_
   {-# WARNING_ON_USAGE _∼_
   "Warning: _∼_ was deprecated in v2.0.

--- a/src/Relation/Binary/Construct/Closure/ReflexiveTransitive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/ReflexiveTransitive/Properties.agda
@@ -17,7 +17,8 @@ open import Relation.Binary.Construct.Closure.ReflexiveTransitive
 open import Relation.Binary.PropositionalEquality.Core as PropEq
   using (_≡_; refl; sym; cong; cong₂)
 import Relation.Binary.PropositionalEquality.Properties as PropEq
-import Relation.Binary.Reasoning.Preorder as PreR
+import Relation.Binary.Reasoning.Preorder as PreorderReasoning
+open import Relation.Binary.Reasoning.Syntax
 
 ------------------------------------------------------------------------
 -- _◅◅_
@@ -112,17 +113,9 @@ module _ {i t} {I : Set i} (T : Rel I t) where
 -- Preorder reasoning for Star
 
 module StarReasoning {i t} {I : Set i} (T : Rel I t) where
-  private module Base = PreR (preorder T)
+  private module Base = PreorderReasoning (preorder T)
 
-  open Base public
-    hiding (step-≈; step-∼)
+  open Base public hiding (step-≈; step-∼)
 
-  infixr 2 step-⟶ step-⟶⋆
-
-  step-⟶⋆ = Base.step-∼
-
-  step-⟶ : ∀ x {y z} → y IsRelatedTo z → T x y → x IsRelatedTo z
-  step-⟶ x y⟶⋆z x⟶y = step-⟶⋆ x y⟶⋆z (x⟶y ◅ ε)
-
-  syntax step-⟶⋆ x y⟶⋆z x⟶⋆y = x ⟶⋆⟨ x⟶⋆y ⟩ y⟶⋆z
-  syntax step-⟶  x y⟶⋆z x⟶y  = x ⟶⟨ x⟶y ⟩ y⟶⋆z
+  open ⟶-syntax _IsRelatedTo_ _IsRelatedTo_ (Base.∼-go ∘ (_◅ ε)) public
+  open ⟶*-syntax _IsRelatedTo_ _IsRelatedTo_ Base.∼-go public

--- a/src/Relation/Binary/HeterogeneousEquality.agda
+++ b/src/Relation/Binary/HeterogeneousEquality.agda
@@ -19,15 +19,16 @@ open import Relation.Unary using (Pred)
 open import Relation.Binary.Core using (Rel; REL; _⇒_)
 open import Relation.Binary.Bundles using (Setoid; DecSetoid; Preorder)
 open import Relation.Binary.Structures using (IsEquivalence; IsPreorder)
-open import Relation.Binary.Definitions using (Substitutive; Irrelevant; Decidable; _Respects₂_)
+open import Relation.Binary.Definitions using (Substitutive; Irrelevant; Decidable; _Respects₂_; Trans; Reflexive)
 open import Relation.Binary.Consequences
 open import Relation.Binary.Indexed.Heterogeneous
   using (IndexedSetoid)
 open import Relation.Binary.Indexed.Heterogeneous.Construct.At
   using (_atₛ_)
 open import Relation.Binary.PropositionalEquality.Core as P using (_≡_; refl)
-import Relation.Binary.PropositionalEquality.Properties as P
+open import Relation.Binary.Reasoning.Syntax
 
+import Relation.Binary.PropositionalEquality.Properties as P
 import Relation.Binary.HeterogeneousEquality.Core as Core
 
 private
@@ -231,17 +232,30 @@ module ≅-Reasoning where
   -- The code in `Relation.Binary.Reasoning.Setoid` cannot handle
   -- heterogeneous equalities, hence the code duplication here.
 
-  infix  4 _IsRelatedTo_
-  infix  3 _∎
-  infixr 2 _≅⟨_⟩_ _≅˘⟨_⟩_ _≡⟨_⟩_ _≡˘⟨_⟩_ _≡⟨⟩_
-  infix  1 begin_
+  infix 4 _IsRelatedTo_
 
-  data _IsRelatedTo_ {A : Set ℓ} (x : A) {B : Set ℓ} (y : B) :
-                     Set ℓ where
+  data _IsRelatedTo_ {A : Set ℓ} {B : Set ℓ} (x : A) (y : B) : Set ℓ where
     relTo : (x≅y : x ≅ y) → x IsRelatedTo y
 
-  begin_ : ∀ {x : A} {y : B} → x IsRelatedTo y → x ≅ y
-  begin relTo x≅y = x≅y
+  start : ∀ {x : A} {y : B} → x IsRelatedTo y → x ≅ y
+  start (relTo x≅y) = x≅y
+
+  ≡-go : ∀ {A : Set a} → Trans {A = A} {C = A} _≡_ _IsRelatedTo_ _IsRelatedTo_
+  ≡-go x≡y (relTo y≅z) = relTo (trans (reflexive x≡y) y≅z)
+
+  -- Combinators with one heterogeneous relation
+  module _ {A : Set ℓ} {B : Set ℓ} where
+    open begin-syntax (_IsRelatedTo_ {A = A} {B}) start public
+
+  -- Combinators with homogeneous relations
+  module _ {A : Set ℓ} where
+    open ≡-syntax (_IsRelatedTo_ {A = A}) ≡-go public
+    open end-syntax (_IsRelatedTo_ {A = A}) (relTo refl) public
+
+  -- Can't create syntax in the standard `Syntax` module for
+  -- heterogeneous steps because it would force that module to use
+  -- the `--with-k` option.
+  infixr 2 _≅⟨_⟩_ _≅˘⟨_⟩_
 
   _≅⟨_⟩_ : ∀ (x : A) {y : B} {z : C} →
            x ≅ y → y IsRelatedTo z → x IsRelatedTo z
@@ -250,20 +264,6 @@ module ≅-Reasoning where
   _≅˘⟨_⟩_ : ∀ (x : A) {y : B} {z : C} →
             y ≅ x → y IsRelatedTo z → x IsRelatedTo z
   _ ≅˘⟨ y≅x ⟩ relTo y≅z = relTo (trans (sym y≅x) y≅z)
-
-  _≡⟨_⟩_ : ∀ (x : A) {y : A} {z : C} →
-           x ≡ y → y IsRelatedTo z → x IsRelatedTo z
-  _ ≡⟨ x≡y ⟩ relTo y≅z = relTo (trans (reflexive x≡y) y≅z)
-
-  _≡˘⟨_⟩_ : ∀ (x : A) {y : A} {z : C} →
-            y ≡ x → y IsRelatedTo z → x IsRelatedTo z
-  _ ≡˘⟨ y≡x ⟩ relTo y≅z = relTo (trans (sym (reflexive y≡x)) y≅z)
-
-  _≡⟨⟩_ : ∀ (x : A) {y : B} → x IsRelatedTo y → x IsRelatedTo y
-  _ ≡⟨⟩ x≅y = x≅y
-
-  _∎ : ∀ (x : A) → x IsRelatedTo x
-  _∎ _ = relTo refl
 
 ------------------------------------------------------------------------
 -- Inspect

--- a/src/Relation/Binary/Reasoning/Base/Apartness.agda
+++ b/src/Relation/Binary/Reasoning/Base/Apartness.agda
@@ -7,9 +7,15 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
+open import Level using (Level; _⊔_)
+open import Function using (case_of_)
+open import Relation.Nullary.Decidable using (Dec; yes; no)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Structures using (IsEquivalence)
-open import Relation.Binary.Definitions using (Transitive; Symmetric; Trans)
+open import Relation.Binary.Definitions using (Reflexive; Transitive; Symmetric; Trans)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
+
 
 module Relation.Binary.Reasoning.Base.Apartness {a ℓ₁ ℓ₂} {A : Set a}
   {_≈_ : Rel A ℓ₁} {_#_ : Rel A ℓ₂}
@@ -18,18 +24,10 @@ module Relation.Binary.Reasoning.Base.Apartness {a ℓ₁ ℓ₂} {A : Set a}
   (#-≈-trans : Trans _#_ _≈_ _#_) (≈-#-trans : Trans _≈_ _#_ _#_)
   where
 
-open import Level using (Level; _⊔_)
-open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; refl; sym)
-open import Relation.Nullary.Decidable using (Dec; yes; no)
-open import Relation.Nullary.Decidable using (True; toWitness)
+module Eq = IsEquivalence ≈-equiv
 
-open IsEquivalence ≈-equiv
-  renaming
-  ( refl  to ≈-refl
-  ; sym   to ≈-sym
-  ; trans to ≈-trans
-  )
+------------------------------------------------------------------------
+-- A datatype to hide the current relation type
 
 infix 4 _IsRelatedTo_
 
@@ -37,6 +35,27 @@ data _IsRelatedTo_ (x y : A) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
   nothing   :                 x IsRelatedTo y
   apartness : (x#y : x # y) → x IsRelatedTo y
   equals    : (x≈y : x ≈ y) → x IsRelatedTo y
+
+≡-go : Trans _≡_ _IsRelatedTo_ _IsRelatedTo_
+≡-go x≡y nothing = nothing
+≡-go x≡y (apartness y#z) = apartness (case x≡y of λ where P.refl → y#z)
+≡-go x≡y (equals y≈z) = equals (case x≡y of λ where P.refl → y≈z)
+
+≈-go  : Trans _≈_ _IsRelatedTo_ _IsRelatedTo_
+≈-go x≈y nothing         = nothing
+≈-go x≈y (apartness y#z) = apartness (≈-#-trans x≈y y#z)
+≈-go x≈y (equals    y≈z) = equals    (Eq.trans   x≈y y≈z)
+
+#-go : Trans _#_ _IsRelatedTo_ _IsRelatedTo_
+#-go x#y nothing         = nothing
+#-go x#y (apartness y#z) = nothing
+#-go x#y (equals    y≈z) = apartness (#-≈-trans x#y y≈z)
+
+stop : Reflexive _IsRelatedTo_
+stop = equals Eq.refl
+
+------------------------------------------------------------------------
+-- Apartness subrelation
 
 data IsApartness {x y} : x IsRelatedTo y → Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
   isApartness : ∀ x#y → IsApartness (apartness x#y)
@@ -49,6 +68,16 @@ IsApartness? (equals x≈y)    = no (λ ())
 extractApartness : ∀ {x y} {x#y : x IsRelatedTo y} → IsApartness x#y → x # y
 extractApartness (isApartness x#y) = x#y
 
+apartnessRelation : SubRelation _IsRelatedTo_ _ _
+apartnessRelation = record
+  { IsS = IsApartness
+  ; IsS? = IsApartness?
+  ; extract = extractApartness
+  }
+
+------------------------------------------------------------------------
+-- Equality subrelation
+
 data IsEquality {x y} : x IsRelatedTo y → Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
   isEquality : ∀ x≈y → IsEquality (equals x≈y)
 
@@ -60,49 +89,19 @@ IsEquality? (equals  x≈y) = yes (isEquality x≈y)
 extractEquality : ∀ {x y} {x≲y : x IsRelatedTo y} → IsEquality x≲y → x ≈ y
 extractEquality (isEquality x≈y) = x≈y
 
-infix  1 begin-apartness_ begin-equality_
-infixr 2 step-≈ step-≈˘ step-≡ step-≡˘ step-# step-#˘ _≡⟨⟩_
-infix  3 _∎
+eqRelation : SubRelation _IsRelatedTo_ _ _
+eqRelation = record
+  { IsS = IsEquality
+  ; IsS? = IsEquality?
+  ; extract = extractEquality
+  }
 
-begin-apartness_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsApartness? r)} → x # y
-begin-apartness_ _ {s} = extractApartness (toWitness s)
+------------------------------------------------------------------------
+-- Reasoning combinators
 
-begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsEquality? r)} → x ≈ y
-begin-equality_ _ {s} = extractEquality (toWitness s)
-
-step-# : ∀ (x : A) {y z} → y IsRelatedTo z → x # y → x IsRelatedTo z
-step-# x nothing  _          = nothing
-step-# x (apartness y#z) x#y = nothing
-step-# x (equals    y≈z) x#y = apartness (#-≈-trans x#y y≈z)
-
-step-#˘ : ∀ (x : A) {y z} → y IsRelatedTo z → y # x → x IsRelatedTo z
-step-#˘ x y-z y#x = step-# x y-z (#-sym y#x)
-
-step-≈  : ∀ (x : A) {y z} → y IsRelatedTo z → x ≈ y → x IsRelatedTo z
-step-≈ x nothing         x≈y = nothing
-step-≈ x (apartness y#z) x≈y = apartness (≈-#-trans x≈y y#z)
-step-≈ x (equals    y≈z) x≈y = equals    (≈-trans   x≈y y≈z)
-
-step-≈˘ : ∀ x {y z} → y IsRelatedTo z → y ≈ x → x IsRelatedTo z
-step-≈˘ x y∼z x≈y = step-≈ x y∼z (≈-sym x≈y)
-
-step-≡ : ∀ (x : A) {y z} → y IsRelatedTo z → x ≡ y → x IsRelatedTo z
-step-≡ x nothing _            = nothing
-step-≡ x (apartness x#y) refl = apartness x#y
-step-≡ x (equals    x≈y) refl = equals    x≈y
-
-step-≡˘ : ∀ x {y z} → y IsRelatedTo z → y ≡ x → x IsRelatedTo z
-step-≡˘ x y∼z x≡y = step-≡ x y∼z (sym x≡y)
-
-_≡⟨⟩_ : ∀ (x : A) {y} → x IsRelatedTo y → x IsRelatedTo y
-x ≡⟨⟩ x-y = x-y
-
-_∎ : ∀ x → x IsRelatedTo x
-x ∎ = equals ≈-refl
-
-syntax step-#  x y∼z x#y = x #⟨  x#y ⟩ y∼z
-syntax step-#˘ x y∼z x#y = x #˘⟨ x#y ⟩ y∼z
-syntax step-≈  x y∼z x≈y = x ≈⟨  x≈y ⟩ y∼z
-syntax step-≈˘ x y∼z y≈x = x ≈˘⟨ y≈x ⟩ y∼z
-syntax step-≡  x y∼z x≡y = x ≡⟨  x≡y ⟩ y∼z
-syntax step-≡˘ x y∼z y≡x = x ≡˘⟨ y≡x ⟩ y∼z
+open begin-apartness-syntax _IsRelatedTo_ apartnessRelation public
+open begin-equality-syntax _IsRelatedTo_ eqRelation public
+open ≡-syntax _IsRelatedTo_ ≡-go public
+open #-syntax _IsRelatedTo_ _IsRelatedTo_ #-go #-sym public
+open ≈-syntax _IsRelatedTo_ _IsRelatedTo_ ≈-go Eq.sym public
+open end-syntax _IsRelatedTo_ stop public

--- a/src/Relation/Binary/Reasoning/Base/Double.agda
+++ b/src/Relation/Binary/Reasoning/Base/Double.agda
@@ -10,20 +10,19 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Core using (Rel)
+open import Level using (_⊔_)
+open import Function using (case_of_)
+open import Relation.Nullary.Decidable.Core using (Dec; yes; no)
+open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Definitions using (Reflexive; Trans)
 open import Relation.Binary.Structures using (IsPreorder)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
+
 
 module Relation.Binary.Reasoning.Base.Double {a ℓ₁ ℓ₂} {A : Set a}
   {_≈_ : Rel A ℓ₁} {_∼_ : Rel A ℓ₂} (isPreorder : IsPreorder _≈_ _∼_)
   where
-
-open import Data.Product.Base using (proj₁; proj₂)
-open import Level using (Level; _⊔_; Lift; lift)
-open import Function.Base using (case_of_; id)
-open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; refl; sym)
-open import Relation.Nullary.Decidable.Core
-  using (Dec; yes; no; True; toWitness)
 
 open IsPreorder isPreorder
 
@@ -35,6 +34,25 @@ infix 4 _IsRelatedTo_
 data _IsRelatedTo_ (x y : A) : Set (a ⊔ ℓ₁ ⊔ ℓ₂) where
   nonstrict : (x∼y : x ∼ y) → x IsRelatedTo y
   equals    : (x≈y : x ≈ y) → x IsRelatedTo y
+
+start : _IsRelatedTo_ ⇒ _∼_
+start (equals x≈y) = reflexive x≈y
+start (nonstrict x∼y) = x∼y
+
+≡-go : Trans _≡_ _IsRelatedTo_ _IsRelatedTo_
+≡-go x≡y (equals y≈z) = equals (case x≡y of λ where P.refl → y≈z)
+≡-go x≡y (nonstrict y≤z) = nonstrict (case x≡y of λ where P.refl → y≤z)
+
+∼-go : Trans _∼_ _IsRelatedTo_ _IsRelatedTo_
+∼-go x∼y (equals y≈z) = nonstrict (∼-respʳ-≈ y≈z x∼y)
+∼-go x∼y (nonstrict y∼z) = nonstrict (trans x∼y y∼z)
+
+≈-go : Trans _≈_ _IsRelatedTo_ _IsRelatedTo_
+≈-go x≈y (equals y≈z) = equals (Eq.trans x≈y y≈z)
+≈-go x≈y (nonstrict y∼z) = nonstrict (∼-respˡ-≈ (Eq.sym x≈y) y∼z)
+
+stop : Reflexive _IsRelatedTo_
+stop = equals Eq.refl
 
 ------------------------------------------------------------------------
 -- A record that is used to ensure that the final relation proved by the
@@ -50,67 +68,19 @@ IsEquality? (equals x≈y)  = yes (isEquality x≈y)
 extractEquality : ∀ {x y} {x≲y : x IsRelatedTo y} → IsEquality x≲y → x ≈ y
 extractEquality (isEquality x≈y) = x≈y
 
+equalitySubRelation : SubRelation  _IsRelatedTo_ _ _
+equalitySubRelation = record
+  { IsS = IsEquality
+  ; IsS? = IsEquality?
+  ; extract = extractEquality
+  }
+
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
--- See `Relation.Binary.Reasoning.Base.Partial` for the design decisions
--- behind these combinators.
-
-infix  1 begin_ begin-equality_
-infixr 2 step-∼ step-≈ step-≈˘ step-≡ step-≡˘ _≡⟨⟩_
-infix  3 _∎
-
--- Beginnings of various types of proofs
-
-begin_ : ∀ {x y} (r : x IsRelatedTo y) → x ∼ y
-begin (nonstrict x∼y) = x∼y
-begin (equals    x≈y) = reflexive x≈y
-
-begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsEquality? r)} → x ≈ y
-begin-equality_ r {s} = extractEquality (toWitness s)
-
--- Step with the main relation
-
-step-∼ : ∀ (x : A) {y z} → y IsRelatedTo z → x ∼ y → x IsRelatedTo z
-step-∼ x (nonstrict y∼z) x∼y = nonstrict (trans x∼y y∼z)
-step-∼ x (equals    y≈z) x∼y = nonstrict (∼-respʳ-≈ y≈z x∼y)
-
--- Step with the setoid equality
-
-step-≈ : ∀ (x : A) {y z} → y IsRelatedTo z → x ≈ y → x IsRelatedTo z
-step-≈ x (nonstrict y∼z) x≈y = nonstrict (∼-respˡ-≈ (Eq.sym x≈y) y∼z)
-step-≈ x (equals    y≈z) x≈y = equals    (Eq.trans x≈y y≈z)
-
--- Flipped step with the setoid equality
-
-step-≈˘ : ∀ x {y z} → y IsRelatedTo z → y ≈ x → x IsRelatedTo z
-step-≈˘ x y∼z x≈y = step-≈ x y∼z (Eq.sym x≈y)
-
--- Step with non-trivial propositional equality
-
-step-≡ : ∀ (x : A) {y z} → y IsRelatedTo z → x ≡ y → x IsRelatedTo z
-step-≡ x (nonstrict y∼z) x≡y = nonstrict (case x≡y of λ where refl → y∼z)
-step-≡ x (equals    y≈z) x≡y = equals    (case x≡y of λ where refl → y≈z)
-
--- Flipped step with non-trivial propositional equality
-
-step-≡˘ : ∀ x {y z} → y IsRelatedTo z → y ≡ x → x IsRelatedTo z
-step-≡˘ x y∼z x≡y = step-≡ x y∼z (sym x≡y)
-
--- Step with trivial propositional equality
-
-_≡⟨⟩_ : ∀ (x : A) {y} → x IsRelatedTo y → x IsRelatedTo y
-x ≡⟨⟩ x≲y = x≲y
-
--- Termination step
-
-_∎ : ∀ x → x IsRelatedTo x
-x ∎ = equals Eq.refl
-
--- Syntax declarations
-
-syntax step-∼  x y∼z x∼y = x ∼⟨  x∼y ⟩ y∼z
-syntax step-≈  x y∼z x≈y = x ≈⟨  x≈y ⟩ y∼z
-syntax step-≈˘ x y∼z y≈x = x ≈˘⟨ y≈x ⟩ y∼z
-syntax step-≡  x y∼z x≡y = x ≡⟨  x≡y ⟩ y∼z
-syntax step-≡˘ x y∼z y≡x = x ≡˘⟨ y≡x ⟩ y∼z
+open begin-syntax  _IsRelatedTo_ start public
+open begin-equality-syntax  _IsRelatedTo_ equalitySubRelation public
+open ≡-syntax _IsRelatedTo_ ≡-go public
+open ∼-syntax _IsRelatedTo_ _IsRelatedTo_ ∼-go public
+open ≈-syntax _IsRelatedTo_ _IsRelatedTo_ ≈-go Eq.sym public
+open end-syntax _IsRelatedTo_ stop public

--- a/src/Relation/Binary/Reasoning/Base/Partial.agda
+++ b/src/Relation/Binary/Reasoning/Base/Partial.agda
@@ -6,13 +6,14 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
+open import Function using (case_of_)
+open import Level using (_⊔_)
 open import Relation.Binary.Core
 open import Relation.Binary.Definitions
-open import Level using (_⊔_)
-open import Relation.Binary.PropositionalEquality.Core as P
-  using (_≡_)
 open import Relation.Nullary.Decidable using (Dec; yes; no)
-open import Relation.Nullary.Decidable using (True)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
+
 
 module Relation.Binary.Reasoning.Base.Partial
   {a ℓ} {A : Set a} (_∼_ : Rel A ℓ) (trans : Transitive _∼_)
@@ -30,6 +31,13 @@ data _IsRelatedTo_ : A → A → Set (a ⊔ ℓ) where
   singleStep : ∀ x → x IsRelatedTo x
   multiStep  : ∀ {x y} (x∼y : x ∼ y) → x IsRelatedTo y
 
+∼-go : Trans _∼_ _IsRelatedTo_ _IsRelatedTo_
+∼-go x∼y (singleStep y) = multiStep x∼y
+∼-go x∼y (multiStep y∼z) = multiStep (trans x∼y y∼z)
+
+stop : Reflexive _IsRelatedTo_
+stop = singleStep _
+
 ------------------------------------------------------------------------
 -- Types that are used to ensure that the final relation proved by the
 -- chain of reasoning can be converted into the required relation.
@@ -41,61 +49,23 @@ IsMultiStep? : ∀ {x y} (x∼y : x IsRelatedTo y) → Dec (IsMultiStep x∼y)
 IsMultiStep? (multiStep x<y) = yes (isMultiStep x<y)
 IsMultiStep? (singleStep _)  = no λ()
 
+extractMultiStep : ∀ {x y} {x∼y : x IsRelatedTo y} → IsMultiStep x∼y → x ∼ y
+extractMultiStep (isMultiStep x≈y) = x≈y
+
+multiStepSubRelation : SubRelation _IsRelatedTo_ _ _
+multiStepSubRelation = record
+  { IsS = IsMultiStep
+  ; IsS? = IsMultiStep?
+  ; extract = extractMultiStep
+  }
+
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
--- Note that the arguments to the `step`s are not provided in their
--- "natural" order and syntax declarations are later used to re-order
--- them. This is because the `step` ordering allows the type-checker to
--- better infer the middle argument `y` from the `_IsRelatedTo_`
--- argument (see issue 622).
---
--- This has two practical benefits. First it speeds up type-checking by
--- approximately a factor of 5. Secondly it allows the combinators to be
--- used with macros that use reflection, e.g. `Tactic.RingSolver`, where
--- they need to be able to extract `y` using reflection.
-
-infix  1 begin_
-infixr 2 step-∼ step-≡ step-≡˘
-infixr 2 _≡⟨⟩_
-infix  3 _∎⟨_⟩ _∎
-
--- Beginning of a proof
-
-begin_ : ∀ {x y} (x∼y : x IsRelatedTo y) → {True (IsMultiStep? x∼y)} → x ∼ y
-begin (multiStep x∼y) = x∼y
-
--- Standard step with the relation
-
-step-∼ : ∀ x {y z} → y IsRelatedTo z → x ∼ y → x IsRelatedTo z
-step-∼ _ (singleStep _) x∼y  = multiStep x∼y
-step-∼ _ (multiStep y∼z) x∼y = multiStep (trans x∼y y∼z)
-
--- Step with a non-trivial propositional equality
-
-step-≡ : ∀ x {y z} → y IsRelatedTo z → x ≡ y → x IsRelatedTo z
-step-≡ _ x∼z P.refl = x∼z
-
--- Step with a flipped non-trivial propositional equality
-
-step-≡˘ : ∀ x {y z} → y IsRelatedTo z → y ≡ x → x IsRelatedTo z
-step-≡˘ _ x∼z P.refl = x∼z
-
--- -- Step with a trivial propositional equality
-
-_≡⟨⟩_ : ∀ x {y} → x IsRelatedTo y → x IsRelatedTo y
-_ ≡⟨⟩ x∼y = x∼y
-
--- Termination
-
-_∎ : ∀ x → x IsRelatedTo x
-_∎ = singleStep
-
--- Syntax declarations
-
-syntax step-∼  x y∼z x∼y = x ∼⟨  x∼y ⟩ y∼z
-syntax step-≡  x y≡z x≡y = x ≡⟨  x≡y ⟩ y≡z
-syntax step-≡˘ x y≡z y≡x = x ≡˘⟨ y≡x ⟩ y≡z
+open begin-subrelation-syntax _IsRelatedTo_ multiStepSubRelation public
+open ≡-noncomputing-syntax _IsRelatedTo_ public
+open ∼-syntax _IsRelatedTo_ _IsRelatedTo_ ∼-go public
+open end-syntax _IsRelatedTo_ stop public
 
 
 ------------------------------------------------------------------------
@@ -105,6 +75,8 @@ syntax step-≡˘ x y≡z y≡x = x ≡˘⟨ y≡x ⟩ y≡z
 -- not guaranteed.
 
 -- Version 1.6
+
+infix  3 _∎⟨_⟩
 
 _∎⟨_⟩ : ∀ x → x ∼ x → x IsRelatedTo x
 _ ∎⟨ x∼x ⟩ = multiStep x∼x

--- a/src/Relation/Binary/Reasoning/Base/Single.agda
+++ b/src/Relation/Binary/Reasoning/Base/Single.agda
@@ -6,23 +6,17 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Definitions using (Reflexive; Transitive)
+open import Level using (_⊔_)
+open import Function.Base using (case_of_)
+open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Definitions using (Reflexive; Transitive; Trans)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
 
 module Relation.Binary.Reasoning.Base.Single
   {a ℓ} {A : Set a} (_∼_ : Rel A ℓ)
   (refl : Reflexive _∼_) (trans : Transitive _∼_)
   where
-
--- TODO: the following part is copied from Relation.Binary.Reasoning.Base.Partial
--- in order to avoid larger refactors. We will refactor this part later
--- so taht we use the same framework as Relation.Binary.Reasoning.Base.Partial.
-
-open import Level using (_⊔_)
-open import Relation.Binary.PropositionalEquality.Core as P
-  using (_≡_)
-
-infix  4 _IsRelatedTo_
 
 ------------------------------------------------------------------------
 -- Definition of "related to"
@@ -30,60 +24,27 @@ infix  4 _IsRelatedTo_
 -- This seemingly unnecessary type is used to make it possible to
 -- infer arguments even if the underlying equality evaluates.
 
+infix 4 _IsRelatedTo_
+
 data _IsRelatedTo_ (x y : A) : Set ℓ where
   relTo : (x∼y : x ∼ y) → x IsRelatedTo y
+
+start : _IsRelatedTo_ ⇒ _∼_
+start (relTo x∼y) = x∼y
+
+∼-go : Trans _∼_ _IsRelatedTo_ _IsRelatedTo_
+∼-go x∼y (relTo y∼z) = relTo (trans x∼y y∼z)
+
+≡-go : Trans _≡_ _IsRelatedTo_ _IsRelatedTo_
+≡-go x≡y (relTo y∼z) = relTo (case x≡y of λ where P.refl → y∼z)
+
+stop : Reflexive _IsRelatedTo_
+stop = relTo refl
 
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
--- Note that the arguments to the `step`s are not provided in their
--- "natural" order and syntax declarations are later used to re-order
--- them. This is because the `step` ordering allows the type-checker to
--- better infer the middle argument `y` from the `_IsRelatedTo_`
--- argument (see issue 622).
---
--- This has two practical benefits. First it speeds up type-checking by
--- approximately a factor of 5. Secondly it allows the combinators to be
--- used with macros that use reflection, e.g. `Tactic.RingSolver`, where
--- they need to be able to extract `y` using reflection.
-
-infix  1 begin_
-infixr 2 step-∼ step-≡ step-≡˘
-infixr 2 _≡⟨⟩_
-infix  3 _∎
-
--- Beginning of a proof
-
-begin_ : ∀ {x y} → x IsRelatedTo y → x ∼ y
-begin relTo x∼y = x∼y
-
--- Standard step with the relation
-
-step-∼ : ∀ x {y z} → y IsRelatedTo z → x ∼ y → x IsRelatedTo z
-step-∼ _ (relTo y∼z) x∼y = relTo (trans x∼y y∼z)
-
--- Step with a non-trivial propositional equality
-
-step-≡ : ∀ x {y z} → y IsRelatedTo z → x ≡ y → x IsRelatedTo z
-step-≡ _ x∼z P.refl = x∼z
-
--- Step with a flipped non-trivial propositional equality
-
-step-≡˘ : ∀ x {y z} → y IsRelatedTo z → y ≡ x → x IsRelatedTo z
-step-≡˘ _ x∼z P.refl = x∼z
-
--- Step with a trivial propositional equality
-
-_≡⟨⟩_ : ∀ x {y} → x IsRelatedTo y → x IsRelatedTo y
-_ ≡⟨⟩ x∼y = x∼y
-
--- Termination
-
-_∎ : ∀ x → x IsRelatedTo x
-x ∎ = relTo refl
-
--- Syntax declarations
-
-syntax step-∼  x y∼z x∼y = x ∼⟨  x∼y ⟩ y∼z
-syntax step-≡  x y≡z x≡y = x ≡⟨  x≡y ⟩ y≡z
-syntax step-≡˘ x y≡z y≡x = x ≡˘⟨ y≡x ⟩ y≡z
+open begin-syntax _IsRelatedTo_ start public
+open ≡-syntax _IsRelatedTo_ ≡-go public
+open ∼-syntax _IsRelatedTo_ _IsRelatedTo_ ∼-go public
+open end-syntax _IsRelatedTo_ stop public

--- a/src/Relation/Binary/Reasoning/Base/Triple.agda
+++ b/src/Relation/Binary/Reasoning/Base/Triple.agda
@@ -10,35 +10,27 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
+open import Data.Product.Base using (proj₁; proj₂)
+open import Level using (_⊔_)
+open import Function using (case_of_)
+open import Relation.Nullary.Decidable.Core
+  using (Dec; yes; no)
 open import Relation.Binary.Core using (Rel; _⇒_)
 open import Relation.Binary.Structures using (IsPreorder)
 open import Relation.Binary.Definitions
-  using (Transitive; _Respects₂_; Trans; Irreflexive)
+  using (Transitive; _Respects₂_; Reflexive; Trans; Irreflexive; Asymmetric)
+open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
 
 module Relation.Binary.Reasoning.Base.Triple {a ℓ₁ ℓ₂ ℓ₃} {A : Set a}
   {_≈_ : Rel A ℓ₁} {_≤_ : Rel A ℓ₂} {_<_ : Rel A ℓ₃}
   (isPreorder : IsPreorder _≈_ _≤_)
-  (<-irrefl : Irreflexive _≈_ _<_) (<-trans : Transitive _<_) (<-resp-≈ : _<_ Respects₂ _≈_)
+  (<-asym : Asymmetric _<_) (<-trans : Transitive _<_) (<-resp-≈ : _<_ Respects₂ _≈_)
   (<⇒≤ : _<_ ⇒ _≤_)
   (<-≤-trans : Trans _<_ _≤_ _<_) (≤-<-trans : Trans _≤_ _<_ _<_)
   where
 
-open import Data.Product.Base using (proj₁; proj₂)
-open import Function.Base using (case_of_; id)
-open import Level using (Level; _⊔_; Lift; lift)
-open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; refl; sym)
-open import Relation.Nullary using (¬_)
-open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable.Core
-  using (Dec; yes; no; True; toWitness)
-
 open IsPreorder isPreorder
-  renaming
-  ( reflexive to ≤-reflexive
-  ; trans     to ≤-trans
-  ; ∼-resp-≈  to ≤-resp-≈
-  )
 
 ------------------------------------------------------------------------
 -- A datatype to abstract over the current relation
@@ -49,6 +41,35 @@ data _IsRelatedTo_ (x y : A) : Set (a ⊔ ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃) where
   strict    : (x<y : x < y) → x IsRelatedTo y
   nonstrict : (x≤y : x ≤ y) → x IsRelatedTo y
   equals    : (x≈y : x ≈ y) → x IsRelatedTo y
+
+start : _IsRelatedTo_ ⇒ _≤_
+start (equals x≈y) = reflexive x≈y
+start (nonstrict x≤y) = x≤y
+start (strict x<y) = <⇒≤ x<y
+
+≡-go : Trans _≡_ _IsRelatedTo_ _IsRelatedTo_
+≡-go x≡y (equals y≈z) = equals (case x≡y of λ where P.refl → y≈z)
+≡-go x≡y (nonstrict y≤z) = nonstrict (case x≡y of λ where P.refl → y≤z)
+≡-go x≡y (strict y<z) = strict (case x≡y of λ where P.refl → y<z)
+
+≈-go : Trans _≈_ _IsRelatedTo_ _IsRelatedTo_
+≈-go x≈y (equals y≈z) = equals (Eq.trans x≈y y≈z)
+≈-go x≈y (nonstrict y≤z) = nonstrict (∼-respˡ-≈ (Eq.sym x≈y) y≤z)
+≈-go x≈y (strict y<z) = strict (proj₂ <-resp-≈ (Eq.sym x≈y) y<z)
+
+≤-go : Trans _≤_ _IsRelatedTo_ _IsRelatedTo_
+≤-go x≤y (equals y≈z) = nonstrict (∼-respʳ-≈ y≈z x≤y)
+≤-go x≤y (nonstrict y≤z) = nonstrict (trans x≤y y≤z)
+≤-go x≤y (strict y<z) = strict (≤-<-trans x≤y y<z)
+
+<-go : Trans _<_ _IsRelatedTo_ _IsRelatedTo_
+<-go x<y (equals y≈z) = strict (proj₁ <-resp-≈ y≈z x<y)
+<-go x<y (nonstrict y≤z) = strict (<-≤-trans x<y y≤z)
+<-go x<y (strict y<z) = strict (<-trans x<y y<z)
+
+stop : Reflexive _IsRelatedTo_
+stop = equals Eq.refl
+
 
 ------------------------------------------------------------------------
 -- Types that are used to ensure that the final relation proved by the
@@ -65,6 +86,16 @@ IsStrict? (equals    _)   = no λ()
 extractStrict : ∀ {x y} {x≲y : x IsRelatedTo y} → IsStrict x≲y → x < y
 extractStrict (isStrict x<y) = x<y
 
+strictRelation : SubRelation _IsRelatedTo_ _ _
+strictRelation = record
+  { IsS = IsStrict
+  ; IsS? = IsStrict?
+  ; extract = extractStrict
+  }
+
+------------------------------------------------------------------------
+-- Equality sub-relation
+
 data IsEquality {x y} : x IsRelatedTo y → Set (a ⊔ ℓ₁ ⊔ ℓ₂ ⊔ ℓ₃) where
   isEquality : ∀ x≈y → IsEquality (equals x≈y)
 
@@ -76,89 +107,22 @@ IsEquality? (equals x≈y)  = yes (isEquality x≈y)
 extractEquality : ∀ {x y} {x≲y : x IsRelatedTo y} → IsEquality x≲y → x ≈ y
 extractEquality (isEquality x≈y) = x≈y
 
+eqRelation : SubRelation _IsRelatedTo_ _ _
+eqRelation = record
+  { IsS = IsEquality
+  ; IsS? = IsEquality?
+  ; extract = extractEquality
+  }
+
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
--- See `Relation.Binary.Reasoning.Base.Partial` for the design decisions
--- behind these combinators.
-
-infix  1 begin_ begin-strict_ begin-equality_ begin-contradiction_
-infixr 2 step-< step-≤ step-≈ step-≈˘ step-≡ step-≡˘ _≡⟨⟩_
-infix  3 _∎
-
--- Beginnings of various types of proofs
-
-begin_ : ∀ {x y} → x IsRelatedTo y → x ≤ y
-begin (strict    x<y) = <⇒≤ x<y
-begin (nonstrict x≤y) = x≤y
-begin (equals    x≈y) = ≤-reflexive x≈y
-
-begin-strict_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsStrict? r)} → x < y
-begin-strict_ r {s} = extractStrict (toWitness s)
-
-begin-equality_ : ∀ {x y} (r : x IsRelatedTo y) → {s : True (IsEquality? r)} → x ≈ y
-begin-equality_ r {s} = extractEquality (toWitness s)
-
-begin-contradiction_ : ∀ {x} (r : x IsRelatedTo x) {s : True (IsStrict? r)} →
-                      ∀ {a} {A : Set a} → A
-begin-contradiction_ {x} r {s} = contradiction x<x (<-irrefl Eq.refl)
-  where
-  x<x : x < x
-  x<x = extractStrict (toWitness s)
-
--- Step with the strict relation
-
-step-< : ∀ (x : A) {y z} → y IsRelatedTo z → x < y → x IsRelatedTo z
-step-< x (strict    y<z) x<y = strict (<-trans x<y y<z)
-step-< x (nonstrict y≤z) x<y = strict (<-≤-trans x<y y≤z)
-step-< x (equals    y≈z) x<y = strict (proj₁ <-resp-≈ y≈z x<y)
-
--- Step with the non-strict relation
-
-step-≤ : ∀ (x : A) {y z} → y IsRelatedTo z → x ≤ y → x IsRelatedTo z
-step-≤ x (strict    y<z) x≤y = strict    (≤-<-trans x≤y y<z)
-step-≤ x (nonstrict y≤z) x≤y = nonstrict (≤-trans x≤y y≤z)
-step-≤ x (equals    y≈z) x≤y = nonstrict (proj₁ ≤-resp-≈ y≈z x≤y)
-
--- Step with the setoid equality
-
-step-≈  : ∀ (x : A) {y z} → y IsRelatedTo z → x ≈ y → x IsRelatedTo z
-step-≈ x (strict    y<z) x≈y = strict    (proj₂ <-resp-≈ (Eq.sym x≈y) y<z)
-step-≈ x (nonstrict y≤z) x≈y = nonstrict (proj₂ ≤-resp-≈ (Eq.sym x≈y) y≤z)
-step-≈ x (equals    y≈z) x≈y = equals    (Eq.trans x≈y y≈z)
-
--- Flipped step with the setoid equality
-
-step-≈˘ : ∀ x {y z} → y IsRelatedTo z → y ≈ x → x IsRelatedTo z
-step-≈˘ x y∼z x≈y = step-≈ x y∼z (Eq.sym x≈y)
-
--- Step with non-trivial propositional equality
-
-step-≡ : ∀ (x : A) {y z} → y IsRelatedTo z → x ≡ y → x IsRelatedTo z
-step-≡ x (strict    y<z) x≡y  = strict    (case x≡y of λ where refl → y<z)
-step-≡ x (nonstrict y≤z) x≡y  = nonstrict (case x≡y of λ where refl → y≤z)
-step-≡ x (equals    y≈z) x≡y  = equals    (case x≡y of λ where refl → y≈z)
-
--- Flipped step with non-trivial propositional equality
-
-step-≡˘ : ∀ x {y z} → y IsRelatedTo z → y ≡ x → x IsRelatedTo z
-step-≡˘ x y∼z x≡y = step-≡ x y∼z (sym x≡y)
-
--- Step with trivial propositional equality
-
-_≡⟨⟩_ : ∀ (x : A) {y} → x IsRelatedTo y → x IsRelatedTo y
-x ≡⟨⟩ x≲y = x≲y
-
--- Termination step
-
-_∎ : ∀ x → x IsRelatedTo x
-x ∎ = equals Eq.refl
-
--- Syntax declarations
-
-syntax step-<  x y∼z x<y = x <⟨  x<y ⟩ y∼z
-syntax step-≤  x y∼z x≤y = x ≤⟨  x≤y ⟩ y∼z
-syntax step-≈  x y∼z x≈y = x ≈⟨  x≈y ⟩ y∼z
-syntax step-≈˘ x y∼z y≈x = x ≈˘⟨ y≈x ⟩ y∼z
-syntax step-≡  x y∼z x≡y = x ≡⟨  x≡y ⟩ y∼z
-syntax step-≡˘ x y∼z y≡x = x ≡˘⟨ y≡x ⟩ y∼z
+open begin-syntax _IsRelatedTo_ start public
+open begin-equality-syntax _IsRelatedTo_ eqRelation public
+open begin-strict-syntax _IsRelatedTo_ strictRelation public
+open begin-contradiction-syntax _IsRelatedTo_ strictRelation <-asym public
+open ≡-syntax _IsRelatedTo_ ≡-go public
+open ≈-syntax _IsRelatedTo_ _IsRelatedTo_ ≈-go Eq.sym public
+open ≤-syntax _IsRelatedTo_ _IsRelatedTo_ ≤-go public
+open <-syntax _IsRelatedTo_ _IsRelatedTo_ <-go public
+open end-syntax _IsRelatedTo_ stop public

--- a/src/Relation/Binary/Reasoning/MultiSetoid.agda
+++ b/src/Relation/Binary/Reasoning/MultiSetoid.agda
@@ -26,56 +26,51 @@
 
 module Relation.Binary.Reasoning.MultiSetoid where
 
-open import Function.Base using (flip)
-open import Level using (_⊔_)
+open import Level using (Level; _⊔_)
+open import Function.Base using (case_of_)
+open import Relation.Binary.Core using (_⇒_)
+open import Relation.Binary.Definitions using (Trans; Reflexive)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
+open import Relation.Binary.Reasoning.Syntax
 
-import Relation.Binary.Reasoning.Setoid as EqR
+private
+  variable
+    a ℓ : Level
 
 ------------------------------------------------------------------------
 -- Combinators that take the current setoid as an explicit argument.
 
-module _ {c ℓ} (S : Setoid c ℓ) where
+module _ (S : Setoid a ℓ) where
   open Setoid S
 
-  data IsRelatedTo (x y : _) : Set (c ⊔ ℓ) where
-    relTo : (x∼y : x ≈ y) → IsRelatedTo x y
+  data IsRelatedTo (x y : _) : Set (a ⊔ ℓ) where
+    relTo : (x≈y : x ≈ y) → IsRelatedTo x y
 
-  infix 1 begin⟨_⟩_
+  start : IsRelatedTo ⇒ _≈_
+  start (relTo x≈y) = x≈y
 
-  begin⟨_⟩_ : ∀ {x y} → IsRelatedTo x y → x ≈ y
-  begin⟨_⟩_ (relTo eq) = eq
+  ≡-go : Trans _≡_ IsRelatedTo IsRelatedTo
+  ≡-go x≡y (relTo y∼z) = relTo (case x≡y of λ where P.refl → y∼z)
+
+  ≈-go : Trans _≈_ IsRelatedTo IsRelatedTo
+  ≈-go x≈y (relTo y≈z) = relTo (trans x≈y y≈z)
+
+  end : Reflexive IsRelatedTo
+  end = relTo refl
 
 ------------------------------------------------------------------------
--- Combinators that take the current setoid as an implicit argument.
+-- Reasoning combinators
 
-module _ {c ℓ} {S : Setoid c ℓ} where
+-- Those that take the current setoid as an explicit argument.
+  open begin-syntax IsRelatedTo start public
+    renaming (begin_ to begin⟨_⟩_)
 
-  open Setoid S renaming (_≈_ to _≈_)
 
-  infixr 2 step-≈ step-≈˘ step-≡ step-≡˘ _≡⟨⟩_
-  infix 3 _∎
+-- Those that take the current setoid as an implicit argument.
+module _ {S : Setoid a ℓ} where
+  open Setoid S
 
-  step-≈ : ∀ x {y z} → IsRelatedTo S y z → x ≈ y → IsRelatedTo S x z
-  step-≈ x (relTo y∼z) x∼y = relTo (trans x∼y y∼z)
-
-  step-≈˘ : ∀ x {y z} → IsRelatedTo S y z → y ≈ x → IsRelatedTo S x z
-  step-≈˘ x y∼z x≈y = step-≈ x y∼z (sym x≈y)
-
-  step-≡ : ∀ x {y z} → IsRelatedTo S y z → x ≡ y → IsRelatedTo S x z
-  step-≡ _ x∼z P.refl = x∼z
-
-  step-≡˘ : ∀ x {y z} → IsRelatedTo S y z → y ≡ x → IsRelatedTo S x z
-  step-≡˘ _ x∼z P.refl = x∼z
-
-  _≡⟨⟩_ : ∀ x {y} → IsRelatedTo S x y → IsRelatedTo S x y
-  _ ≡⟨⟩ x∼y = x∼y
-
-  _∎ : ∀ x → IsRelatedTo S x x
-  _∎ _ = relTo refl
-
-  syntax step-≈  x y∼z x≈y = x ≈⟨  x≈y ⟩ y∼z
-  syntax step-≈˘ x y∼z y≈x = x ≈˘⟨ y≈x ⟩ y∼z
-  syntax step-≡  x y≡z x≡y = x ≡⟨  x≡y ⟩ y≡z
-  syntax step-≡˘ x y≡z y≡x = x ≡˘⟨ y≡x ⟩ y≡z
+  open ≡-syntax (IsRelatedTo S) (≡-go S)
+  open ≈-syntax (IsRelatedTo S) (IsRelatedTo S) (≈-go S) sym public
+  open end-syntax (IsRelatedTo S) (end S) public

--- a/src/Relation/Binary/Reasoning/PartialOrder.agda
+++ b/src/Relation/Binary/Reasoning/PartialOrder.agda
@@ -54,7 +54,7 @@ open import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_
 
 open import Relation.Binary.Reasoning.Base.Triple
   isPreorder
-  Strict.<-irrefl
+  (Strict.<-asym antisym)
   (Strict.<-trans isPartialOrder)
   (Strict.<-resp-≈ isEquivalence ≤-resp-≈)
   Strict.<⇒≤

--- a/src/Relation/Binary/Reasoning/PartialSetoid.agda
+++ b/src/Relation/Binary/Reasoning/PartialSetoid.agda
@@ -7,31 +7,22 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 open import Relation.Binary.Bundles using (PartialSetoid)
+open import Relation.Binary.Reasoning.Syntax
 
 module Relation.Binary.Reasoning.PartialSetoid
   {s₁ s₂} (S : PartialSetoid s₁ s₂) where
 
 open PartialSetoid S
-import Relation.Binary.Reasoning.Base.Partial _≈_ trans as Base
+
+import Relation.Binary.Reasoning.Base.Partial _≈_ trans
+  as PartialReasoning
 
 ------------------------------------------------------------------------
--- Re-export the contents of the base module
+-- Reasoning combinators
 
-open Base public
-  hiding (step-∼)
+-- Export the combinators for partial relation reasoning, hiding the
+-- single misnamed combinator.
+open PartialReasoning public hiding (step-∼)
 
-------------------------------------------------------------------------
--- Additional reasoning combinators
-
-infixr 2 step-≈ step-≈˘
-
--- A step using an equality
-
-step-≈ = Base.step-∼
-syntax step-≈ x y≈z x≈y = x ≈⟨ x≈y ⟩ y≈z
-
--- A step using a symmetric equality
-
-step-≈˘ : ∀ x {y z} → y IsRelatedTo z → y ≈ x → x IsRelatedTo z
-step-≈˘ x y∼z y≈x = x ≈⟨ sym y≈x ⟩ y∼z
-syntax step-≈˘ x y≈z y≈x = x ≈˘⟨ y≈x ⟩ y≈z
+-- Re-export the equality-based combinators instead
+open ≈-syntax _IsRelatedTo_ _IsRelatedTo_ PartialReasoning.∼-go sym public

--- a/src/Relation/Binary/Reasoning/Setoid.agda
+++ b/src/Relation/Binary/Reasoning/Setoid.agda
@@ -21,26 +21,21 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 open import Relation.Binary.Bundles using (Setoid)
+open import Relation.Binary.Reasoning.Syntax
 
 module Relation.Binary.Reasoning.Setoid {s₁ s₂} (S : Setoid s₁ s₂) where
 
 open Setoid S
 
+import Relation.Binary.Reasoning.Base.Single _≈_ refl trans
+  as SingleRelReasoning
+
 ------------------------------------------------------------------------
 -- Reasoning combinators
 
-open import Relation.Binary.Reasoning.Base.Single _≈_ refl trans as Base public
-  hiding (step-∼)
+-- Export the combinators for single relation reasoning, hiding the
+-- single misnamed combinator.
+open SingleRelReasoning public hiding (step-∼)
 
-infixr 2 step-≈ step-≈˘
-
--- A step using an equality
-
-step-≈ = Base.step-∼
-syntax step-≈ x y≈z x≈y = x ≈⟨ x≈y ⟩ y≈z
-
--- A step using a symmetric equality
-
-step-≈˘ : ∀ x {y z} → y IsRelatedTo z → y ≈ x → x IsRelatedTo z
-step-≈˘ x y∼z y≈x = x ≈⟨ sym y≈x ⟩ y∼z
-syntax step-≈˘ x y≈z y≈x = x ≈˘⟨ y≈x ⟩ y≈z
+-- Re-export the equality-based combinators instead
+open ≈-syntax _IsRelatedTo_ _IsRelatedTo_ SingleRelReasoning.∼-go sym public

--- a/src/Relation/Binary/Reasoning/StrictPartialOrder.agda
+++ b/src/Relation/Binary/Reasoning/StrictPartialOrder.agda
@@ -53,7 +53,7 @@ import Relation.Binary.Construct.StrictToNonStrict _≈_ _<_ as NonStrict
 
 open import Relation.Binary.Reasoning.Base.Triple
   (NonStrict.isPreorder₂ isStrictPartialOrder)
-  irrefl
+  asym
   trans
   <-resp-≈
   NonStrict.<⇒≤

--- a/src/Relation/Binary/Reasoning/Syntax.agda
+++ b/src/Relation/Binary/Reasoning/Syntax.agda
@@ -1,0 +1,366 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The basic code for equational reasoning with a single relation
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+open import Level using (Level; _⊔_; suc)
+open import Relation.Nullary.Decidable.Core
+  using (Dec; True; toWitness)
+open import Relation.Nullary.Negation using (contradiction)
+open import Relation.Binary.Core using (Rel; REL; _⇒_)
+open import Relation.Binary.Definitions
+open import Relation.Binary.PropositionalEquality.Core as P
+  using (_≡_)
+
+-- List of `Reasoning` modules that do not use this framework and so
+-- need to be updated manually if the syntax changes.
+--
+--   Data/Vec/Relation/Binary/Equality/Cast
+--   Relation/Binary/HeterogeneousEquality
+--   Effect/Monad/Partiality
+--   Effect/Monad/Partiality/All
+--   Relation/Binary/PropositionalEquality/Core
+--   Codata/Guarded/Stream/Relation/Binary/Pointwise
+--   Codata/Sized/Stream/Bisimilarity
+--   Function/Reasoning
+ 
+module Relation.Binary.Reasoning.Syntax where
+
+private
+  variable
+    a ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
+    A B C : Set a
+    x y z : A
+
+------------------------------------------------------------------------
+-- Syntax for beginning a reasoning chain
+------------------------------------------------------------------------
+
+------------------------------------------------------------------------
+-- Basic begin syntax
+
+module begin-syntax
+  (R : REL A B ℓ₁)
+  {S : REL A B ℓ₂}
+  (reflexive : R ⇒ S)
+  where
+
+  infix 1 begin_
+
+  begin_ : R x y → S x y
+  begin_ = reflexive
+
+------------------------------------------------------------------------
+-- Begin subrelation syntax
+
+-- Sometimes we want to support sub-relations with the
+-- same reasoning operators as the main relations (e.g. perform equality
+-- proofs with non-strict reasoning operators). This record bundles all
+-- the parts needed to extract the sub-relation proofs.
+record SubRelation {A : Set a} (R : Rel A ℓ₁) ℓ₂ ℓ₃ : Set (a ⊔ ℓ₁ ⊔ suc ℓ₂ ⊔ suc ℓ₃) where
+  field
+    S : Rel A ℓ₂
+    IsS : R x y → Set ℓ₃
+    IsS? : ∀ (xRy : R x y) → Dec (IsS xRy)
+    extract : ∀ {xRy : R x y} → IsS xRy → S x y
+
+module begin-subrelation-syntax
+  (R : Rel A ℓ₁)
+  (sub : SubRelation R ℓ₂ ℓ₃)
+  where
+  open SubRelation sub
+
+  infix 1 begin_
+
+  begin_ : ∀ {x y} (xRy : R x y) → {s : True (IsS? xRy)} → S x y
+  begin_ r {s} = extract (toWitness s)
+
+-- Begin equality syntax
+module begin-equality-syntax
+  (R : Rel A ℓ₁)
+  (sub : SubRelation R ℓ₂ ℓ₃) where
+
+  open begin-subrelation-syntax R sub public
+    renaming (begin_ to begin-equality_)
+
+-- Begin apartness syntax
+module begin-apartness-syntax
+  (R : Rel A ℓ₁)
+  (sub : SubRelation R ℓ₂ ℓ₃) where
+
+  open begin-subrelation-syntax R sub public
+    renaming (begin_ to begin-apartness_)
+
+-- Begin strict syntax
+module begin-strict-syntax
+  (R : Rel A ℓ₁)
+  (sub : SubRelation R ℓ₂ ℓ₃) where
+
+  open begin-subrelation-syntax R sub public
+    renaming (begin_ to begin-strict_)
+
+------------------------------------------------------------------------
+-- Begin membership syntax
+
+module begin-membership-syntax
+  (R : Rel A ℓ₁)
+  (_∈_ : REL B A ℓ₂)
+  (resp : _∈_ Respectsʳ R) where
+
+  infix  1 step-∈
+
+  step-∈ : ∀ (x : B) {xs ys} → R xs ys → x ∈ xs → x ∈ ys
+  step-∈ x = resp
+
+  syntax step-∈ x  xs⊆ys x∈xs  = x ∈⟨ x∈xs ⟩ xs⊆ys
+
+------------------------------------------------------------------------
+-- Begin contradiction syntax
+
+-- Used with asymmetric subrelations to derive a contradiction from a
+-- proof that an element is related to itself.
+module begin-contradiction-syntax
+  (R : Rel A ℓ₁)
+  (sub : SubRelation R ℓ₂ ℓ₃)
+  (asym : Asymmetric (SubRelation.S sub))
+  where
+
+  open SubRelation sub
+
+  infix 1 begin-contradiction_
+
+  begin-contradiction_ : ∀ (xRx : R x x) {s : True (IsS? xRx)} →
+                         ∀ {b} {B : Set b} → B
+  begin-contradiction_ {x} r {s} = contradiction x<x (asym x<x)
+    where
+    x<x : S x x
+    x<x = extract (toWitness s)
+
+------------------------------------------------------------------------
+-- Syntax for continuing a chain of reasoning steps
+------------------------------------------------------------------------
+
+-- Note that the arguments to the `step`s are not provided in their
+-- "natural" order and syntax declarations are later used to re-order
+-- them. This is because the `step` ordering allows the type-checker to
+-- better infer the middle argument `y` from the `_IsRelatedTo_`
+-- argument (see issue 622).
+--
+-- This has two practical benefits. First it speeds up type-checking by
+-- approximately a factor of 5. Secondly it allows the combinators to be
+-- used with macros that use reflection, e.g. `Tactic.RingSolver`, where
+-- they need to be able to extract `y` using reflection.
+
+------------------------------------------------------------------------
+-- Syntax for unidirectional relations
+
+-- See https://github.com/agda/agda-stdlib/issues/2150 for a possible
+-- simplification.
+
+module _
+  {R : REL A B ℓ₂}
+  (S : REL B C ℓ₁)
+  (T : REL A C ℓ₃)
+  (step : Trans R S T)
+  where
+
+  forward : ∀ (x : A) {y z} → S y z → R x y → T x z
+  forward x yRz x∼y = step {x} x∼y yRz
+
+
+  -- Preorder syntax
+  module ∼-syntax where
+    infixr 2 step-∼
+    step-∼ = forward
+    syntax step-∼ x yRz x∼y = x ∼⟨ x∼y ⟩ yRz
+
+
+  -- Partial order syntax
+  module ≤-syntax where
+    infixr 2 step-≤
+    step-≤ = forward
+    syntax step-≤ x yRz x≤y = x ≤⟨ x≤y ⟩ yRz
+
+
+  -- Strict partial order syntax
+  module <-syntax where
+    infixr 2 step-<
+    step-< = forward
+    syntax step-< x yRz x<y = x <⟨ x<y ⟩ yRz
+
+
+  -- Subset order syntax
+  module ⊆-syntax where
+    infixr 2 step-⊆
+    step-⊆ = forward
+    syntax step-⊆ x yRz x⊆y = x ⊆⟨ x⊆y ⟩ yRz
+
+
+  -- Strict subset order syntax
+  module ⊂-syntax where
+    infixr 2 step-⊂
+    step-⊂ = forward
+    syntax step-⊂ x yRz x⊂y = x ⊂⟨ x⊂y ⟩ yRz
+
+
+  -- Square subset order syntax
+  module ⊑-syntax where
+    infixr 2 step-⊑
+    step-⊑ = forward
+    syntax step-⊑ x yRz x⊑y = x ⊑⟨ x⊑y ⟩ yRz
+
+
+  -- Strict square subset order syntax
+  module ⊏-syntax where
+    infixr 2 step-⊏
+    step-⊏ = forward
+    syntax step-⊏ x yRz x⊏y = x ⊏⟨ x⊏y ⟩ yRz
+
+
+  -- Divisibility syntax
+  module ∣-syntax where
+    infixr 2 step-∣
+    step-∣ = forward
+    syntax step-∣ x yRz x∣y = x ∣⟨ x∣y ⟩ yRz
+
+
+  -- Single-step syntax
+  module ⟶-syntax where
+    infixr 2 step-⟶
+    step-⟶ = forward
+    syntax step-⟶ x yRz x∣y = x ⟶⟨ x∣y ⟩ yRz
+
+
+  -- Multi-step syntax
+  module ⟶*-syntax where
+    infixr 2 step-⟶*
+    step-⟶* = forward
+    syntax step-⟶* x yRz x∣y = x ⟶*⟨ x∣y ⟩ yRz
+
+
+------------------------------------------------------------------------
+-- Syntax for bidirectional relations
+
+  module _
+    {U : REL B A ℓ₄}
+    (sym : Sym U R)
+    where
+
+    backward : ∀ x {y z} → S y z → U y x → T x z
+    backward x yRz x≈y = forward x yRz (sym x≈y)
+
+    -- Setoid equality syntax
+    module ≈-syntax where
+      infixr 2 step-≈ step-≈˘
+      step-≈ = forward
+      step-≈˘ = backward
+      syntax step-≈  x yRz x≈y = x ≈⟨ x≈y ⟩ yRz
+      syntax step-≈˘ x yRz y≈x = x ≈˘⟨ y≈x ⟩ yRz
+
+
+    -- Container equality syntax
+    module ≋-syntax where
+      infixr 2 step-≋ step-≋˘
+      step-≋ = forward
+      step-≋˘ = backward
+      syntax step-≋  x yRz x≋y = x ≋⟨ x≋y ⟩ yRz
+      syntax step-≋˘ x yRz y≋x = x ≋˘⟨ y≋x ⟩ yRz
+
+
+    -- Other equality syntax
+    module ≃-syntax where
+      infixr 2 step-≃ step-≃˘
+      step-≃ = forward
+      step-≃˘ = backward
+      syntax step-≃  x yRz x≃y = x ≃⟨ x≃y ⟩ yRz
+      syntax step-≃˘ x yRz y≃x = x ≃˘⟨ y≃x ⟩ yRz
+
+
+    -- Apartness relation syntax
+    module #-syntax where
+      infixr 2 step-# step-#˘
+      step-# = forward
+      step-#˘ = backward
+      syntax step-#  x yRz x#y = x #⟨ x#y ⟩ yRz
+      syntax step-#˘ x yRz y#x = x #˘⟨ y#x ⟩ yRz
+
+
+    -- Bijection syntax
+    module ⤖-syntax where
+      infixr 2 step-⤖ step-⬻
+      step-⤖ = forward
+      step-⬻ = backward
+      syntax step-⤖ x yRz x⤖y = x ⤖⟨ x⤖y ⟩ yRz
+      syntax step-⬻ x yRz y⤖x = x ⬻⟨ y⤖x ⟩ yRz
+
+
+    -- Inverse syntax
+    module ↔-syntax where
+      infixr 2 step-↔ step-↔-sym
+      step-↔ = forward
+      step-↔-sym = backward
+      syntax step-↔ x yRz x⤖y = x ↔⟨ x⤖y ⟩ yRz
+      syntax step-↔-sym x yRz y⤖x = x ↔˘⟨ y⤖x ⟩ yRz
+
+
+    -- Inverse syntax
+    module ↭-syntax where
+      infixr 2 step-↭ step-↭-sym
+      step-↭ = forward
+      step-↭-sym = backward
+      syntax step-↭ x yRz x⤖y = x ↭⟨ x⤖y ⟩ yRz
+      syntax step-↭-sym x yRz y⤖x = x ↭˘⟨ y⤖x ⟩ yRz
+
+------------------------------------------------------------------------
+-- Propositional equality
+
+-- Crucially often the step function cannot just be `subst` or pattern
+-- match on `refl` as we often want to compute which constructor the
+-- relation begins with, in order for the implicit subrelation
+-- arguments to resolve. See `≡-noncomputable-syntax` below if this
+-- is not required.
+module ≡-syntax
+  (R : REL A B ℓ₁)
+  (step : Trans _≡_ R R)
+  where
+
+  infixr 2 step-≡ step-≡-refl step-≡˘
+  step-≡ = forward R R step
+  step-≡˘ = backward R R step P.sym
+
+  step-≡-refl : ∀ x {y} → R x y → R x y
+  step-≡-refl x xRy = xRy
+
+  syntax step-≡-refl x xRy     = x ≡⟨⟩ xRy
+  syntax step-≡˘     x yRz y≡x = x ≡˘⟨ y≡x ⟩ yRz
+  syntax step-≡      x yRz x≡y = x ≡⟨ x≡y ⟩ yRz
+
+
+-- Unlike ≡-syntax above, chains of reasoning using this syntax will not
+-- reduce when proofs of propositional equality which are not definitionally
+-- equal to `refl` are passed.
+module ≡-noncomputing-syntax (R : REL A B ℓ₁) where
+
+  private
+    step : Trans _≡_ R R
+    step P.refl xRy = xRy
+
+  open ≡-syntax R step public
+
+------------------------------------------------------------------------
+-- Syntax for ending a chain of reasoning
+------------------------------------------------------------------------
+
+module end-syntax
+  (R : Rel A ℓ₁)
+  (reflexive : Reflexive R)
+  where
+
+  infix 3 _∎
+
+  _∎ : ∀ x → R x x
+  x ∎ = reflexive
+

--- a/src/Relation/Binary/Reasoning/Syntax.agda
+++ b/src/Relation/Binary/Reasoning/Syntax.agda
@@ -302,8 +302,8 @@ module _
       infixr 2 step-↔ step-↔-sym
       step-↔ = forward
       step-↔-sym = backward
-      syntax step-↔ x yRz x⤖y = x ↔⟨ x⤖y ⟩ yRz
-      syntax step-↔-sym x yRz y⤖x = x ↔˘⟨ y⤖x ⟩ yRz
+      syntax step-↔ x yRz x↔y = x ↔⟨ x↔y ⟩ yRz
+      syntax step-↔-sym x yRz y↔x = x ↔˘⟨ y↔x ⟩ yRz
 
 
     -- Inverse syntax
@@ -311,8 +311,8 @@ module _
       infixr 2 step-↭ step-↭-sym
       step-↭ = forward
       step-↭-sym = backward
-      syntax step-↭ x yRz x⤖y = x ↭⟨ x⤖y ⟩ yRz
-      syntax step-↭-sym x yRz y⤖x = x ↭˘⟨ y⤖x ⟩ yRz
+      syntax step-↭ x yRz x↭y = x ↭⟨ x↭y ⟩ yRz
+      syntax step-↭-sym x yRz y↭x = x ↭˘⟨ y↭x ⟩ yRz
 
 ------------------------------------------------------------------------
 -- Propositional equality

--- a/src/Relation/Binary/Reasoning/Syntax.agda
+++ b/src/Relation/Binary/Reasoning/Syntax.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- The basic code for equational reasoning with a single relation
+-- Syntax for the building blocks of equational reasoning modules 
 ------------------------------------------------------------------------
 
 {-# OPTIONS --cubical-compatible --safe #-}


### PR DESCRIPTION
Fixes #2146. The main contribution of this to move as many reasoning syntax declarations as possible into the new module `Relation.Binary.Reasoning.Syntax`, whose parts are then picked as desired by each individual `Reasoning` module.

This has several advantages:
 1. Much easier to rename or add new syntax to when building custom `Reasoning` modules
 2. Centralises all the syntax declarations and documentation so that it is much easier to maintain.

See the list at the top of the `Syntax` module for the short list of `Reasoning` modules that for a variety of reasons aren't immediately amenable to this approach.

This change is backwards compatible as evidenced by the fact that no reasoning proofs have had to be changed. The interface for the `Reasoning` modules themselves also remains the same.