### PR TITLE
finer-grained analysis of `NonZero` arguments

### DIFF
--- a/src/Data/Digit.agda
+++ b/src/Data/Digit.agda
@@ -56,7 +56,7 @@ toNatDigits base@(suc (suc _)) n = aux (<-wellFounded-fast n) []
   aux {zero}        _      xs =  (0 ∷ xs)
   aux {n@(suc _)} (acc wf) xs with does (0 <? n / base)
   ... | false = (n % base) ∷ xs -- Could this more simply be n ∷ xs here?
-  ... | true  = aux (wf (m/n<m n base sz<ss)) ((n % base) ∷ xs)
+  ... | true  = aux (wf (m/n<m n base)) ((n % base) ∷ xs)
 
 ------------------------------------------------------------------------
 -- Converting between `ℕ` and expansions of `Digit base`

--- a/src/Data/Nat/DivMod.agda
+++ b/src/Data/Nat/DivMod.agda
@@ -205,7 +205,7 @@ m/n≤m m n = *-cancelʳ-≤ (m / n) m n (begin
 
 m/n<m : ∀ m n .{{_ : NonZero m}} .{{_ : NonTrivial n}} →
         let instance _ = nonTrivial⇒nonZero n in m / n < m
-m/n<m m n     = *-cancelʳ-< _ (m / n) m $ begin-strict
+m/n<m m n = *-cancelʳ-< _ (m / n) m $ begin-strict
   m / n * n ≤⟨ m/n*n≤m m n ⟩
   m         <⟨ m<m*n m n (nonTrivial⇒n>1 n) ⟩
   m * n     ∎
@@ -240,7 +240,7 @@ m≥n⇒m/n>0 {m@(suc _)} {n@(suc _)} m≥n = begin
   m / n ∎
 
 m/n≡0⇒m<n : ∀ {m n} .{{_ : NonZero n}} → m / n ≡ 0 → m < n
-m/n≡0⇒m<n {m} {n@(suc _)} m/n≡0  with <-≤-connex m n
+m/n≡0⇒m<n {m} {n} m/n≡0  with <-≤-connex m n
 ... | inj₁ m<n = m<n
 ... | inj₂ n≤m = contradiction m/n≡0 (≢-nonZero⁻¹ _)
   where instance _ =  >-nonZero (m≥n⇒m/n>0 n≤m)


### PR DESCRIPTION
[Breaking changes so held back from merge of #2182 into v2.1]

Essentially a placeholder `DRAFT` PR in which to accumulate all such things, towards an eventual v3.0 merge.

NB: currently, the statements/proofs follow a rather clunky
* `let instance _ =...` in the statements;
* `where instance _ = ...` in the proofs.

Suggest subsequent refactorings to make all such things anonymous modules which set up all the appropriate scope... esp. in the cases where there are auxiliary lemmas. 

UPDATED: @MatthewDaggitt 's review comment gives me pause... So I'll refrain from committing further for the time being!