### PR TITLE
Add new operations (cf. `RawQuasigroup`) to `IsGroup`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ Additions to existing modules
   quasigroup      : Quasigroup _ _
   isLoop          : IsLoop _∙_ _\\_ _//_ ε
   loop            : Loop _ _
+  ⁻¹-selfInverse  : SelfInverse _⁻¹
   \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
   comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Additions to existing modules
   ```agda
   isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
   isLoop : IsLoop _∙_ _\\_ _//_ ε
+  \\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
   ```
 
 * In `Algebra.Structures.IsGroup`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,10 +83,19 @@ Additions to existing modules
 
 * In `Algebra.Properties.Group`:
   ```agda
-  isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
-  isLoop : IsLoop _∙_ _\\_ _//_ ε
+  isQuasigroup    : IsQuasigroup _∙_ _\\_ _//_
+  quasigroup      : Quasigroup _ _
+  isLoop          : IsLoop _∙_ _\\_ _//_ ε
+  loop            : Loop _ _
   \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
   comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
+  ```
+
+* In `Algebra.Properties.Loop`:
+  ```agda
+  identityˡ-unique : x ∙ y ≈ y → x ≈ ε
+  identityʳ-unique : x ∙ y ≈ x → y ≈ ε
+  identity-unique  : Identity x _∙_ → x ≈ ε
   ```
 
 * In `Algebra.Structures.IsGroup`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ Additions to existing modules
 * In `Algebra.Structures.IsGroup`:
   ```agda
   infixl 6 _//_
-  infixr 6 _⁻¹∙_
+  infixr 6 _\\_
   _//_ _\\_ : Op₂ A
   x // y = x ∙ (y ⁻¹)
   x \\ y = (x ⁻¹) ∙ y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@ Additions to existing modules
   rawModule          : RawModule R c ℓ
   ```
 
+* In `Algebra.Properties.Group`:
+  ```agda
+  isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
+  isLoop : IsLoop _∙_ _\\_ _//_ ε
+  ```
+
 * In `Algebra.Structures.IsGroup`:
   ```agda
   infixl 6 _//_
@@ -88,6 +94,7 @@ Additions to existing modules
   _//_ _\\_ : Op₂ A
   x // y = x ∙ (y ⁻¹)
   x \\ y = (x ⁻¹) ∙ y
+  ```
 
 * In `Data.Fin.Properties`:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,10 @@ Additions to existing modules
 * In `Algebra.Structures.IsGroup`:
   ```agda
   infixl 6 _//_
-  infixr 6 _\\_
-  _//_ _\\_ : Op₂ A
+  _//_ : Op₂ A
   x // y = x ∙ (y ⁻¹)
+  infixr 6 _\\_
+  _\\_ : Op₂ A
   x \\ y = (x ⁻¹) ∙ y
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ New modules
 Additions to existing modules
 -----------------------------
 
+* In `Algebra.Structures.IsGroup`:
+  ```agda
+  infixl 6 _∙⁻¹_
+  infixr 6 _⁻¹∙_
+  _∙⁻¹_ : Op₂ A
+  x ∙⁻¹ y = x ∙ (y ⁻¹)
+  _⁻¹∙_ : Op₂ A
+  x ⁻¹∙  y = (x ⁻¹) ∙ y
+  ```
+
 * In `Data.Fin.Properties`:
   ```agda
   nonZeroIndex : Fin n → ℕ.NonZero n

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ Deprecated modules
 Deprecated names
 ----------------
 
+* In `Algebra.Structures.IsGroup`:
+  ```agda
+  _-_  ↦  _//_
+  ```
+
 * In `Data.Nat.Divisibility.Core`:
   ```agda
   *-pres-∣  ↦  Data.Nat.Divisibility.*-pres-∣
@@ -78,12 +83,11 @@ Additions to existing modules
 
 * In `Algebra.Structures.IsGroup`:
   ```agda
-  infixl 6 _∙⁻¹_
+  infixl 6 _//_
   infixr 6 _⁻¹∙_
-  _∙⁻¹_ : Op₂ A
-  x ∙⁻¹ y = x ∙ (y ⁻¹)
-  _⁻¹∙_ : Op₂ A
-  x ⁻¹∙  y = (x ⁻¹) ∙ y
+  _//_ _\\_ : Op₂ A
+  x // y = x ∙ (y ⁻¹)
+  x \\ y = (x ⁻¹) ∙ y
 
 * In `Data.Fin.Properties`:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,8 @@ Additions to existing modules
   ```agda
   isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
   isLoop : IsLoop _∙_ _\\_ _//_ ε
-  \\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
-  comm⇒\\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
+  \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
+  comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
   ```
 
 * In `Algebra.Structures.IsGroup`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,14 @@ Additions to existing modules
   quasigroup      : Quasigroup _ _
   isLoop          : IsLoop _∙_ _\\_ _//_ ε
   loop            : Loop _ _
+  
+  \\-leftDividesˡ  : LeftDividesˡ _∙_ _\\_
+  \\-leftDividesʳ  : LeftDividesʳ _∙_ _\\_
+  \\-leftDivides   : LeftDivides _∙_ _\\_
+  //-rightDividesˡ : RightDividesˡ _∙_ _//_
+  //-rightDividesʳ : RightDividesʳ _∙_ _//_
+  //-rightDivides  : RightDivides _∙_ _//_
+
   ⁻¹-selfInverse  : SelfInverse _⁻¹
   \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
   comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ Additions to existing modules
   rawModule          : RawModule R c ℓ
   ```
 
+* In `Algebra.Properties.AbelianGroup`:
+  ```agda
+  \\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
+  ```
+
 * In `Algebra.Properties.Group`:
   ```agda
   isQuasigroup : IsQuasigroup _∙_ _\\_ _//_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,16 +81,12 @@ Additions to existing modules
   rawModule          : RawModule R c ℓ
   ```
 
-* In `Algebra.Properties.AbelianGroup`:
-  ```agda
-  \\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
-  ```
-
 * In `Algebra.Properties.Group`:
   ```agda
   isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
   isLoop : IsLoop _∙_ _\\_ _//_ ε
   \\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
+  comm⇒\\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
   ```
 
 * In `Algebra.Structures.IsGroup`:

--- a/src/Algebra/Properties/AbelianGroup.agda
+++ b/src/Algebra/Properties/AbelianGroup.agda
@@ -36,3 +36,13 @@ xyx⁻¹≈y x y = begin
   x ⁻¹ ∙ y ⁻¹ ≈⟨ ⁻¹-anti-homo-∙ y x ⟨
   (y ∙ x) ⁻¹  ≈⟨ ⁻¹-cong $ comm y x ⟩
   (x ∙ y) ⁻¹  ∎
+
+module _ where
+  open IsGroup isGroup using (_//_; _\\_)
+
+  \\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
+  \\≗//ᵒ x y = begin
+    x \\ y    ≈⟨ refl ⟩
+    x ⁻¹ ∙ y  ≈⟨ comm _ _ ⟩
+    y ∙ x ⁻¹  ≈⟨ refl ⟩
+    y // x    ∎

--- a/src/Algebra/Properties/AbelianGroup.agda
+++ b/src/Algebra/Properties/AbelianGroup.agda
@@ -36,13 +36,3 @@ xyx⁻¹≈y x y = begin
   x ⁻¹ ∙ y ⁻¹ ≈⟨ ⁻¹-anti-homo-∙ y x ⟨
   (y ∙ x) ⁻¹  ≈⟨ ⁻¹-cong $ comm y x ⟩
   (x ∙ y) ⁻¹  ∎
-
-module _ where
-  open IsGroup isGroup using (_//_; _\\_)
-
-  \\≗//ᵒ : ∀ x y → x \\ y ≈ y // x
-  \\≗//ᵒ x y = begin
-    x \\ y    ≈⟨ refl ⟩
-    x ⁻¹ ∙ y  ≈⟨ comm _ _ ⟩
-    y ∙ x ⁻¹  ≈⟨ refl ⟩
-    y // x    ∎

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -17,6 +17,12 @@ open import Relation.Binary.Reasoning.Setoid setoid
 open import Function.Base using (_$_; _⟨_⟩_)
 open import Data.Product.Base using (_,_; proj₂)
 
+\\-cong₂ : Congruent₂ _\\_
+\\-cong₂ x≈y u≈v = ∙-cong (⁻¹-cong x≈y) u≈v
+
+//-cong₂ : Congruent₂ _//_
+//-cong₂ x≈y u≈v = ∙-cong x≈y (⁻¹-cong u≈v)
+
 leftDividesˡ : ∀ x y → x ∙ (x \\ y) ≈ y
 leftDividesˡ x y = begin
   x  ∙ (x \\ y)  ≈⟨ assoc x (x ⁻¹) y ⟨
@@ -47,12 +53,12 @@ rightDividesʳ x y = begin
 
 isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
 isQuasigroup = record
-                 { isMagma = isMagma
-                 ; \\-cong = λ x≈y u≈v → ∙-cong (⁻¹-cong x≈y) u≈v
-                 ; //-cong = λ x≈y u≈v → ∙-cong x≈y (⁻¹-cong u≈v)
-                 ; leftDivides = leftDividesˡ , leftDividesʳ
-                 ; rightDivides = rightDividesˡ , rightDividesʳ
-                 }
+  { isMagma = isMagma
+  ; \\-cong = \\-cong₂
+  ; //-cong = //-cong₂
+  ; leftDivides = leftDividesˡ , leftDividesʳ
+  ; rightDivides = rightDividesˡ , rightDividesʳ
+  }
 
 isLoop : IsLoop _∙_ _\\_ _//_ ε
 isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -134,11 +134,9 @@ inverseʳ-unique x y eq = begin
 
 \\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
 \\≗//ᵒ⇒comm \\≗//ᵒ x y = begin
-  x ∙ y                ≈⟨ identityʳ _ ⟨
-  (x ∙ y) ∙ ε          ≈⟨ ∙-congˡ (inverseˡ x) ⟨
-  (x ∙ y) ∙ (x ⁻¹ ∙ x) ≈⟨ assoc (x ∙ y) (x ⁻¹) x ⟨
-  (x ∙ y) ∙ x ⁻¹ ∙ x   ≈⟨ ∙-congʳ (assoc x y (x ⁻¹)) ⟩
-  x ∙ (y // x) ∙ x     ≈⟨ ∙-congʳ (∙-congˡ (\\≗//ᵒ x y)) ⟨
+  x ∙ y                ≈⟨ ∙-congˡ (rightDividesˡ x y) ⟨
+  x ∙ ((y // x) ∙ x)   ≈⟨ ∙-congˡ (∙-congʳ (\\≗//ᵒ x y)) ⟨
+  x ∙ ((x \\ y) ∙ x)   ≈⟨ assoc x (x \\ y) x ⟨
   x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (leftDividesˡ x y) ⟩
   y ∙ x                ∎
 

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -10,15 +10,16 @@ open import Algebra.Bundles
 
 module Algebra.Properties.Group {g₁ g₂} (G : Group g₁ g₂) where
 
-open Group G
-open import Algebra.Consequences.Setoid setoid
-open import Algebra.Definitions _≈_
 import Algebra.Properties.Loop as LoopProperties
 import Algebra.Properties.Quasigroup as QuasigroupProperties
-open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Data.Product.Base using (_,_)
 open import Function.Base using (_$_)
 open import Function.Definitions
+
+open Group G
+open import Algebra.Consequences.Setoid setoid
+open import Algebra.Definitions _≈_
+open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Relation.Binary.Reasoning.Setoid setoid
 
 \\-cong₂ : Congruent₂ _\\_
@@ -27,41 +28,51 @@ open import Relation.Binary.Reasoning.Setoid setoid
 //-cong₂ : Congruent₂ _//_
 //-cong₂ x≈y u≈v = ∙-cong x≈y (⁻¹-cong u≈v)
 
-leftDividesˡ : ∀ x y → x ∙ (x \\ y) ≈ y
-leftDividesˡ x y = begin
+------------------------------------------------------------------------
+-- Groups are quasi-groups
+
+\\-leftDividesˡ : LeftDividesˡ _∙_ _\\_
+\\-leftDividesˡ x y = begin
   x  ∙ (x \\ y)  ≈⟨ assoc x (x ⁻¹) y ⟨
   x ∙ x ⁻¹ ∙ y   ≈⟨ ∙-congʳ (inverseʳ x) ⟩
   ε ∙ y          ≈⟨ identityˡ y ⟩
   y              ∎
 
-leftDividesʳ : ∀ x y → x \\ x ∙ y ≈ y
-leftDividesʳ x y = begin
+\\-leftDividesʳ : LeftDividesʳ _∙_ _\\_
+\\-leftDividesʳ x y = begin
   x \\ x ∙ y     ≈⟨ assoc (x ⁻¹) x y ⟨
   x ⁻¹ ∙ x ∙ y   ≈⟨ ∙-congʳ (inverseˡ x) ⟩
   ε ∙ y          ≈⟨ identityˡ y ⟩
   y              ∎
 
-rightDividesˡ : ∀ x y → (y // x) ∙ x ≈ y
-rightDividesˡ x y = begin
+
+\\-leftDivides : LeftDivides _∙_ _\\_
+\\-leftDivides = \\-leftDividesˡ , \\-leftDividesʳ
+
+//-rightDividesˡ : RightDividesˡ _∙_ _//_
+//-rightDividesˡ x y = begin
   (y // x) ∙ x    ≈⟨ assoc y (x ⁻¹) x ⟩
   y ∙ (x ⁻¹ ∙ x)  ≈⟨ ∙-congˡ (inverseˡ x) ⟩
   y ∙ ε           ≈⟨ identityʳ y ⟩
   y               ∎
 
-rightDividesʳ : ∀ x y → y ∙ x // x ≈ y
-rightDividesʳ x y = begin
+//-rightDividesʳ : RightDividesʳ _∙_ _//_
+//-rightDividesʳ x y = begin
   y ∙ x // x    ≈⟨ assoc y x (x ⁻¹) ⟩
   y ∙ (x // x)  ≈⟨ ∙-congˡ (inverseʳ x) ⟩
   y ∙ ε         ≈⟨ identityʳ y ⟩
   y             ∎
+
+//-rightDivides : RightDivides _∙_ _//_
+//-rightDivides = //-rightDividesˡ , //-rightDividesʳ
 
 isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
 isQuasigroup = record
   { isMagma = isMagma
   ; \\-cong = \\-cong₂
   ; //-cong = //-cong₂
-  ; leftDivides = leftDividesˡ , leftDividesʳ
-  ; rightDivides = rightDividesˡ , rightDividesʳ
+  ; leftDivides = \\-leftDivides
+  ; rightDivides = //-rightDivides
   }
 
 quasigroup : Quasigroup _ _
@@ -70,6 +81,21 @@ quasigroup = record { isQuasigroup = isQuasigroup }
 open QuasigroupProperties quasigroup public
   using (x≈z//y; y≈x\\z)
   renaming (cancelˡ to ∙-cancelˡ; cancelʳ to ∙-cancelʳ; cancel to ∙-cancel)
+
+------------------------------------------------------------------------
+-- Groups are loops
+
+isLoop : IsLoop _∙_ _\\_ _//_ ε
+isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
+
+loop : Loop _ _
+loop = record { isLoop = isLoop }
+
+open LoopProperties loop public
+  using (identityˡ-unique; identityʳ-unique; identity-unique)
+
+------------------------------------------------------------------------
+-- Other properties
 
 inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
 inverseˡ-unique x y eq = trans (x≈z//y x y ε eq) (identityˡ _)
@@ -92,29 +118,20 @@ inverseʳ-unique x y eq = trans (y≈x\\z x y ε eq) (identityʳ _)
 ⁻¹-injective : Injective _≈_ _≈_ _⁻¹
 ⁻¹-injective = selfInverse⇒injective ⁻¹-selfInverse
 
-isLoop : IsLoop _∙_ _\\_ _//_ ε
-isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
-
-loop : Loop _ _
-loop = record { isLoop = isLoop }
-
-open LoopProperties loop public
-  using (identityˡ-unique; identityʳ-unique; identity-unique)
-
 ⁻¹-anti-homo-∙ : ∀ x y → (x ∙ y) ⁻¹ ≈ y ⁻¹ ∙ x ⁻¹
 ⁻¹-anti-homo-∙ x y = ∙-cancelˡ _ _ _ $ begin
   x ∙ y ∙ (x ∙ y) ⁻¹    ≈⟨ inverseʳ _ ⟩
   ε                     ≈⟨ inverseʳ _ ⟨
-  x ∙ x ⁻¹              ≈⟨ ∙-congʳ (rightDividesʳ y x) ⟨
+  x ∙ x ⁻¹              ≈⟨ ∙-congʳ (//-rightDividesʳ y x) ⟨
   (x ∙ y) ∙ y ⁻¹ ∙ x ⁻¹ ≈⟨ assoc (x ∙ y) (y ⁻¹) (x ⁻¹) ⟩
   x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎
 
 \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
 \\≗flip-//⇒comm \\≗//ᵒ x y = begin
-  x ∙ y                ≈⟨ ∙-congˡ (rightDividesˡ x y) ⟨
+  x ∙ y                ≈⟨ ∙-congˡ (//-rightDividesˡ x y) ⟨
   x ∙ ((y // x) ∙ x)   ≈⟨ ∙-congˡ (∙-congʳ (\\≗//ᵒ x y)) ⟨
   x ∙ ((x \\ y) ∙ x)   ≈⟨ assoc x (x \\ y) x ⟨
-  x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (leftDividesˡ x y) ⟩
+  x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (\\-leftDividesˡ x y) ⟩
   y ∙ x                ∎
 
 comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -138,16 +138,16 @@ inverseʳ-unique x y eq = begin
   y ⁻¹ ⁻¹ ≈⟨ ⁻¹-cong (inverseˡ-unique x y eq) ⟨
   x ⁻¹    ∎
 
-\\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
-\\≗//ᵒ⇒comm \\≗//ᵒ x y = begin
+\\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
+\\≗flip-//⇒comm \\≗//ᵒ x y = begin
   x ∙ y                ≈⟨ ∙-congˡ (rightDividesˡ x y) ⟨
   x ∙ ((y // x) ∙ x)   ≈⟨ ∙-congˡ (∙-congʳ (\\≗//ᵒ x y)) ⟨
   x ∙ ((x \\ y) ∙ x)   ≈⟨ assoc x (x \\ y) x ⟨
   x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (leftDividesˡ x y) ⟩
   y ∙ x                ∎
 
-comm⇒\\≗//ᵒ : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
-comm⇒\\≗//ᵒ comm x y = begin
+comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
+comm⇒\\≗flip-// comm x y = begin
   x \\ y    ≈⟨ refl ⟩
   x ⁻¹ ∙ y  ≈⟨ comm _ _ ⟩
   y ∙ x ⁻¹  ≈⟨ refl ⟩

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -63,26 +63,18 @@ isQuasigroup = record
 isLoop : IsLoop _∙_ _\\_ _//_ ε
 isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
 
-private
-
-  left-helper : ∀ x y → x ≈ (x ∙ y) ∙ y ⁻¹
-  left-helper x y = sym (rightDividesʳ y x)
-
-  right-helper : ∀ x y → y ≈ x ⁻¹ ∙ (x ∙ y)
-  right-helper x y = sym (leftDividesʳ x y)
-
 ∙-cancelˡ : LeftCancellative _∙_
 ∙-cancelˡ x y z eq = begin
-              y  ≈⟨ right-helper x y ⟩
+              y  ≈⟨ leftDividesʳ x y ⟨
   x ⁻¹ ∙ (x ∙ y) ≈⟨ ∙-congˡ eq ⟩
-  x ⁻¹ ∙ (x ∙ z) ≈⟨ right-helper x z ⟨
+  x ⁻¹ ∙ (x ∙ z) ≈⟨ leftDividesʳ x z ⟩
               z  ∎
 
 ∙-cancelʳ : RightCancellative _∙_
 ∙-cancelʳ x y z eq = begin
-  y            ≈⟨ left-helper y x ⟩
+  y            ≈⟨ rightDividesʳ x y ⟨
   y ∙ x ∙ x ⁻¹ ≈⟨ ∙-congʳ eq ⟩
-  z ∙ x ∙ x ⁻¹ ≈⟨ left-helper z x ⟨
+  z ∙ x ∙ x ⁻¹ ≈⟨ rightDividesʳ x z ⟩
   z            ∎
 
 ∙-cancel : Cancellative _∙_
@@ -92,7 +84,7 @@ private
 ⁻¹-involutive x = begin
   x ⁻¹ ⁻¹              ≈⟨ identityʳ _ ⟨
   x ⁻¹ ⁻¹ ∙ ε          ≈⟨ ∙-congˡ $ inverseˡ _ ⟨
-  x ⁻¹ ⁻¹ ∙ (x ⁻¹ ∙ x) ≈⟨ right-helper (x ⁻¹) x ⟨
+  x ⁻¹ ⁻¹ ∙ (x ⁻¹ ∙ x) ≈⟨ leftDividesʳ (x ⁻¹) x ⟩
   x                    ∎
 
 ⁻¹-injective : ∀ {x y} → x ⁻¹ ≈ y ⁻¹ → x ≈ y
@@ -106,21 +98,21 @@ private
 ⁻¹-anti-homo-∙ x y = ∙-cancelˡ _ _ _ ( begin
   x ∙ y ∙ (x ∙ y) ⁻¹    ≈⟨ inverseʳ _ ⟩
   ε                     ≈⟨ inverseʳ _ ⟨
-  x ∙ x ⁻¹              ≈⟨ ∙-congʳ (left-helper x y) ⟩
+  x ∙ x ⁻¹              ≈⟨ ∙-congʳ (rightDividesʳ y x) ⟨
   (x ∙ y) ∙ y ⁻¹ ∙ x ⁻¹ ≈⟨ assoc (x ∙ y) (y ⁻¹) (x ⁻¹) ⟩
   x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎ )
 
 identityˡ-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
 identityˡ-unique x y eq = begin
-  x              ≈⟨ left-helper x y ⟩
+  x              ≈⟨ rightDividesʳ y x ⟨
   (x ∙ y) ∙ y ⁻¹ ≈⟨ ∙-congʳ eq ⟩
        y  ∙ y ⁻¹ ≈⟨ inverseʳ y ⟩
   ε              ∎
 
 identityʳ-unique : ∀ x y → x ∙ y ≈ x → y ≈ ε
 identityʳ-unique x y eq = begin
-  y              ≈⟨ right-helper x y ⟩
-  x ⁻¹ ∙ (x ∙ y) ≈⟨ refl ⟨ ∙-cong ⟩ eq ⟩
+  y              ≈⟨ leftDividesʳ x y ⟨
+  x ⁻¹ ∙ (x ∙ y) ≈⟨ ∙-congˡ  eq ⟩
   x ⁻¹ ∙  x      ≈⟨ inverseˡ x ⟩
   ε              ∎
 
@@ -129,7 +121,7 @@ identity-unique {x} id = identityˡ-unique x x (proj₂ id x)
 
 inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
 inverseˡ-unique x y eq = begin
-  x              ≈⟨ left-helper x y ⟩
+  x              ≈⟨ rightDividesʳ y x ⟨
   (x ∙ y) ∙ y ⁻¹ ≈⟨ ∙-congʳ eq ⟩
        ε  ∙ y ⁻¹ ≈⟨ identityˡ (y ⁻¹) ⟩
             y ⁻¹ ∎

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -15,9 +15,9 @@ open import Algebra.Definitions _≈_
 import Algebra.Properties.Loop as LoopProperties
 import Algebra.Properties.Quasigroup as QuasigroupProperties
 open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
-open import Relation.Binary.Reasoning.Setoid setoid
+open import Data.Product.Base using (_,_)
 open import Function.Base using (_$_)
-open import Data.Product.Base using (_,_; proj₂)
+open import Relation.Binary.Reasoning.Setoid setoid
 
 \\-cong₂ : Congruent₂ _\\_
 \\-cong₂ x≈y u≈v = ∙-cong (⁻¹-cong x≈y) u≈v
@@ -66,7 +66,7 @@ quasigroup : Quasigroup _ _
 quasigroup = record { isQuasigroup = isQuasigroup }
 
 open QuasigroupProperties quasigroup public
-  using ()
+  using (x≈z//y; y≈x\\z)
   renaming (cancelˡ to ∙-cancelˡ; cancelʳ to ∙-cancelʳ; cancel to ∙-cancel)
 
 isLoop : IsLoop _∙_ _\\_ _//_ ε
@@ -83,6 +83,12 @@ open LoopProperties loop public
   ε ⁻¹      ≈⟨ identityʳ (ε ⁻¹) ⟨
   ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
   ε         ∎
+
+inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
+inverseˡ-unique x y eq = trans (x≈z//y x y ε eq) (identityˡ _)
+
+inverseʳ-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹
+inverseʳ-unique x y eq = trans (y≈x\\z x y ε eq) (identityʳ _)
 
 ⁻¹-involutive : ∀ x → x ⁻¹ ⁻¹ ≈ x
 ⁻¹-involutive x = begin
@@ -105,19 +111,6 @@ open LoopProperties loop public
   x ∙ x ⁻¹              ≈⟨ ∙-congʳ (rightDividesʳ y x) ⟨
   (x ∙ y) ∙ y ⁻¹ ∙ x ⁻¹ ≈⟨ assoc (x ∙ y) (y ⁻¹) (x ⁻¹) ⟩
   x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎
-
-inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
-inverseˡ-unique x y eq = begin
-  x              ≈⟨ rightDividesʳ y x ⟨
-  (x ∙ y) ∙ y ⁻¹ ≈⟨ ∙-congʳ eq ⟩
-       ε  ∙ y ⁻¹ ≈⟨ identityˡ (y ⁻¹) ⟩
-            y ⁻¹ ∎
-
-inverseʳ-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹
-inverseʳ-unique x y eq = begin
-  y       ≈⟨ ⁻¹-involutive y ⟨
-  y ⁻¹ ⁻¹ ≈⟨ ⁻¹-cong (inverseˡ-unique x y eq) ⟨
-  x ⁻¹    ∎
 
 \\≗flip-//⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
 \\≗flip-//⇒comm \\≗//ᵒ x y = begin

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -12,6 +12,7 @@ module Algebra.Properties.Group {g₁ g₂} (G : Group g₁ g₂) where
 
 open Group G
 open import Algebra.Definitions _≈_
+open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Relation.Binary.Reasoning.Setoid setoid
 open import Function.Base using (_$_; _⟨_⟩_)
 open import Data.Product.Base using (_,_; proj₂)
@@ -22,21 +23,53 @@ open import Data.Product.Base using (_,_; proj₂)
   ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
   ε         ∎
 
+leftDividesˡ : ∀ x y → x ∙ (x \\ y) ≈ y
+leftDividesˡ x y = begin
+  x  ∙ (x \\ y)  ≈⟨ assoc x (x ⁻¹) y ⟨
+  x ∙ x ⁻¹ ∙ y   ≈⟨ ∙-congʳ (inverseʳ x) ⟩
+  ε ∙ y          ≈⟨ identityˡ y ⟩
+  y              ∎
+
+leftDividesʳ : ∀ x y → x \\ x ∙ y ≈ y
+leftDividesʳ x y = begin
+  x \\ x ∙ y     ≈⟨ assoc (x ⁻¹) x y ⟨
+  x ⁻¹ ∙ x ∙ y   ≈⟨ ∙-congʳ (inverseˡ x) ⟩
+  ε ∙ y          ≈⟨ identityˡ y ⟩
+  y              ∎
+
+rightDividesˡ : ∀ x y → (y // x) ∙ x ≈ y
+rightDividesˡ x y = begin
+  (y // x) ∙ x    ≈⟨ assoc y (x ⁻¹) x ⟩
+  y ∙ (x ⁻¹ ∙ x)  ≈⟨ ∙-congˡ (inverseˡ x) ⟩
+  y ∙ ε           ≈⟨ identityʳ y ⟩
+  y               ∎
+
+rightDividesʳ : ∀ x y → y ∙ x // x ≈ y
+rightDividesʳ x y = begin
+  y ∙ x // x    ≈⟨ assoc y x (x ⁻¹) ⟩
+  y ∙ (x // x)  ≈⟨ ∙-congˡ (inverseʳ x) ⟩
+  y ∙ ε         ≈⟨ identityʳ y ⟩
+  y             ∎
+
+isQuasigroup : IsQuasigroup _∙_ _\\_ _//_
+isQuasigroup = record
+                 { isMagma = isMagma
+                 ; \\-cong = λ x≈y u≈v → ∙-cong (⁻¹-cong x≈y) u≈v
+                 ; //-cong = λ x≈y u≈v → ∙-cong x≈y (⁻¹-cong u≈v)
+                 ; leftDivides = leftDividesˡ , leftDividesʳ
+                 ; rightDivides = rightDividesˡ , rightDividesʳ
+                 }
+
+isLoop : IsLoop _∙_ _\\_ _//_ ε
+isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
+
 private
 
   left-helper : ∀ x y → x ≈ (x ∙ y) ∙ y ⁻¹
-  left-helper x y = begin
-    x              ≈⟨ sym (identityʳ x) ⟩
-    x ∙ ε          ≈⟨ ∙-congˡ $ sym (inverseʳ y) ⟩
-    x ∙ (y ∙ y ⁻¹) ≈⟨ sym (assoc x y (y ⁻¹)) ⟩
-    (x ∙ y) ∙ y ⁻¹ ∎
+  left-helper x y = sym (rightDividesʳ y x)
 
   right-helper : ∀ x y → y ≈ x ⁻¹ ∙ (x ∙ y)
-  right-helper x y = begin
-    y              ≈⟨ sym (identityˡ y) ⟩
-    ε          ∙ y ≈⟨ ∙-congʳ $ sym (inverseˡ x) ⟩
-    (x ⁻¹ ∙ x) ∙ y ≈⟨ assoc (x ⁻¹) x y ⟩
-    x ⁻¹ ∙ (x ∙ y) ∎
+  right-helper x y = sym (leftDividesʳ x y)
 
 ∙-cancelˡ : LeftCancellative _∙_
 ∙-cancelˡ x y z eq = begin
@@ -106,3 +139,13 @@ inverseʳ-unique x y eq = begin
   y       ≈⟨ sym (⁻¹-involutive y) ⟩
   y ⁻¹ ⁻¹ ≈⟨ ⁻¹-cong (sym (inverseˡ-unique x y eq)) ⟩
   x ⁻¹    ∎
+{-
+\\≗//⇒comm : (∀ {x y} → x \\ y ≈ x // y) → Commutative _∙_
+\\≗//⇒comm \\≗// x y = begin
+  x ∙ y ≈⟨ {!inverseʳ y!} ⟩
+  {!!} ≈⟨ {!!} ⟩
+  {!!} ≈⟨ {!!} ⟩
+  {!!} ≈⟨ {!!} ⟩
+  {!!} ≈⟨ {!!} ⟩
+  y ∙ x ∎
+-}

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -12,6 +12,8 @@ module Algebra.Properties.Group {g₁ g₂} (G : Group g₁ g₂) where
 
 open Group G
 open import Algebra.Definitions _≈_
+import Algebra.Properties.Loop as LoopProperties
+import Algebra.Properties.Quasigroup as QuasigroupProperties
 open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Relation.Binary.Reasoning.Setoid setoid
 open import Function.Base using (_$_)
@@ -60,31 +62,27 @@ isQuasigroup = record
   ; rightDivides = rightDividesˡ , rightDividesʳ
   }
 
+quasigroup : Quasigroup _ _
+quasigroup = record { isQuasigroup = isQuasigroup }
+
+open QuasigroupProperties quasigroup public
+  using ()
+  renaming (cancelˡ to ∙-cancelˡ; cancelʳ to ∙-cancelʳ; cancel to ∙-cancel)
+
 isLoop : IsLoop _∙_ _\\_ _//_ ε
 isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
+
+loop : Loop _ _
+loop = record { isLoop = isLoop }
+
+open LoopProperties loop public
+  using (identityˡ-unique; identityʳ-unique; identity-unique)
 
 ε⁻¹≈ε : ε ⁻¹ ≈ ε
 ε⁻¹≈ε = begin
   ε ⁻¹      ≈⟨ identityʳ (ε ⁻¹) ⟨
   ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
   ε         ∎
-
-∙-cancelˡ : LeftCancellative _∙_
-∙-cancelˡ x y z eq = begin
-              y  ≈⟨ leftDividesʳ x y ⟨
-  x ⁻¹ ∙ (x ∙ y) ≈⟨ ∙-congˡ eq ⟩
-  x ⁻¹ ∙ (x ∙ z) ≈⟨ leftDividesʳ x z ⟩
-              z  ∎
-
-∙-cancelʳ : RightCancellative _∙_
-∙-cancelʳ x y z eq = begin
-  y            ≈⟨ rightDividesʳ x y ⟨
-  y ∙ x ∙ x ⁻¹ ≈⟨ ∙-congʳ eq ⟩
-  z ∙ x ∙ x ⁻¹ ≈⟨ rightDividesʳ x z ⟩
-  z            ∎
-
-∙-cancel : Cancellative _∙_
-∙-cancel = ∙-cancelˡ , ∙-cancelʳ
 
 ⁻¹-involutive : ∀ x → x ⁻¹ ⁻¹ ≈ x
 ⁻¹-involutive x = begin
@@ -107,23 +105,6 @@ isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
   x ∙ x ⁻¹              ≈⟨ ∙-congʳ (rightDividesʳ y x) ⟨
   (x ∙ y) ∙ y ⁻¹ ∙ x ⁻¹ ≈⟨ assoc (x ∙ y) (y ⁻¹) (x ⁻¹) ⟩
   x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎
-
-identityˡ-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
-identityˡ-unique x y eq = begin
-  x              ≈⟨ rightDividesʳ y x ⟨
-  (x ∙ y) ∙ y ⁻¹ ≈⟨ ∙-congʳ eq ⟩
-       y  ∙ y ⁻¹ ≈⟨ inverseʳ y ⟩
-  ε              ∎
-
-identityʳ-unique : ∀ x y → x ∙ y ≈ x → y ≈ ε
-identityʳ-unique x y eq = begin
-  y              ≈⟨ leftDividesʳ x y ⟨
-  x ⁻¹ ∙ (x ∙ y) ≈⟨ ∙-congˡ  eq ⟩
-  x ⁻¹ ∙  x      ≈⟨ inverseˡ x ⟩
-  ε              ∎
-
-identity-unique : ∀ {x} → Identity x _∙_ → x ≈ ε
-identity-unique {x} id = identityˡ-unique x x (proj₂ id x)
 
 inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
 inverseˡ-unique x y eq = begin

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -14,7 +14,7 @@ open Group G
 open import Algebra.Definitions _≈_
 open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Relation.Binary.Reasoning.Setoid setoid
-open import Function.Base using (_$_; _⟨_⟩_)
+open import Function.Base using (_$_)
 open import Data.Product.Base using (_,_; proj₂)
 
 \\-cong₂ : Congruent₂ _\\_
@@ -148,7 +148,7 @@ inverseʳ-unique x y eq = begin
 
 comm⇒\\≗flip-// : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
 comm⇒\\≗flip-// comm x y = begin
-  x \\ y    ≈⟨ refl ⟩
+  x \\ y    ≡⟨⟩
   x ⁻¹ ∙ y  ≈⟨ comm _ _ ⟩
-  y ∙ x ⁻¹  ≈⟨ refl ⟩
+  y ∙ x ⁻¹  ≡⟨⟩
   y // x    ∎

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -17,12 +17,6 @@ open import Relation.Binary.Reasoning.Setoid setoid
 open import Function.Base using (_$_; _⟨_⟩_)
 open import Data.Product.Base using (_,_; proj₂)
 
-ε⁻¹≈ε : ε ⁻¹ ≈ ε
-ε⁻¹≈ε = begin
-  ε ⁻¹      ≈⟨ sym $ identityʳ (ε ⁻¹) ⟩
-  ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
-  ε         ∎
-
 leftDividesˡ : ∀ x y → x ∙ (x \\ y) ≈ y
 leftDividesˡ x y = begin
   x  ∙ (x \\ y)  ≈⟨ assoc x (x ⁻¹) y ⟨
@@ -63,6 +57,12 @@ isQuasigroup = record
 isLoop : IsLoop _∙_ _\\_ _//_ ε
 isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
 
+ε⁻¹≈ε : ε ⁻¹ ≈ ε
+ε⁻¹≈ε = begin
+  ε ⁻¹      ≈⟨ identityʳ (ε ⁻¹) ⟨
+  ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
+  ε         ∎
+
 ∙-cancelˡ : LeftCancellative _∙_
 ∙-cancelˡ x y z eq = begin
               y  ≈⟨ leftDividesʳ x y ⟨
@@ -88,19 +88,19 @@ isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
   x                    ∎
 
 ⁻¹-injective : ∀ {x y} → x ⁻¹ ≈ y ⁻¹ → x ≈ y
-⁻¹-injective {x} {y} eq = ∙-cancelʳ _ _ _ ( begin
+⁻¹-injective {x} {y} eq = ∙-cancelʳ _ _ _ $ begin
   x ∙ x ⁻¹ ≈⟨ inverseʳ x ⟩
   ε        ≈⟨ inverseʳ y ⟨
   y ∙ y ⁻¹ ≈⟨ ∙-congˡ eq ⟨
-  y ∙ x ⁻¹ ∎ )
+  y ∙ x ⁻¹ ∎
 
 ⁻¹-anti-homo-∙ : ∀ x y → (x ∙ y) ⁻¹ ≈ y ⁻¹ ∙ x ⁻¹
-⁻¹-anti-homo-∙ x y = ∙-cancelˡ _ _ _ ( begin
+⁻¹-anti-homo-∙ x y = ∙-cancelˡ _ _ _ $ begin
   x ∙ y ∙ (x ∙ y) ⁻¹    ≈⟨ inverseʳ _ ⟩
   ε                     ≈⟨ inverseʳ _ ⟨
   x ∙ x ⁻¹              ≈⟨ ∙-congʳ (rightDividesʳ y x) ⟨
   (x ∙ y) ∙ y ⁻¹ ∙ x ⁻¹ ≈⟨ assoc (x ∙ y) (y ⁻¹) (x ⁻¹) ⟩
-  x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎ )
+  x ∙ y ∙ (y ⁻¹ ∙ x ⁻¹) ∎
 
 identityˡ-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
 identityˡ-unique x y eq = begin
@@ -128,16 +128,17 @@ inverseˡ-unique x y eq = begin
 
 inverseʳ-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹
 inverseʳ-unique x y eq = begin
-  y       ≈⟨ sym (⁻¹-involutive y) ⟩
-  y ⁻¹ ⁻¹ ≈⟨ ⁻¹-cong (sym (inverseˡ-unique x y eq)) ⟩
+  y       ≈⟨ ⁻¹-involutive y ⟨
+  y ⁻¹ ⁻¹ ≈⟨ ⁻¹-cong (inverseˡ-unique x y eq) ⟨
   x ⁻¹    ∎
-{-
-\\≗//⇒comm : (∀ {x y} → x \\ y ≈ x // y) → Commutative _∙_
-\\≗//⇒comm \\≗// x y = begin
-  x ∙ y ≈⟨ {!inverseʳ y!} ⟩
-  {!!} ≈⟨ {!!} ⟩
-  {!!} ≈⟨ {!!} ⟩
-  {!!} ≈⟨ {!!} ⟩
-  {!!} ≈⟨ {!!} ⟩
-  y ∙ x ∎
--}
+
+\\≗//ᵒ⇒comm : (∀ x y → x \\ y ≈ y // x) → Commutative _∙_
+\\≗//ᵒ⇒comm \\≗//ᵒ x y = begin
+  x ∙ y                ≈⟨ identityʳ _ ⟨
+  (x ∙ y) ∙ ε          ≈⟨ ∙-congˡ (inverseˡ x) ⟨
+  (x ∙ y) ∙ (x ⁻¹ ∙ x) ≈⟨ assoc (x ∙ y) (x ⁻¹) x ⟨
+  (x ∙ y) ∙ x ⁻¹ ∙ x   ≈⟨ ∙-congʳ (assoc x y (x ⁻¹)) ⟩
+  x ∙ (y // x) ∙ x     ≈⟨ ∙-congʳ (∙-congˡ (\\≗//ᵒ x y)) ⟨
+  x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (leftDividesˡ x y) ⟩
+  y ∙ x                ∎
+

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -11,12 +11,14 @@ open import Algebra.Bundles
 module Algebra.Properties.Group {g₁ g₂} (G : Group g₁ g₂) where
 
 open Group G
+open import Algebra.Consequences.Setoid setoid
 open import Algebra.Definitions _≈_
 import Algebra.Properties.Loop as LoopProperties
 import Algebra.Properties.Quasigroup as QuasigroupProperties
 open import Algebra.Structures _≈_ using (IsLoop; IsQuasigroup)
 open import Data.Product.Base using (_,_)
 open import Function.Base using (_$_)
+open import Function.Definitions
 open import Relation.Binary.Reasoning.Setoid setoid
 
 \\-cong₂ : Congruent₂ _\\_
@@ -69,6 +71,27 @@ open QuasigroupProperties quasigroup public
   using (x≈z//y; y≈x\\z)
   renaming (cancelˡ to ∙-cancelˡ; cancelʳ to ∙-cancelʳ; cancel to ∙-cancel)
 
+inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
+inverseˡ-unique x y eq = trans (x≈z//y x y ε eq) (identityˡ _)
+
+inverseʳ-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹
+inverseʳ-unique x y eq = trans (y≈x\\z x y ε eq) (identityʳ _)
+
+ε⁻¹≈ε : ε ⁻¹ ≈ ε
+ε⁻¹≈ε = sym $ inverseˡ-unique _ _ (identityˡ ε)
+
+⁻¹-selfInverse : SelfInverse _⁻¹
+⁻¹-selfInverse {x} {y} eq = sym $ inverseˡ-unique x y $ begin
+  x ∙ y    ≈⟨ ∙-congˡ eq ⟨
+  x ∙ x ⁻¹ ≈⟨ inverseʳ x  ⟩
+  ε        ∎
+
+⁻¹-involutive : Involutive _⁻¹
+⁻¹-involutive = selfInverse⇒involutive ⁻¹-selfInverse
+
+⁻¹-injective : Injective _≈_ _≈_ _⁻¹
+⁻¹-injective = selfInverse⇒injective ⁻¹-selfInverse
+
 isLoop : IsLoop _∙_ _\\_ _//_ ε
 isLoop = record { isQuasigroup = isQuasigroup ; identity = identity }
 
@@ -77,32 +100,6 @@ loop = record { isLoop = isLoop }
 
 open LoopProperties loop public
   using (identityˡ-unique; identityʳ-unique; identity-unique)
-
-ε⁻¹≈ε : ε ⁻¹ ≈ ε
-ε⁻¹≈ε = begin
-  ε ⁻¹      ≈⟨ identityʳ (ε ⁻¹) ⟨
-  ε ⁻¹ ∙ ε  ≈⟨ inverseˡ ε ⟩
-  ε         ∎
-
-inverseˡ-unique : ∀ x y → x ∙ y ≈ ε → x ≈ y ⁻¹
-inverseˡ-unique x y eq = trans (x≈z//y x y ε eq) (identityˡ _)
-
-inverseʳ-unique : ∀ x y → x ∙ y ≈ ε → y ≈ x ⁻¹
-inverseʳ-unique x y eq = trans (y≈x\\z x y ε eq) (identityʳ _)
-
-⁻¹-involutive : ∀ x → x ⁻¹ ⁻¹ ≈ x
-⁻¹-involutive x = begin
-  x ⁻¹ ⁻¹              ≈⟨ identityʳ _ ⟨
-  x ⁻¹ ⁻¹ ∙ ε          ≈⟨ ∙-congˡ $ inverseˡ _ ⟨
-  x ⁻¹ ⁻¹ ∙ (x ⁻¹ ∙ x) ≈⟨ leftDividesʳ (x ⁻¹) x ⟩
-  x                    ∎
-
-⁻¹-injective : ∀ {x y} → x ⁻¹ ≈ y ⁻¹ → x ≈ y
-⁻¹-injective {x} {y} eq = ∙-cancelʳ _ _ _ $ begin
-  x ∙ x ⁻¹ ≈⟨ inverseʳ x ⟩
-  ε        ≈⟨ inverseʳ y ⟨
-  y ∙ y ⁻¹ ≈⟨ ∙-congˡ eq ⟨
-  y ∙ x ⁻¹ ∎
 
 ⁻¹-anti-homo-∙ : ∀ x y → (x ∙ y) ⁻¹ ≈ y ⁻¹ ∙ x ⁻¹
 ⁻¹-anti-homo-∙ x y = ∙-cancelˡ _ _ _ $ begin

--- a/src/Algebra/Properties/Group.agda
+++ b/src/Algebra/Properties/Group.agda
@@ -140,3 +140,9 @@ inverseʳ-unique x y eq = begin
   x ∙ (x \\ y) ∙ x     ≈⟨ ∙-congʳ (leftDividesˡ x y) ⟩
   y ∙ x                ∎
 
+comm⇒\\≗//ᵒ : Commutative _∙_ → ∀ x y → x \\ y ≈ y // x
+comm⇒\\≗//ᵒ comm x y = begin
+  x \\ y    ≈⟨ refl ⟩
+  x ⁻¹ ∙ y  ≈⟨ comm _ _ ⟩
+  y ∙ x ⁻¹  ≈⟨ refl ⟩
+  y // x    ∎

--- a/src/Algebra/Properties/Loop.agda
+++ b/src/Algebra/Properties/Loop.agda
@@ -18,25 +18,25 @@ open import Relation.Binary.Reasoning.Setoid setoid
 
 x//x≈ε : ∀ x → x // x ≈ ε
 x//x≈ε x = begin
-  x // x       ≈⟨ //-congʳ (sym (identityˡ x)) ⟩
+  x // x       ≈⟨ //-congʳ (identityˡ x) ⟨
   (ε ∙ x) // x ≈⟨ rightDividesʳ x ε ⟩
   ε            ∎
 
-x\\x≈ε : ∀ x → x \\ x ≈ ε
+x\\x≈ε : ∀ x → x \\ x ≈ ε
 x\\x≈ε x = begin
-  x \\ x       ≈⟨ \\-congˡ (sym (identityʳ x )) ⟩
+  x \\ x       ≈⟨ \\-congˡ (identityʳ x ) ⟨
   x \\ (x ∙ ε) ≈⟨ leftDividesʳ x ε ⟩
   ε            ∎
 
 ε\\x≈x : ∀ x → ε \\ x ≈ x
 ε\\x≈x x = begin
-  ε \\ x       ≈⟨ sym (identityˡ (ε \\ x)) ⟩
+  ε \\ x       ≈⟨ identityˡ (ε \\ x) ⟨
   ε ∙ (ε \\ x) ≈⟨ leftDividesˡ ε x ⟩
   x            ∎
 
 x//ε≈x : ∀ x → x // ε ≈ x
 x//ε≈x x = begin
- x // ε       ≈⟨ sym (identityʳ (x // ε)) ⟩
+ x // ε       ≈⟨ identityʳ (x // ε) ⟨
  (x // ε) ∙ ε ≈⟨ rightDividesˡ ε x ⟩
  x            ∎
 

--- a/src/Algebra/Properties/Loop.agda
+++ b/src/Algebra/Properties/Loop.agda
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Some basic properties of Quasigroup
+-- Some basic properties of Loop
 ------------------------------------------------------------------------
 
 {-# OPTIONS --cubical-compatible --safe #-}
@@ -12,8 +12,9 @@ module Algebra.Properties.Loop {l₁ l₂} (L : Loop l₁ l₂) where
 
 open Loop L
 open import Algebra.Definitions _≈_
-open import Relation.Binary.Reasoning.Setoid setoid
 open import Algebra.Properties.Quasigroup
+open import Data.Product.Base using (proj₂)
+open import Relation.Binary.Reasoning.Setoid setoid
 
 x//x≈ε : ∀ x → x // x ≈ ε
 x//x≈ε x = begin
@@ -38,3 +39,21 @@ x//ε≈x x = begin
  x // ε       ≈⟨ sym (identityʳ (x // ε)) ⟩
  (x // ε) ∙ ε ≈⟨ rightDividesˡ ε x ⟩
  x            ∎
+
+identityˡ-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
+identityˡ-unique x y eq = begin
+  x            ≈⟨ rightDividesʳ y x ⟨
+  (x ∙ y) // y ≈⟨ //-congʳ eq ⟩
+       y  // y ≈⟨ x//x≈ε y ⟩
+  ε            ∎
+
+identityʳ-unique : ∀ x y → x ∙ y ≈ x → y ≈ ε
+identityʳ-unique x y eq = begin
+  y            ≈⟨ leftDividesʳ x y ⟨
+  x \\ (x ∙ y) ≈⟨ \\-congˡ  eq ⟩
+  x \\ x       ≈⟨ x\\x≈ε x ⟩
+  ε            ∎
+
+identity-unique : ∀ {x} → Identity x _∙_ → x ≈ ε
+identity-unique {x} id = identityˡ-unique x x (proj₂ id x)
+

--- a/src/Algebra/Properties/Loop.agda
+++ b/src/Algebra/Properties/Loop.agda
@@ -12,7 +12,7 @@ module Algebra.Properties.Loop {l₁ l₂} (L : Loop l₁ l₂) where
 
 open Loop L
 open import Algebra.Definitions _≈_
-open import Algebra.Properties.Quasigroup
+open import Algebra.Properties.Quasigroup quasigroup
 open import Data.Product.Base using (proj₂)
 open import Relation.Binary.Reasoning.Setoid setoid
 
@@ -42,17 +42,15 @@ x//ε≈x x = begin
 
 identityˡ-unique : ∀ x y → x ∙ y ≈ y → x ≈ ε
 identityˡ-unique x y eq = begin
-  x            ≈⟨ rightDividesʳ y x ⟨
-  (x ∙ y) // y ≈⟨ //-congʳ eq ⟩
-       y  // y ≈⟨ x//x≈ε y ⟩
-  ε            ∎
+  x      ≈⟨ x≈z//y x y y eq ⟩
+  y // y ≈⟨ x//x≈ε y ⟩
+  ε      ∎
 
 identityʳ-unique : ∀ x y → x ∙ y ≈ x → y ≈ ε
 identityʳ-unique x y eq = begin
-  y            ≈⟨ leftDividesʳ x y ⟨
-  x \\ (x ∙ y) ≈⟨ \\-congˡ  eq ⟩
-  x \\ x       ≈⟨ x\\x≈ε x ⟩
-  ε            ∎
+  y       ≈⟨ y≈x\\z x y x eq ⟩
+  x \\ x  ≈⟨ x\\x≈ε x ⟩
+  ε       ∎
 
 identity-unique : ∀ {x} → Identity x _∙_ → x ≈ ε
 identity-unique {x} id = identityˡ-unique x x (proj₂ id x)

--- a/src/Algebra/Properties/Quasigroup.agda
+++ b/src/Algebra/Properties/Quasigroup.agda
@@ -17,14 +17,14 @@ open import Data.Product.Base using (_,_)
 
 cancelˡ : LeftCancellative _∙_
 cancelˡ x y z eq = begin
-  y             ≈⟨ sym( leftDividesʳ x y) ⟩
+  y             ≈⟨ leftDividesʳ x y ⟨
   x \\ (x ∙ y)  ≈⟨ \\-congˡ eq ⟩
   x \\ (x ∙ z)  ≈⟨ leftDividesʳ x z ⟩
   z             ∎
 
 cancelʳ : RightCancellative _∙_
 cancelʳ x y z eq = begin
-  y             ≈⟨ sym( rightDividesʳ x y) ⟩
+  y             ≈⟨ rightDividesʳ x y ⟨
   (y ∙ x) // x  ≈⟨ //-congʳ eq ⟩
   (z ∙ x) // x  ≈⟨ rightDividesʳ x z ⟩
   z             ∎
@@ -34,12 +34,12 @@ cancel = cancelˡ , cancelʳ
 
 y≈x\\z : ∀ x y z → x ∙ y ≈ z → y ≈ x \\ z
 y≈x\\z x y z eq = begin
-  y            ≈⟨ sym (leftDividesʳ x y) ⟩
+  y            ≈⟨ leftDividesʳ x y ⟨
   x \\ (x ∙ y) ≈⟨ \\-congˡ eq ⟩
   x \\ z       ∎
 
 x≈z//y : ∀ x y z → x ∙ y ≈ z → x ≈ z // y
 x≈z//y x y z eq = begin
-  x            ≈⟨ sym (rightDividesʳ y x) ⟩
+  x            ≈⟨ rightDividesʳ y x ⟨
   (x ∙ y) // y ≈⟨ //-congʳ eq ⟩
   z // y       ∎

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -253,16 +253,20 @@ record IsGroup (_∙_ : Op₂ A) (ε : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ) w
 
   open IsMonoid isMonoid public
 
-  infixl 6 _∙⁻¹_
-  infixr 6 _⁻¹∙_
-  _∙⁻¹_ : Op₂ A
-  x ∙⁻¹ y = x ∙ (y ⁻¹)
-  _⁻¹∙_ : Op₂ A
-  x ⁻¹∙  y = (x ⁻¹) ∙ y
+  infixl 6 _//_
+  infixr 6 _\\_
+  _//_ _\\_ : Op₂ A
+  x // y = x ∙ (y ⁻¹)
+  x \\ y = (x ⁻¹) ∙ y
 
+  -- Deprecated.
   infixl 6 _-_
   _-_ : Op₂ A
-  _-_ = _∙⁻¹_
+  _-_ = _//_
+  {-# WARNING_ON_USAGE _-_
+  "Warning: _-_ was deprecated in v2.1.
+  Please use _//_ instead. "
+  #-}
 
   inverseˡ : LeftInverse ε _⁻¹ _∙_
   inverseˡ = proj₁ inverse
@@ -298,7 +302,7 @@ record IsAbelianGroup (∙ : Op₂ A)
     isGroup : IsGroup ∙ ε ⁻¹
     comm    : Commutative ∙
 
-  open IsGroup isGroup public hiding (_∙⁻¹_; _⁻¹∙_)
+  open IsGroup isGroup public renaming (_//_ to _-_) hiding (_\\_; _-_)
 
   isCommutativeMonoid : IsCommutativeMonoid ∙ ε
   isCommutativeMonoid = record

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -253,11 +253,13 @@ record IsGroup (_∙_ : Op₂ A) (ε : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ) w
 
   open IsMonoid isMonoid public
 
-  infixl 6 _//_
   infixr 6 _\\_
-  _//_ _\\_ : Op₂ A
-  x // y = x ∙ (y ⁻¹)
+  _\\_ : Op₂ A
   x \\ y = (x ⁻¹) ∙ y
+
+  infixl 6 _//_
+  _//_ : Op₂ A
+  x // y = x ∙ (y ⁻¹)
 
   -- Deprecated.
   infixl 6 _-_

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -253,9 +253,16 @@ record IsGroup (_∙_ : Op₂ A) (ε : A) (_⁻¹ : Op₁ A) : Set (a ⊔ ℓ) w
 
   open IsMonoid isMonoid public
 
+  infixl 6 _∙⁻¹_
+  infixr 6 _⁻¹∙_
+  _∙⁻¹_ : Op₂ A
+  x ∙⁻¹ y = x ∙ (y ⁻¹)
+  _⁻¹∙_ : Op₂ A
+  x ⁻¹∙  y = (x ⁻¹) ∙ y
+
   infixl 6 _-_
   _-_ : Op₂ A
-  x - y = x ∙ (y ⁻¹)
+  _-_ = _∙⁻¹_
 
   inverseˡ : LeftInverse ε _⁻¹ _∙_
   inverseˡ = proj₁ inverse
@@ -291,7 +298,7 @@ record IsAbelianGroup (∙ : Op₂ A)
     isGroup : IsGroup ∙ ε ⁻¹
     comm    : Commutative ∙
 
-  open IsGroup isGroup public
+  open IsGroup isGroup public hiding (_∙⁻¹_; _⁻¹∙_)
 
   isCommutativeMonoid : IsCommutativeMonoid ∙ ε
   isCommutativeMonoid = record


### PR DESCRIPTION
Tackles second item of #2247 .

Issues:
* deprecation of `_-_` in `IsGroup`?
* adding operations to `Algebra.Bundles.Raw.RawGroup`?

Knock-on changes (potentially):

* Instances of `_-_` defined in, and hence would clash with any opening of the `RawGroup`|`IsGroup` instance:
- [ ] `Data.Integer.Base|Properties`
- [ ] `Data.Rational.Base|Properties`
- [ ] `Data.Rational.Unnormalised.Base|Properties`

* Instances of `_-_` not defined in, but would be by opening the `RawGroup`|`IsGroup` instance:
- [ ] `Data.Parity.Base|Properties`
- [ ] `Data.Sign.Base|Properties`
