### PR TITLE
a better `scanr`, via `Data.List.NonEmpty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ Deprecated modules
 Deprecated names
 ----------------
 
+* In `Data.List.Base`:
+  ```agda
+  scanr  : (A → B → B) → B → List A → List B
+  ```
+
 * In `Data.Nat.Divisibility.Core`:
   ```agda
   *-pres-∣  ↦  Data.Nat.Divisibility.*-pres-∣
@@ -35,6 +40,12 @@ Additions to existing modules
 * In `Data.Fin.Properties`:
   ```agda
   nonZeroIndex : Fin n → ℕ.NonZero n
+  ```
+
+* In `Data.List.NonEmpty.Base`:
+  ```agda
+  scanr⁺ : (A → B → B) → B → List A → List⁺ B
+  scanr  : (A → B → B) → B → List A → List B
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Additions to existing modules
 * In `Data.List.NonEmpty.Properties`:
   ```agda
   toList-injective : toList xs ≡ toList ys → xs ≡ ys
-  
+
   toList-tails⁺ : toList ∘ tails⁺ ≗ List.tails
   scanr⁺-defn   : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
   toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Additions to existing modules
 * In `Data.List.NonEmpty.Properties`:
   ```agda
   toList-injective : toList xs ≡ toList ys → xs ≡ ys
-
+  toList-map    : (f : A → B) → toList ∘ map f ≗ List.map f ∘ toList
   toList-tails⁺ : toList ∘ tails⁺ ≗ List.tails
   scanr⁺-defn   : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
   toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Deprecated names
   scanr  : (A → B → B) → B → List A → List B
   ```
 
+* In `Data.List.Properties`:
+  ```agda
+  scanr-defn : scanr f e ≗ map (foldr f e) ∘ tails
+  ```
+
 * In `Data.Nat.Divisibility.Core`:
   ```agda
   *-pres-∣  ↦  Data.Nat.Divisibility.*-pres-∣
@@ -46,6 +51,11 @@ Additions to existing modules
   ```agda
   scanr⁺ : (A → B → B) → B → List A → List⁺ B
   scanr  : (A → B → B) → B → List A → List B
+  ```
+
+* In `Data.List.NonEmpty.Properties`:
+  ```agda
+  scanr-defn : scanr f e ≗ List.map (List.foldr f e) ∘ List.tails
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,19 @@ Additions to existing modules
 * In `Data.List`:
   ```agda
   scanr      : (A → B → B) → B → List A → List B
-  scanr-defn : scanr f e ≗ map (foldr f e) ∘ tails
+  ```
+
+* In `Data.List.NonEmpty.Base`:
+  ```agda
+  tails⁺     : List A → List⁺ (List A)
+  scanr⁺     : (A → B → B) → B → List A → List⁺ B
+  ```
+
+* In `Data.List.NonEmpty.Properties`:
+  ```agda
+  toList-tails⁺ : toList ∘ tails⁺ ≗ List.tails
+  scanr⁺-defn   : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
+  toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,12 @@ Additions to existing modules
 * In `Data.List.NonEmpty.Base`:
   ```agda
   scanr⁺ : (A → B → B) → B → List A → List⁺ B
-  scanr  : (A → B → B) → B → List A → List B
   ```
 
-* In `Data.List.NonEmpty.Properties`:
+* In `Data.List`:
   ```agda
-  scanr-defn : scanr f e ≗ List.map (List.foldr f e) ∘ List.tails
+  scanr      : (A → B → B) → B → List A → List B
+  scanr-defn : scanr f e ≗ map (foldr f e) ∘ tails
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Additions to existing modules
 
 * In `Data.List.NonEmpty.Properties`:
   ```agda
+  toList-injective : toList xs ≡ toList ys → xs ≡ ys
+  
   toList-tails⁺ : toList ∘ tails⁺ ≗ List.tails
   scanr⁺-defn   : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
   toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,11 +47,6 @@ Additions to existing modules
   nonZeroIndex : Fin n → ℕ.NonZero n
   ```
 
-* In `Data.List.NonEmpty.Base`:
-  ```agda
-  scanr⁺ : (A → B → B) → B → List A → List⁺ B
-  ```
-
 * In `Data.List`:
   ```agda
   scanr      : (A → B → B) → B → List A → List B

--- a/src/Data/List.agda
+++ b/src/Data/List.agda
@@ -12,9 +12,7 @@
 module Data.List where
 
 import Data.List.NonEmpty.Base as List⁺
-import Data.List.Properties as List
 open import Function.Base using (_∘_)
-open import Relation.Binary.PropositionalEquality using (refl; cong₂; _≗_)
 
 ------------------------------------------------------------------------
 -- Types and basic operations
@@ -26,20 +24,17 @@ open import Data.List.Base public hiding (scanr)
 
 module _ {a b} {A : Set a} {B : Set b} (f : A → B → B) (e : B) where
 
-  open List⁺ using (List⁺; _∷_; toList)
+  open List⁺ using (toList; scanr⁺)
 
 -- definition
 
   scanr : List A → List B
-  scanr = toList ∘ go where
-    go : List A → List⁺ B
-    go []       = e ∷ []
-    go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
+  scanr = toList ∘ scanr⁺ f e
 
--- property
+{-
+-- which satisfies the following property:
 
   scanr-defn : scanr ≗ map (foldr f e) ∘ tails
-  scanr-defn []                 = refl
-  scanr-defn (x ∷ [])           = refl
-  scanr-defn (x ∷ y∷ys@(_ ∷ _)) = let eq = scanr-defn y∷ys in
-    cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
+  scanr-defn = Data.List.NonEmpty.Properties.toList-scanr⁺
+-}
+

--- a/src/Data/List.agda
+++ b/src/Data/List.agda
@@ -36,13 +36,11 @@ module _ {a b} {A : Set a} {B : Set b} where
     go []       = e ∷ []
     go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
 
-
 -- property
 
   scanr-defn : ∀ (f : A → B → B) (e : B) →
                scanr f e ≗ map (foldr f e) ∘ tails
   scanr-defn f e []                 = refl
   scanr-defn f e (x ∷ [])           = refl
-  scanr-defn f e (x ∷ y∷xs@(_ ∷ _)) = let eq = scanr-defn f e y∷xs in
+  scanr-defn f e (x ∷ y∷ys@(_ ∷ _)) = let eq = scanr-defn f e y∷ys in
     cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
-

--- a/src/Data/List.agda
+++ b/src/Data/List.agda
@@ -11,7 +11,32 @@
 
 module Data.List where
 
+import Data.List.NonEmpty as List⁺
+import Data.List.Properties as List
+open import Function.Base using (_∘_)
+open import Relation.Binary.PropositionalEquality using (refl; cong₂; _≗_)
+
 ------------------------------------------------------------------------
 -- Types and basic operations
 
-open import Data.List.Base public
+open import Data.List.Base public hiding (scanr)
+
+------------------------------------------------------------------------
+-- scanr
+
+module _ {a b} {A : Set a} {B : Set b} where
+
+-- definition
+
+  scanr  : (A → B → B) → B → List A → List B
+  scanr f e = List⁺.toList ∘ List⁺.scanr⁺ f e
+
+-- property
+
+  scanr-defn : ∀ (f : A → B → B) (e : B) →
+               scanr f e ≗ map (foldr f e) ∘ tails
+  scanr-defn f e []                 = refl
+  scanr-defn f e (x ∷ [])           = refl
+  scanr-defn f e (x ∷ y∷xs@(_ ∷ _)) = let eq = scanr-defn f e y∷xs in
+    cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
+

--- a/src/Data/List.agda
+++ b/src/Data/List.agda
@@ -24,23 +24,22 @@ open import Data.List.Base public hiding (scanr)
 ------------------------------------------------------------------------
 -- scanr
 
-module _ {a b} {A : Set a} {B : Set b} where
+module _ {a b} {A : Set a} {B : Set b} (f : A → B → B) (e : B) where
 
   open List⁺ using (List⁺; _∷_; toList)
 
 -- definition
 
-  scanr  : (A → B → B) → B → List A → List B
-  scanr f e = toList ∘ go where
+  scanr : List A → List B
+  scanr = toList ∘ go where
     go : List A → List⁺ B
     go []       = e ∷ []
     go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
 
 -- property
 
-  scanr-defn : ∀ (f : A → B → B) (e : B) →
-               scanr f e ≗ map (foldr f e) ∘ tails
-  scanr-defn f e []                 = refl
-  scanr-defn f e (x ∷ [])           = refl
-  scanr-defn f e (x ∷ y∷ys@(_ ∷ _)) = let eq = scanr-defn f e y∷ys in
+  scanr-defn : scanr ≗ map (foldr f e) ∘ tails
+  scanr-defn []                 = refl
+  scanr-defn (x ∷ [])           = refl
+  scanr-defn (x ∷ y∷ys@(_ ∷ _)) = let eq = scanr-defn y∷ys in
     cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq

--- a/src/Data/List.agda
+++ b/src/Data/List.agda
@@ -11,7 +11,7 @@
 
 module Data.List where
 
-import Data.List.NonEmpty as List⁺
+import Data.List.NonEmpty.Base as List⁺
 import Data.List.Properties as List
 open import Function.Base using (_∘_)
 open import Relation.Binary.PropositionalEquality using (refl; cong₂; _≗_)
@@ -26,10 +26,16 @@ open import Data.List.Base public hiding (scanr)
 
 module _ {a b} {A : Set a} {B : Set b} where
 
+  open List⁺ using (List⁺; _∷_; toList)
+
 -- definition
 
   scanr  : (A → B → B) → B → List A → List B
-  scanr f e = List⁺.toList ∘ List⁺.scanr⁺ f e
+  scanr f e = toList ∘ go where
+    go : List A → List⁺ B
+    go []       = e ∷ []
+    go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
+
 
 -- property
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -574,6 +574,6 @@ scanr f e (x ∷ xs) with scanr f e xs
 ... | y ∷ ys = f x y ∷ y ∷ ys
 {-# WARNING_ON_USAGE scanr
 "Warning: scanr was deprecated in v2.1.
-Please use List.NonEmpty.base.scanr instead."
+Please use List.NonEmpty.Base.scanr instead."
 #-}
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -574,6 +574,6 @@ scanr f e (x ∷ xs) with scanr f e xs
 ... | y ∷ ys = f x y ∷ y ∷ ys
 {-# WARNING_ON_USAGE scanr
 "Warning: scanr was deprecated in v2.1.
-Please use List.NonEmpty.Base.scanr instead."
+Please use List.scanr instead."
 #-}
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -570,8 +570,8 @@ Please use removeAt instead."
 scanr : (A → B → B) → B → List A → List B
 scanr f e []       = e ∷ []
 scanr f e (x ∷ xs) with scanr f e xs
-... | []     = []                -- dead branch
-... | y ∷ ys = f x y ∷ y ∷ ys
+... | []         = []                -- dead branch
+... | ys@(y ∷ _) = f x y ∷ ys
 {-# WARNING_ON_USAGE scanr
 "Warning: scanr was deprecated in v2.1.
 Please use List.scanr instead."

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -210,12 +210,6 @@ updateAt (x ∷ xs) (suc i) f = x ∷ updateAt xs i f
 
 -- Scans
 
-scanr : (A → B → B) → B → List A → List B
-scanr f e []       = e ∷ []
-scanr f e (x ∷ xs) with scanr f e xs
-... | []     = []                -- dead branch
-... | y ∷ ys = f x y ∷ y ∷ ys
-
 scanl : (A → B → A) → A → List B → List A
 scanl f e []       = e ∷ []
 scanl f e (x ∷ xs) = e ∷ scanl f (f e x) xs
@@ -570,3 +564,16 @@ _─_ = removeAt
 "Warning: _─_ was deprecated in v2.0.
 Please use removeAt instead."
 #-}
+
+-- Version 2.1
+
+scanr : (A → B → B) → B → List A → List B
+scanr f e []       = e ∷ []
+scanr f e (x ∷ xs) with scanr f e xs
+... | []     = []                -- dead branch
+... | y ∷ ys = f x y ∷ y ∷ ys
+{-# WARNING_ON_USAGE scanr
+"Warning: scanr was deprecated in v2.1.
+Please use List.NonEmpty.base.scanr instead."
+#-}
+

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -121,14 +121,13 @@ foldl c s (x ∷ xs) = List.foldl c (s x) xs
 foldl₁ : (A → A → A) → List⁺ A → A
 foldl₁ f = foldl f id
 
+-- Scanr (see `Data.List`).
+
 scanr⁺ : (A → B → B) → B → List A → List⁺ B
 scanr⁺ {A = A} {B = B} f e = go where
   go : List A → List⁺ B
   go []       = e ∷ []
   go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
-
-scanr  : (A → B → B) → B → List A → List B
-scanr f e xs = toList (scanr⁺ f e xs)
 
 -- Append (several variants).
 

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -122,7 +122,7 @@ foldl₁ : (A → A → A) → List⁺ A → A
 foldl₁ f = foldl f id
 
 scanr⁺ : (A → B → B) → B → List A → List⁺ B
-scanr⁺ {A = A} {B = B} f e xs = go xs where
+scanr⁺ {A = A} {B = B} f e = go where
   go : List A → List⁺ B
   go []       = e ∷ []
   go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -121,14 +121,6 @@ foldl c s (x ∷ xs) = List.foldl c (s x) xs
 foldl₁ : (A → A → A) → List⁺ A → A
 foldl₁ f = foldl f id
 
--- Scanr (see `Data.List`).
-
-scanr⁺ : (A → B → B) → B → List A → List⁺ B
-scanr⁺ {A = A} {B = B} f e = go where
-  go : List A → List⁺ B
-  go []       = e ∷ []
-  go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
-
 -- Append (several variants).
 
 infixr 5 _⁺++⁺_ _++⁺_ _⁺++_

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -121,6 +121,15 @@ foldl c s (x ∷ xs) = List.foldl c (s x) xs
 foldl₁ : (A → A → A) → List⁺ A → A
 foldl₁ f = foldl f id
 
+scanr⁺ : (A → B → B) → B → List A → List⁺ B
+scanr⁺ {A = A} {B = B} f e xs = go xs where
+  go : List A → List⁺ B
+  go []       = e ∷ []
+  go (x ∷ xs) = let y ∷ ys = go xs in f x y ∷ y ∷ ys
+
+scanr  : (A → B → B) → B → List A → List B
+scanr f e xs = toList (scanr⁺ f e xs)
+
 -- Append (several variants).
 
 infixr 5 _⁺++⁺_ _++⁺_ _⁺++_

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -143,6 +143,21 @@ concatMap f = concat ∘′ map f
 ap : List⁺ (A → B) → List⁺ A → List⁺ B
 ap fs as = concatMap (λ f → map f as) fs
 
+-- Tails
+
+tails⁺ : List A → List⁺ (List A)
+tails⁺ xs = xs ∷ go xs
+  where
+  go : List A → List (List A)
+  go []       = []
+  go (x ∷ xs) = xs ∷ go xs
+
+-- Scanr
+
+scanr⁺ : (f : A → B → B) (e : B) → List A → List⁺ B
+scanr⁺ f e []       = e ∷ []
+scanr⁺ f e (x ∷ xs) = let y ∷ ys = scanr⁺ f e xs in f x y ∷ y ∷ ys
+
 -- Reverse
 
 reverse : List⁺ A → List⁺ A

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -131,20 +131,23 @@ toList-tails⁺ ys@(_ ∷ xs) = cong (ys ∷_) (toList-tails⁺ xs)
 
 module _ (f : A → B → B) (e : B) where
 
-  scanr⁺-defn : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
+  private
+    h = List.foldr f e
+
+  scanr⁺-defn : scanr⁺ f e ≗ map h ∘ tails⁺
   scanr⁺-defn []       = refl
   scanr⁺-defn (x ∷ xs) = let eq = scanr⁺-defn xs
     in cong₂ (λ z → f x z ∷_) (cong head eq) (cong toList eq)
 
-  toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails
+  toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map h ∘ List.tails
   toList-scanr⁺ xs = begin
     toList (scanr⁺ f e xs)
       ≡⟨ cong toList (scanr⁺-defn xs) ⟩
-    toList (map (List.foldr f e) (tails⁺ xs))
-      ≡⟨ toList-map _ (tails⁺ xs) ⟩
-    List.map (List.foldr f e) (toList (tails⁺ xs))
-      ≡⟨ cong (List.map (List.foldr f e)) (toList-tails⁺ xs) ⟩
-    List.map (List.foldr f e) (List.tails xs) ∎
+    toList (map h (tails⁺ xs))
+      ≡⟨ toList-map h (tails⁺ xs) ⟩
+    List.map h (toList (tails⁺ xs))
+      ≡⟨ cong (List.map h) (toList-tails⁺ xs) ⟩
+    List.map h (List.tails xs) ∎
 
 ------------------------------------------------------------------------
 -- groupSeqs

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -116,6 +116,9 @@ map-cong f≗g (x ∷ xs) = cong₂ _∷_ (f≗g x) (List.map-cong f≗g xs)
 map-∘ : {g : B → C} {f : A → B} → map (g ∘ f) ≗ map g ∘ map f
 map-∘ (x ∷ xs) = cong (_ ∷_) (List.map-∘ xs)
 
+toList-map : (f : A → B) → toList ∘ map f ≗ List.map f ∘ toList
+toList-map f (x ∷ xs) = refl
+
 ------------------------------------------------------------------------
 -- tails
 
@@ -129,16 +132,19 @@ toList-tails⁺ ys@(_ ∷ xs) = cong (ys ∷_) (toList-tails⁺ xs)
 module _ (f : A → B → B) (e : B) where
 
   scanr⁺-defn : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
-  scanr⁺-defn []                = refl
-  scanr⁺-defn (x ∷ [])          = refl
-  scanr⁺-defn (x ∷ xs@(_ ∷ _)) = let eq = scanr⁺-defn xs
+  scanr⁺-defn []       = refl
+  scanr⁺-defn (x ∷ xs) = let eq = scanr⁺-defn xs
     in cong₂ (λ z → f x z ∷_) (cong head eq) (cong toList eq)
 
   toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails
-  toList-scanr⁺ []                = refl
-  toList-scanr⁺ (x ∷ [])          = refl
-  toList-scanr⁺ (x ∷ xs@(_ ∷ _)) = let eq = toList-scanr⁺ xs
-    in cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
+  toList-scanr⁺ xs = begin
+    toList (scanr⁺ f e xs)
+      ≡⟨ cong toList (scanr⁺-defn xs) ⟩
+    toList (map (List.foldr f e) (tails⁺ xs))
+      ≡⟨ toList-map _ (tails⁺ xs) ⟩
+    List.map (List.foldr f e) (toList (tails⁺ xs))
+      ≡⟨ cong (List.map (List.foldr f e)) (toList-tails⁺ xs) ⟩
+    List.map (List.foldr f e) (List.tails xs) ∎
 
 ------------------------------------------------------------------------
 -- groupSeqs

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -114,6 +114,16 @@ map-∘ : {g : B → C} {f : A → B} → map (g ∘ f) ≗ map g ∘ map f
 map-∘ (x ∷ xs) = cong (_ ∷_) (List.map-∘ xs)
 
 ------------------------------------------------------------------------
+-- scanr
+
+scanr-defn : ∀ (f : A → B → B) (e : B) →
+             scanr f e ≗ List.map (List.foldr f e) ∘ List.tails
+scanr-defn f e []                 = refl
+scanr-defn f e (x ∷ [])           = refl
+scanr-defn f e (x ∷ y∷xs@(_ ∷ _)) = let eq = scanr-defn f e y∷xs in
+  cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
+
+------------------------------------------------------------------------
 -- groupSeqs
 
 -- Groups all contiguous elements for which the predicate returns the

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -114,16 +114,6 @@ map-∘ : {g : B → C} {f : A → B} → map (g ∘ f) ≗ map g ∘ map f
 map-∘ (x ∷ xs) = cong (_ ∷_) (List.map-∘ xs)
 
 ------------------------------------------------------------------------
--- scanr
-
-scanr-defn : ∀ (f : A → B → B) (e : B) →
-             scanr f e ≗ List.map (List.foldr f e) ∘ List.tails
-scanr-defn f e []                 = refl
-scanr-defn f e (x ∷ [])           = refl
-scanr-defn f e (x ∷ y∷xs@(_ ∷ _)) = let eq = scanr-defn f e y∷xs in
-  cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
-
-------------------------------------------------------------------------
 -- groupSeqs
 
 -- Groups all contiguous elements for which the predicate returns the

--- a/src/Data/List/NonEmpty/Properties.agda
+++ b/src/Data/List/NonEmpty/Properties.agda
@@ -46,6 +46,9 @@ private
 η : ∀ (xs : List⁺ A) → head xs ∷ tail xs ≡ toList xs
 η _ = refl
 
+toList-injective : {xs ys : List⁺ A} → toList xs ≡ toList ys → xs ≡ ys
+toList-injective refl = refl
+
 toList-fromList : ∀ x (xs : List A) → x ∷ xs ≡ toList (x ∷ xs)
 toList-fromList _ _ = refl
 
@@ -112,6 +115,30 @@ map-cong f≗g (x ∷ xs) = cong₂ _∷_ (f≗g x) (List.map-cong f≗g xs)
 
 map-∘ : {g : B → C} {f : A → B} → map (g ∘ f) ≗ map g ∘ map f
 map-∘ (x ∷ xs) = cong (_ ∷_) (List.map-∘ xs)
+
+------------------------------------------------------------------------
+-- tails
+
+toList-tails⁺ : toList ∘ tails⁺ ≗ List.tails {A = A}
+toList-tails⁺ []          = refl
+toList-tails⁺ ys@(_ ∷ xs) = cong (ys ∷_) (toList-tails⁺ xs)
+
+------------------------------------------------------------------------
+-- scanr
+
+module _ (f : A → B → B) (e : B) where
+
+  scanr⁺-defn : scanr⁺ f e ≗ map (List.foldr f e) ∘ tails⁺
+  scanr⁺-defn []                = refl
+  scanr⁺-defn (x ∷ [])          = refl
+  scanr⁺-defn (x ∷ xs@(_ ∷ _)) = let eq = scanr⁺-defn xs
+    in cong₂ (λ z → f x z ∷_) (cong head eq) (cong toList eq)
+
+  toList-scanr⁺ : toList ∘ scanr⁺ f e ≗ List.map (List.foldr f e) ∘ List.tails
+  toList-scanr⁺ []                = refl
+  toList-scanr⁺ (x ∷ [])          = refl
+  toList-scanr⁺ (x ∷ xs@(_ ∷ _)) = let eq = toList-scanr⁺ xs
+    in cong₂ (λ z → f x z ∷_) (List.∷-injectiveˡ eq) eq
 
 ------------------------------------------------------------------------
 -- groupSeqs

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -1294,6 +1294,6 @@ scanr-defn f e (x ∷ y∷xs@(_ ∷ _))
   = let z≡fy⦇f⦈xs , _ = ∷-injective eq in cong₂ (λ z → f x z ∷_) z≡fy⦇f⦈xs eq
 {-# WARNING_ON_USAGE scanr-defn
 "Warning: scanr-defn was deprecated in v2.1.
-Please use List.NonEmpty.Properties.scanr-defn instead."
+Please use List.scanr-defn instead."
 #-}
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -1294,6 +1294,6 @@ scanr-defn f e (x ∷ xs@(_ ∷ _))
   = cong₂ (λ z → f x z ∷_) (∷-injectiveˡ eq) eq
 {-# WARNING_ON_USAGE scanr-defn
 "Warning: scanr-defn was deprecated in v2.1.
-Please use List.scanr-defn instead."
+Please use Data.List.NonEmpty.toList-scanr⁺ instead."
 #-}
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -8,6 +8,7 @@
 -- equalities than _≡_.
 
 {-# OPTIONS --cubical-compatible --safe #-}
+{-# OPTIONS --warn=noUserWarning #-} -- for deprecated `scanr` (PR #2258)
 
 module Data.List.Properties where
 
@@ -617,18 +618,6 @@ sum-++ (x ∷ xs) ys = begin
 ∈⇒∣product : ∀ {n ns} → n ∈ ns → n ∣ product ns
 ∈⇒∣product {n} {n ∷ ns} (here  refl) = divides (product ns) (*-comm n (product ns))
 ∈⇒∣product {n} {m ∷ ns} (there n∈ns) = ∣n⇒∣m*n m (∈⇒∣product n∈ns)
-
-------------------------------------------------------------------------
--- scanr
-
-scanr-defn : ∀ (f : A → B → B) (e : B) →
-             scanr f e ≗ map (foldr f e) ∘ tails
-scanr-defn f e []             = refl
-scanr-defn f e (x ∷ [])       = refl
-scanr-defn f e (x ∷ y∷xs@(_ ∷ _))
-  with eq ← scanr-defn f e y∷xs
-  with z ∷ zs ← scanr f e y∷xs
-  = let z≡fy⦇f⦈xs , _ = ∷-injective eq in cong₂ (λ z → f x z ∷_) z≡fy⦇f⦈xs eq
 
 ------------------------------------------------------------------------
 -- scanl
@@ -1292,3 +1281,19 @@ map-─ = map-removeAt
 "Warning: map-─ was deprecated in v2.0.
 Please use map-removeAt instead."
 #-}
+
+-- Version 2.1
+
+scanr-defn : ∀ (f : A → B → B) (e : B) →
+             scanr f e ≗ map (foldr f e) ∘ tails
+scanr-defn f e []             = refl
+scanr-defn f e (x ∷ [])       = refl
+scanr-defn f e (x ∷ y∷xs@(_ ∷ _))
+  with eq ← scanr-defn f e y∷xs
+  with z ∷ zs ← scanr f e y∷xs
+  = let z≡fy⦇f⦈xs , _ = ∷-injective eq in cong₂ (λ z → f x z ∷_) z≡fy⦇f⦈xs eq
+{-# WARNING_ON_USAGE scanr-defn
+"Warning: scanr-defn was deprecated in v2.1.
+Please use List.NonEmpty.Properties.scanr-defn instead."
+#-}
+

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -1288,10 +1288,10 @@ scanr-defn : ∀ (f : A → B → B) (e : B) →
              scanr f e ≗ map (foldr f e) ∘ tails
 scanr-defn f e []             = refl
 scanr-defn f e (x ∷ [])       = refl
-scanr-defn f e (x ∷ y∷xs@(_ ∷ _))
-  with eq ← scanr-defn f e y∷xs
-  with z ∷ zs ← scanr f e y∷xs
-  = let z≡fy⦇f⦈xs , _ = ∷-injective eq in cong₂ (λ z → f x z ∷_) z≡fy⦇f⦈xs eq
+scanr-defn f e (x ∷ xs@(_ ∷ _))
+  with eq ← scanr-defn f e xs
+  with ys@(_ ∷ _) ← scanr f e xs
+  = cong₂ (λ z → f x z ∷_) (∷-injectiveˡ eq) eq
 {-# WARNING_ON_USAGE scanr-defn
 "Warning: scanr-defn was deprecated in v2.1.
 Please use List.scanr-defn instead."


### PR DESCRIPTION
Avoids the [`with`-based definition](https://stackoverflow.com/questions/77821802/agda-how-to-prove-basic-properties-of-scanr-in-agda-involving-branch-reasoning) in favour of a simpler definition using (pattern-matching ;-)) `let`, with no dead-code branch... cf. also #1937 , #2123 