### PR TITLE
add lemma(s) about `Relation.Nullary.Decidable.Core.isYes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,8 @@ Additions to existing modules
 
 * In `Function.Bundles`, added `_⟶ₛ_` as a synonym for `Func` that can
   be used infix.
+
+* Added new proof in `Relation.Nullary.Decidable`:
+  ```agda
+  ⌊⌋-map′ : (a? : Dec A) → ⌊ map′ t f a? ⌋ ≡ ⌊ a? ⌋
+  ```

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -19,7 +19,8 @@ open import Relation.Binary.Bundles using (Setoid; module Setoid)
 open import Relation.Binary.Definitions using (Decidable)
 open import Relation.Nullary
 open import Relation.Nullary.Reflects using (invert)
-open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; cong′)
+open import Relation.Binary.PropositionalEquality.Core
+  using (_≡_; refl; sym; trans; cong′)
 
 private
   variable
@@ -80,3 +81,6 @@ dec-no (no _) _ | refl = refl
 dec-yes-irr : (a? : Dec A) → Irrelevant A → (a : A) → a? ≡ yes a
 dec-yes-irr a? irr a with dec-yes a? a
 ... | a′ , eq rewrite irr a a′ = eq
+
+⌊⌋-map′ : ∀ t f (a? : Dec A) → ⌊ map′ {B = B} t f a? ⌋ ≡ ⌊ a? ⌋
+⌊⌋-map′ t f a? = trans (isYes≗does (map′ t f a?)) (sym (isYes≗does a?))


### PR DESCRIPTION
fixes #846 . Prompt to identify any other 'missing' such properties.