### PR TITLE
Qualified import of `Data.Nat` fixing #2280

### DIFF
--- a/src/Algebra/Properties/Semiring/Binomial.agda
+++ b/src/Algebra/Properties/Semiring/Binomial.agda
@@ -10,10 +10,10 @@
 
 open import Algebra.Bundles using (Semiring)
 open import Data.Bool.Base using (true)
-open import Data.Nat.Base as Nat hiding (_+_; _*_; _^_)
+open import Data.Nat.Base as ℕ hiding (_+_; _*_; _^_)
 open import Data.Nat.Combinatorics
   using (_C_; nCn≡1; nC1≡n; nCk+nC[k+1]≡[n+1]C[k+1])
-open import Data.Nat.Properties as Nat
+open import Data.Nat.Properties as ℕ
   using (<⇒<ᵇ; n<1+n; n∸n≡0; +-∸-assoc)
 open import Data.Fin.Base as Fin
   using (Fin; zero; suc; toℕ; fromℕ; inject₁)
@@ -154,8 +154,8 @@ y*lemma x*y≈y*x {n} j = begin
 -- Now, a lemma characterising the sum of the term₁ and term₂ expressions
 
 private
-  n<ᵇ1+n : ∀ n → (n Nat.<ᵇ suc n) ≡ true
-  n<ᵇ1+n n with true ← n Nat.<ᵇ suc n | _ ← <⇒<ᵇ (n<1+n n) = ≡.refl
+  n<ᵇ1+n : ∀ n → (n ℕ.<ᵇ suc n) ≡ true
+  n<ᵇ1+n n with true ← n ℕ.<ᵇ suc n | _ ← <⇒<ᵇ (n<1+n n) = ≡.refl
 
 term₁+term₂≈term : x * y ≈ y * x → ∀ n i → term₁ n i + term₂ n i ≈ binomialTerm (suc n) i
 
@@ -193,7 +193,7 @@ term₁+term₂≈term x*y≈y*x n (suc i) with view i
     ≈⟨ +-congˡ (×-congˡ nC[k+1]≡nC[j+1]) ⟨
   (nCk × [x^k+1]*[y^n-k]) + (nC[k+1] × [x^k+1]*[y^n-k])
     ≈⟨ ×-homo-+ [x^k+1]*[y^n-k] nCk nC[k+1] ⟨
-  (nCk Nat.+ nC[k+1]) × [x^k+1]*[y^n-k]
+  (nCk ℕ.+ nC[k+1]) × [x^k+1]*[y^n-k]
     ≡⟨ cong (_× [x^k+1]*[y^n-k]) (nCk+nC[k+1]≡[n+1]C[k+1] n k) ⟩
   ((suc n) C (suc k)) × [x^k+1]*[y^n-k]
     ≡⟨⟩

--- a/src/Codata/Sized/Cowriter.agda
+++ b/src/Codata/Sized/Cowriter.agda
@@ -17,7 +17,7 @@ open import Codata.Sized.Stream as Stream using (Stream; _∷_)
 open import Data.Unit.Base
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.NonEmpty.Base using (List⁺; _∷_)
-open import Data.Nat.Base as Nat using (ℕ; zero; suc)
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc)
 open import Data.Product.Base as Prod using (_×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Data.Vec.Base using (Vec; []; _∷_)

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -11,7 +11,7 @@ module Data.Char.Properties where
 open import Data.Bool.Base using (Bool)
 open import Data.Char.Base
 import Data.Nat.Base as ℕ
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (_,_)
 
 open import Function.Base
@@ -56,7 +56,7 @@ open import Agda.Builtin.Char.Properties
 
 infix 4 _≟_
 _≟_ : Decidable {A = Char} _≡_
-x ≟ y = map′ ≈⇒≡ ≈-reflexive (toℕ x ℕₚ.≟ toℕ y)
+x ≟ y = map′ ≈⇒≡ ≈-reflexive (toℕ x ℕ.≟ toℕ y)
 
 setoid : Setoid _ _
 setoid = PropEq.setoid Char
@@ -95,22 +95,22 @@ private
 
 infix 4 _<?_
 _<?_ : Decidable _<_
-_<?_ = On.decidable toℕ ℕ._<_ ℕₚ._<?_
+_<?_ = On.decidable toℕ ℕ._<_ ℕ._<?_
 
 <-cmp : Trichotomous _≡_ _<_
-<-cmp c d with ℕₚ.<-cmp (toℕ c) (toℕ d)
+<-cmp c d with ℕ.<-cmp (toℕ c) (toℕ d)
 ... | tri< lt ¬eq ¬gt = tri< lt (≉⇒≢ ¬eq) ¬gt
 ... | tri≈ ¬lt eq ¬gt = tri≈ ¬lt (≈⇒≡ eq) ¬gt
 ... | tri> ¬lt ¬eq gt = tri> ¬lt (≉⇒≢ ¬eq) gt
 
 <-irrefl : Irreflexive _≡_ _<_
-<-irrefl = ℕₚ.<-irrefl ∘′ cong toℕ
+<-irrefl = ℕ.<-irrefl ∘′ cong toℕ
 
 <-trans : Transitive _<_
-<-trans {c} {d} {e} = On.transitive toℕ ℕ._<_ ℕₚ.<-trans {c} {d} {e}
+<-trans {c} {d} {e} = On.transitive toℕ ℕ._<_ ℕ.<-trans {c} {d} {e}
 
 <-asym : Asymmetric _<_
-<-asym {c} {d} = On.asymmetric toℕ ℕ._<_ ℕₚ.<-asym {c} {d}
+<-asym {c} {d} = On.asymmetric toℕ ℕ._<_ ℕ.<-asym {c} {d}
 
 <-isStrictPartialOrder : IsStrictPartialOrder _≡_ _<_
 <-isStrictPartialOrder = record
@@ -151,7 +151,7 @@ _≤?_ = Reflₚ.decidable <-cmp
 ≤-trans = Reflₚ.trans (λ {a} {b} {c} → <-trans {a} {b} {c})
 
 ≤-antisym : Antisymmetric _≡_ _≤_
-≤-antisym = Reflₚ.antisym _≡_ refl ℕₚ.<-asym
+≤-antisym = Reflₚ.antisym _≡_ refl ℕ.<-asym
 
 ≤-isPreorder : IsPreorder _≡_ _≤_
 ≤-isPreorder = record
@@ -220,7 +220,7 @@ Please use Propositional Equality's subst instead."
 
 infix 4 _≈?_
 _≈?_ : Decidable _≈_
-x ≈? y = toℕ x ℕₚ.≟ toℕ y
+x ≈? y = toℕ x ℕ.≟ toℕ y
 
 ≈-isEquivalence : IsEquivalence _≈_
 ≈-isEquivalence = record
@@ -277,28 +277,28 @@ Please use decSetoid instead."
 #-}
 
 <-isStrictPartialOrder-≈ : IsStrictPartialOrder _≈_ _<_
-<-isStrictPartialOrder-≈ = On.isStrictPartialOrder toℕ ℕₚ.<-isStrictPartialOrder
+<-isStrictPartialOrder-≈ = On.isStrictPartialOrder toℕ ℕ.<-isStrictPartialOrder
 {-# WARNING_ON_USAGE <-isStrictPartialOrder-≈
 "Warning: <-isStrictPartialOrder-≈ was deprecated in v1.5.
 Please use <-isStrictPartialOrder instead."
 #-}
 
 <-isStrictTotalOrder-≈ : IsStrictTotalOrder _≈_ _<_
-<-isStrictTotalOrder-≈ = On.isStrictTotalOrder toℕ ℕₚ.<-isStrictTotalOrder
+<-isStrictTotalOrder-≈ = On.isStrictTotalOrder toℕ ℕ.<-isStrictTotalOrder
 {-# WARNING_ON_USAGE <-isStrictTotalOrder-≈
 "Warning: <-isStrictTotalOrder-≈ was deprecated in v1.5.
 Please use <-isStrictTotalOrder instead."
 #-}
 
 <-strictPartialOrder-≈ : StrictPartialOrder _ _ _
-<-strictPartialOrder-≈ = On.strictPartialOrder ℕₚ.<-strictPartialOrder toℕ
+<-strictPartialOrder-≈ = On.strictPartialOrder ℕ.<-strictPartialOrder toℕ
 {-# WARNING_ON_USAGE <-strictPartialOrder-≈
 "Warning: <-strictPartialOrder-≈ was deprecated in v1.5.
 Please use <-strictPartialOrder instead."
 #-}
 
 <-strictTotalOrder-≈ : StrictTotalOrder _ _ _
-<-strictTotalOrder-≈ = On.strictTotalOrder ℕₚ.<-strictTotalOrder toℕ
+<-strictTotalOrder-≈ = On.strictTotalOrder ℕ.<-strictTotalOrder toℕ
 {-# WARNING_ON_USAGE <-strictTotalOrder-≈
 "Warning: <-strictTotalOrder-≈ was deprecated in v1.5.
 Please use <-strictTotalOrder instead."

--- a/src/Data/DifferenceNat.agda
+++ b/src/Data/DifferenceNat.agda
@@ -9,7 +9,7 @@
 
 module Data.DifferenceNat where
 
-open import Data.Nat.Base as N using (ℕ)
+open import Data.Nat.Base as ℕ using (ℕ)
 open import Function.Base using (_⟨_⟩_)
 
 infixl 6 _+_
@@ -21,7 +21,7 @@ Diffℕ = ℕ → ℕ
 0# = λ k → k
 
 suc : Diffℕ → Diffℕ
-suc n = λ k → N.suc (n k)
+suc n = λ k → ℕ.suc (n k)
 
 1# : Diffℕ
 1# = suc 0#
@@ -35,4 +35,4 @@ toℕ n = n 0
 -- fromℕ n is linear in the size of n.
 
 fromℕ : ℕ → Diffℕ
-fromℕ n = λ k → n ⟨ N._+_ ⟩ k
+fromℕ n = λ k → n ⟨ ℕ._+_ ⟩ k

--- a/src/Data/DifferenceVec.agda
+++ b/src/Data/DifferenceVec.agda
@@ -9,9 +9,9 @@
 module Data.DifferenceVec where
 
 open import Data.DifferenceNat
-open import Data.Vec.Base as V using (Vec)
+open import Data.Vec.Base as Vec using (Vec)
 open import Function.Base using (_⟨_⟩_)
-import Data.Nat.Base as N
+import Data.Nat.Base as ℕ
 
 infixr 5 _∷_ _++_
 
@@ -22,7 +22,7 @@ DiffVec A m = ∀ {n} → Vec A n → Vec A (m n)
 [] = λ k → k
 
 _∷_ : ∀ {a} {A : Set a} {n} → A → DiffVec A n → DiffVec A (suc n)
-x ∷ xs = λ k → V._∷_ x (xs k)
+x ∷ xs = λ k → Vec._∷_ x (xs k)
 
 [_] : ∀ {a} {A : Set a} → A → DiffVec A 1#
 [ x ] = x ∷ []
@@ -32,25 +32,25 @@ _++_ : ∀ {a} {A : Set a} {m n} →
 xs ++ ys = λ k → xs (ys k)
 
 toVec : ∀ {a} {A : Set a} {n} → DiffVec A n → Vec A (toℕ n)
-toVec xs = xs V.[]
+toVec xs = xs Vec.[]
 
 -- fromVec xs is linear in the length of xs.
 
 fromVec : ∀ {a} {A : Set a} {n} → Vec A n → DiffVec A (fromℕ n)
-fromVec xs = λ k → xs ⟨ V._++_ ⟩ k
+fromVec xs = λ k → xs ⟨ Vec._++_ ⟩ k
 
 head : ∀ {a} {A : Set a} {n} → DiffVec A (suc n) → A
-head xs = V.head (toVec xs)
+head xs = Vec.head (toVec xs)
 
 tail : ∀ {a} {A : Set a} {n} → DiffVec A (suc n) → DiffVec A n
-tail xs = λ k → V.tail (xs k)
+tail xs = λ k → Vec.tail (xs k)
 
 take : ∀ {a} {A : Set a} m {n} →
        DiffVec A (fromℕ m + n) → DiffVec A (fromℕ m)
-take N.zero    xs = []
-take (N.suc m) xs = head xs ∷ take m (tail xs)
+take ℕ.zero    xs = []
+take (ℕ.suc m) xs = head xs ∷ take m (tail xs)
 
 drop : ∀ {a} {A : Set a} m {n} →
        DiffVec A (fromℕ m + n) → DiffVec A n
-drop N.zero    xs = xs
-drop (N.suc m) xs = drop m (tail xs)
+drop ℕ.zero    xs = xs
+drop (ℕ.suc m) xs = drop m (tail xs)

--- a/src/Data/Fin.agda
+++ b/src/Data/Fin.agda
@@ -9,8 +9,7 @@
 module Data.Fin where
 
 open import Relation.Nullary.Decidable.Core
-open import Data.Nat.Base using (suc)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 
 ------------------------------------------------------------------------
 -- Publicly re-export the contents of the base module
@@ -27,5 +26,5 @@ open import Data.Fin.Properties public
 
 infix 10 #_
 
-#_ : ∀ m {n} {m<n : True (suc m ℕₚ.≤? n)} → Fin n
+#_ : ∀ m {n} {m<n : True (m ℕ.<? n)} → Fin n
 #_ _ {m<n = m<n} = fromℕ< (toWitness m<n)

--- a/src/Data/Fin/Permutation/Components.agda
+++ b/src/Data/Fin/Permutation/Components.agda
@@ -12,7 +12,6 @@ open import Data.Bool.Base using (Bool; true; false)
 open import Data.Fin.Base
 open import Data.Fin.Properties
 open import Data.Nat.Base as ℕ using (zero; suc; _∸_)
-import Data.Nat.Properties as ℕₚ
 open import Data.Product.Base using (proj₂)
 open import Function.Base using (_∘_)
 open import Relation.Nullary.Reflects using (invert)

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -20,7 +20,7 @@ open import Data.Fin.Base
 open import Data.Fin.Patterns
 open import Data.Nat.Base as ℕ
   using (ℕ; zero; suc; s≤s; z≤n; z<s; s<s; s<s⁻¹; _∸_; _^_)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Nat.Solver
 open import Data.Unit using (⊤; tt)
 open import Data.Product.Base as Prod
@@ -174,14 +174,14 @@ toℕ≤pred[n] zero                 = z≤n
 toℕ≤pred[n] (suc {n = suc n} i)  = s≤s (toℕ≤pred[n] i)
 
 toℕ≤n : ∀ (i : Fin n) → toℕ i ℕ.≤ n
-toℕ≤n {suc n} i = ℕₚ.m≤n⇒m≤1+n (toℕ≤pred[n] i)
+toℕ≤n {suc n} i = ℕ.m≤n⇒m≤1+n (toℕ≤pred[n] i)
 
 -- A simpler implementation of toℕ≤pred[n],
 -- however, with a different reduction behavior.
 -- If no one needs the reduction behavior of toℕ≤pred[n],
 -- it can be removed in favor of toℕ≤pred[n]′.
 toℕ≤pred[n]′ : ∀ (i : Fin n) → toℕ i ℕ.≤ ℕ.pred n
-toℕ≤pred[n]′ i = ℕₚ.<⇒≤pred (toℕ<n i)
+toℕ≤pred[n]′ i = ℕ.<⇒≤pred (toℕ<n i)
 
 toℕ-mono-< : i < j → toℕ i ℕ.< toℕ j
 toℕ-mono-< i<j = i<j
@@ -223,7 +223,7 @@ toℕ-fromℕ< {m = zero}  {n = suc _} _   = refl
 toℕ-fromℕ< {m = suc m} {n = suc _} m<n = cong suc (toℕ-fromℕ< (ℕ.s<s⁻¹ m<n))
 
 -- fromℕ is a special case of fromℕ<.
-fromℕ-def : ∀ n → fromℕ n ≡ fromℕ< ℕₚ.≤-refl
+fromℕ-def : ∀ n → fromℕ n ≡ fromℕ< ℕ.≤-refl
 fromℕ-def zero    = refl
 fromℕ-def (suc n) = cong suc (fromℕ-def n)
 
@@ -231,7 +231,7 @@ fromℕ<-cong : ∀ m n {o} → m ≡ n → .(m<o : m ℕ.< o) .(n<o : n ℕ.< o
               fromℕ< m<o ≡ fromℕ< n<o
 fromℕ<-cong 0       0                   _ _   _   = refl
 fromℕ<-cong (suc _) (suc _) {o = suc _} r m<n n<o
-  = cong suc (fromℕ<-cong _ _ (ℕₚ.suc-injective r) (ℕ.s<s⁻¹ m<n) (ℕ.s<s⁻¹ n<o))
+  = cong suc (fromℕ<-cong _ _ (ℕ.suc-injective r) (ℕ.s<s⁻¹ m<n) (ℕ.s<s⁻¹ n<o))
 
 fromℕ<-injective : ∀ m n {o} → .(m<o : m ℕ.< o) .(n<o : n ℕ.< o) →
                    fromℕ< m<o ≡ fromℕ< n<o → m ≡ n
@@ -252,8 +252,8 @@ fromℕ<≡fromℕ<″ {m = suc m} m<n (ℕ.<″-offset _)
 
 toℕ-fromℕ<″ : ∀ (m<n : m ℕ.<″ n) → toℕ (fromℕ<″ m m<n) ≡ m
 toℕ-fromℕ<″ {m} {n} m<n = begin
-  toℕ (fromℕ<″ m m<n)  ≡⟨ cong toℕ (sym (fromℕ<≡fromℕ<″ (ℕₚ.≤″⇒≤ m<n) m<n)) ⟩
-  toℕ (fromℕ< _)       ≡⟨ toℕ-fromℕ< (ℕₚ.≤″⇒≤ m<n) ⟩
+  toℕ (fromℕ<″ m m<n)  ≡⟨ cong toℕ (sym (fromℕ<≡fromℕ<″ (ℕ.≤″⇒≤ m<n) m<n)) ⟩
+  toℕ (fromℕ< _)       ≡⟨ toℕ-fromℕ< (ℕ.≤″⇒≤ m<n) ⟩
   m                    ∎
   where open ≡-Reasoning
 
@@ -267,7 +267,7 @@ toℕ-cast {n = suc n} eq (suc k) = cong suc (toℕ-cast (cong ℕ.pred eq) k)
 
 cast-is-id : .(eq : m ≡ m) (k : Fin m) → cast eq k ≡ k
 cast-is-id eq zero    = refl
-cast-is-id eq (suc k) = cong suc (cast-is-id (ℕₚ.suc-injective eq) k)
+cast-is-id eq (suc k) = cong suc (cast-is-id (ℕ.suc-injective eq) k)
 
 subst-is-cast : (eq : m ≡ n) (k : Fin m) → subst Fin eq k ≡ cast eq k
 subst-is-cast refl k = sym (cast-is-id refl k)
@@ -276,7 +276,7 @@ cast-trans : .(eq₁ : m ≡ n) .(eq₂ : n ≡ o) (k : Fin m) →
              cast eq₂ (cast eq₁ k) ≡ cast (trans eq₁ eq₂) k
 cast-trans {m = suc _} {n = suc _} {o = suc _} eq₁ eq₂ zero = refl
 cast-trans {m = suc _} {n = suc _} {o = suc _} eq₁ eq₂ (suc k) =
-  cong suc (cast-trans (ℕₚ.suc-injective eq₁) (ℕₚ.suc-injective eq₂) k)
+  cong suc (cast-trans (ℕ.suc-injective eq₁) (ℕ.suc-injective eq₂) k)
 
 ------------------------------------------------------------------------
 -- Properties of _≤_
@@ -284,30 +284,30 @@ cast-trans {m = suc _} {n = suc _} {o = suc _} eq₁ eq₂ (suc k) =
 -- Relational properties
 
 ≤-reflexive : _≡_ ⇒ (_≤_ {n})
-≤-reflexive refl = ℕₚ.≤-refl
+≤-reflexive refl = ℕ.≤-refl
 
 ≤-refl : Reflexive (_≤_ {n})
 ≤-refl = ≤-reflexive refl
 
 ≤-trans : Transitive (_≤_ {n})
-≤-trans = ℕₚ.≤-trans
+≤-trans = ℕ.≤-trans
 
 ≤-antisym : Antisymmetric _≡_ (_≤_ {n})
-≤-antisym x≤y y≤x = toℕ-injective (ℕₚ.≤-antisym x≤y y≤x)
+≤-antisym x≤y y≤x = toℕ-injective (ℕ.≤-antisym x≤y y≤x)
 
 ≤-total : Total (_≤_ {n})
-≤-total x y = ℕₚ.≤-total (toℕ x) (toℕ y)
+≤-total x y = ℕ.≤-total (toℕ x) (toℕ y)
 
 ≤-irrelevant : Irrelevant (_≤_ {m} {n})
-≤-irrelevant = ℕₚ.≤-irrelevant
+≤-irrelevant = ℕ.≤-irrelevant
 
 infix 4 _≤?_ _<?_
 
 _≤?_ : B.Decidable (_≤_ {m} {n})
-a ≤? b = toℕ a ℕₚ.≤? toℕ b
+a ≤? b = toℕ a ℕ.≤? toℕ b
 
 _<?_ : B.Decidable (_<_ {m} {n})
-m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
+m <? n = suc (toℕ m) ℕ.≤? toℕ n
 
 ------------------------------------------------------------------------
 -- Structures
@@ -367,13 +367,13 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 -- Relational properties
 
 <-irrefl : Irreflexive _≡_ (_<_ {n})
-<-irrefl refl = ℕₚ.<-irrefl refl
+<-irrefl refl = ℕ.<-irrefl refl
 
 <-asym : Asymmetric (_<_ {n})
-<-asym = ℕₚ.<-asym
+<-asym = ℕ.<-asym
 
 <-trans : Transitive (_<_ {n})
-<-trans = ℕₚ.<-trans
+<-trans = ℕ.<-trans
 
 <-cmp : Trichotomous _≡_ (_<_ {n})
 <-cmp zero    zero    = tri≈ (λ()) refl  (λ())
@@ -394,7 +394,7 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 <-resp₂-≡ = <-respʳ-≡ , <-respˡ-≡
 
 <-irrelevant : Irrelevant (_<_ {m} {n})
-<-irrelevant = ℕₚ.<-irrelevant
+<-irrelevant = ℕ.<-irrelevant
 
 ------------------------------------------------------------------------
 -- Structures
@@ -430,10 +430,10 @@ m <? n = suc (toℕ m) ℕₚ.≤? toℕ n
 -- Other properties
 
 i<1+i : ∀ (i : Fin n) → i < suc i
-i<1+i = ℕₚ.n<1+n ∘ toℕ
+i<1+i = ℕ.n<1+n ∘ toℕ
 
 <⇒≢ : i < j → i ≢ j
-<⇒≢ i<i refl = ℕₚ.n≮n _ i<i
+<⇒≢ i<i refl = ℕ.n≮n _ i<i
 
 ≤∧≢⇒< : i ≤ j → i ≢ j → i < j
 ≤∧≢⇒< {i = zero}  {zero}  _         0≢0   = contradiction refl 0≢0
@@ -466,13 +466,13 @@ toℕ-inject₁ zero    = refl
 toℕ-inject₁ (suc i) = cong suc (toℕ-inject₁ i)
 
 toℕ-inject₁-≢ : ∀ (i : Fin n) → n ≢ toℕ (inject₁ i)
-toℕ-inject₁-≢ (suc i) = toℕ-inject₁-≢ i ∘ ℕₚ.suc-injective
+toℕ-inject₁-≢ (suc i) = toℕ-inject₁-≢ i ∘ ℕ.suc-injective
 
 inject₁ℕ< : ∀ (i : Fin n) → toℕ (inject₁ i) ℕ.< n
 inject₁ℕ< i rewrite toℕ-inject₁ i = toℕ<n i
 
 inject₁ℕ≤ : ∀ (i : Fin n) → toℕ (inject₁ i) ℕ.≤ n
-inject₁ℕ≤ = ℕₚ.<⇒≤ ∘ inject₁ℕ<
+inject₁ℕ≤ = ℕ.<⇒≤ ∘ inject₁ℕ<
 
 ≤̄⇒inject₁< : i ≤ j → inject₁ i < suc j
 ≤̄⇒inject₁< {i = i} i≤j rewrite sym (toℕ-inject₁ i) = s<s i≤j
@@ -482,7 +482,7 @@ inject₁ℕ≤ = ℕₚ.<⇒≤ ∘ inject₁ℕ<
 
 i≤inject₁[j]⇒i≤1+j : i ≤ inject₁ j → i ≤ suc j
 i≤inject₁[j]⇒i≤1+j {i = zero}              _   = z≤n
-i≤inject₁[j]⇒i≤1+j {i = suc i} {j = suc j} i≤j = s≤s (ℕₚ.m≤n⇒m≤1+n (subst (toℕ i ℕ.≤_) (toℕ-inject₁ j) (ℕ.s≤s⁻¹ i≤j)))
+i≤inject₁[j]⇒i≤1+j {i = suc i} {j = suc j} i≤j = s≤s (ℕ.m≤n⇒m≤1+n (subst (toℕ i ℕ.≤_) (toℕ-inject₁ j) (ℕ.s≤s⁻¹ i≤j)))
 
 ------------------------------------------------------------------------
 -- lower₁
@@ -552,7 +552,7 @@ inject≤-idempotent {_} {suc n} {suc o} (suc i) _ _ _ =
   cong suc (inject≤-idempotent i _ _ _)
 
 inject≤-trans : ∀ (i : Fin m) .(m≤n : m ℕ.≤ n) .(n≤o : n ℕ.≤ o) →
-                inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i (ℕₚ.≤-trans m≤n n≤o)
+                inject≤ (inject≤ i m≤n) n≤o ≡ inject≤ i (ℕ.≤-trans m≤n n≤o)
 inject≤-trans i _ _ = inject≤-idempotent i _ _ _
 
 inject≤-injective : ∀ .(m≤n m≤n′ : m ℕ.≤ n) i j →
@@ -571,7 +571,7 @@ inject≤-irrelevant _ _ i = refl
 
 pred< : ∀ (i : Fin (suc n)) → i ≢ zero → pred i < i
 pred< zero    i≢0 = contradiction refl i≢0
-pred< (suc i) _   = ≤̄⇒inject₁< ℕₚ.≤-refl
+pred< (suc i) _   = ≤̄⇒inject₁< ℕ.≤-refl
 
 ------------------------------------------------------------------------
 -- splitAt
@@ -665,7 +665,7 @@ toℕ-combine {suc m} {n} i@0F j = begin
   toℕ (combine i j)          ≡⟨⟩
   toℕ (j ↑ˡ (m ℕ.* n))       ≡⟨ toℕ-↑ˡ j (m ℕ.* n) ⟩
   toℕ j                      ≡⟨⟩
-  0 ℕ.+ toℕ j                ≡⟨ cong (ℕ._+ toℕ j) (ℕₚ.*-zeroʳ n) ⟨
+  0 ℕ.+ toℕ j                ≡⟨ cong (ℕ._+ toℕ j) (ℕ.*-zeroʳ n) ⟨
   n ℕ.* toℕ i ℕ.+ toℕ j      ∎
   where open ≡-Reasoning
 toℕ-combine {suc m} {n} (suc i) j = begin
@@ -680,15 +680,15 @@ combine-monoˡ-< : ∀ {i j : Fin m} (k l : Fin n) →
                   i < j → combine i k < combine j l
 combine-monoˡ-< {m} {n} {i} {j} k l i<j = begin-strict
   toℕ (combine i k)      ≡⟨ toℕ-combine i k ⟩
-  n ℕ.* toℕ i ℕ.+ toℕ k  <⟨ ℕₚ.+-monoʳ-< (n ℕ.* toℕ i) (toℕ<n k) ⟩
-  n ℕ.* toℕ i ℕ.+ n      ≡⟨ ℕₚ.+-comm _ n ⟩
-  n ℕ.+ n ℕ.* toℕ i      ≡⟨ cong (n ℕ.+_) (ℕₚ.*-comm n _) ⟩
-  n ℕ.+ toℕ i ℕ.* n      ≡⟨ ℕₚ.*-comm (suc (toℕ i)) n ⟩
-  n ℕ.* suc (toℕ i)      ≤⟨ ℕₚ.*-monoʳ-≤ n (toℕ-mono-< i<j) ⟩
-  n ℕ.* toℕ j            ≤⟨ ℕₚ.m≤m+n (n ℕ.* toℕ j) (toℕ l) ⟩
+  n ℕ.* toℕ i ℕ.+ toℕ k  <⟨ ℕ.+-monoʳ-< (n ℕ.* toℕ i) (toℕ<n k) ⟩
+  n ℕ.* toℕ i ℕ.+ n      ≡⟨ ℕ.+-comm _ n ⟩
+  n ℕ.+ n ℕ.* toℕ i      ≡⟨ cong (n ℕ.+_) (ℕ.*-comm n _) ⟩
+  n ℕ.+ toℕ i ℕ.* n      ≡⟨ ℕ.*-comm (suc (toℕ i)) n ⟩
+  n ℕ.* suc (toℕ i)      ≤⟨ ℕ.*-monoʳ-≤ n (toℕ-mono-< i<j) ⟩
+  n ℕ.* toℕ j            ≤⟨ ℕ.m≤m+n (n ℕ.* toℕ j) (toℕ l) ⟩
   n ℕ.* toℕ j ℕ.+ toℕ l  ≡⟨ toℕ-combine j l ⟨
   toℕ (combine j l)      ∎
-  where open ℕₚ.≤-Reasoning; open +-*-Solver
+  where open ℕ.≤-Reasoning; open +-*-Solver
 
 combine-injectiveˡ : ∀ (i : Fin m) (j : Fin n) (k : Fin m) (l : Fin n) →
                      combine i j ≡ combine k l → i ≡ k
@@ -701,7 +701,7 @@ combine-injectiveʳ : ∀ (i : Fin m) (j : Fin n) (k : Fin m) (l : Fin n) →
                      combine i j ≡ combine k l → j ≡ l
 combine-injectiveʳ {m} {n} i j k l cᵢⱼ≡cₖₗ
   with refl ← combine-injectiveˡ i j k l cᵢⱼ≡cₖₗ
-  = toℕ-injective (ℕₚ.+-cancelˡ-≡ (n ℕ.* toℕ i) _ _ (begin
+  = toℕ-injective (ℕ.+-cancelˡ-≡ (n ℕ.* toℕ i) _ _ (begin
   n ℕ.* toℕ i ℕ.+ toℕ j ≡⟨ toℕ-combine i j ⟨
   toℕ (combine i j)     ≡⟨ cong toℕ cᵢⱼ≡cₖₗ ⟩
   toℕ (combine i l)     ≡⟨ toℕ-combine i l ⟩
@@ -817,12 +817,12 @@ toℕ‿ℕ- (suc n) (suc i)  = toℕ‿ℕ- n i
 ℕ-ℕ≡toℕ‿ℕ- (suc n) (suc i) = ℕ-ℕ≡toℕ‿ℕ- n i
 
 nℕ-ℕi≤n : ∀ n i → n ℕ-ℕ i ℕ.≤ n
-nℕ-ℕi≤n n       zero     = ℕₚ.≤-refl
+nℕ-ℕi≤n n       zero     = ℕ.≤-refl
 nℕ-ℕi≤n (suc n) (suc i)  = begin
   n ℕ-ℕ i  ≤⟨ nℕ-ℕi≤n n i ⟩
-  n        ≤⟨ ℕₚ.n≤1+n n ⟩
+  n        ≤⟨ ℕ.n≤1+n n ⟩
   suc n    ∎
-  where open ℕₚ.≤-Reasoning
+  where open ℕ.≤-Reasoning
 
 ------------------------------------------------------------------------
 -- punchIn
@@ -1017,10 +1017,10 @@ injective⇒≤ {suc _} {suc _} {f} inj = s≤s (injective⇒≤ (λ eq →
     (contraInjective inj 0≢1+n) eq))))
 
 <⇒notInjective : ∀ {f : Fin m → Fin n} → n ℕ.< m → ¬ (Injective _≡_ _≡_ f)
-<⇒notInjective n<m inj = ℕₚ.≤⇒≯ (injective⇒≤ inj) n<m
+<⇒notInjective n<m inj = ℕ.≤⇒≯ (injective⇒≤ inj) n<m
 
 ℕ→Fin-notInjective : ∀ (f : ℕ → Fin n) → ¬ (Injective _≡_ _≡_ f)
-ℕ→Fin-notInjective f inj = ℕₚ.<-irrefl refl
+ℕ→Fin-notInjective f inj = ℕ.<-irrefl refl
   (injective⇒≤ (Comp.injective _≡_ _≡_ _≡_ toℕ-injective inj))
 
 -- Cantor-Schröder-Bernstein for finite sets
@@ -1028,7 +1028,7 @@ injective⇒≤ {suc _} {suc _} {f} inj = s≤s (injective⇒≤ (λ eq →
 cantor-schröder-bernstein : ∀ {f : Fin m → Fin n} {g : Fin n → Fin m} →
                             Injective _≡_ _≡_ f → Injective _≡_ _≡_ g →
                             m ≡ n
-cantor-schröder-bernstein f-inj g-inj = ℕₚ.≤-antisym
+cantor-schröder-bernstein f-inj g-inj = ℕ.≤-antisym
   (injective⇒≤ f-inj) (injective⇒≤ g-inj)
 
 ------------------------------------------------------------------------
@@ -1086,7 +1086,7 @@ opposite-involutive : Involutive {A = Fin n} _≡_ opposite
 opposite-involutive {suc n} i = toℕ-injective (begin
   toℕ (opposite (opposite i)) ≡⟨ opposite-prop (opposite i) ⟩
   n ∸ (toℕ (opposite i))      ≡⟨ cong (n ∸_) (opposite-prop i) ⟩
-  n ∸ (n ∸ (toℕ i))           ≡⟨ ℕₚ.m∸[m∸n]≡n (toℕ≤pred[n] i) ⟩
+  n ∸ (n ∸ (toℕ i))           ≡⟨ ℕ.m∸[m∸n]≡n (toℕ≤pred[n] i) ⟩
   toℕ i                       ∎)
   where open ≡-Reasoning
 
@@ -1172,14 +1172,14 @@ private
   ≺⇒< (n ≻toℕ i) = toℕ<n i
 
 ≺⇒<′ : _≺_ ⇒ ℕ._<′_
-≺⇒<′ lt = ℕₚ.<⇒<′ (≺⇒< lt)
+≺⇒<′ lt = ℕ.<⇒<′ (≺⇒< lt)
 {-# WARNING_ON_USAGE ≺⇒<′
 "Warning: ≺⇒<′ was deprecated in v2.0.
 Please use <⇒<′ instead."
 #-}
 
 <′⇒≺ : ℕ._<′_ ⇒ _≺_
-<′⇒≺ lt = <⇒≺ (ℕₚ.<′⇒< lt)
+<′⇒≺ lt = <⇒≺ (ℕ.<′⇒< lt)
 {-# WARNING_ON_USAGE <′⇒≺
 "Warning: <′⇒≺ was deprecated in v2.0.
 Please use <′⇒< instead."

--- a/src/Data/Fin/Subset/Properties.agda
+++ b/src/Data/Fin/Subset/Properties.agda
@@ -22,7 +22,7 @@ open import Data.Fin.Base using (Fin; suc; zero)
 open import Data.Fin.Subset
 open import Data.Fin.Properties using (any?; decFinSubset)
 open import Data.Nat.Base hiding (∣_-_∣)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product as Product using (∃; ∄; _×_; _,_; proj₁)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Vec.Base
@@ -134,8 +134,8 @@ nonempty? p = any? (_∈? p)
 ∣p∣≤n = count≤n (_≟ inside)
 
 ∣p∣≤∣x∷p∣ : ∀ x (p : Subset n)  → ∣ p ∣ ≤ ∣ x ∷ p ∣
-∣p∣≤∣x∷p∣ outside p = ℕₚ.≤-refl
-∣p∣≤∣x∷p∣ inside  p = ℕₚ.n≤1+n ∣ p ∣
+∣p∣≤∣x∷p∣ outside p = ℕ.≤-refl
+∣p∣≤∣x∷p∣ inside  p = ℕ.n≤1+n ∣ p ∣
 
 ------------------------------------------------------------------------
 -- ⊥
@@ -166,8 +166,8 @@ nonempty? p = any? (_∈? p)
 
 ∣p∣≡n⇒p≡⊤ : ∣ p ∣ ≡ n → p ≡ ⊤ {n}
 ∣p∣≡n⇒p≡⊤ {p = []}          _     = refl
-∣p∣≡n⇒p≡⊤ {p = outside ∷ p} |p|≡n = contradiction |p|≡n (ℕₚ.<⇒≢ (s≤s (∣p∣≤n p)))
-∣p∣≡n⇒p≡⊤ {p = inside  ∷ p} |p|≡n = cong (inside ∷_) (∣p∣≡n⇒p≡⊤ (ℕₚ.suc-injective |p|≡n))
+∣p∣≡n⇒p≡⊤ {p = outside ∷ p} |p|≡n = contradiction |p|≡n (ℕ.<⇒≢ (s≤s (∣p∣≤n p)))
+∣p∣≡n⇒p≡⊤ {p = inside  ∷ p} |p|≡n = cong (inside ∷_) (∣p∣≡n⇒p≡⊤ (ℕ.suc-injective |p|≡n))
 
 ------------------------------------------------------------------------
 -- ⁅_⁆
@@ -257,7 +257,7 @@ module _ (n : ℕ) where
 p⊆q⇒∣p∣≤∣q∣ : p ⊆ q → ∣ p ∣ ≤ ∣ q ∣
 p⊆q⇒∣p∣≤∣q∣ {p = []}          {[]}          p⊆q = z≤n
 p⊆q⇒∣p∣≤∣q∣ {p = outside ∷ p} {outside ∷ q} p⊆q = p⊆q⇒∣p∣≤∣q∣ (drop-∷-⊆ p⊆q)
-p⊆q⇒∣p∣≤∣q∣ {p = outside ∷ p} {inside  ∷ q} p⊆q = ℕₚ.m≤n⇒m≤1+n (p⊆q⇒∣p∣≤∣q∣ (drop-∷-⊆ p⊆q))
+p⊆q⇒∣p∣≤∣q∣ {p = outside ∷ p} {inside  ∷ q} p⊆q = ℕ.m≤n⇒m≤1+n (p⊆q⇒∣p∣≤∣q∣ (drop-∷-⊆ p⊆q))
 p⊆q⇒∣p∣≤∣q∣ {p = inside  ∷ p} {outside ∷ q} p⊆q = contradiction (p⊆q here) λ()
 p⊆q⇒∣p∣≤∣q∣ {p = inside  ∷ p} {inside  ∷ q} p⊆q = s≤s (p⊆q⇒∣p∣≤∣q∣ (drop-∷-⊆ p⊆q))
 
@@ -358,7 +358,7 @@ p∪∁p≡⊤ (inside  ∷ p) = cong (inside ∷_) (p∪∁p≡⊤ p)
 ∣∁p∣≡n∸∣p∣ (inside  ∷ p) = ∣∁p∣≡n∸∣p∣ p
 ∣∁p∣≡n∸∣p∣ (outside ∷ p) = begin
   suc ∣ ∁ p ∣     ≡⟨ cong suc (∣∁p∣≡n∸∣p∣ p) ⟩
-  suc (_ ∸ ∣ p ∣) ≡⟨ sym (ℕₚ.+-∸-assoc 1 (∣p∣≤n p)) ⟩
+  suc (_ ∸ ∣ p ∣) ≡⟨ sym (ℕ.+-∸-assoc 1 (∣p∣≤n p)) ⟩
   suc  _ ∸ ∣ p ∣  ∎
   where open ≡-Reasoning
 
@@ -515,7 +515,7 @@ x∈p∩q⁻ (s      ∷ p) (t      ∷ q) (there x∈p∩q) =
 ∣p∩q∣≤∣q∣ p q = p⊆q⇒∣p∣≤∣q∣ (p∩q⊆q p q)
 
 ∣p∩q∣≤∣p∣⊓∣q∣ : ∀ (p q : Subset n) → ∣ p ∩ q ∣ ≤ ∣ p ∣ ⊓ ∣ q ∣
-∣p∩q∣≤∣p∣⊓∣q∣ p q = ℕₚ.⊓-glb (∣p∩q∣≤∣p∣ p q) (∣p∩q∣≤∣q∣ p q)
+∣p∩q∣≤∣p∣⊓∣q∣ p q = ℕ.⊓-glb (∣p∩q∣≤∣p∣ p q) (∣p∩q∣≤∣q∣ p q)
 
 ------------------------------------------------------------------------
 -- _∪_
@@ -753,7 +753,7 @@ x∈p∪q⁺ (inj₂ x∈q) = q⊆p∪q _ _ x∈q
 ∣q∣≤∣p∪q∣ p q = p⊆q⇒∣p∣≤∣q∣ (q⊆p∪q p q)
 
 ∣p∣⊔∣q∣≤∣p∪q∣ : ∀ (p q : Subset n) → ∣ p ∣ ⊔ ∣ q ∣ ≤ ∣ p ∪ q ∣
-∣p∣⊔∣q∣≤∣p∪q∣ p q = ℕₚ.⊔-lub (∣p∣≤∣p∪q∣ p q) (∣q∣≤∣p∪q∣ p q)
+∣p∣⊔∣q∣≤∣p∪q∣ p q = ℕ.⊔-lub (∣p∣≤∣p∪q∣ p q) (∣q∣≤∣p∪q∣ p q)
 
 ------------------------------------------------------------------------
 -- Properties of _─_

--- a/src/Data/Float/Properties.agda
+++ b/src/Data/Float/Properties.agda
@@ -10,11 +10,11 @@ module Data.Float.Properties where
 
 open import Data.Bool.Base as Bool using (Bool)
 open import Data.Float.Base
-import Data.Maybe.Base as M
-import Data.Maybe.Properties as Mₚ
-import Data.Nat.Properties as Nₚ
+import Data.Maybe.Base as Maybe
+import Data.Maybe.Properties as Maybe
+import Data.Nat.Properties as ℕ
 import Data.Word.Base as Word
-import Data.Word.Properties as Wₚ
+import Data.Word.Properties as Word
 open import Function.Base using (_∘_)
 open import Relation.Nullary.Decidable as RN using (map′)
 open import Relation.Binary.Core using (_⇒_)
@@ -37,10 +37,10 @@ open import Agda.Builtin.Float.Properties
 -- Properties of _≈_
 
 ≈⇒≡ : _≈_ ⇒ _≡_
-≈⇒≡ eq = toWord-injective _ _ (Mₚ.map-injective Wₚ.≈⇒≡ eq)
+≈⇒≡ eq = toWord-injective _ _ (Maybe.map-injective Word.≈⇒≡ eq)
 
 ≈-reflexive : _≡_ ⇒ _≈_
-≈-reflexive eq = cong (M.map Word.toℕ ∘ toWord) eq
+≈-reflexive eq = cong (Maybe.map Word.toℕ ∘ toWord) eq
 
 ≈-refl : Reflexive _≈_
 ≈-refl = refl
@@ -56,7 +56,7 @@ open import Agda.Builtin.Float.Properties
 
 infix 4 _≈?_
 _≈?_ : Decidable _≈_
-_≈?_ = On.decidable (M.map Word.toℕ ∘ toWord) _≡_ (Mₚ.≡-dec Nₚ._≟_)
+_≈?_ = On.decidable (Maybe.map Word.toℕ ∘ toWord) _≡_ (Maybe.≡-dec ℕ._≟_)
 
 ≈-isEquivalence : IsEquivalence _≈_
 ≈-isEquivalence = record

--- a/src/Data/Graph/Acyclic.agda
+++ b/src/Data/Graph/Acyclic.agda
@@ -13,13 +13,12 @@
 module Data.Graph.Acyclic where
 
 open import Level using (_⊔_)
-open import Data.Nat.Base as Nat using (ℕ; zero; suc; _<′_)
+open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _<′_)
 open import Data.Nat.Induction using (<′-rec; <′-Rec)
-import Data.Nat.Properties as Nat
+import Data.Nat.Properties as ℕ
 open import Data.Fin as Fin
   using (Fin; Fin′; zero; suc; #_; toℕ; _≟_; opposite) renaming (_ℕ-ℕ_ to _-_)
-import Data.Fin.Properties as FP
-import Data.Fin.Permutation.Components as PC
+import Data.Fin.Properties as Fin
 open import Data.Product.Base as Prod using (∃; _×_; _,_)
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; decToMaybe)
 open import Data.Empty
@@ -36,7 +35,7 @@ open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
 private
 
   lemma : ∀ n (i : Fin n) → n - suc i <′ n
-  lemma (suc n) i  = Nat.≤⇒≤′ $ Nat.s≤s $ FP.nℕ-ℕi≤n n i
+  lemma (suc n) i  = ℕ.≤⇒≤′ $ ℕ.s≤s $ Fin.nℕ-ℕi≤n n i
 
 ------------------------------------------------------------------------
 -- Node contexts
@@ -253,7 +252,7 @@ private
 -- Weakens a node label.
 
 weaken : ∀ {n} {i : Fin n} → Fin (n - suc i) → Fin n
-weaken {n} {i} j = Fin.inject≤ j (FP.nℕ-ℕi≤n n (suc i))
+weaken {n} {i} j = Fin.inject≤ j (Fin.nℕ-ℕi≤n n (suc i))
 
 -- Labels each node with its node number.
 

--- a/src/Data/Integer/Divisibility.agda
+++ b/src/Data/Integer/Divisibility.agda
@@ -1,4 +1,4 @@
-------------------------------------------------------------------------
+-----------------------------------------------------------------------
 -- The Agda standard library
 --
 -- Unsigned divisibility
@@ -14,9 +14,7 @@ open import Function.Base using (_on_; _$_)
 open import Data.Integer.Base
 open import Data.Integer.Properties
 import Data.Nat.Base as ℕ
-import Data.Nat.Properties as ℕᵖ
 import Data.Nat.Divisibility as ℕᵈ
-import Data.Nat.Coprimality as ℕᶜ
 open import Level
 open import Relation.Binary.Core using (Rel; _Preserves_⟶_)
 open import Relation.Binary.PropositionalEquality

--- a/src/Data/List/Extrema/Nat.agda
+++ b/src/Data/List/Extrema/Nat.agda
@@ -12,7 +12,7 @@
 module Data.List.Extrema.Nat where
 
 open import Data.Nat.Base using (ℕ; _≤_; _<_)
-open import Data.Nat.Properties as ℕₚ using (≤∧≢⇒<; <⇒≤; <⇒≢)
+open import Data.Nat.Properties as ℕ using (≤∧≢⇒<; <⇒≤; <⇒≢)
 open import Data.Sum.Base as Sum using (_⊎_)
 open import Data.List.Base using (List)
 import Data.List.Extrema
@@ -33,7 +33,7 @@ private
   <×⇒< : ∀ {x y} → x ≤ y × x ≢ y → x < y
   <×⇒< (x≤y , x≢y) = ≤∧≢⇒< x≤y x≢y
 
-  module Extrema = Data.List.Extrema ℕₚ.≤-totalOrder
+  module Extrema = Data.List.Extrema ℕ.≤-totalOrder
 
 ------------------------------------------------------------------------
 -- Re-export the contents of Extrema

--- a/src/Data/List/Relation/Binary/Infix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Infix/Heterogeneous/Properties.agda
@@ -13,7 +13,7 @@ open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
 open import Data.List.Base as List using (List; []; _∷_; length; map; filter; replicate)
 open import Data.Nat.Base using (zero; suc; _≤_)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Function.Base using (case_of_; _$′_)
 
@@ -68,7 +68,7 @@ module _ {c t} {C : Set c} {T : REL A C t} where
 
 length-mono : ∀ {as bs} → Infix R as bs → length as ≤ length bs
 length-mono (here pref) = Prefixₚ.length-mono pref
-length-mono (there p)   = ℕₚ.m≤n⇒m≤1+n (length-mono p)
+length-mono (there p)   = ℕ.m≤n⇒m≤1+n (length-mono p)
 
 ------------------------------------------------------------------------
 -- As an order
@@ -98,20 +98,20 @@ module _ {c t} {C : Set c} {T : REL A C t} where
   antisym : Antisym R S T → Antisym (Infix R) (Infix S) (Pointwise T)
   antisym asym (here p) (here q) = Prefixₚ.antisym asym p q
   antisym asym {i = a ∷ as} {j = bs} p@(here _) (there q)
-    = ⊥-elim $′ ℕₚ.<-irrefl refl $′ begin-strict
+    = ⊥-elim $′ ℕ.<-irrefl refl $′ begin-strict
       length as <⟨ length-mono p ⟩
       length bs ≤⟨ length-mono q ⟩
-      length as ∎ where open ℕₚ.≤-Reasoning
+      length as ∎ where open ℕ.≤-Reasoning
   antisym asym {i = as} {j = b ∷ bs} (there p) q@(here _)
-    = ⊥-elim $′ ℕₚ.<-irrefl refl $′ begin-strict
+    = ⊥-elim $′ ℕ.<-irrefl refl $′ begin-strict
       length bs <⟨ length-mono q ⟩
       length as ≤⟨ length-mono p ⟩
-      length bs ∎ where open ℕₚ.≤-Reasoning
+      length bs ∎ where open ℕ.≤-Reasoning
   antisym asym {i = a ∷ as} {j = b ∷ bs} (there p) (there q)
-    = ⊥-elim $′ ℕₚ.<-irrefl refl $′ begin-strict
+    = ⊥-elim $′ ℕ.<-irrefl refl $′ begin-strict
       length as <⟨ length-mono p ⟩
       length bs <⟨ length-mono q ⟩
-      length as ∎ where open ℕₚ.≤-Reasoning
+      length as ∎ where open ℕ.≤-Reasoning
 
 ------------------------------------------------------------------------
 -- map

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -23,7 +23,7 @@ open import Data.List.Relation.Binary.Sublist.Heterogeneous
 
 open import Data.Maybe.Relation.Unary.All as MAll using (nothing; just)
 open import Data.Nat.Base using (ℕ; _≤_; _≥_); open ℕ; open _≤_
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (∃₂; _×_; _,_; <_,_>; proj₂; uncurry)
 
 open import Function.Base
@@ -62,7 +62,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   length-mono-≤ : ∀ {as bs} → Sublist R as bs → length as ≤ length bs
   length-mono-≤ []        = z≤n
-  length-mono-≤ (y ∷ʳ rs) = ℕₚ.m≤n⇒m≤1+n (length-mono-≤ rs)
+  length-mono-≤ (y ∷ʳ rs) = ℕ.m≤n⇒m≤1+n (length-mono-≤ rs)
   length-mono-≤ (r ∷ rs)  = s≤s (length-mono-≤ rs)
 
 ------------------------------------------------------------------------
@@ -75,9 +75,9 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   toPointwise : ∀ {as bs} → length as ≡ length bs →
                 Sublist R as bs → Pointwise R as bs
   toPointwise {bs = []}     eq []         = []
-  toPointwise {bs = b ∷ bs} eq (r ∷ rs)   = r ∷ toPointwise (ℕₚ.suc-injective eq) rs
+  toPointwise {bs = b ∷ bs} eq (r ∷ rs)   = r ∷ toPointwise (ℕ.suc-injective eq) rs
   toPointwise {bs = b ∷ bs} eq (b ∷ʳ rs) =
-    ⊥-elim $ ℕₚ.<-irrefl eq (s≤s (length-mono-≤ rs))
+    ⊥-elim $ ℕ.<-irrefl eq (s≤s (length-mono-≤ rs))
 
 ------------------------------------------------------------------------
 -- Various functions' outputs are sublists
@@ -190,7 +190,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   ++⁻ : ∀ {as bs cs ds} → length as ≡ length bs →
         Sublist R (as ++ cs) (bs ++ ds) → Sublist R cs ds
   ++⁻ {[]}     {[]}     eq rs = rs
-  ++⁻ {a ∷ as} {b ∷ bs} eq rs = ++⁻ (ℕₚ.suc-injective eq) (∷⁻ rs)
+  ++⁻ {a ∷ as} {b ∷ bs} eq rs = ++⁻ (ℕ.suc-injective eq) (∷⁻ rs)
 
   ++ˡ : ∀ {as bs} (cs : List B) → Sublist R as bs → Sublist R as (cs ++ bs)
   ++ˡ zs = ++⁺ (minimum zs)
@@ -223,7 +223,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
           Sublist R (drop m as) (drop n bs)
   drop⁺ {m} z≤n       rs        = drop-Sublist m rs
   drop⁺     (s≤s m≥n) []        = []
-  drop⁺     (s≤s m≥n) (y ∷ʳ rs) = drop⁺ (ℕₚ.m≤n⇒m≤1+n m≥n) rs
+  drop⁺     (s≤s m≥n) (y ∷ʳ rs) = drop⁺ (ℕ.m≤n⇒m≤1+n m≥n) rs
   drop⁺     (s≤s m≥n) (r ∷ rs)  = drop⁺ m≥n rs
 
   drop⁺-≥ : ∀ {m n as bs} → m ≥ n → Pointwise R as bs →
@@ -232,7 +232,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   drop⁺-⊆ : ∀ {as bs} m → Sublist R as bs →
             Sublist R (drop m as) (drop m bs)
-  drop⁺-⊆ m = drop⁺ (ℕₚ.≤-refl {m})
+  drop⁺-⊆ m = drop⁺ (ℕ.≤-refl {m})
 
 module _ {a b r p q} {A : Set a} {B : Set b}
          {R : REL A B r} {P : Pred A p} {Q : Pred B q}
@@ -385,25 +385,25 @@ module Antisymmetry
     {R : REL A B r} {S : REL B A s} {E : REL A B e}
     (rs⇒e : Antisym R S E) where
 
-  open ℕₚ.≤-Reasoning
+  open ℕ.≤-Reasoning
 
   antisym : Antisym (Sublist R) (Sublist S) (Pointwise E)
   antisym []        []        = []
   antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss
   -- impossible cases
   antisym (_∷ʳ_ {xs} {ys₁} y rs) (_∷ʳ_ {ys₂} {zs} z ss) =
-    ⊥-elim $ ℕₚ.<-irrefl P.refl $ begin
+    ⊥-elim $ ℕ.<-irrefl P.refl $ begin
     length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
-    length zs        ≤⟨ ℕₚ.n≤1+n (length zs) ⟩
+    length zs        ≤⟨ ℕ.n≤1+n (length zs) ⟩
     length (z ∷ zs)  ≤⟨ length-mono-≤ rs ⟩
     length ys₁       ∎
   antisym (_∷ʳ_ {xs} {ys₁} y rs) (_∷_ {y} {ys₂} {z} {zs} s ss)  =
-    ⊥-elim $ ℕₚ.<-irrefl P.refl $ begin
+    ⊥-elim $ ℕ.<-irrefl P.refl $ begin
     length (z ∷ zs) ≤⟨ length-mono-≤ rs ⟩
     length ys₁      ≤⟨ length-mono-≤ ss ⟩
     length zs       ∎
   antisym (_∷_ {x} {xs} {y} {ys₁} r rs)  (_∷ʳ_ {ys₂} {zs} z ss) =
-    ⊥-elim $ ℕₚ.<-irrefl P.refl $ begin
+    ⊥-elim $ ℕ.<-irrefl P.refl $ begin
     length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
     length xs        ≤⟨ length-mono-≤ rs ⟩
     length ys₁       ∎

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Solver.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Solver.agda
@@ -21,8 +21,8 @@ module Data.List.Relation.Binary.Sublist.Heterogeneous.Solver
 
 open import Level using (_⊔_)
 open import Data.Fin as Fin
-open import Data.Maybe.Base as M
-open import Data.Nat.Base as Nat using (ℕ)
+open import Data.Maybe.Base as Maybe
+open import Data.Nat.Base as ℕ using (ℕ)
 open import Data.Product.Base using (Σ-syntax; _,_)
 open import Data.Vec.Base as Vec using (Vec ; lookup)
 open import Data.List.Base hiding (lookup)
@@ -124,8 +124,8 @@ private
 
 -- Solver for items
 solveI : ∀ {n} (a b : Item n) → Maybe (a ⊆I b)
-solveI (var k) (var l) = M.map var $ decToMaybe (k Fin.≟ l)
-solveI (val a) (val b) = M.map val $ decToMaybe (R? a b)
+solveI (var k) (var l) = Maybe.map var $ decToMaybe (k Fin.≟ l)
+solveI (val a) (val b) = Maybe.map val $ decToMaybe (R? a b)
 solveI _ _ = nothing
 
 -- Solver for linearised expressions
@@ -135,8 +135,8 @@ solveR [] e  = just (λ ρ → minimum _)
 solveR d  [] = nothing
 -- actual work
 solveR (a ∷ d) (b ∷ e) with solveI a b
-... | just it = M.map (keep-it it d e) (solveR d e)
-... | nothing = M.map (skip-it b (a ∷ d) e) (solveR (a ∷ d) e)
+... | just it = Maybe.map (keep-it it d e) (solveR d e)
+... | nothing = Maybe.map (skip-it b (a ∷ d) e) (solveR (a ∷ d) e)
 
 -- Coming back to ASTs thanks to flatten
 

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -16,7 +16,7 @@ open import Data.List.Base hiding (_∷ʳ_)
 open import Data.List.Relation.Unary.Any using (Any)
 import Data.Maybe.Relation.Unary.All as Maybe
 open import Data.Nat.Base using (_≤_; _≥_)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (∃; _,_; proj₂)
 open import Function.Base
 open import Function.Bundles using (_⇔_; _⤖_)
@@ -159,7 +159,7 @@ module _ {m n} {xs : List A} where
 module _ {xs ys : List A} where
 
   drop⁺-⊆ : ∀ n → xs ⊆ ys → drop n xs ⊆ drop n ys
-  drop⁺-⊆ n xs⊆ys = drop⁺ {n} ℕₚ.≤-refl xs⊆ys
+  drop⁺-⊆ n xs⊆ys = drop⁺ {n} ℕ.≤-refl xs⊆ys
 
 ------------------------------------------------------------------------
 -- takeWhile / dropWhile

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -18,8 +18,8 @@ open import Data.Nat.Binary.Base
 open import Data.Nat as ℕ using (ℕ; z≤n; s≤s; s<s⁻¹)
 open import Data.Nat.DivMod using (_%_; _/_; m/n≤m; +-distrib-/-∣ˡ)
 open import Data.Nat.Divisibility using (∣-refl)
-import Data.Nat.Base as ℕᵇ
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Base as ℕ
+import Data.Nat.Properties as ℕ
 open import Data.Nat.Solver
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂; ∃)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
@@ -39,7 +39,7 @@ open import Relation.Nullary.Negation using (contradiction)
 open import Algebra.Definitions {A = ℕᵇ} _≡_
 open import Algebra.Structures {A = ℕᵇ} _≡_
 import Algebra.Properties.CommutativeSemigroup as CommSemigProp
-import Algebra.Properties.CommutativeSemigroup ℕₚ.+-commutativeSemigroup
+import Algebra.Properties.CommutativeSemigroup ℕ.+-commutativeSemigroup
   as ℕ-+-semigroupProperties
 import Relation.Binary.Construct.StrictToNonStrict _≡_ _<_
   as StrictToNonStrict
@@ -94,16 +94,16 @@ zero     ≟ 1+[2 _ ] =  no λ()
 toℕ-double : ∀ x → toℕ (double x) ≡ 2 ℕ.* (toℕ x)
 toℕ-double zero     =  refl
 toℕ-double 1+[2 x ] =  cong ((2 ℕ.*_) ∘ ℕ.suc) (toℕ-double x)
-toℕ-double 2[1+ x ] =  cong (2 ℕ.*_) (sym (ℕₚ.*-distribˡ-+ 2 1 (toℕ x)))
+toℕ-double 2[1+ x ] =  cong (2 ℕ.*_) (sym (ℕ.*-distribˡ-+ 2 1 (toℕ x)))
 
 toℕ-suc : ∀ x → toℕ (suc x) ≡ ℕ.suc (toℕ x)
 toℕ-suc zero     =  refl
 toℕ-suc 2[1+ x ] =  cong (ℕ.suc ∘ (2 ℕ.*_)) (toℕ-suc x)
-toℕ-suc 1+[2 x ] =  ℕₚ.*-distribˡ-+ 2 1 (toℕ x)
+toℕ-suc 1+[2 x ] =  ℕ.*-distribˡ-+ 2 1 (toℕ x)
 
 toℕ-pred : ∀ x → toℕ (pred x) ≡ ℕ.pred (toℕ x)
 toℕ-pred zero     =  refl
-toℕ-pred 2[1+ x ] =  cong ℕ.pred $ sym $ ℕₚ.*-distribˡ-+ 2 1 (toℕ x)
+toℕ-pred 2[1+ x ] =  cong ℕ.pred $ sym $ ℕ.*-distribˡ-+ 2 1 (toℕ x)
 toℕ-pred 1+[2 x ] =  toℕ-double x
 
 toℕ-fromℕ' : toℕ ∘ fromℕ' ≗ id
@@ -116,7 +116,7 @@ toℕ-fromℕ' (ℕ.suc n) = begin
   where open ≡-Reasoning
 
 fromℕ≡fromℕ' : fromℕ ≗ fromℕ'
-fromℕ≡fromℕ' n = fromℕ-helper≡fromℕ' n n ℕₚ.≤-refl
+fromℕ≡fromℕ' n = fromℕ-helper≡fromℕ' n n ℕ.≤-refl
   where
   split : ℕᵇ → Maybe Bool × ℕᵇ
   split zero     = nothing , zero
@@ -170,7 +170,7 @@ fromℕ≡fromℕ' n = fromℕ-helper≡fromℕ' n n ℕₚ.≤-refl
       just (n % 2 ℕ.≡ᵇ 0) , fromℕ' (n / 2)               ≡⟨ cong₂ _,_ (head-homo n) (tail-homo n) ⟨
       head (fromℕ' (ℕ.suc n)) , tail (fromℕ' (ℕ.suc n))  ≡⟨⟩
       split (fromℕ' (ℕ.suc n))                           ∎)
-    where rec-n/2 = fromℕ-helper≡fromℕ' (n / 2) w (ℕₚ.≤-trans (m/n≤m n 2) n≤w)
+    where rec-n/2 = fromℕ-helper≡fromℕ' (n / 2) w (ℕ.≤-trans (m/n≤m n 2) n≤w)
 
 toℕ-fromℕ : toℕ ∘ fromℕ ≗ id
 toℕ-fromℕ n rewrite fromℕ≡fromℕ' n = toℕ-fromℕ' n
@@ -179,20 +179,20 @@ toℕ-injective : Injective _≡_ _≡_ toℕ
 toℕ-injective {zero}     {zero}     _               =  refl
 toℕ-injective {2[1+ x ]} {2[1+ y ]} 2[1+xN]≡2[1+yN] =  cong 2[1+_] x≡y
   where
-  1+xN≡1+yN = ℕₚ.*-cancelˡ-≡ (ℕ.suc _) (ℕ.suc _) 2 2[1+xN]≡2[1+yN]
+  1+xN≡1+yN = ℕ.*-cancelˡ-≡ (ℕ.suc _) (ℕ.suc _) 2 2[1+xN]≡2[1+yN]
   xN≡yN     = cong ℕ.pred 1+xN≡1+yN
   x≡y       = toℕ-injective xN≡yN
 
 toℕ-injective {2[1+ x ]} {1+[2 y ]} 2[1+xN]≡1+2yN =
-  contradiction 2[1+xN]≡1+2yN (ℕₚ.even≢odd (ℕ.suc (toℕ x)) (toℕ y))
+  contradiction 2[1+xN]≡1+2yN (ℕ.even≢odd (ℕ.suc (toℕ x)) (toℕ y))
 
 toℕ-injective {1+[2 x ]} {2[1+ y ]} 1+2xN≡2[1+yN] =
-  contradiction (sym 1+2xN≡2[1+yN]) (ℕₚ.even≢odd (ℕ.suc (toℕ y)) (toℕ x))
+  contradiction (sym 1+2xN≡2[1+yN]) (ℕ.even≢odd (ℕ.suc (toℕ y)) (toℕ x))
 
 toℕ-injective {1+[2 x ]} {1+[2 y ]} 1+2xN≡1+2yN =  cong 1+[2_] x≡y
   where
   2xN≡2yN = cong ℕ.pred 1+2xN≡1+2yN
-  xN≡yN   = ℕₚ.*-cancelˡ-≡ _ _ 2 2xN≡2yN
+  xN≡yN   = ℕ.*-cancelˡ-≡ _ _ 2 2xN≡2yN
   x≡y     = toℕ-injective xN≡yN
 
 toℕ-surjective : Surjective _≡_ _≡_ toℕ
@@ -285,43 +285,43 @@ x≢0⇒x>0 {1+[2 _ ]} _   =  0<odd
 -- Properties of _<_ and toℕ & fromℕ.
 
 toℕ-mono-< : toℕ Preserves _<_ ⟶ ℕ._<_
-toℕ-mono-< {zero}     {2[1+ _ ]} _               =  ℕₚ.0<1+n
-toℕ-mono-< {zero}     {1+[2 _ ]} _               =  ℕₚ.0<1+n
+toℕ-mono-< {zero}     {2[1+ _ ]} _               =  ℕ.0<1+n
+toℕ-mono-< {zero}     {1+[2 _ ]} _               =  ℕ.0<1+n
 toℕ-mono-< {2[1+ x ]} {2[1+ y ]} (even<even x<y) =  begin
-  ℕ.suc (2 ℕ.* (ℕ.suc xN))    ≤⟨ ℕₚ.+-monoʳ-≤ 1 (ℕₚ.*-monoʳ-≤ 2 xN<yN) ⟩
-  ℕ.suc (2 ℕ.* yN)            ≤⟨ ℕₚ.n≤1+n _ ⟩
-  2 ℕ.+ (2 ℕ.* yN)            ≡⟨ sym (ℕₚ.*-distribˡ-+ 2 1 yN) ⟩
+  ℕ.suc (2 ℕ.* (ℕ.suc xN))    ≤⟨ ℕ.+-monoʳ-≤ 1 (ℕ.*-monoʳ-≤ 2 xN<yN) ⟩
+  ℕ.suc (2 ℕ.* yN)            ≤⟨ ℕ.n≤1+n _ ⟩
+  2 ℕ.+ (2 ℕ.* yN)            ≡⟨ sym (ℕ.*-distribˡ-+ 2 1 yN) ⟩
   2 ℕ.* (ℕ.suc yN)            ∎
-  where open ℕₚ.≤-Reasoning;  xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
+  where open ℕ.≤-Reasoning;  xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
 toℕ-mono-< {2[1+ x ]} {1+[2 y ]} (even<odd x<y) =
-  ℕₚ.+-monoʳ-≤ 1 (ℕₚ.*-monoʳ-≤ 2 (toℕ-mono-< x<y))
+  ℕ.+-monoʳ-≤ 1 (ℕ.*-monoʳ-≤ 2 (toℕ-mono-< x<y))
 toℕ-mono-< {1+[2 x ]} {2[1+ y ]} (odd<even (inj₁ x<y)) =   begin
   ℕ.suc (ℕ.suc (2 ℕ.* xN))    ≡⟨⟩
-  2 ℕ.+ (2 ℕ.* xN)            ≡⟨ sym (ℕₚ.*-distribˡ-+ 2 1 xN) ⟩
-  2 ℕ.* (ℕ.suc xN)            ≤⟨ ℕₚ.*-monoʳ-≤ 2 xN<yN ⟩
-  2 ℕ.* yN                    ≤⟨ ℕₚ.*-monoʳ-≤ 2 (ℕₚ.n≤1+n _) ⟩
+  2 ℕ.+ (2 ℕ.* xN)            ≡⟨ sym (ℕ.*-distribˡ-+ 2 1 xN) ⟩
+  2 ℕ.* (ℕ.suc xN)            ≤⟨ ℕ.*-monoʳ-≤ 2 xN<yN ⟩
+  2 ℕ.* yN                    ≤⟨ ℕ.*-monoʳ-≤ 2 (ℕ.n≤1+n _) ⟩
   2 ℕ.* (ℕ.suc yN)            ∎
-  where open ℕₚ.≤-Reasoning;  xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
+  where open ℕ.≤-Reasoning;  xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
 toℕ-mono-< {1+[2 x ]} {2[1+ .x ]} (odd<even (inj₂ refl)) =
-  ℕₚ.≤-reflexive (sym (ℕₚ.*-distribˡ-+ 2 1 (toℕ x)))
-toℕ-mono-< {1+[2 x ]} {1+[2 y ]} (odd<odd x<y) =  ℕₚ.+-monoʳ-< 1 (ℕₚ.*-monoʳ-< 2 xN<yN)
+  ℕ.≤-reflexive (sym (ℕ.*-distribˡ-+ 2 1 (toℕ x)))
+toℕ-mono-< {1+[2 x ]} {1+[2 y ]} (odd<odd x<y) =  ℕ.+-monoʳ-< 1 (ℕ.*-monoʳ-< 2 xN<yN)
   where xN = toℕ x;  yN = toℕ y;  xN<yN = toℕ-mono-< x<y
 
 toℕ-cancel-< : ∀ {x y} → toℕ x ℕ.< toℕ y → x < y
 toℕ-cancel-< {zero}     {2[1+ y ]} x<y = 0<even
 toℕ-cancel-< {zero}     {1+[2 y ]} x<y = 0<odd
 toℕ-cancel-< {2[1+ x ]} {2[1+ y ]} x<y =
-  even<even (toℕ-cancel-< (s<s⁻¹ (ℕₚ.*-cancelˡ-< 2 _ _ x<y)))
+  even<even (toℕ-cancel-< (s<s⁻¹ (ℕ.*-cancelˡ-< 2 _ _ x<y)))
 toℕ-cancel-< {2[1+ x ]} {1+[2 y ]} x<y
-  rewrite ℕₚ.*-distribˡ-+ 2 1 (toℕ x) =
-  even<odd (toℕ-cancel-< (ℕₚ.*-cancelˡ-< 2 _ _ (ℕₚ.≤-trans (s≤s (ℕₚ.n≤1+n _)) (s<s⁻¹ x<y))))
-toℕ-cancel-< {1+[2 x ]} {2[1+ y ]} x<y with toℕ x ℕₚ.≟ toℕ y
+  rewrite ℕ.*-distribˡ-+ 2 1 (toℕ x) =
+  even<odd (toℕ-cancel-< (ℕ.*-cancelˡ-< 2 _ _ (ℕ.≤-trans (s≤s (ℕ.n≤1+n _)) (s<s⁻¹ x<y))))
+toℕ-cancel-< {1+[2 x ]} {2[1+ y ]} x<y with toℕ x ℕ.≟ toℕ y
 ... | yes x≡y = odd<even (inj₂ (toℕ-injective x≡y))
 ... | no  x≢y
-  rewrite ℕₚ.+-suc (toℕ y) (toℕ y ℕ.+ 0) =
-  odd<even (inj₁ (toℕ-cancel-< (ℕₚ.≤∧≢⇒< (ℕₚ.*-cancelˡ-≤ 2 (ℕₚ.+-cancelˡ-≤ 2 _ _ x<y)) x≢y)))
+  rewrite ℕ.+-suc (toℕ y) (toℕ y ℕ.+ 0) =
+  odd<even (inj₁ (toℕ-cancel-< (ℕ.≤∧≢⇒< (ℕ.*-cancelˡ-≤ 2 (ℕ.+-cancelˡ-≤ 2 _ _ x<y)) x≢y)))
 toℕ-cancel-< {1+[2 x ]} {1+[2 y ]} x<y =
-  odd<odd (toℕ-cancel-< (ℕₚ.*-cancelˡ-< 2 _ _ (s<s⁻¹ x<y)))
+  odd<odd (toℕ-cancel-< (ℕ.*-cancelˡ-< 2 _ _ (s<s⁻¹ x<y)))
 
 fromℕ-cancel-< : ∀ {x y} → fromℕ x < fromℕ y → x ℕ.< y
 fromℕ-cancel-< = subst₂ ℕ._<_ (toℕ-fromℕ _) (toℕ-fromℕ _) ∘ toℕ-mono-<
@@ -482,13 +482,13 @@ x≤0⇒x≡0 (inj₂ x≡0) = x≡0
 -- Properties of _<_ and toℕ & fromℕ.
 
 fromℕ-mono-≤ : fromℕ Preserves ℕ._≤_ ⟶ _≤_
-fromℕ-mono-≤ m≤n  with ℕₚ.m≤n⇒m<n∨m≡n m≤n
+fromℕ-mono-≤ m≤n  with ℕ.m≤n⇒m<n∨m≡n m≤n
 ... | inj₁ m<n =  inj₁ (fromℕ-mono-< m<n)
 ... | inj₂ m≡n =  inj₂ (cong fromℕ m≡n)
 
 toℕ-mono-≤ : toℕ Preserves _≤_ ⟶ ℕ._≤_
-toℕ-mono-≤ (inj₁ x<y)  =  ℕₚ.<⇒≤ (toℕ-mono-< x<y)
-toℕ-mono-≤ (inj₂ refl) =  ℕₚ.≤-reflexive refl
+toℕ-mono-≤ (inj₁ x<y)  =  ℕ.<⇒≤ (toℕ-mono-< x<y)
+toℕ-mono-≤ (inj₂ refl) =  ℕ.≤-reflexive refl
 
 toℕ-cancel-≤ : ∀ {x y} → toℕ x ℕ.≤ toℕ y → x ≤ y
 toℕ-cancel-≤ = subst₂ _≤_ (fromℕ-toℕ _) (fromℕ-toℕ _) ∘ fromℕ-mono-≤
@@ -637,8 +637,8 @@ module ≤-Reasoning where
 
 toℕ-homo-+ : ∀ x y → toℕ (x + y) ≡ toℕ x ℕ.+ toℕ y
 toℕ-homo-+ zero     _        = refl
-toℕ-homo-+ 2[1+ x ] zero     = cong ℕ.suc (sym (ℕₚ.+-identityʳ _))
-toℕ-homo-+ 1+[2 x ] zero     = cong ℕ.suc (sym (ℕₚ.+-identityʳ _))
+toℕ-homo-+ 2[1+ x ] zero     = cong ℕ.suc (sym (ℕ.+-identityʳ _))
+toℕ-homo-+ 1+[2 x ] zero     = cong ℕ.suc (sym (ℕ.+-identityʳ _))
 toℕ-homo-+ 2[1+ x ] 2[1+ y ] = begin
   toℕ (2[1+ x ] + 2[1+ y ])          ≡⟨⟩
   toℕ 2[1+ (suc (x + y)) ]           ≡⟨⟩
@@ -686,19 +686,19 @@ toℕ-homo-+ 1+[2 x ] 1+[2 y ] = begin
   toℕ 1+[2 x ] ℕ.+ toℕ 1+[2 y ]           ∎
   where open ≡-Reasoning;  m = toℕ x;  n = toℕ y
 
-toℕ-isMagmaHomomorphism-+ : IsMagmaHomomorphism +-rawMagma ℕᵇ.+-rawMagma toℕ
+toℕ-isMagmaHomomorphism-+ : IsMagmaHomomorphism +-rawMagma ℕ.+-rawMagma toℕ
 toℕ-isMagmaHomomorphism-+ = record
   { isRelHomomorphism = toℕ-isRelHomomorphism
   ; homo              = toℕ-homo-+
   }
 
-toℕ-isMonoidHomomorphism-+ : IsMonoidHomomorphism +-0-rawMonoid ℕᵇ.+-0-rawMonoid toℕ
+toℕ-isMonoidHomomorphism-+ : IsMonoidHomomorphism +-0-rawMonoid ℕ.+-0-rawMonoid toℕ
 toℕ-isMonoidHomomorphism-+ = record
   { isMagmaHomomorphism = toℕ-isMagmaHomomorphism-+
   ; ε-homo              = refl
   }
 
-toℕ-isMonoidMonomorphism-+ : IsMonoidMonomorphism +-0-rawMonoid ℕᵇ.+-0-rawMonoid toℕ
+toℕ-isMonoidMonomorphism-+ : IsMonoidMonomorphism +-0-rawMonoid ℕ.+-0-rawMonoid toℕ
 toℕ-isMonoidMonomorphism-+ = record
   { isMonoidHomomorphism = toℕ-isMonoidHomomorphism-+
   ; injective            = toℕ-injective
@@ -745,25 +745,25 @@ private
   module +-Monomorphism = MonoidMonomorphism toℕ-isMonoidMonomorphism-+
 
 +-assoc : Associative _+_
-+-assoc = +-Monomorphism.assoc ℕₚ.+-isMagma ℕₚ.+-assoc
++-assoc = +-Monomorphism.assoc ℕ.+-isMagma ℕ.+-assoc
 
 +-comm : Commutative _+_
-+-comm = +-Monomorphism.comm ℕₚ.+-isMagma ℕₚ.+-comm
++-comm = +-Monomorphism.comm ℕ.+-isMagma ℕ.+-comm
 
 +-identityˡ : LeftIdentity zero _+_
 +-identityˡ _ = refl
 
 +-identityʳ : RightIdentity zero _+_
-+-identityʳ = +-Monomorphism.identityʳ ℕₚ.+-isMagma ℕₚ.+-identityʳ
++-identityʳ = +-Monomorphism.identityʳ ℕ.+-isMagma ℕ.+-identityʳ
 
 +-identity : Identity zero _+_
 +-identity = +-identityˡ , +-identityʳ
 
 +-cancelˡ-≡ : LeftCancellative _+_
-+-cancelˡ-≡ = +-Monomorphism.cancelˡ ℕₚ.+-isMagma ℕₚ.+-cancelˡ-≡
++-cancelˡ-≡ = +-Monomorphism.cancelˡ ℕ.+-isMagma ℕ.+-cancelˡ-≡
 
 +-cancelʳ-≡ : RightCancellative _+_
-+-cancelʳ-≡ = +-Monomorphism.cancelʳ ℕₚ.+-isMagma ℕₚ.+-cancelʳ-≡
++-cancelʳ-≡ = +-Monomorphism.cancelʳ ℕ.+-isMagma ℕ.+-cancelʳ-≡
 
 ------------------------------------------------------------------------
 -- Structures for _+_
@@ -772,7 +772,7 @@ private
 +-isMagma = isMagma _+_
 
 +-isSemigroup : IsSemigroup _+_
-+-isSemigroup = +-Monomorphism.isSemigroup ℕₚ.+-isSemigroup
++-isSemigroup = +-Monomorphism.isSemigroup ℕ.+-isSemigroup
 
 +-isCommutativeSemigroup : IsCommutativeSemigroup _+_
 +-isCommutativeSemigroup = record
@@ -781,10 +781,10 @@ private
   }
 
 +-0-isMonoid : IsMonoid _+_ 0ᵇ
-+-0-isMonoid = +-Monomorphism.isMonoid ℕₚ.+-0-isMonoid
++-0-isMonoid = +-Monomorphism.isMonoid ℕ.+-0-isMonoid
 
 +-0-isCommutativeMonoid : IsCommutativeMonoid _+_ 0ᵇ
-+-0-isCommutativeMonoid = +-Monomorphism.isCommutativeMonoid ℕₚ.+-0-isCommutativeMonoid
++-0-isCommutativeMonoid = +-Monomorphism.isCommutativeMonoid ℕ.+-0-isCommutativeMonoid
 
 ------------------------------------------------------------------------
 -- Bundles for _+_
@@ -822,7 +822,7 @@ module Bin+CSemigroup = CommSemigProp +-commutativeSemigroup
 +-mono-≤ {x} {x′} {y} {y′} x≤x′ y≤y′ =  begin
   x + y                 ≡⟨ sym $ cong₂ _+_ (fromℕ-toℕ x) (fromℕ-toℕ y) ⟩
   fromℕ m + fromℕ n     ≡⟨ sym (fromℕ-homo-+ m n) ⟩
-  fromℕ (m ℕ.+ n)       ≤⟨ fromℕ-mono-≤ (ℕₚ.+-mono-≤ m≤m′ n≤n′) ⟩
+  fromℕ (m ℕ.+ n)       ≤⟨ fromℕ-mono-≤ (ℕ.+-mono-≤ m≤m′ n≤n′) ⟩
   fromℕ (m′ ℕ.+ n′)     ≡⟨ fromℕ-homo-+ m′ n′ ⟩
   fromℕ m′ + fromℕ n′   ≡⟨ cong₂ _+_ (fromℕ-toℕ x′) (fromℕ-toℕ y′) ⟩
   x′ + y′               ∎
@@ -842,7 +842,7 @@ module Bin+CSemigroup = CommSemigProp +-commutativeSemigroup
 +-mono-<-≤ {x} {x′} {y} {y′} x<x′ y≤y′ =  begin-strict
   x + y                  ≡⟨ sym $ cong₂ _+_ (fromℕ-toℕ x) (fromℕ-toℕ y) ⟩
   fromℕ m + fromℕ n      ≡⟨ sym (fromℕ-homo-+ m n) ⟩
-  fromℕ (m ℕ.+ n)        <⟨ fromℕ-mono-< (ℕₚ.+-mono-<-≤ m<m′ n≤n′) ⟩
+  fromℕ (m ℕ.+ n)        <⟨ fromℕ-mono-< (ℕ.+-mono-<-≤ m<m′ n≤n′) ⟩
   fromℕ (m′ ℕ.+ n′)      ≡⟨ fromℕ-homo-+ m′ n′ ⟩
   fromℕ m′ + fromℕ n′    ≡⟨ cong₂ _+_ (fromℕ-toℕ x′) (fromℕ-toℕ y′) ⟩
   x′ + y′                ∎
@@ -880,7 +880,7 @@ x≤x+y x y =  begin
 x<x+y : ∀ x {y} → y > 0ᵇ → x < x + y
 x<x+y x {y} y>0 = begin-strict
   x                             ≡⟨ sym (fromℕ-toℕ x) ⟩
-  fromℕ (toℕ x)                 <⟨ fromℕ-mono-< (ℕₚ.m<m+n (toℕ x) (toℕ-mono-< y>0)) ⟩
+  fromℕ (toℕ x)                 <⟨ fromℕ-mono-< (ℕ.m<m+n (toℕ x) (toℕ-mono-< y>0)) ⟩
   fromℕ (toℕ x ℕ.+ toℕ y)       ≡⟨ fromℕ-homo-+ (toℕ x) (toℕ y) ⟩
   fromℕ (toℕ x) + fromℕ (toℕ y) ≡⟨ cong₂ _+_ (fromℕ-toℕ x) (fromℕ-toℕ y) ⟩
   x + y                         ∎
@@ -910,12 +910,12 @@ x≢0⇒x+y≢0 {zero}     _    0≢0 =  contradiction refl 0≢0
 private  2*ₙ2*ₙ =  (2 ℕ.*_) ∘ (2 ℕ.*_)
 
 toℕ-homo-* : ∀ x y → toℕ (x * y) ≡ toℕ x ℕ.* toℕ y
-toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
+toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕ.≤-refl
   where
   aux : (x y : ℕᵇ) → (cnt : ℕ) → (size x ℕ.+ size y ℕ.≤ cnt) →  toℕ (x * y) ≡ toℕ x ℕ.* toℕ y
   aux zero     _        _ _ = refl
-  aux 2[1+ x ] zero     _ _ = sym (ℕₚ.*-zeroʳ (toℕ x ℕ.+ (ℕ.suc (toℕ x ℕ.+ 0))))
-  aux 1+[2 x ] zero     _ _ = sym (ℕₚ.*-zeroʳ (toℕ x ℕ.+ (toℕ x ℕ.+ 0)))
+  aux 2[1+ x ] zero     _ _ = sym (ℕ.*-zeroʳ (toℕ x ℕ.+ (ℕ.suc (toℕ x ℕ.+ 0))))
+  aux 1+[2 x ] zero     _ _ = sym (ℕ.*-zeroʳ (toℕ x ℕ.+ (toℕ x ℕ.+ 0)))
   aux 2[1+ x ] 2[1+ y ] (ℕ.suc cnt) (s≤s |x|+1+|y|≤cnt) = begin
     toℕ (2[1+ x ] * 2[1+ y ])                ≡⟨⟩
     toℕ (double 2[1+ (x + (y + xy)) ])       ≡⟨ toℕ-double 2[1+ (x + (y + xy)) ] ⟩
@@ -932,7 +932,7 @@ toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
     where
     open ≡-Reasoning;  m = toℕ x;  n = toℕ y;  xy = x * y
 
-    |x|+|y|≤cnt = ℕₚ.≤-trans (ℕₚ.+-monoʳ-≤ (size x) (ℕₚ.n≤1+n (size y))) |x|+1+|y|≤cnt
+    |x|+|y|≤cnt = ℕ.≤-trans (ℕ.+-monoʳ-≤ (size x) (ℕ.n≤1+n (size y))) |x|+1+|y|≤cnt
 
   aux 2[1+ x ] 1+[2 y ] (ℕ.suc cnt) (s≤s |x|+1+|y|≤cnt) = begin
     toℕ (2[1+ x ] * 1+[2 y ])                  ≡⟨⟩
@@ -980,13 +980,13 @@ toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
     ℕ.suc (2 ℕ.* (toℕ (x + y * 1+2x)))      ≡⟨ cong (ℕ.suc ∘ (2 ℕ.*_)) (toℕ-homo-+ x (y * 1+2x)) ⟩
     ℕ.suc (2 ℕ.* (m ℕ.+ (toℕ (y * 1+2x))))  ≡⟨ cong (ℕ.suc ∘ (2 ℕ.*_) ∘ (m ℕ.+_))
                                                  (aux y 1+2x cnt |y|+1+|x|≤cnt) ⟩
-    ℕ.suc (2 ℕ.* (m ℕ.+ (n ℕ.* [1+2x]′)))   ≡⟨ cong ℕ.suc $ ℕₚ.*-distribˡ-+ 2 m (n ℕ.* [1+2x]′) ⟩
-    ℕ.suc (2m ℕ.+ (2 ℕ.* (n ℕ.* [1+2x]′)))  ≡⟨ cong (ℕ.suc ∘ (2m ℕ.+_)) (sym (ℕₚ.*-assoc 2 n _)) ⟩
+    ℕ.suc (2 ℕ.* (m ℕ.+ (n ℕ.* [1+2x]′)))   ≡⟨ cong ℕ.suc $ ℕ.*-distribˡ-+ 2 m (n ℕ.* [1+2x]′) ⟩
+    ℕ.suc (2m ℕ.+ (2 ℕ.* (n ℕ.* [1+2x]′)))  ≡⟨ cong (ℕ.suc ∘ (2m ℕ.+_)) (sym (ℕ.*-assoc 2 n _)) ⟩
     (ℕ.suc 2m) ℕ.+ 2n ℕ.* [1+2x]′           ≡⟨⟩
     [1+2x]′ ℕ.+ 2n ℕ.* [1+2x]′              ≡⟨ cong (ℕ._+ (2n ℕ.* [1+2x]′)) $
-                                                    sym (ℕₚ.*-identityˡ [1+2x]′) ⟩
-    1 ℕ.* [1+2x]′ ℕ.+ 2n ℕ.* [1+2x]′        ≡⟨ sym (ℕₚ.*-distribʳ-+ [1+2x]′ 1 2n) ⟩
-    (ℕ.suc 2n) ℕ.* [1+2x]′                  ≡⟨ ℕₚ.*-comm (ℕ.suc 2n) [1+2x]′ ⟩
+                                                    sym (ℕ.*-identityˡ [1+2x]′) ⟩
+    1 ℕ.* [1+2x]′ ℕ.+ 2n ℕ.* [1+2x]′        ≡⟨ sym (ℕ.*-distribʳ-+ [1+2x]′ 1 2n) ⟩
+    (ℕ.suc 2n) ℕ.* [1+2x]′                  ≡⟨ ℕ.*-comm (ℕ.suc 2n) [1+2x]′ ⟩
     toℕ 1+[2 x ] ℕ.* toℕ 1+[2 y ]           ∎
     where
     open ≡-Reasoning
@@ -999,19 +999,19 @@ toℕ-homo-* x y =  aux x y (size x ℕ.+ size y) ℕₚ.≤-refl
     |y|+1+|x|≤cnt = subst (ℕ._≤ cnt) eq |x|+1+|y|≤cnt
 
 
-toℕ-isMagmaHomomorphism-* : IsMagmaHomomorphism *-rawMagma ℕᵇ.*-rawMagma toℕ
+toℕ-isMagmaHomomorphism-* : IsMagmaHomomorphism *-rawMagma ℕ.*-rawMagma toℕ
 toℕ-isMagmaHomomorphism-* = record
   { isRelHomomorphism = toℕ-isRelHomomorphism
   ; homo              = toℕ-homo-*
   }
 
-toℕ-isMonoidHomomorphism-* : IsMonoidHomomorphism *-1-rawMonoid ℕᵇ.*-1-rawMonoid toℕ
+toℕ-isMonoidHomomorphism-* : IsMonoidHomomorphism *-1-rawMonoid ℕ.*-1-rawMonoid toℕ
 toℕ-isMonoidHomomorphism-* = record
   { isMagmaHomomorphism = toℕ-isMagmaHomomorphism-*
   ; ε-homo              = refl
   }
 
-toℕ-isMonoidMonomorphism-* : IsMonoidMonomorphism *-1-rawMonoid ℕᵇ.*-1-rawMonoid toℕ
+toℕ-isMonoidMonomorphism-* : IsMonoidMonomorphism *-1-rawMonoid ℕ.*-1-rawMonoid toℕ
 toℕ-isMonoidMonomorphism-* = record
   { isMonoidHomomorphism = toℕ-isMonoidHomomorphism-*
   ; injective            = toℕ-injective
@@ -1038,13 +1038,13 @@ private
 -- by `toℕ`/`fromℕ`.
 
 *-assoc : Associative _*_
-*-assoc = *-Monomorphism.assoc ℕₚ.*-isMagma ℕₚ.*-assoc
+*-assoc = *-Monomorphism.assoc ℕ.*-isMagma ℕ.*-assoc
 
 *-comm : Commutative _*_
-*-comm = *-Monomorphism.comm ℕₚ.*-isMagma ℕₚ.*-comm
+*-comm = *-Monomorphism.comm ℕ.*-isMagma ℕ.*-comm
 
 *-identityˡ : LeftIdentity 1ᵇ _*_
-*-identityˡ = *-Monomorphism.identityˡ ℕₚ.*-isMagma ℕₚ.*-identityˡ
+*-identityˡ = *-Monomorphism.identityˡ ℕ.*-isMagma ℕ.*-identityˡ
 
 *-identityʳ : RightIdentity 1ᵇ _*_
 *-identityʳ x =  trans (*-comm x 1ᵇ) (*-identityˡ x)
@@ -1068,7 +1068,7 @@ private
   a * (b + c)                          ≡⟨ sym (fromℕ-toℕ (a * (b + c))) ⟩
   fromℕ (toℕ (a * (b + c)))            ≡⟨ cong fromℕ (toℕ-homo-* a (b + c)) ⟩
   fromℕ (k ℕ.* (toℕ (b + c)))          ≡⟨ cong (fromℕ ∘ (k ℕ.*_)) (toℕ-homo-+ b c) ⟩
-  fromℕ (k ℕ.* (m ℕ.+ n))              ≡⟨ cong fromℕ (ℕₚ.*-distribˡ-+ k m n) ⟩
+  fromℕ (k ℕ.* (m ℕ.+ n))              ≡⟨ cong fromℕ (ℕ.*-distribˡ-+ k m n) ⟩
   fromℕ (k ℕ.* m ℕ.+ k ℕ.* n)          ≡⟨ cong fromℕ $ sym $
                                             cong₂ ℕ._+_ (toℕ-homo-* a b) (toℕ-homo-* a c) ⟩
   fromℕ (toℕ (a * b) ℕ.+ toℕ (a * c))  ≡⟨ cong fromℕ (sym (toℕ-homo-+ (a * b) (a * c))) ⟩
@@ -1089,13 +1089,13 @@ private
 *-isMagma = isMagma _*_
 
 *-isSemigroup : IsSemigroup _*_
-*-isSemigroup = *-Monomorphism.isSemigroup ℕₚ.*-isSemigroup
+*-isSemigroup = *-Monomorphism.isSemigroup ℕ.*-isSemigroup
 
 *-1-isMonoid : IsMonoid _*_ 1ᵇ
-*-1-isMonoid = *-Monomorphism.isMonoid ℕₚ.*-1-isMonoid
+*-1-isMonoid = *-Monomorphism.isMonoid ℕ.*-1-isMonoid
 
 *-1-isCommutativeMonoid : IsCommutativeMonoid _*_ 1ᵇ
-*-1-isCommutativeMonoid = *-Monomorphism.isCommutativeMonoid ℕₚ.*-1-isCommutativeMonoid
+*-1-isCommutativeMonoid = *-Monomorphism.isCommutativeMonoid ℕ.*-1-isCommutativeMonoid
 
 +-*-isSemiringWithoutAnnihilatingZero : IsSemiringWithoutAnnihilatingZero _+_ _*_ zero 1ᵇ
 +-*-isSemiringWithoutAnnihilatingZero = record
@@ -1157,10 +1157,10 @@ private
 *-mono-≤ : _*_ Preserves₂ _≤_ ⟶ _≤_ ⟶ _≤_
 *-mono-≤ {x} {u} {y} {v} x≤u y≤v = toℕ-cancel-≤ (begin
   toℕ (x * y)      ≡⟨ toℕ-homo-* x y ⟩
-  toℕ x ℕ.* toℕ y  ≤⟨ ℕₚ.*-mono-≤ (toℕ-mono-≤ x≤u) (toℕ-mono-≤ y≤v) ⟩
+  toℕ x ℕ.* toℕ y  ≤⟨ ℕ.*-mono-≤ (toℕ-mono-≤ x≤u) (toℕ-mono-≤ y≤v) ⟩
   toℕ u ℕ.* toℕ v  ≡⟨ sym (toℕ-homo-* u v) ⟩
   toℕ (u * v)      ∎)
-  where open ℕₚ.≤-Reasoning
+  where open ℕ.≤-Reasoning
 
 *-monoʳ-≤ : ∀ x → (x *_) Preserves _≤_ ⟶ _≤_
 *-monoʳ-≤ x y≤y′ = *-mono-≤ (≤-refl {x}) y≤y′
@@ -1171,10 +1171,10 @@ private
 *-mono-< : _*_ Preserves₂ _<_ ⟶ _<_ ⟶ _<_
 *-mono-< {x} {u} {y} {v} x<u y<v = toℕ-cancel-< (begin-strict
   toℕ (x * y)      ≡⟨ toℕ-homo-* x y ⟩
-  toℕ x ℕ.* toℕ y  <⟨ ℕₚ.*-mono-< (toℕ-mono-< x<u) (toℕ-mono-< y<v) ⟩
+  toℕ x ℕ.* toℕ y  <⟨ ℕ.*-mono-< (toℕ-mono-< x<u) (toℕ-mono-< y<v) ⟩
   toℕ u ℕ.* toℕ v  ≡⟨ sym (toℕ-homo-* u v) ⟩
   toℕ (u * v)      ∎)
-  where open ℕₚ.≤-Reasoning
+  where open ℕ.≤-Reasoning
 
 *-monoʳ-< : ∀ x → ((1ᵇ + x) *_) Preserves _<_ ⟶ _<_
 *-monoʳ-< x {y} {z} y<z = begin-strict
@@ -1455,7 +1455,7 @@ pred-mono-≤ : pred Preserves _≤_ ⟶ _≤_
 pred-mono-≤ {x} {y} x≤y = begin
   pred x             ≡⟨ cong pred (sym (fromℕ-toℕ x)) ⟩
   pred (fromℕ m)     ≡⟨ sym (fromℕ-pred m) ⟩
-  fromℕ (ℕ.pred m)   ≤⟨ fromℕ-mono-≤ (ℕₚ.pred-mono-≤ (toℕ-mono-≤ x≤y)) ⟩
+  fromℕ (ℕ.pred m)   ≤⟨ fromℕ-mono-≤ (ℕ.pred-mono-≤ (toℕ-mono-≤ x≤y)) ⟩
   fromℕ (ℕ.pred n)   ≡⟨ fromℕ-pred n ⟩
   pred (fromℕ n)     ≡⟨ cong pred (fromℕ-toℕ y) ⟩
   pred y             ∎

--- a/src/Data/Nat/Binary/Subtraction.agda
+++ b/src/Data/Nat/Binary/Subtraction.agda
@@ -15,7 +15,7 @@ open import Data.Bool.Base using (true; false)
 open import Data.Nat as ℕ using (ℕ)
 open import Data.Nat.Binary.Base
 open import Data.Nat.Binary.Properties
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂; ∃)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Data.Vec.Base using ([]; _∷_)
@@ -77,39 +77,39 @@ toℕ-homo-∸ 2[1+ x ] zero     = refl
 toℕ-homo-∸ 2[1+ x ] 2[1+ y ] = begin
   toℕ (double (x ∸ y))          ≡⟨ toℕ-double (x ∸ y) ⟩
   2 ℕ.* toℕ (x ∸ y)             ≡⟨ cong (2 ℕ.*_) (toℕ-homo-∸ x y) ⟩
-  2 ℕ.* (toℕ x ℕ.∸ toℕ y)       ≡⟨ ℕₚ.*-distribˡ-∸ 2 (ℕ.suc (toℕ x)) (ℕ.suc (toℕ y)) ⟩
+  2 ℕ.* (toℕ x ℕ.∸ toℕ y)       ≡⟨ ℕ.*-distribˡ-∸ 2 (ℕ.suc (toℕ x)) (ℕ.suc (toℕ y)) ⟩
   toℕ 2[1+ x ] ℕ.∸ toℕ 2[1+ y ] ∎
   where open ≡-Reasoning
 toℕ-homo-∸ 2[1+ x ] 1+[2 y ] with x <? y
-... | yes x<y  = sym (ℕₚ.m≤n⇒m∸n≡0 (toℕ-mono-≤ (inj₁ (even<odd x<y))))
+... | yes x<y  = sym (ℕ.m≤n⇒m∸n≡0 (toℕ-mono-≤ (inj₁ (even<odd x<y))))
 ... | no  x≮y  = begin
   ℕ.suc (2 ℕ.* toℕ (x ∸ y))                     ≡⟨ cong (ℕ.suc ∘ (2 ℕ.*_)) (toℕ-homo-∸ x y) ⟩
-  ℕ.suc (2 ℕ.* (toℕ x ℕ.∸ toℕ y))               ≡⟨ cong ℕ.suc (ℕₚ.*-distribˡ-∸ 2 (toℕ x) (toℕ y)) ⟩
-  ℕ.suc (2 ℕ.* toℕ x ℕ.∸ 2 ℕ.* toℕ y)           ≡⟨ sym (ℕₚ.+-∸-assoc 1 (ℕₚ.*-monoʳ-≤ 2 (toℕ-mono-≤ (≮⇒≥ x≮y)))) ⟩
-  ℕ.suc (2 ℕ.* toℕ x) ℕ.∸ 2 ℕ.* toℕ y           ≡⟨ sym (cong (ℕ._∸ 2 ℕ.* toℕ y) (ℕₚ.+-suc (toℕ x) (1 ℕ.* toℕ x))) ⟩
+  ℕ.suc (2 ℕ.* (toℕ x ℕ.∸ toℕ y))               ≡⟨ cong ℕ.suc (ℕ.*-distribˡ-∸ 2 (toℕ x) (toℕ y)) ⟩
+  ℕ.suc (2 ℕ.* toℕ x ℕ.∸ 2 ℕ.* toℕ y)           ≡⟨ sym (ℕ.+-∸-assoc 1 (ℕ.*-monoʳ-≤ 2 (toℕ-mono-≤ (≮⇒≥ x≮y)))) ⟩
+  ℕ.suc (2 ℕ.* toℕ x) ℕ.∸ 2 ℕ.* toℕ y           ≡⟨ sym (cong (ℕ._∸ 2 ℕ.* toℕ y) (ℕ.+-suc (toℕ x) (1 ℕ.* toℕ x))) ⟩
   2 ℕ.* (ℕ.suc (toℕ x)) ℕ.∸ ℕ.suc (2 ℕ.* toℕ y) ∎
   where open ≡-Reasoning
 toℕ-homo-∸ 1+[2 x ] zero     = refl
 toℕ-homo-∸ 1+[2 x ] 2[1+ y ] with x ≤? y
-... | yes x≤y = sym (ℕₚ.m≤n⇒m∸n≡0 (toℕ-mono-≤ (inj₁ (odd<even x≤y))))
+... | yes x≤y = sym (ℕ.m≤n⇒m∸n≡0 (toℕ-mono-≤ (inj₁ (odd<even x≤y))))
 ... | no  _   = begin
   toℕ (pred (double (x ∸ y)))                   ≡⟨ toℕ-pred (double (x ∸ y)) ⟩
   ℕ.pred (toℕ (double (x ∸ y)))                 ≡⟨ cong ℕ.pred (toℕ-double (x ∸ y)) ⟩
   ℕ.pred (2 ℕ.* toℕ (x ∸ y))                    ≡⟨ cong (ℕ.pred ∘ (2 ℕ.*_)) (toℕ-homo-∸ x y) ⟩
-  ℕ.pred (2 ℕ.* (toℕ x ℕ.∸ toℕ y))              ≡⟨ cong ℕ.pred (ℕₚ.*-distribˡ-∸ 2 (toℕ x) (toℕ y)) ⟩
-  ℕ.pred (2 ℕ.* toℕ x ℕ.∸ 2 ℕ.* toℕ y)          ≡⟨ ℕₚ.pred[m∸n]≡m∸[1+n] (2 ℕ.* toℕ x) (2 ℕ.* toℕ y) ⟩
-  2 ℕ.* toℕ x ℕ.∸ ℕ.suc (2 ℕ.* toℕ y)           ≡⟨ sym (cong (2 ℕ.* toℕ x ℕ.∸_) (ℕₚ.+-suc (toℕ y) (1 ℕ.* toℕ y))) ⟩
+  ℕ.pred (2 ℕ.* (toℕ x ℕ.∸ toℕ y))              ≡⟨ cong ℕ.pred (ℕ.*-distribˡ-∸ 2 (toℕ x) (toℕ y)) ⟩
+  ℕ.pred (2 ℕ.* toℕ x ℕ.∸ 2 ℕ.* toℕ y)          ≡⟨ ℕ.pred[m∸n]≡m∸[1+n] (2 ℕ.* toℕ x) (2 ℕ.* toℕ y) ⟩
+  2 ℕ.* toℕ x ℕ.∸ ℕ.suc (2 ℕ.* toℕ y)           ≡⟨ sym (cong (2 ℕ.* toℕ x ℕ.∸_) (ℕ.+-suc (toℕ y) (1 ℕ.* toℕ y))) ⟩
   ℕ.suc (2 ℕ.* toℕ x) ℕ.∸ 2 ℕ.* (ℕ.suc (toℕ y)) ∎
   where open ≡-Reasoning
 toℕ-homo-∸ 1+[2 x ] 1+[2 y ] = begin
   toℕ (double (x ∸ y))        ≡⟨ toℕ-double (x ∸ y) ⟩
   2 ℕ.* toℕ (x ∸ y)           ≡⟨ cong (2 ℕ.*_) (toℕ-homo-∸ x y) ⟩
-  2 ℕ.* (toℕ x ℕ.∸ toℕ y)     ≡⟨ ℕₚ.*-distribˡ-∸ 2 (toℕ x) (toℕ y) ⟩
+  2 ℕ.* (toℕ x ℕ.∸ toℕ y)     ≡⟨ ℕ.*-distribˡ-∸ 2 (toℕ x) (toℕ y) ⟩
   2 ℕ.* toℕ x ℕ.∸ 2 ℕ.* toℕ y ∎
   where open ≡-Reasoning
 
 fromℕ-homo-∸ : ∀ m n → fromℕ (m ℕ.∸ n) ≡ (fromℕ m) ∸ (fromℕ n)
-fromℕ-homo-∸ = homomorphic₂-inv ∸-magma ℕₚ.∸-magma
+fromℕ-homo-∸ = homomorphic₂-inv ∸-magma ℕ.∸-magma
   (cong fromℕ) toℕ-inverseᵇ toℕ-homo-∸
 
 ------------------------------------------------------------------------
@@ -126,13 +126,13 @@ odd∸even-for> {x} {y} x>y with x ≤? y
 ... | yes x≤y = contradiction x>y (≤⇒≯ x≤y)
 
 x≤y⇒x∸y≡0 : x ≤ y → x ∸ y ≡ 0ᵇ
-x≤y⇒x∸y≡0 {x} {y} = toℕ-injective ∘ trans (toℕ-homo-∸ x y) ∘ ℕₚ.m≤n⇒m∸n≡0 ∘ toℕ-mono-≤
+x≤y⇒x∸y≡0 {x} {y} = toℕ-injective ∘ trans (toℕ-homo-∸ x y) ∘ ℕ.m≤n⇒m∸n≡0 ∘ toℕ-mono-≤
 
 x∸y≡0⇒x≤y : x ∸ y ≡ 0ᵇ → x ≤ y
-x∸y≡0⇒x≤y {x} {y} = toℕ-cancel-≤ ∘ ℕₚ.m∸n≡0⇒m≤n ∘ trans (sym (toℕ-homo-∸ x y)) ∘ cong toℕ
+x∸y≡0⇒x≤y {x} {y} = toℕ-cancel-≤ ∘ ℕ.m∸n≡0⇒m≤n ∘ trans (sym (toℕ-homo-∸ x y)) ∘ cong toℕ
 
 x<y⇒y∸x>0 : x < y → y ∸ x > 0ᵇ
-x<y⇒y∸x>0 {x} {y} = toℕ-cancel-< ∘ subst (ℕ._> 0) (sym (toℕ-homo-∸ y x)) ∘ ℕₚ.m<n⇒0<n∸m ∘ toℕ-mono-<
+x<y⇒y∸x>0 {x} {y} = toℕ-cancel-< ∘ subst (ℕ._> 0) (sym (toℕ-homo-∸ y x)) ∘ ℕ.m<n⇒0<n∸m ∘ toℕ-mono-<
 
 ------------------------------------------------------------------------
 -- Properties of _∸_ and _+_
@@ -141,7 +141,7 @@ x<y⇒y∸x>0 {x} {y} = toℕ-cancel-< ∘ subst (ℕ._> 0) (sym (toℕ-homo-∸
 [x∸y]+y≡x {x} {y} x≥y = toℕ-injective (begin
   toℕ (x ∸ y + y)             ≡⟨ toℕ-homo-+ (x ∸ y) y ⟩
   toℕ (x ∸ y) ℕ.+ toℕ y       ≡⟨ cong (ℕ._+ toℕ y) (toℕ-homo-∸ x y) ⟩
-  (toℕ x ℕ.∸ toℕ y) ℕ.+ toℕ y ≡⟨ ℕₚ.m∸n+n≡m (toℕ-mono-≤ x≥y) ⟩
+  (toℕ x ℕ.∸ toℕ y) ℕ.+ toℕ y ≡⟨ ℕ.m∸n+n≡m (toℕ-mono-≤ x≥y) ⟩
   toℕ x                       ∎)
   where open ≡-Reasoning
 
@@ -162,7 +162,7 @@ x+[y∸x]≡y {x} {y} x≤y = begin-equality
 ∸-+-assoc x y z = toℕ-injective $ begin
   toℕ ((x ∸ y) ∸ z)       ≡⟨ toℕ-homo-∸ (x ∸ y) z ⟩
   toℕ (x ∸ y) ℕ.∸ n       ≡⟨ cong (ℕ._∸ n) (toℕ-homo-∸ x y) ⟩
-  (k ℕ.∸ m) ℕ.∸ n         ≡⟨ ℕₚ.∸-+-assoc k m n ⟩
+  (k ℕ.∸ m) ℕ.∸ n         ≡⟨ ℕ.∸-+-assoc k m n ⟩
   k ℕ.∸ (m ℕ.+ n)         ≡⟨ cong (k ℕ.∸_) (sym (toℕ-homo-+ y z)) ⟩
   k ℕ.∸ (toℕ (y + z))     ≡⟨ sym (toℕ-homo-∸ x (y + z)) ⟩
   toℕ (x ∸ (y + z))       ∎
@@ -172,7 +172,7 @@ x+[y∸x]≡y {x} {y} x≤y = begin-equality
 +-∸-assoc x {y} {z} z≤y = toℕ-injective $ begin
   toℕ ((x + y) ∸ z)     ≡⟨ toℕ-homo-∸ (x + y) z ⟩
   (toℕ (x + y)) ℕ.∸ n   ≡⟨ cong (ℕ._∸ n) (toℕ-homo-+ x y) ⟩
-  (k ℕ.+ m) ℕ.∸ n       ≡⟨ ℕₚ.+-∸-assoc k n≤m ⟩
+  (k ℕ.+ m) ℕ.∸ n       ≡⟨ ℕ.+-∸-assoc k n≤m ⟩
   k ℕ.+ (m ℕ.∸ n)       ≡⟨ cong (k ℕ.+_) (sym (toℕ-homo-∸ y z)) ⟩
   k ℕ.+ toℕ (y ∸ z)     ≡⟨ sym (toℕ-homo-+ x (y ∸ z)) ⟩
   toℕ (x + (y ∸ z))     ∎
@@ -196,10 +196,10 @@ suc[x]∸suc[y] x y = begin-equality
 ∸-mono-≤ : _∸_ Preserves₂ _≤_ ⟶ _≥_ ⟶ _≤_
 ∸-mono-≤ {x} {y} {u} {v} x≤y v≤u = toℕ-cancel-≤ (begin
   toℕ (x ∸ u)      ≡⟨ toℕ-homo-∸ x u ⟩
-  toℕ x ℕ.∸ toℕ u  ≤⟨ ℕₚ.∸-mono (toℕ-mono-≤ x≤y) (toℕ-mono-≤ v≤u) ⟩
+  toℕ x ℕ.∸ toℕ u  ≤⟨ ℕ.∸-mono (toℕ-mono-≤ x≤y) (toℕ-mono-≤ v≤u) ⟩
   toℕ y ℕ.∸ toℕ v  ≡⟨ sym (toℕ-homo-∸ y v) ⟩
   toℕ (y ∸ v)      ∎)
-  where open ℕₚ.≤-Reasoning
+  where open ℕ.≤-Reasoning
 
 ∸-monoˡ-≤ : (x : ℕᵇ) → (_∸ x) Preserves _≤_ ⟶ _≤_
 ∸-monoˡ-≤ x y≤z = ∸-mono-≤ y≤z (≤-refl {x})
@@ -230,7 +230,7 @@ x∸y<x {x} {y} x≢0 y≢0 = begin-strict
 *-distribˡ-∸ x y z = toℕ-injective $ begin
   toℕ (x * (y ∸ z))              ≡⟨ toℕ-homo-* x (y ∸ z) ⟩
   k ℕ.* (toℕ (y ∸ z))            ≡⟨ cong (k ℕ.*_) (toℕ-homo-∸ y z) ⟩
-  k ℕ.* (m ℕ.∸ n)                ≡⟨ ℕₚ.*-distribˡ-∸ k m n ⟩
+  k ℕ.* (m ℕ.∸ n)                ≡⟨ ℕ.*-distribˡ-∸ k m n ⟩
   (k ℕ.* m) ℕ.∸ (k ℕ.* n)        ≡⟨ cong₂ ℕ._∸_ (sym (toℕ-homo-* x y)) (sym (toℕ-homo-* x z)) ⟩
   toℕ (x * y) ℕ.∸ toℕ (x * z)    ≡⟨ sym (toℕ-homo-∸ (x * y) (x * z)) ⟩
   toℕ ((x * y) ∸ (x * z))        ∎

--- a/src/Data/Rational/Base.agda
+++ b/src/Data/Rational/Base.agda
@@ -14,7 +14,7 @@ open import Data.Integer.Base as ℤ
   using (ℤ; +_; +0; +[1+_]; -[1+_])
   hiding (module ℤ)
 open import Data.Nat.GCD
-open import Data.Nat.Coprimality as C
+open import Data.Nat.Coprimality as ℕ
   using (Coprime; Bézout-coprime; coprime-/gcd; coprime?; ¬0-coprimeTo-2+)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; 2+) hiding (module ℕ)
 open import Data.Rational.Unnormalised.Base as ℚᵘ using (ℚᵘ; mkℚᵘ)
@@ -193,7 +193,7 @@ open ℤ public
 ≢-nonZero {mkℚ +[1+ _ ] _         _} _   = _
 ≢-nonZero {mkℚ +0       zero      _} p≢0 = contradiction refl p≢0
 ≢-nonZero {mkℚ +0       d@(suc m) c} p≢0 =
-  contradiction (λ {d} → C.recompute c {d}) (¬0-coprimeTo-2+ {{ℕ.nonTrivial {m}}})
+  contradiction (λ {d} → ℕ.recompute c {d}) (¬0-coprimeTo-2+ {{ℕ.nonTrivial {m}}})
 
 >-nonZero : ∀ {p} → p > 0ℚ → NonZero p
 >-nonZero {p@(mkℚ _ _ _)} (*<* p<q) = ℚᵘ.>-nonZero {toℚᵘ p} (ℚᵘ.*<* p<q)
@@ -237,8 +237,8 @@ p - q = p + (- q)
 
 -- reciprocal: requires a proof that the numerator is not zero
 1/_ : (p : ℚ) → .{{_ : NonZero p}} → ℚ
-1/ mkℚ +[1+ n ] d prf = mkℚ +[1+ d ] n (C.sym prf)
-1/ mkℚ -[1+ n ] d prf = mkℚ -[1+ d ] n (C.sym prf)
+1/ mkℚ +[1+ n ] d prf = mkℚ +[1+ d ] n (ℕ.sym prf)
+1/ mkℚ -[1+ n ] d prf = mkℚ -[1+ d ] n (ℕ.sym prf)
 
 -- division: requires a proof that the denominator is not zero
 _÷_ : (p q : ℚ) → .{{_ : NonZero q}} → ℚ

--- a/src/Data/String.agda
+++ b/src/Data/String.agda
@@ -12,9 +12,9 @@ open import Data.Bool.Base using (if_then_else_)
 open import Data.Char as Char using (Char)
 open import Function.Base using (_∘_; _$_)
 open import Data.Nat.Base as ℕ using (ℕ)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.List.Base as List using (List)
-open import Data.List.Extrema ℕₚ.≤-totalOrder
+open import Data.List.Extrema ℕ.≤-totalOrder
 open import Data.Vec.Base as Vec using (Vec)
 open import Data.Char.Base as Char using (Char)
 import Data.Char.Properties as Char using (_≟_)

--- a/src/Data/Vec.agda
+++ b/src/Data/Vec.agda
@@ -18,7 +18,7 @@ module Data.Vec where
 
 open import Level
 open import Data.Bool.Base
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Vec.Bounded.Base as Vec≤
   using (Vec≤; ≤-cast; fromVec)
 open import Relation.Nullary
@@ -43,7 +43,7 @@ module _ {P : A → Set p} (P? : Decidable P) where
   filter []       = Vec≤.[]
   filter (a ∷ as) with does (P? a)
   ... | true  = a Vec≤.∷ filter as
-  ... | false = ≤-cast (ℕₚ.n≤1+n _) (filter as)
+  ... | false = ≤-cast (ℕ.n≤1+n _) (filter as)
 
   takeWhile : ∀ {n} → Vec A n → Vec≤ A n
   takeWhile []       = Vec≤.[]
@@ -54,5 +54,5 @@ module _ {P : A → Set p} (P? : Decidable P) where
   dropWhile : ∀ {n} → Vec A n → Vec≤ A n
   dropWhile Vec.[]       = Vec≤.[]
   dropWhile (a Vec.∷ as) with does (P? a)
-  ... | true  = ≤-cast (ℕₚ.n≤1+n _) (dropWhile as)
+  ... | true  = ≤-cast (ℕ.n≤1+n _) (dropWhile as)
   ... | false = fromVec (a Vec.∷ as)

--- a/src/Data/Vec/Functional/Properties.agda
+++ b/src/Data/Vec/Functional/Properties.agda
@@ -11,13 +11,13 @@ module Data.Vec.Functional.Properties where
 open import Data.Empty using (⊥-elim)
 open import Data.Fin.Base
 open import Data.Nat as ℕ
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base as Product using (_×_; _,_; proj₁; proj₂)
-open import Data.List.Base as L using (List)
-import Data.List.Properties as Lₚ
+open import Data.List.Base as List using (List)
+import Data.List.Properties as List
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
-open import Data.Vec.Base as V using (Vec)
-import Data.Vec.Properties as Vₚ
+open import Data.Vec.Base as Vec using (Vec)
+import Data.Vec.Properties as Vec
 open import Data.Vec.Functional
 open import Function.Base
 open import Level using (Level)
@@ -177,7 +177,7 @@ module _ {ys ys′ : Vector A m} where
 
   ++-cong : ∀ (xs xs′ : Vector A n) →
             xs ≗ xs′ → ys ≗ ys′ → xs ++ ys ≗ xs′ ++ ys′
-  ++-cong {n} xs xs′ eq₁ eq₂ i with toℕ i ℕₚ.<? n
+  ++-cong {n} xs xs′ eq₁ eq₂ i with toℕ i ℕ.<? n
   ... | yes i<n = begin
     (xs ++ ys) i      ≡⟨ lookup-++-< xs ys i i<n ⟩
     xs (fromℕ< i<n)   ≡⟨ eq₁ (fromℕ< i<n) ⟩
@@ -185,9 +185,9 @@ module _ {ys ys′ : Vector A m} where
     (xs′ ++ ys′) i    ∎
     where open ≡-Reasoning
   ... | no i≮n = begin
-    (xs ++ ys) i               ≡⟨ lookup-++-≥ xs ys i (ℕₚ.≮⇒≥ i≮n) ⟩
-    ys (reduce≥ i (ℕₚ.≮⇒≥ i≮n))   ≡⟨ eq₂ (reduce≥ i (ℕₚ.≮⇒≥ i≮n)) ⟩
-    ys′ (reduce≥ i (ℕₚ.≮⇒≥ i≮n))  ≡⟨ lookup-++-≥ xs′ ys′ i (ℕₚ.≮⇒≥ i≮n) ⟨
+    (xs ++ ys) i               ≡⟨ lookup-++-≥ xs ys i (ℕ.≮⇒≥ i≮n) ⟩
+    ys (reduce≥ i (ℕ.≮⇒≥ i≮n))   ≡⟨ eq₂ (reduce≥ i (ℕ.≮⇒≥ i≮n)) ⟩
+    ys′ (reduce≥ i (ℕ.≮⇒≥ i≮n))  ≡⟨ lookup-++-≥ xs′ ys′ i (ℕ.≮⇒≥ i≮n) ⟨
     (xs′ ++ ys′) i             ∎
     where open ≡-Reasoning
 
@@ -255,13 +255,13 @@ insertAt-removeAt {n = suc n} xs (suc i) (suc j) = insertAt-removeAt (tail xs) i
 -- Conversion functions
 
 toVec∘fromVec : (xs : Vec A n) → toVec (fromVec xs) ≡ xs
-toVec∘fromVec = Vₚ.tabulate∘lookup
+toVec∘fromVec = Vec.tabulate∘lookup
 
 fromVec∘toVec : (xs : Vector A n) → fromVec (toVec xs) ≗ xs
-fromVec∘toVec = Vₚ.lookup∘tabulate
+fromVec∘toVec = Vec.lookup∘tabulate
 
 toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
-toList∘fromList = Lₚ.tabulate-lookup
+toList∘fromList = List.tabulate-lookup
 
 ------------------------------------------------------------------------
 -- DEPRECATED NAMES

--- a/src/Data/Word/Properties.agda
+++ b/src/Data/Word/Properties.agda
@@ -11,7 +11,7 @@ module Data.Word.Properties where
 import Data.Nat.Base as ℕ
 open import Data.Bool.Base using (Bool)
 open import Data.Word.Base
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Function.Base
 open import Relation.Nullary.Decidable using (map′; ⌊_⌋)
 open import Relation.Binary
@@ -51,7 +51,7 @@ open import Agda.Builtin.Word.Properties
 
 infix 4 _≈?_
 _≈?_ : Decidable _≈_
-x ≈? y = toℕ x ℕₚ.≟ toℕ y
+x ≈? y = toℕ x ℕ.≟ toℕ y
 
 ≈-isEquivalence : IsEquivalence _≈_
 ≈-isEquivalence = record
@@ -100,7 +100,7 @@ w₁ == w₂ = ⌊ w₁ ≟ w₂ ⌋
 
 infix 4 _<?_
 _<?_ : Decidable _<_
-_<?_ = On.decidable toℕ ℕ._<_ ℕₚ._<?_
+_<?_ = On.decidable toℕ ℕ._<_ ℕ._<?_
 
 <-strictTotalOrder-≈ : StrictTotalOrder _ _ _
-<-strictTotalOrder-≈ = On.strictTotalOrder ℕₚ.<-strictTotalOrder toℕ
+<-strictTotalOrder-≈ = On.strictTotalOrder ℕ.<-strictTotalOrder toℕ

--- a/src/Induction/Lexicographic.agda
+++ b/src/Induction/Lexicographic.agda
@@ -68,13 +68,13 @@ RecA ⊗ RecB = Σ-Rec RecA (λ _ → RecB)
 private
 
   open import Data.Nat.Base
-  open import Data.Nat.Induction as N
+  open import Data.Nat.Induction as ℕ
 
   -- The Ackermann function à la Rózsa Péter.
 
   ackermann : ℕ → ℕ → ℕ
   ackermann m n =
-    build [ N.recBuilder ⊗ N.recBuilder ]
+    build [ ℕ.recBuilder ⊗ ℕ.recBuilder ]
           (λ _ → ℕ)
           (λ { (zero  , n)     _                   → 1 + n
              ; (suc m , zero)  (_         , ackm•) → ackm• 1

--- a/src/Reflection/AST/Definition.agda
+++ b/src/Reflection/AST/Definition.agda
@@ -8,8 +8,8 @@
 
 module Reflection.AST.Definition where
 
-import Data.List.Properties as Listₚ                   using (≡-dec)
-import Data.Nat.Properties as ℕₚ                       using (_≟_)
+import Data.List.Properties as List                    using (≡-dec)
+import Data.Nat.Properties as ℕ                        using (_≟_)
 open import Data.Product.Base                          using (_×_; <_,_>; uncurry)
 open import Relation.Nullary.Decidable.Core            using (map′; _×-dec_; yes; no)
 open import Relation.Binary.Definitions                using (DecidableEquality)
@@ -66,10 +66,10 @@ function cs       ≟ function cs′        =
   map′ (cong function) function-injective (cs Term.≟-Clauses cs′)
 data-type pars cs ≟ data-type pars′ cs′ =
   map′ (uncurry (cong₂ data-type)) data-type-injective
-           (pars ℕₚ.≟ pars′ ×-dec Listₚ.≡-dec Name._≟_ cs cs′)
+           (pars ℕ.≟ pars′ ×-dec List.≡-dec Name._≟_ cs cs′)
 record′ c fs      ≟ record′ c′ fs′      =
   map′ (uncurry (cong₂ record′)) record′-injective
-           (c Name.≟ c′ ×-dec Listₚ.≡-dec (Arg.≡-dec Name._≟_) fs fs′)
+           (c Name.≟ c′ ×-dec List.≡-dec (Arg.≡-dec Name._≟_) fs fs′)
 constructor′ d    ≟ constructor′ d′     =
   map′ (cong constructor′) constructor′-injective (d Name.≟ d′)
 axiom             ≟ axiom               = yes refl

--- a/src/Reflection/AST/Meta.agda
+++ b/src/Reflection/AST/Meta.agda
@@ -8,7 +8,7 @@
 
 module Reflection.AST.Meta where
 
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Function.Base                              using (_on_)
 open import Relation.Nullary.Decidable.Core            using (map′)
 open import Relation.Binary.Core                       using (Rel)
@@ -30,7 +30,7 @@ _≈_ : Rel Meta _
 _≈_ = _≡_ on toℕ
 
 _≈?_ : Decidable _≈_
-_≈?_ = On.decidable toℕ _≡_ ℕₚ._≟_
+_≈?_ = On.decidable toℕ _≡_ ℕ._≟_
 
 _≟_ : DecidableEquality Meta
 m ≟ n = map′ (toℕ-injective _ _) (cong toℕ) (m ≈? n)

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -31,7 +31,7 @@ open import Data.Char.Base   as Char  using (toℕ)
 open import Data.Float.Base  as Float using (_≡ᵇ_)
 open import Data.List.Base   as List  using ([]; _∷_)
 open import Data.Maybe.Base  as Maybe using (Maybe; just; nothing)
-open import Data.Nat.Base    as Nat   using (ℕ; zero; suc; _≡ᵇ_; _+_)
+open import Data.Nat.Base    as ℕ     using (ℕ; zero; suc; _≡ᵇ_; _+_)
 open import Data.Unit.Base            using (⊤)
 open import Data.Word.Base   as Word  using (toℕ)
 open import Data.Product.Base         using (_×_; map₁; _,_)
@@ -62,7 +62,7 @@ open import Reflection.TCM.Syntax
 private
   -- Descend past a variable.
   varDescend : ℕ → ℕ → ℕ
-  varDescend ϕ x = if ϕ Nat.≤ᵇ x then suc x else x
+  varDescend ϕ x = if ϕ ℕ.≤ᵇ x then suc x else x
 
   -- Descend a variable underneath pattern variables.
   patternDescend : ℕ → Pattern → Pattern × ℕ
@@ -136,7 +136,7 @@ private
   antiUnifyClauses : ℕ → Clauses → Clauses → Maybe Clauses
   antiUnifyClause  : ℕ → Clause → Clause → Maybe Clause
 
-  antiUnify ϕ (var x args) (var y args') with x Nat.≡ᵇ y | antiUnifyArgs ϕ args args'
+  antiUnify ϕ (var x args) (var y args') with x ℕ.≡ᵇ y | antiUnifyArgs ϕ args args'
   ... | _     | nothing    = var ϕ []
   ... | false | just uargs = var ϕ uargs
   ... | true  | just uargs = var (varDescend ϕ x) uargs
@@ -158,13 +158,13 @@ private
     Π[ s ∶ arg i (antiUnify ϕ a a') ] antiUnify (suc ϕ) b b'
   antiUnify ϕ (sort (set t)) (sort (set t')) =
     sort (set (antiUnify ϕ t t'))
-  antiUnify ϕ (sort (lit n)) (sort (lit n')) with n Nat.≡ᵇ n'
+  antiUnify ϕ (sort (lit n)) (sort (lit n')) with n ℕ.≡ᵇ n'
   ... | true  = sort (lit n)
   ... | false = var ϕ []
-  antiUnify ϕ (sort (propLit n)) (sort (propLit n')) with n Nat.≡ᵇ n'
+  antiUnify ϕ (sort (propLit n)) (sort (propLit n')) with n ℕ.≡ᵇ n'
   ... | true  = sort (propLit n)
   ... | false = var ϕ []
-  antiUnify ϕ (sort (inf n)) (sort (inf n')) with n Nat.≡ᵇ n'
+  antiUnify ϕ (sort (inf n)) (sort (inf n')) with n ℕ.≡ᵇ n'
   ... | true  = sort (inf n)
   ... | false = var ϕ []
   antiUnify ϕ (sort unknown) (sort unknown) =

--- a/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Addition.agda
+++ b/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Addition.agda
@@ -13,12 +13,12 @@ module Tactic.RingSolver.Core.Polynomial.Homomorphism.Addition
   (homo : Homomorphism r₁ r₂ r₃ r₄)
   where
 
-open import Data.Nat            as ℕ  using (ℕ; suc; zero; compare; _≤′_; ≤′-step; ≤′-refl)
-open import Data.Nat.Properties as ℕₚ using (≤′-trans)
-open import Data.Product.Base         using (_,_; _×_; proj₂)
-open import Data.List.Base            using (_∷_; [])
+open import Data.Nat            as ℕ using (ℕ; suc; zero; compare; _≤′_; ≤′-step; ≤′-refl)
+open import Data.Nat.Properties as ℕ using (≤′-trans)
+open import Data.Product.Base        using (_,_; _×_; proj₂)
+open import Data.List.Base           using (_∷_; [])
 open import Data.List.Kleene
-open import Data.Vec.Base             using (Vec)
+open import Data.Vec.Base            using (Vec)
 open import Function.Base using (_⟨_⟩_; flip)
 open import Relation.Unary
 
@@ -206,7 +206,7 @@ mutual
             ρ ^ suc j * ((ρ * ⅀?⟦ xs ⟧ (ρ , Ρ) + ⟦ poly x ⟧ Ρ) *⟨ ρ ⟩^ k)
           ≈⟨ pow-add _ _ k j ⟩
             (ρ * ⅀?⟦ xs ⟧ (ρ , Ρ) + ⟦ poly x ⟧ Ρ) *⟨ ρ ⟩^ (k ℕ.+ suc j)
-            ≡⟨ ≡.cong (λ i → (ρ * ⅀?⟦ xs ⟧ (ρ , Ρ) + ⟦ poly x ⟧ Ρ) *⟨ ρ ⟩^ i) (ℕₚ.+-comm k (suc j)) ⟩
+            ≡⟨ ≡.cong (λ i → (ρ * ⅀?⟦ xs ⟧ (ρ , Ρ) + ⟦ poly x ⟧ Ρ) *⟨ ρ ⟩^ i) (ℕ.+-comm k (suc j)) ⟩
             (ρ * ⅀?⟦ xs ⟧ (ρ , Ρ) + ⟦ poly x ⟧ Ρ) *⟨ ρ ⟩^ (suc j ℕ.+ k)
           ∎)
     ⟩

--- a/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Exponentiation.agda
+++ b/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Exponentiation.agda
@@ -20,7 +20,7 @@ open import Data.Product.Base  using (_,_; _×_; proj₁; proj₂)
 open import Data.List.Kleene
 open import Data.Vec.Base      using (Vec)
 
-import Data.Nat.Properties as ℕ-Prop
+import Data.Nat.Properties as ℕ
 import Relation.Binary.PropositionalEquality.Core as ≡
 
 open Homomorphism homo
@@ -64,7 +64,7 @@ pow-eval-hom x (suc i) = (*-homo _ x) ⟨ trans ⟩ (≪* pow-eval-hom x i)
   rearrange zero =
     begin
       (ρ′ RawPow.^ (i ℕ.* 0)) * (⟦ x ⟧ Ρ RawPow.^ suc i)
-    ≡⟨ ≡.cong (λ k →  (ρ′ RawPow.^ k) * (⟦ x ⟧ Ρ RawPow.^ suc i)) (ℕ-Prop.*-zeroʳ i) ⟩
+    ≡⟨ ≡.cong (λ k →  (ρ′ RawPow.^ k) * (⟦ x ⟧ Ρ RawPow.^ suc i)) (ℕ.*-zeroʳ i) ⟩
       1# * (⟦ x ⟧ Ρ RawPow.^ suc i)
     ≈⟨ *-identityˡ _ ⟩
       ⟦ x ⟧ Ρ RawPow.^ suc i
@@ -72,7 +72,7 @@ pow-eval-hom x (suc i) = (*-homo _ x) ⟨ trans ⟩ (≪* pow-eval-hom x i)
   rearrange j@(suc j′) =
     begin
       (ρ′ RawPow.^ (suc i ℕ.* j))           * (⟦ x ⟧ Ρ RawPow.^ suc i)
-    ≡⟨ ≡.cong (λ v → (ρ′ RawPow.^ v) * (⟦ x ⟧ Ρ RawPow.^ suc i)) (ℕ-Prop.*-comm (suc i) j) ⟩
+    ≡⟨ ≡.cong (λ v → (ρ′ RawPow.^ v) * (⟦ x ⟧ Ρ RawPow.^ suc i)) (ℕ.*-comm (suc i) j) ⟩
       (ρ′ RawPow.^ (j ℕ.* suc i))           * (⟦ x ⟧ Ρ RawPow.^ suc i)
     ≈⟨ ≪* sym (RawPow.^-assocʳ ρ′ j (suc i)) ⟩
       ((ρ′ RawPow.^ suc j′) RawPow.^ suc i) * (⟦ x ⟧ Ρ RawPow.^ suc i)

--- a/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Lemmas.agda
+++ b/src/Tactic/RingSolver/Core/Polynomial/Homomorphism/Lemmas.agda
@@ -15,7 +15,7 @@ module Tactic.RingSolver.Core.Polynomial.Homomorphism.Lemmas
 
 open import Data.Bool                                       using (Bool;true;false)
 open import Data.Nat.Base as ℕ                              using (ℕ; suc; zero; compare; _≤′_; ≤′-step; ≤′-refl)
-open import Data.Nat.Properties as ℕₚ                       using (≤′-trans)
+open import Data.Nat.Properties as ℕ                        using (≤′-trans)
 open import Data.Vec.Base as Vec                            using (Vec; _∷_)
 open import Data.Fin                                        using (Fin; zero; suc)
 open import Data.List.Base                                  using (_∷_; [])
@@ -65,7 +65,7 @@ pow-hom : ∀ {n} i
         → (xs : Coeff n +)
         → ∀ ρ ρs
         → ⅀⟦ xs ⟧ (ρ , ρs) *⟨ ρ ⟩^ i ≈ ⅀⟦ xs ⍓+ i ⟧ (ρ , ρs)
-pow-hom zero (x Δ j & xs) ρ ρs rewrite ℕₚ.+-identityʳ j = refl
+pow-hom zero (x Δ j & xs) ρ ρs rewrite ℕ.+-identityʳ j = refl
 pow-hom (suc i) (x ≠0 Δ j & xs) ρ ρs =
   begin
     ρ ^ (suc i) * (((x , xs) ⟦∷⟧ (ρ , ρs)) *⟨ ρ ⟩^ j)

--- a/src/Text/Pretty.agda
+++ b/src/Text/Pretty.agda
@@ -26,8 +26,8 @@ open import Effect.Monad using (RawMonad)
 import Data.List.Effectful as List
 open RawMonad (List.monad {Level.zero})
 
-import Data.Nat.Properties as ℕₚ
-open import Data.List.Extrema.Core ℕₚ.≤-totalOrder using (⊓ᴸ)
+import Data.Nat.Properties as ℕ
+open import Data.List.Extrema.Core ℕ.≤-totalOrder using (⊓ᴸ)
 
 ------------------------------------------------------------------------
 -- Internal representation of documents and rendering function

--- a/src/Text/Printf.agda
+++ b/src/Text/Printf.agda
@@ -11,18 +11,17 @@ module Text.Printf where
 open import Data.String.Base using (String; fromChar; concat)
 open import Function.Base using (id)
 
-import Data.Char.Base    as Cₛ
-import Data.Integer.Show as ℤₛ
-import Data.Float        as Fₛ
-import Data.Nat.Show     as ℕₛ  using (show)
+import Data.Integer.Show as ℤ
+import Data.Float        as Float
+import Data.Nat.Show     as ℕ
 
 open import Text.Format as Format hiding (Error)
 open import Text.Printf.Generic
 
 printfSpec : PrintfSpec formatSpec String
-printfSpec .PrintfSpec.renderArg ℕArg      = ℕₛ.show
-printfSpec .PrintfSpec.renderArg ℤArg      = ℤₛ.show
-printfSpec .PrintfSpec.renderArg FloatArg  = Fₛ.show
+printfSpec .PrintfSpec.renderArg ℕArg      = ℕ.show
+printfSpec .PrintfSpec.renderArg ℤArg      = ℤ.show
+printfSpec .PrintfSpec.renderArg FloatArg  = Float.show
 printfSpec .PrintfSpec.renderArg CharArg   = fromChar
 printfSpec .PrintfSpec.renderArg StringArg = id
 printfSpec .PrintfSpec.renderStr           = id


### PR DESCRIPTION
One or two additional renamings where it was easiest to do in-place.
Outstanding issue: `Data.Integer.Divisibility` seems to need to disambiguate the module imports, but perhaps this can be fixed by a `pattern` synonym or a renaming?