### PR TITLE
lemmas about semiring structure induced by `_× x`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Deprecated modules
 Deprecated names
 ----------------
 
+* In `Algebra.Properties.Semiring.Mult`:
+  ```agda
+  1×-identityʳ  ↦  Algebra.Properties.Monoid.Mult.×-homo-1
+  ```
+
 * In `Data.Nat.Divisibility.Core`:
   ```agda
   *-pres-∣  ↦  Data.Nat.Divisibility.*-pres-∣
@@ -82,6 +87,17 @@ Additions to existing modules
   rawBimodule        : RawBimodule R c ℓ
   rawSemimodule      : RawSemimodule R c ℓ
   rawModule          : RawModule R c ℓ
+  ```
+
+* In `Algebra.Properties.Monoid.Mult`:
+  ```agda
+  ×-homo-0 : ∀ x → 0 × x ≈ 0#
+  ×-homo-1 : ∀ x → 1 × x ≈ x
+  ```
+
+* In `Algebra.Properties.Semiring.Mult`:
+  ```agda
+  ×-homo-0 : ∀ x → 0 × x ≈ 0# * x
   ```
 
 * In `Data.Fin.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Additions to existing modules
 * In `Algebra.Properties.Semiring.Mult`:
   ```agda
   ×-homo-0# : ∀ x → 0 × x ≈ 0# * x
+  ×-homo-1# : ∀ x → 1 × x ≈ 1# * x
   ```
 
 * In `Data.Fin.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Deprecated names
 
 * In `Algebra.Properties.Semiring.Mult`:
   ```agda
-  1×-identityʳ  ↦  Algebra.Properties.Monoid.Mult.×-homo-1
+  1×-identityʳ  ↦  ×-homo-1
   ```
 
 * In `Data.Nat.Divisibility.Core`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,9 @@ Additions to existing modules
 
 * In `Algebra.Properties.Semiring.Mult`:
   ```agda
-  ×-homo-0# : ∀ x → 0 × x ≈ 0# * x
-  ×-homo-1# : ∀ x → 1 × x ≈ 1# * x
+  ×-homo-0#     : ∀ x → 0 × x ≈ 0# * x
+  ×-homo-1#     : ∀ x → 1 × x ≈ 1# * x
+  idem-×-homo-* : (_*_ IdempotentOn x) → (m × x) * (n × x) ≈ (m ℕ.* n) × x
   ```
 
 * In `Data.Fin.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ Additions to existing modules
 
 * In `Algebra.Properties.Semiring.Mult`:
   ```agda
-  ×-homo-0 : ∀ x → 0 × x ≈ 0# * x
+  ×-homo-0# : ∀ x → 0 × x ≈ 0# * x
   ```
 
 * In `Data.Fin.Properties`:

--- a/src/Algebra/Properties/Monoid/Mult.agda
+++ b/src/Algebra/Properties/Monoid/Mult.agda
@@ -51,6 +51,9 @@ open import Algebra.Definitions.RawMonoid rawMonoid public
 
 -- _×_ is homomorphic with respect to _ℕ+_/_+_.
 
+×-homo-1 : ∀ x → 1 × x ≈ x
+×-homo-1 = +-identityʳ
+
 ×-homo-+ : ∀ x m n → (m ℕ.+ n) × x ≈ m × x + n × x
 ×-homo-+ x 0       n = sym (+-identityˡ (n × x))
 ×-homo-+ x (suc m) n = begin

--- a/src/Algebra/Properties/Monoid/Mult.agda
+++ b/src/Algebra/Properties/Monoid/Mult.agda
@@ -51,6 +51,9 @@ open import Algebra.Definitions.RawMonoid rawMonoid public
 
 -- _×_ is homomorphic with respect to _ℕ+_/_+_.
 
+×-homo-0 : ∀ x → 0 × x ≈ 0#
+×-homo-0 x = refl
+
 ×-homo-1 : ∀ x → 1 × x ≈ x
 ×-homo-1 = +-identityʳ
 

--- a/src/Algebra/Properties/Semiring/Binomial.agda
+++ b/src/Algebra/Properties/Semiring/Binomial.agda
@@ -216,7 +216,7 @@ term₁+term₂≈term x*y≈y*x n (suc i) with view i
 theorem : x * y ≈ y * x → ∀ n → (x + y) ^ n ≈ binomialExpansion n
 theorem x*y≈y*x zero    = begin
   (x + y) ^ 0                     ≡⟨⟩
-  1#                              ≈⟨ 1×-identityʳ 1# ⟨
+  1#                              ≈⟨ +-identityʳ 1# ⟨
   1 × 1#                          ≈⟨ *-identityʳ (1 × 1#) ⟨
   (1 × 1#) * 1#                   ≈⟨ ×-assoc-* 1 1# 1# ⟩
   1 × (1# * 1#)                   ≡⟨⟩

--- a/src/Algebra/Properties/Semiring/Binomial.agda
+++ b/src/Algebra/Properties/Semiring/Binomial.agda
@@ -216,7 +216,7 @@ term₁+term₂≈term x*y≈y*x n (suc i) with view i
 theorem : x * y ≈ y * x → ∀ n → (x + y) ^ n ≈ binomialExpansion n
 theorem x*y≈y*x zero    = begin
   (x + y) ^ 0                     ≡⟨⟩
-  1#                              ≈⟨ +-identityʳ 1# ⟨
+  1#                              ≈⟨ ×-homo-1 1# ⟨
   1 × 1#                          ≈⟨ *-identityʳ (1 × 1#) ⟨
   (1 × 1#) * 1#                   ≈⟨ ×-assoc-* 1 1# 1# ⟩
   1 × (1# * 1#)                   ≡⟨⟩

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -82,5 +82,5 @@ idem-×-homo-* m n {x} idem = begin
 1×-identityʳ = ×-homo-1
 {-# WARNING_ON_USAGE 1×-identityʳ
 "Warning: 1×-identityʳ was deprecated in v2.1.
-Please use Algebra.Properties.Monoid.Mult.×-homo-1 instead. "
+Please use ×-homo-1 instead. "
 #-}

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -6,7 +6,7 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Algebra
+open import Algebra.Bundles using (Semiring)
 open import Data.Nat.Base as ℕ using (zero; suc)
 
 module Algebra.Properties.Semiring.Mult
@@ -14,6 +14,7 @@ module Algebra.Properties.Semiring.Mult
 
 open Semiring S renaming (zero to *-zero)
 open import Relation.Binary.Reasoning.Setoid setoid
+open import Algebra.Definitions _≈_ using (_IdempotentOn_)
 
 ------------------------------------------------------------------------
 -- Re-export definition from the monoid
@@ -32,17 +33,6 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 
 ×-homo-1# : ∀ x → 1 × x ≈ 1# * x
 ×-homo-1# x = trans (×-homo-1 x) (sym (*-identityˡ x))
-
--- (_× 1#) is homomorphic with respect to _ℕ.*_/_*_.
-
-×1-homo-* : ∀ m n → (m ℕ.* n) × 1# ≈ (m × 1#) * (n × 1#)
-×1-homo-* 0       n = sym (zeroˡ (n × 1#))
-×1-homo-* (suc m) n = begin
-  (n ℕ.+ m ℕ.* n) × 1#                ≈⟨ ×-homo-+ 1# n (m ℕ.* n) ⟩
-  n × 1# + (m ℕ.* n) × 1#             ≈⟨ +-congˡ (×1-homo-* m n) ⟩
-  n × 1# + (m × 1#) * (n × 1#)        ≈⟨ +-congʳ (*-identityˡ _) ⟨
-  1# * (n × 1#) + (m × 1#) * (n × 1#) ≈⟨ distribʳ (n × 1#) 1# (m × 1#) ⟨
-  (1# + m × 1#) * (n × 1#)            ∎
 
 -- (n ×_) commutes with _*_
 
@@ -66,6 +56,23 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
   x * y + n × (x * y)   ≡⟨⟩
   suc n × (x * y)       ∎
 
+-- (_× x) is homomorphic with respect to _ℕ.*_/_*_ for idempotent x.
+
+module _ {x} (idem : _*_ IdempotentOn x) where
+
+  idem-×-homo-* : ∀ m n → (m × x) * (n × x) ≈ (m ℕ.* n) × x
+  idem-×-homo-* m n = begin
+    (m × x) * (n × x)   ≈⟨ ×-assoc-* m x (n × x) ⟩
+    m × (x * (n × x))   ≈⟨ ×-congʳ m (×-comm-* n x x) ⟩
+    m × (n × (x * x))   ≈⟨ ×-assocˡ _ m n ⟩
+    (m ℕ.* n) × (x * x) ≈⟨ ×-congʳ (m ℕ.* n) idem ⟩
+    (m ℕ.* n) × x       ∎
+
+-- (_× 1#) is homomorphic with respect to _ℕ.*_/_*_.
+
+×1-homo-* : ∀ m n → (m ℕ.* n) × 1# ≈ (m × 1#) * (n × 1#)
+×1-homo-* m n = sym (idem-×-homo-* (*-identityʳ 1#) m n)
+
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES
 ------------------------------------------------------------------------
@@ -75,7 +82,6 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 -- Version 2.1
 
 1×-identityʳ = ×-homo-1
-
 {-# WARNING_ON_USAGE 1×-identityʳ
 "Warning: 1×-identityʳ was deprecated in v2.1.
 Please use Algebra.Properties.Monoid.Mult.×-homo-1 instead. "

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -23,6 +23,16 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 ------------------------------------------------------------------------
 -- Properties of _×_
 
+-- (0 ×_) is (0# *_)
+
+×-homo-0# : ∀ x → 0 × x ≈ 0# * x
+×-homo-0# x = sym (zeroˡ x)
+
+-- (1 ×_) is (1# *_)
+
+×-homo-1# : ∀ x → 1 × x ≈ 1# * x
+×-homo-1# x = trans (×-homo-1 x) (sym (*-identityˡ x))
+
 -- (_× 1#) is homomorphic with respect to _ℕ.*_/_*_.
 
 ×1-homo-* : ∀ m n → (m ℕ.* n) × 1# ≈ (m × 1#) * (n × 1#)
@@ -33,11 +43,6 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
   n × 1# + (m × 1#) * (n × 1#)        ≈⟨ +-congʳ (*-identityˡ _) ⟨
   1# * (n × 1#) + (m × 1#) * (n × 1#) ≈⟨ distribʳ (n × 1#) 1# (m × 1#) ⟨
   (1# + m × 1#) * (n × 1#)            ∎
-
--- (0 ×_) is (0# *_)
-
-×-homo-0# : ∀ x → 0 × x ≈ 0# * x
-×-homo-0# x = sym (zeroˡ x)
 
 -- (n ×_) commutes with _*_
 

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -36,8 +36,8 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 
 -- (0 ×_) is (0# *_)
 
-×-homo-0 : ∀ x → 0 × x ≈ 0# * x
-×-homo-0 x = sym (zeroˡ x)
+×-homo-0# : ∀ x → 0 × x ≈ 0# * x
+×-homo-0# x = sym (zeroˡ x)
 
 -- (n ×_) commutes with _*_
 

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -28,16 +28,16 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 ×1-homo-* : ∀ m n → (m ℕ.* n) × 1# ≈ (m × 1#) * (n × 1#)
 ×1-homo-* 0       n = sym (zeroˡ (n × 1#))
 ×1-homo-* (suc m) n = begin
-  (n ℕ.+ m ℕ.* n) × 1#                ≈⟨  ×-homo-+ 1# n (m ℕ.* n) ⟩
-  n × 1# + (m ℕ.* n) × 1#             ≈⟨  +-congˡ (×1-homo-* m n) ⟩
+  (n ℕ.+ m ℕ.* n) × 1#                ≈⟨ ×-homo-+ 1# n (m ℕ.* n) ⟩
+  n × 1# + (m ℕ.* n) × 1#             ≈⟨ +-congˡ (×1-homo-* m n) ⟩
   n × 1# + (m × 1#) * (n × 1#)        ≈⟨ +-congʳ (*-identityˡ _) ⟨
   1# * (n × 1#) + (m × 1#) * (n × 1#) ≈⟨ distribʳ (n × 1#) 1# (m × 1#) ⟨
   (1# + m × 1#) * (n × 1#)            ∎
 
--- (1 ×_) is the identity
+-- (0 ×_) is (0# *_)
 
-1×-identityʳ : ∀ x → 1 × x ≈ x
-1×-identityʳ = +-identityʳ
+×-homo-0 : ∀ x → 0 × x ≈ 0# * x
+×-homo-0 x = sym (zeroˡ x)
 
 -- (n ×_) commutes with _*_
 
@@ -60,3 +60,18 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
   x * y + (n × x) * y   ≈⟨ +-congˡ (×-assoc-* n _ _) ⟩
   x * y + n × (x * y)   ≡⟨⟩
   suc n × (x * y)       ∎
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.1
+
+1×-identityʳ = ×-homo-1
+
+{-# WARNING_ON_USAGE 1×-identityʳ
+"Warning: 1×-identityʳ was deprecated in v2.1.
+Please use Algebra.Properties.Monoid.Mult.×-homo-1 instead. "
+#-}

--- a/src/Algebra/Properties/Semiring/Mult.agda
+++ b/src/Algebra/Properties/Semiring/Mult.agda
@@ -58,20 +58,18 @@ open import Algebra.Properties.Monoid.Mult +-monoid public
 
 -- (_× x) is homomorphic with respect to _ℕ.*_/_*_ for idempotent x.
 
-module _ {x} (idem : _*_ IdempotentOn x) where
-
-  idem-×-homo-* : ∀ m n → (m × x) * (n × x) ≈ (m ℕ.* n) × x
-  idem-×-homo-* m n = begin
-    (m × x) * (n × x)   ≈⟨ ×-assoc-* m x (n × x) ⟩
-    m × (x * (n × x))   ≈⟨ ×-congʳ m (×-comm-* n x x) ⟩
-    m × (n × (x * x))   ≈⟨ ×-assocˡ _ m n ⟩
-    (m ℕ.* n) × (x * x) ≈⟨ ×-congʳ (m ℕ.* n) idem ⟩
-    (m ℕ.* n) × x       ∎
+idem-×-homo-* : ∀ m n {x} → (_*_ IdempotentOn x) → (m × x) * (n × x) ≈ (m ℕ.* n) × x
+idem-×-homo-* m n {x} idem = begin
+  (m × x) * (n × x)   ≈⟨ ×-assoc-* m x (n × x) ⟩
+  m × (x * (n × x))   ≈⟨ ×-congʳ m (×-comm-* n x x) ⟩
+  m × (n × (x * x))   ≈⟨ ×-assocˡ _ m n ⟩
+  (m ℕ.* n) × (x * x) ≈⟨ ×-congʳ (m ℕ.* n) idem ⟩
+  (m ℕ.* n) × x       ∎
 
 -- (_× 1#) is homomorphic with respect to _ℕ.*_/_*_.
 
 ×1-homo-* : ∀ m n → (m ℕ.* n) × 1# ≈ (m × 1#) * (n × 1#)
-×1-homo-* m n = sym (idem-×-homo-* (*-identityʳ 1#) m n)
+×1-homo-* m n = sym (idem-×-homo-* m n (*-identityʳ 1#))
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES


### PR DESCRIPTION
This is a largely cosmetic PR, to lay the groundwork for more extensive additions related to #1363 / #2264 .

It adds:
* 'homomorphism' properties for  `0`/`0#` (I'd dithered over this one, because it holds by definition, but I've included it for the sake of uniformity, and fixed the resulting name-clash... ;-)) and `1`/`1#` to `Algebra.Properties.Monoid.Mult`;
* of which the property for `1` was previously, erroneously, placed in `Algebra.Properties.Semiring.Mult` as part of #1928 , so a deprecation is also issued for that;
* repairs the single use of that lemma in  `Algebra.Properties.Semiring.Binomial` in favour of the simpler `Monoid` property;
* the companion property `×-homo-0#` for `0` which *does* require `Semiring` structure (specifically: the `*-zero` property, `AnnihilatingZero`) now has a new (hopefully more uniform) name in `Algebra.Properties.Semiring.Mult`;
* `CHANGELOG` entries.

Outstanding: refactoring this so that all the lemmas except for `×-homo-0#` move to `Algebra.Properties.SemiringWithoutAnnihilatingZero.Mult` which currently doesn't exist, and re-exporting its content under `Algebra.Properties.Semiring.Mult` along with `×-homo-0#`...

Once merged, I plan to follow this up with a more ambitious development of: (UPDATED :man_facepalming: )
* `SuccessorSet` #2273 , and 
* (TODO) the proof that it induces (via freeness/initiality from Nat, as the weakly initial such thing) a sub-*`Semiring`* structure on the carrier of a *`Monoid`* via `_× x`...