### PR TITLE
Move `T?` to `Relation.Nullary.Decidable.Core`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -838,6 +838,9 @@ Non-backwards compatible changes
 
   4. The modules `Relation.Nullary.(Product/Sum/Implication)` have been deprecated
          and their contents moved to `Relation.Nullary.(Negation/Reflects/Decidable)`.
+		 
+  5. The proof `T?` has been moved from `Data.Bool.Properties` to `Relation.Nullary.Decidable.Core`
+	 (but is still re-exported by the former).
 
   as well as the following breaking changes:
 
@@ -3561,6 +3564,11 @@ Additions to existing modules
 
   isPartialOrder : IsPartialOrder _≡_ _≡_
   poset          : Set a → Poset _ _ _
+  ```
+
+* Added new proof in `Relation.Nullary.Reflects`:
+  ```agda
+  T-reflects : Reflects (T b) b
   ```
 
 * Added new operations in `System.Exit`:

--- a/notes/style-guide.md
+++ b/notes/style-guide.md
@@ -402,7 +402,7 @@ word within a compound word is capitalized except for the first word.
 
 * Rational variables are named `p`, `q`, `r`, ... (default `p`)
 
-* All other variables tend to be named `x`, `y`, `z`.
+* All other variables, including `Bool`, should be named `x`, `y`, `z`.
 
 * Collections of elements are usually indicated by appending an `s`
   (e.g. if you are naming your variables `x` and `y` then lists

--- a/src/Data/Bool.agda
+++ b/src/Data/Bool.agda
@@ -8,9 +8,6 @@
 
 module Data.Bool where
 
-open import Relation.Nullary
-open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
-
 ------------------------------------------------------------------------
 -- The boolean type and some operations
 

--- a/src/Data/Bool/Base.agda
+++ b/src/Data/Bool/Base.agda
@@ -57,17 +57,19 @@ true  xor b = not b
 false xor b = b
 
 ------------------------------------------------------------------------
+-- Conversion to Set
+
+-- A function mapping true to an inhabited type and false to an empty
+-- type.
+T : Bool → Set
+T true  = ⊤
+T false = ⊥
+
+------------------------------------------------------------------------
 -- Other operations
 
-infix  0 if_then_else_
+infix 0 if_then_else_
 
 if_then_else_ : Bool → A → A → A
 if true  then t else f = t
 if false then t else f = f
-
--- A function mapping true to an inhabited type and false to an empty
--- type.
-
-T : Bool → Set
-T true  = ⊤
-T false = ⊥

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -29,7 +29,7 @@ open import Relation.Binary.Definitions
 open import Relation.Binary.PropositionalEquality.Core
 open import Relation.Binary.PropositionalEquality.Properties
 open import Relation.Nullary.Reflects using (ofʸ; ofⁿ)
-open import Relation.Nullary.Decidable.Core using (True; does; proof; yes; no)
+open import Relation.Nullary.Decidable.Core using (True; does; proof; yes; no; fromWitness)
 import Relation.Unary as U
 
 open import Algebra.Definitions {A = Bool} _≡_
@@ -726,15 +726,17 @@ xor-∧-commutativeRing = ⊕-∧-commutativeRing
   open XorRing _xor_ xor-is-ok
 
 ------------------------------------------------------------------------
--- Miscellaneous other properties
+-- Properties of if_then_else_
 
-⇔→≡ : {x y z : Bool} → x ≡ z ⇔ y ≡ z → x ≡ y
-⇔→≡ {true } {true }         hyp = refl
-⇔→≡ {true } {false} {true } hyp = sym (Equivalence.to hyp refl)
-⇔→≡ {true } {false} {false} hyp = Equivalence.from hyp refl
-⇔→≡ {false} {true } {true } hyp = Equivalence.from hyp refl
-⇔→≡ {false} {true } {false} hyp = sym (Equivalence.to hyp refl)
-⇔→≡ {false} {false}         hyp = refl
+if-float : ∀ (f : A → B) b {x y} →
+           f (if b then x else y) ≡ (if b then f x else f y)
+if-float _ true  = refl
+if-float _ false = refl
+
+------------------------------------------------------------------------
+-- Properties of T
+
+open Relation.Nullary.Decidable.Core public using (T?)
 
 T-≡ : ∀ {x} → T x ⇔ x ≡ true
 T-≡ {false} = mk⇔ (λ ())       (λ ())
@@ -757,18 +759,20 @@ T-∨ {false} {false} = mk⇔ inj₁ [ id , id ]
 T-irrelevant : U.Irrelevant T
 T-irrelevant {true}  _  _  = refl
 
-T? : U.Decidable T
-does  (T? b) = b
-proof (T? true ) = ofʸ _
-proof (T? false) = ofⁿ λ()
-
 T?-diag : ∀ b → T b → True (T? b)
-T?-diag true  _ = _
+T?-diag b = fromWitness
 
-if-float : ∀ (f : A → B) b {x y} →
-           f (if b then x else y) ≡ (if b then f x else f y)
-if-float _ true  = refl
-if-float _ false = refl
+------------------------------------------------------------------------
+-- Miscellaneous other properties
+
+⇔→≡ : {x y z : Bool} → x ≡ z ⇔ y ≡ z → x ≡ y
+⇔→≡ {true } {true }         hyp = refl
+⇔→≡ {true } {false} {true } hyp = sym (Equivalence.to hyp refl)
+⇔→≡ {true } {false} {false} hyp = Equivalence.from hyp refl
+⇔→≡ {false} {true } {true } hyp = Equivalence.from hyp refl
+⇔→≡ {false} {true } {false} hyp = sym (Equivalence.to hyp refl)
+⇔→≡ {false} {false}         hyp = refl
+
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Relation/Nullary.agda
+++ b/src/Relation/Nullary.agda
@@ -15,20 +15,9 @@ open import Agda.Builtin.Equality
 ------------------------------------------------------------------------
 -- Re-exports
 
-open import Relation.Nullary.Negation.Core public using
-  ( ¬_; _¬-⊎_
-  ; contradiction; contradiction₂; contraposition
-  )
-
-open import Relation.Nullary.Reflects public using
-  ( Reflects; ofʸ; ofⁿ
-  ; _×-reflects_; _⊎-reflects_; _→-reflects_
-  )
-
-open import Relation.Nullary.Decidable.Core public using
-  ( Dec; does; proof; yes; no; _because_; recompute
-  ; ¬?; _×-dec_; _⊎-dec_; _→-dec_
-  )
+open import Relation.Nullary.Negation.Core public
+open import Relation.Nullary.Reflects public
+open import Relation.Nullary.Decidable.Core public
 
 ------------------------------------------------------------------------
 -- Irrelevant types

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -12,7 +12,7 @@
 module Relation.Nullary.Decidable.Core where
 
 open import Level using (Level; Lift)
-open import Data.Bool.Base using (Bool; false; true; not; T; _∧_; _∨_)
+open import Data.Bool.Base using (Bool; T; false; true; not; _∧_; _∨_)
 open import Data.Unit.Base using (⊤)
 open import Data.Empty using (⊥)
 open import Data.Empty.Irrelevant using (⊥-elim)
@@ -78,6 +78,10 @@ recompute (no ¬a) a = ⊥-elim (¬a a)
 
 infixr 1 _⊎-dec_
 infixr 2 _×-dec_ _→-dec_
+
+T? : ∀ b → Dec (T b)
+does  (T? b) = b
+proof (T? b) = T-reflects b
 
 ¬? : Dec A → Dec (¬ A)
 does  (¬? a?) = not (does a?)

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -79,9 +79,9 @@ recompute (no ¬a) a = ⊥-elim (¬a a)
 infixr 1 _⊎-dec_
 infixr 2 _×-dec_ _→-dec_
 
-T? : ∀ b → Dec (T b)
-does  (T? b) = b
-proof (T? b) = T-reflects b
+T? : ∀ x → Dec (T x)
+does  (T? x) = x
+proof (T? x) = T-reflects x
 
 ¬? : Dec A → Dec (¬ A)
 does  (¬? a?) = not (does a?)

--- a/src/Relation/Nullary/Reflects.agda
+++ b/src/Relation/Nullary/Reflects.agda
@@ -11,11 +11,12 @@ module Relation.Nullary.Reflects where
 open import Agda.Builtin.Equality
 
 open import Data.Bool.Base
+open import Data.Unit.Base using (⊤)
 open import Data.Empty
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂)
 open import Level using (Level)
-open import Function.Base using (_$_; _∘_; const)
+open import Function.Base using (_$_; _∘_; const; id)
 
 open import Relation.Nullary.Negation.Core
 
@@ -23,6 +24,7 @@ private
   variable
     a : Level
     A B : Set a
+    x y : Bool
 
 ------------------------------------------------------------------------
 -- `Reflects` idiom.
@@ -43,41 +45,41 @@ data Reflects (A : Set a) : Bool → Set a where
 -- `ofʸ`), and `invert` strips off the constructor to just give either
 -- the proof of `A` or the proof of `¬ A`.
 
-of : ∀ {b} → if b then A else ¬ A → Reflects A b
-of {b = false} ¬a = ofⁿ ¬a
-of {b = true }  a = ofʸ a
+of : if x then A else ¬ A → Reflects A x
+of {x = false} ¬a = ofⁿ ¬a
+of {x = true }  a = ofʸ a
 
-invert : ∀ {b} → Reflects A b → if b then A else ¬ A
+invert : Reflects A x → if x then A else ¬ A
 invert (ofʸ  a) = a
 invert (ofⁿ ¬a) = ¬a
 
 ------------------------------------------------------------------------
 -- Interaction with negation, product, sums etc.
 
+infixr 1 _⊎-reflects_
+infixr 2 _×-reflects_ _→-reflects_
+
+T-reflects : ∀ x → Reflects (T x) x
+T-reflects true  = of _
+T-reflects false = of id
+
 -- If we can decide A, then we can decide its negation.
-¬-reflects : ∀ {b} → Reflects A b → Reflects (¬ A) (not b)
+¬-reflects : Reflects A x → Reflects (¬ A) (not x)
 ¬-reflects (ofʸ  a) = ofⁿ (_$ a)
 ¬-reflects (ofⁿ ¬a) = ofʸ ¬a
 
 -- If we can decide A and Q then we can decide their product
-infixr 2 _×-reflects_
-_×-reflects_ : ∀ {a b} → Reflects A a → Reflects B b →
-               Reflects (A × B) (a ∧ b)
+_×-reflects_ : Reflects A x → Reflects B y → Reflects (A × B) (x ∧ y)
 ofʸ  a ×-reflects ofʸ  b = ofʸ (a , b)
 ofʸ  a ×-reflects ofⁿ ¬b = ofⁿ (¬b ∘ proj₂)
 ofⁿ ¬a ×-reflects _      = ofⁿ (¬a ∘ proj₁)
 
-
-infixr 1 _⊎-reflects_
-_⊎-reflects_ : ∀ {a b} → Reflects A a → Reflects B b →
-               Reflects (A ⊎ B) (a ∨ b)
+_⊎-reflects_ : Reflects A x → Reflects B y → Reflects (A ⊎ B) (x ∨ y)
 ofʸ  a ⊎-reflects      _ = ofʸ (inj₁ a)
 ofⁿ ¬a ⊎-reflects ofʸ  b = ofʸ (inj₂ b)
 ofⁿ ¬a ⊎-reflects ofⁿ ¬b = ofⁿ (¬a ¬-⊎ ¬b)
 
-infixr 2 _→-reflects_
-_→-reflects_ : ∀ {a b} → Reflects A a → Reflects B b →
-                Reflects (A → B) (not a ∨ b)
+_→-reflects_ : Reflects A x → Reflects B y → Reflects (A → B) (not x ∨ y)
 ofʸ  a →-reflects ofʸ  b = ofʸ (const b)
 ofʸ  a →-reflects ofⁿ ¬b = ofⁿ (¬b ∘ (_$ a))
 ofⁿ ¬a →-reflects _      = ofʸ (⊥-elim ∘ ¬a)
@@ -85,12 +87,12 @@ ofⁿ ¬a →-reflects _      = ofʸ (⊥-elim ∘ ¬a)
 ------------------------------------------------------------------------
 -- Other lemmas
 
-fromEquivalence : ∀ {b} → (T b → A) → (A → T b) → Reflects A b
-fromEquivalence {b = true}  sound complete = ofʸ (sound _)
-fromEquivalence {b = false} sound complete = ofⁿ complete
+fromEquivalence : (T x → A) → (A → T x) → Reflects A x
+fromEquivalence {x = true}  sound complete = ofʸ (sound _)
+fromEquivalence {x = false} sound complete = ofⁿ complete
 
 -- `Reflects` is deterministic.
-det : ∀ {b b′} → Reflects A b → Reflects A b′ → b ≡ b′
+det : Reflects A x → Reflects A y → x ≡ y
 det (ofʸ  a) (ofʸ  _) = refl
 det (ofʸ  a) (ofⁿ ¬a) = contradiction a ¬a
 det (ofⁿ ¬a) (ofʸ  a) = contradiction a ¬a


### PR DESCRIPTION
The only thing I haven't addressed is @jamesmckinna's comment:

> And along with T?, please consider (re-)moving its property T?-diag as well (for the sake of keeping the import dependencies of Data.Bool.Properties as small as possible)

I didn't quite understand the reasoning here? Moving `T?-diag` to somewhere in `Relation.Nullary.Decidable.Core` wouldn't make the import dependencies any smaller, because `Data.Bool.Properties`, as expected, heavily already depends on `Relation.Nullary.Decidable.Core`....