### PR TITLE
Qualified import of `Properties` modules fixing #2280

### DIFF
--- a/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
+++ b/src/Codata/Guarded/Stream/Relation/Binary/Pointwise.agda
@@ -17,8 +17,8 @@ open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Definitions
   using (Reflexive; Sym; Trans; Antisym; Symmetric; Transitive)
 open import Relation.Binary.Structures using (IsEquivalence)
-open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
-import Relation.Binary.PropositionalEquality.Properties as P
+open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
+import Relation.Binary.PropositionalEquality.Properties as ≡
 
 private
   variable
@@ -114,16 +114,16 @@ module _ {A : Set a} where
  _≈_ = Pointwise _≡_
 
  refl : Reflexive _≈_
- refl = reflexive P.refl
+ refl = reflexive ≡.refl
 
  sym : Symmetric _≈_
- sym = symmetric P.sym
+ sym = symmetric ≡.sym
 
  trans : Transitive _≈_
- trans = transitive P.trans
+ trans = transitive ≡.trans
 
  ≈-setoid : Setoid _ _
- ≈-setoid = setoid (P.setoid A)
+ ≈-setoid = setoid (≡.setoid A)
 
 ------------------------------------------------------------------------
 -- Pointwise DSL
@@ -161,7 +161,7 @@ module pw-Reasoning (S : Setoid a ℓ) where
 
   `head : ∀ {as bs} → `Pointwise as bs → as .head ∼ bs .head
   `head (`lift rs)         = rs .head
-  `head (`refl eq)         = S.reflexive (P.cong head eq)
+  `head (`refl eq)         = S.reflexive (≡.cong head eq)
   `head (`bisim rs)        = S.reflexive (rs .head)
   `head (`step `rs)        = `rs .head
   `head (`sym `rs)         = S.sym (`head `rs)
@@ -169,7 +169,7 @@ module pw-Reasoning (S : Setoid a ℓ) where
 
   `tail : ∀ {as bs} → `Pointwise as bs → `Pointwise (as .tail)  (bs .tail)
   `tail (`lift rs)         = `lift (rs .tail)
-  `tail (`refl eq)         = `refl (P.cong tail eq)
+  `tail (`refl eq)         = `refl (≡.cong tail eq)
   `tail (`bisim rs)        = `bisim (rs .tail)
   `tail (`step `rs)        = `rs .tail
   `tail (`sym `rs)         = `sym (`tail `rs)
@@ -196,8 +196,8 @@ module pw-Reasoning (S : Setoid a ℓ) where
   pattern _≈⟨_⟨_ as bs∼as bs∼cs = `trans {as = as} (`sym (`bisim bs∼as)) bs∼cs
   pattern _≡⟨_⟩_  as as∼bs bs∼cs = `trans {as = as} (`refl as∼bs) bs∼cs
   pattern _≡⟨_⟨_ as bs∼as bs∼cs = `trans {as = as} (`sym (`refl bs∼as)) bs∼cs
-  pattern _≡⟨⟩_   as as∼bs       = `trans {as = as} (`refl P.refl) as∼bs
-  pattern _∎      as             = `refl  {as = as} P.refl
+  pattern _≡⟨⟩_   as as∼bs       = `trans {as = as} (`refl ≡.refl) as∼bs
+  pattern _∎      as             = `refl  {as = as} ≡.refl
 
 
   -- Deprecated v2.0
@@ -226,7 +226,7 @@ module pw-Reasoning (S : Setoid a ℓ) where
 
 module ≈-Reasoning {a} {A : Set a} where
 
-  open pw-Reasoning (P.setoid A) public
+  open pw-Reasoning (≡.setoid A) public
 
   infix 4 _≈∞_
   _≈∞_ = `Pointwise∞

--- a/src/Codata/Sized/Colist/Properties.agda
+++ b/src/Codata/Sized/Colist/Properties.agda
@@ -14,24 +14,24 @@ open import Codata.Sized.Thunk as Thunk using (Thunk; force)
 open import Codata.Sized.Colist
 open import Codata.Sized.Colist.Bisimilarity
 open import Codata.Sized.Conat
-open import Codata.Sized.Conat.Bisimilarity as coℕᵇ using (zero; suc)
-import Codata.Sized.Conat.Properties as coℕₚ
+open import Codata.Sized.Conat.Bisimilarity as Conat using (zero; suc)
+import Codata.Sized.Conat.Properties as Conat
 open import Codata.Sized.Cowriter as Cowriter using ([_]; _∷_)
-open import Codata.Sized.Cowriter.Bisimilarity as coWriterᵇ using ([_]; _∷_)
+open import Codata.Sized.Cowriter.Bisimilarity as Cowriter using ([_]; _∷_)
 open import Codata.Sized.Stream as Stream using (Stream; _∷_)
 open import Data.Vec.Bounded as Vec≤ using (Vec≤)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_)
 open import Data.List.Relation.Binary.Equality.Propositional using (≋-refl)
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just)
-import Data.Maybe.Properties as Maybeₚ
+import Data.Maybe.Properties as Maybe
 open import Data.Maybe.Relation.Unary.All using (All; nothing; just)
 open import Data.Nat.Base as ℕ using (zero; suc; z≤n; s≤s)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry)
 open import Data.These.Base as These using (These; this; that; these)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Function.Base
-open import Relation.Binary.PropositionalEquality.Core as Eq using (_≡_)
+open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 
 private
   variable
@@ -47,13 +47,13 @@ private
 
 map-id : ∀ (as : Colist A ∞) → i ⊢ map id as ≈ as
 map-id []       = []
-map-id (a ∷ as) = Eq.refl ∷ λ where .force → map-id (as .force)
+map-id (a ∷ as) = ≡.refl ∷ λ where .force → map-id (as .force)
 
 map-∘ : ∀ (f : A → B) (g : B → C) as {i} →
                  i ⊢ map g (map f as) ≈ map (g ∘ f) as
 map-∘ f g []       = []
 map-∘ f g (a ∷ as) =
-  Eq.refl ∷ λ where .force → map-∘ f g (as .force)
+  ≡.refl ∷ λ where .force → map-∘ f g (as .force)
 
 ------------------------------------------------------------------------
 -- Relation to Cowriter
@@ -62,24 +62,24 @@ fromCowriter∘toCowriter≗id : ∀ (as : Colist A ∞) →
   i ⊢ fromCowriter (toCowriter as) ≈ as
 fromCowriter∘toCowriter≗id []       = []
 fromCowriter∘toCowriter≗id (a ∷ as) =
-  Eq.refl ∷ λ where .force → fromCowriter∘toCowriter≗id (as .force)
+  ≡.refl ∷ λ where .force → fromCowriter∘toCowriter≗id (as .force)
 
 ------------------------------------------------------------------------
 -- Properties of length
 
-length-∷ : ∀ (a : A) as → i coℕᵇ.⊢ length (a ∷ as) ≈ 1 ℕ+ length (as .force)
-length-∷ a as = suc (λ where .force → coℕᵇ.refl)
+length-∷ : ∀ (a : A) as → i Conat.⊢ length (a ∷ as) ≈ 1 ℕ+ length (as .force)
+length-∷ a as = suc (λ where .force → Conat.refl)
 
-length-replicate : ∀ n (a : A) → i coℕᵇ.⊢ length (replicate n a) ≈ n
+length-replicate : ∀ n (a : A) → i Conat.⊢ length (replicate n a) ≈ n
 length-replicate zero    a = zero
 length-replicate (suc n) a = suc λ where .force → length-replicate (n .force) a
 
 length-++ : (as bs : Colist A ∞) →
-            i coℕᵇ.⊢ length (as ++ bs) ≈ length as + length bs
-length-++ []       bs = coℕᵇ.refl
+            i Conat.⊢ length (as ++ bs) ≈ length as + length bs
+length-++ []       bs = Conat.refl
 length-++ (a ∷ as) bs = suc λ where .force → length-++ (as .force) bs
 
-length-map : ∀ (f : A → B) as → i coℕᵇ.⊢ length (map f as) ≈ length as
+length-map : ∀ (f : A → B) as → i Conat.⊢ length (map f as) ≈ length as
 length-map f []       = zero
 length-map f (a ∷ as) = suc λ where .force → length-map f (as .force)
 
@@ -89,51 +89,51 @@ length-map f (a ∷ as) = suc λ where .force → length-map f (as .force)
 replicate-+ : ∀ m n (a : A) →
               i ⊢ replicate (m + n) a ≈ replicate m a ++ replicate n a
 replicate-+ zero    n a = refl
-replicate-+ (suc m) n a = Eq.refl ∷ λ where .force → replicate-+ (m .force) n a
+replicate-+ (suc m) n a = ≡.refl ∷ λ where .force → replicate-+ (m .force) n a
 
 map-replicate : ∀ (f : A → B) n a →
                 i ⊢ map f (replicate n a) ≈ replicate n (f a)
 map-replicate f zero    a = []
 map-replicate f (suc n) a =
-  Eq.refl ∷ λ where .force → map-replicate f (n .force) a
+  ≡.refl ∷ λ where .force → map-replicate f (n .force) a
 
 lookup-replicate : ∀ k n (a : A) → All (a ≡_) (lookup (replicate n a) k)
 lookup-replicate k zero          a = nothing
-lookup-replicate zero    (suc n) a = just Eq.refl
+lookup-replicate zero    (suc n) a = just ≡.refl
 lookup-replicate (suc k) (suc n) a = lookup-replicate k (n .force) a
 
 ------------------------------------------------------------------------
 -- Properties of unfold
 
 map-unfold : ∀ (f : B → C) (alg : A → Maybe (A × B)) a →
-             i ⊢ map f (unfold alg a) ≈ unfold (Maybe.map (Prod.map₂ f) ∘ alg) a
+             i ⊢ map f (unfold alg a) ≈ unfold (Maybe.map (Product.map₂ f) ∘ alg) a
 map-unfold f alg a with alg a
 ... | nothing       = []
-... | just (a′ , b) = Eq.refl ∷ λ where .force → map-unfold f alg a′
+... | just (a′ , b) = ≡.refl ∷ λ where .force → map-unfold f alg a′
 
 module _ {alg : A → Maybe (A × B)} {a} where
 
   unfold-nothing : alg a ≡ nothing → unfold alg a ≡ []
   unfold-nothing eq with alg a
-  ... | nothing = Eq.refl
+  ... | nothing = ≡.refl
 
   unfold-just : ∀ {a′ b} → alg a ≡ just (a′ , b) →
                 i ⊢ unfold alg a ≈ b ∷ λ where .force → unfold alg a′
   unfold-just eq with alg a
-  unfold-just Eq.refl | just (a′ , b) = Eq.refl ∷ λ where .force → refl
+  unfold-just ≡.refl | just (a′ , b) = ≡.refl ∷ λ where .force → refl
 
 ------------------------------------------------------------------------
 -- Properties of scanl
 
 length-scanl : ∀ (c : B → A → B) n as →
-               i coℕᵇ.⊢ length (scanl c n as) ≈ 1 ℕ+ length as
+               i Conat.⊢ length (scanl c n as) ≈ 1 ℕ+ length as
 length-scanl c n []       = suc λ where .force → zero
 length-scanl c n (a ∷ as) = suc λ { .force → begin
   length (scanl c (c n a) (as .force))
     ≈⟨ length-scanl c (c n a) (as .force) ⟩
   1 ℕ+ length (as .force)
     ≈⟨ length-∷ a as ⟨
-  length (a ∷ as) ∎ } where open coℕᵇ.≈-Reasoning
+  length (a ∷ as) ∎ } where open Conat.≈-Reasoning
 
 module _ (cons : C → B → C) (alg : A → Maybe (A × B)) where
 
@@ -145,15 +145,15 @@ module _ (cons : C → B → C) (alg : A → Maybe (A × B)) where
   scanl-unfold : ∀ nil a → i ⊢ scanl cons nil (unfold alg a)
                              ≈ nil ∷ (λ where .force → unfold alg′ (a , nil))
   scanl-unfold nil a with alg a in eq
-  ... | nothing      = Eq.refl ∷ λ { .force →
-    sym (fromEq (unfold-nothing (Maybeₚ.map-nothing eq))) }
-  ... | just (a′ , b) = Eq.refl ∷ λ { .force → begin
+  ... | nothing      = ≡.refl ∷ λ { .force →
+    sym (fromEq (unfold-nothing (Maybe.map-nothing eq))) }
+  ... | just (a′ , b) = ≡.refl ∷ λ { .force → begin
     scanl cons (cons nil b) (unfold alg a′)
      ≈⟨ scanl-unfold (cons nil b) a′ ⟩
     (cons nil b ∷ _)
-     ≈⟨ Eq.refl ∷ (λ where .force → refl) ⟩
+     ≈⟨ ≡.refl ∷ (λ where .force → refl) ⟩
     (cons nil b ∷ _)
-     ≈⟨ unfold-just (Maybeₚ.map-just eq) ⟨
+     ≈⟨ unfold-just (Maybe.map-just eq) ⟨
     unfold alg′ (a , nil) ∎ } where open ≈-Reasoning
 
 ------------------------------------------------------------------------
@@ -164,10 +164,10 @@ map-alignWith : ∀ (f : C → D) (al : These A B → C) as bs →
 map-alignWith f al []         bs       = map-∘ (al ∘′ that) f bs
 map-alignWith f al as@(_ ∷ _) []       = map-∘ (al ∘′ this) f as
 map-alignWith f al (a ∷ as)   (b ∷ bs) =
-  Eq.refl ∷ λ where .force → map-alignWith f al (as .force) (bs .force)
+  ≡.refl ∷ λ where .force → map-alignWith f al (as .force) (bs .force)
 
 length-alignWith : ∀ (al : These A B → C) as bs →
-                   i coℕᵇ.⊢ length (alignWith al as bs) ≈ length as ⊔ length bs
+                   i Conat.⊢ length (alignWith al as bs) ≈ length as ⊔ length bs
 length-alignWith al []         bs       = length-map (al ∘ that) bs
 length-alignWith al as@(_ ∷ _) []       = length-map (al ∘ this) as
 length-alignWith al (a ∷ as)   (b ∷ bs) =
@@ -181,10 +181,10 @@ map-zipWith : ∀ (f : C → D) (zp : A → B → C) as bs →
 map-zipWith f zp []       _        = []
 map-zipWith f zp (_ ∷ _)  []       = []
 map-zipWith f zp (a ∷ as) (b ∷ bs) =
-  Eq.refl ∷ λ where .force → map-zipWith f zp (as .force) (bs .force)
+  ≡.refl ∷ λ where .force → map-zipWith f zp (as .force) (bs .force)
 
 length-zipWith : ∀ (zp : A → B → C) as bs →
-                 i coℕᵇ.⊢ length (zipWith zp as bs) ≈ length as ⊓ length bs
+                 i Conat.⊢ length (zipWith zp as bs) ≈ length as ⊓ length bs
 length-zipWith zp []         bs       = zero
 length-zipWith zp as@(_ ∷ _) []       = zero
 length-zipWith zp (a ∷ as)   (b ∷ bs) =
@@ -208,25 +208,25 @@ map-drop f zero    as       = refl
 map-drop f (suc m) []       = []
 map-drop f (suc m) (a ∷ as) = map-drop f m (as .force)
 
-length-drop : ∀ m (as : Colist A ∞) → i coℕᵇ.⊢ length (drop m as) ≈ length as ∸ m
-length-drop zero    as       = coℕᵇ.refl
-length-drop (suc m) []       = coℕᵇ.sym (coℕₚ.0∸m≈0 m)
+length-drop : ∀ m (as : Colist A ∞) → i Conat.⊢ length (drop m as) ≈ length as ∸ m
+length-drop zero    as       = Conat.refl
+length-drop (suc m) []       = Conat.sym (Conat.0∸m≈0 m)
 length-drop (suc m) (a ∷ as) = length-drop m (as .force)
 
 drop-fromList-++-identity : ∀ (as : List A) bs →
                             drop (List.length as) (fromList as ++ bs) ≡ bs
-drop-fromList-++-identity []       bs = Eq.refl
+drop-fromList-++-identity []       bs = ≡.refl
 drop-fromList-++-identity (a ∷ as) bs = drop-fromList-++-identity as bs
 
 drop-fromList-++-≤ : ∀ (as : List A) bs {m} → m ℕ.≤ List.length as →
                      drop m (fromList as ++ bs) ≡ fromList (List.drop m as) ++ bs
-drop-fromList-++-≤ []       bs z≤n     = Eq.refl
-drop-fromList-++-≤ (a ∷ as) bs z≤n     = Eq.refl
+drop-fromList-++-≤ []       bs z≤n     = ≡.refl
+drop-fromList-++-≤ (a ∷ as) bs z≤n     = ≡.refl
 drop-fromList-++-≤ (a ∷ as) bs (s≤s p) = drop-fromList-++-≤ as bs p
 
 drop-fromList-++-≥ : ∀ (as : List A) bs {m} → m ℕ.≥ List.length as →
                      drop m (fromList as ++ bs) ≡ drop (m ℕ.∸ List.length as) bs
-drop-fromList-++-≥ []       bs z≤n     = Eq.refl
+drop-fromList-++-≥ []       bs z≤n     = ≡.refl
 drop-fromList-++-≥ (a ∷ as) bs (s≤s p) = drop-fromList-++-≥ as bs p
 
 drop-⁺++-identity : ∀ (as : List⁺ A) bs →
@@ -236,7 +236,7 @@ drop-⁺++-identity (a ∷ as) bs = drop-fromList-++-identity as (bs .force)
 ------------------------------------------------------------------------
 -- Properties of cotake
 
-length-cotake : ∀ n (as : Stream A ∞) → i coℕᵇ.⊢ length (cotake n as) ≈ n
+length-cotake : ∀ n (as : Stream A ∞) → i Conat.⊢ length (cotake n as) ≈ n
 length-cotake zero    as       = zero
 length-cotake (suc n) (a ∷ as) =
   suc λ where .force → length-cotake (n .force) (as .force)
@@ -245,7 +245,7 @@ map-cotake : ∀ (f : A → B) n as →
              i ⊢ map f (cotake n as) ≈ cotake n (Stream.map f as)
 map-cotake f zero    as       = []
 map-cotake f (suc n) (a ∷ as) =
-  Eq.refl ∷ λ where .force → map-cotake f (n .force) (as .force)
+  ≡.refl ∷ λ where .force → map-cotake f (n .force) (as .force)
 
 ------------------------------------------------------------------------
 -- Properties of chunksOf
@@ -255,20 +255,20 @@ module Map-ChunksOf (f : A → B) n where
   open ChunksOf n using (chunksOfAcc)
 
   map-chunksOf : ∀ as →
-    i coWriterᵇ.⊢ Cowriter.map (Vec.map f) (Vec≤.map f) (chunksOf n as)
+    i Cowriter.⊢ Cowriter.map (Vec.map f) (Vec≤.map f) (chunksOf n as)
                 ≈ chunksOf n (map f as)
   map-chunksOfAcc : ∀ m as {k≤ k≡ k≤′ k≡′} →
                     (∀ vs → Vec≤.map f (k≤ vs) ≡ k≤′ (Vec≤.map f vs)) →
                     (∀ vs → Vec.map f (k≡ vs) ≡ k≡′ (Vec.map f vs)) →
-                    i coWriterᵇ.⊢ Cowriter.map (Vec.map f) (Vec≤.map f)
+                    i Cowriter.⊢ Cowriter.map (Vec.map f) (Vec≤.map f)
                                         (chunksOfAcc m k≤ k≡ as)
                                 ≈ chunksOfAcc m k≤′ k≡′ (map f as)
 
-  map-chunksOf as = map-chunksOfAcc n as (λ vs → Eq.refl) (λ vs → Eq.refl)
+  map-chunksOf as = map-chunksOfAcc n as (λ vs → ≡.refl) (λ vs → ≡.refl)
 
   map-chunksOfAcc zero    as       eq-≤ eq-≡ =
       eq-≡ [] ∷ λ where .force → map-chunksOf as
-  map-chunksOfAcc (suc m) []       eq-≤ eq-≡ = coWriterᵇ.[ eq-≤ Vec≤.[] ]
+  map-chunksOfAcc (suc m) []       eq-≤ eq-≡ = Cowriter.[ eq-≤ Vec≤.[] ]
   map-chunksOfAcc (suc m) (a ∷ as) eq-≤ eq-≡ =
     map-chunksOfAcc m (as .force) (eq-≤ ∘ (a Vec≤.∷_)) (eq-≡ ∘ (a Vec.∷_))
 
@@ -280,21 +280,21 @@ open Map-ChunksOf using (map-chunksOf) public
 fromList-++ : (as bs : List A) →
               i ⊢ fromList (as List.++ bs) ≈ fromList as ++ fromList bs
 fromList-++ []       bs = refl
-fromList-++ (a ∷ as) bs = Eq.refl ∷ λ where .force → fromList-++ as bs
+fromList-++ (a ∷ as) bs = ≡.refl ∷ λ where .force → fromList-++ as bs
 
 fromList-scanl : ∀ (c : B → A → B) n as →
                  i ⊢ fromList (List.scanl c n as) ≈ scanl c n (fromList as)
-fromList-scanl c n []       = Eq.refl ∷ λ where .force → refl
+fromList-scanl c n []       = ≡.refl ∷ λ where .force → refl
 fromList-scanl c n (a ∷ as) =
-  Eq.refl ∷ λ where .force → fromList-scanl c (c n a) as
+  ≡.refl ∷ λ where .force → fromList-scanl c (c n a) as
 
 map-fromList : ∀ (f : A → B) as →
                i ⊢ map f (fromList as) ≈ fromList (List.map f as)
 map-fromList f []       = []
-map-fromList f (a ∷ as) = Eq.refl ∷ λ where .force → map-fromList f as
+map-fromList f (a ∷ as) = ≡.refl ∷ λ where .force → map-fromList f as
 
 length-fromList : (as : List A) →
-                  i coℕᵇ.⊢ length (fromList as) ≈ fromℕ (List.length as)
+                  i Conat.⊢ length (fromList as) ≈ fromℕ (List.length as)
 length-fromList []       = zero
 length-fromList (a ∷ as) = suc (λ where .force → length-fromList as)
 
@@ -304,19 +304,19 @@ length-fromList (a ∷ as) = suc (λ where .force → length-fromList as)
 fromStream-++ : ∀ (as : List A) bs →
                 i ⊢ fromStream (as Stream.++ bs) ≈ fromList as ++ fromStream bs
 fromStream-++ []       bs = refl
-fromStream-++ (a ∷ as) bs = Eq.refl ∷ λ where .force → fromStream-++ as bs
+fromStream-++ (a ∷ as) bs = ≡.refl ∷ λ where .force → fromStream-++ as bs
 
 fromStream-⁺++ : ∀ (as : List⁺ A) bs →
                  i ⊢ fromStream (as Stream.⁺++ bs)
                    ≈ fromList⁺ as ++ fromStream (bs .force)
 fromStream-⁺++ (a ∷ as) bs =
-  Eq.refl ∷ λ where .force → fromStream-++ as (bs .force)
+  ≡.refl ∷ λ where .force → fromStream-++ as (bs .force)
 
 fromStream-concat : (ass : Stream (List⁺ A) ∞) →
                     i ⊢ concat (fromStream ass) ≈ fromStream (Stream.concat ass)
 fromStream-concat (as@(a ∷ _) ∷ ass) = begin
   concat (fromStream (as ∷ ass))
-    ≈⟨ Eq.refl ∷ (λ { .force → ++⁺ ≋-refl (fromStream-concat (ass .force))}) ⟩
+    ≈⟨ ≡.refl ∷ (λ { .force → ++⁺ ≋-refl (fromStream-concat (ass .force))}) ⟩
   a ∷ _
     ≈⟨ sym (fromStream-⁺++ as _) ⟩
   fromStream (Stream.concat (as ∷ ass)) ∎ where open ≈-Reasoning
@@ -325,12 +325,12 @@ fromStream-scanl : ∀ (c : B → A → B) n as →
                    i ⊢ scanl c n (fromStream as)
                      ≈ fromStream (Stream.scanl c n as)
 fromStream-scanl c n (a ∷ as) =
-  Eq.refl ∷ λ where .force → fromStream-scanl c (c n a) (as .force)
+  ≡.refl ∷ λ where .force → fromStream-scanl c (c n a) (as .force)
 
 map-fromStream : ∀ (f : A → B) as →
                  i ⊢ map f (fromStream as) ≈ fromStream (Stream.map f as)
 map-fromStream f (a ∷ as) =
-  Eq.refl ∷ λ where .force → map-fromStream f (as .force)
+  ≡.refl ∷ λ where .force → map-fromStream f (as .force)
 
 ------------------------------------------------------------------------
 -- DEPRECATED

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -27,10 +27,10 @@ open import Relation.Binary.Definitions
 import Relation.Binary.Construct.On as On
 import Relation.Binary.Construct.Subst.Equality as Subst
 import Relation.Binary.Construct.Closure.Reflexive as Refl
-import Relation.Binary.Construct.Closure.Reflexive.Properties as Reflₚ
-open import Relation.Binary.PropositionalEquality.Core as PropEq
+import Relation.Binary.Construct.Closure.Reflexive.Properties as Refl
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; _≢_; refl; cong; sym; trans; subst)
-import Relation.Binary.PropositionalEquality.Properties as PropEq
+import Relation.Binary.PropositionalEquality.Properties as ≡
 
 ------------------------------------------------------------------------
 -- Primitive properties
@@ -59,13 +59,13 @@ _≟_ : Decidable {A = Char} _≡_
 x ≟ y = map′ ≈⇒≡ ≈-reflexive (toℕ x ℕ.≟ toℕ y)
 
 setoid : Setoid _ _
-setoid = PropEq.setoid Char
+setoid = ≡.setoid Char
 
 decSetoid : DecSetoid _ _
-decSetoid = PropEq.decSetoid _≟_
+decSetoid = ≡.decSetoid _≟_
 
 isDecEquivalence : IsDecEquivalence _≡_
-isDecEquivalence = PropEq.isDecEquivalence _≟_
+isDecEquivalence = ≡.isDecEquivalence _≟_
 
 ------------------------------------------------------------------------
 -- Boolean equality test.
@@ -114,11 +114,11 @@ _<?_ = On.decidable toℕ ℕ._<_ ℕ._<?_
 
 <-isStrictPartialOrder : IsStrictPartialOrder _≡_ _<_
 <-isStrictPartialOrder = record
-  { isEquivalence = PropEq.isEquivalence
+  { isEquivalence = ≡.isEquivalence
   ; irrefl        = <-irrefl
   ; trans         = λ {a} {b} {c} → <-trans {a} {b} {c}
-  ; <-resp-≈      = (λ {c} → PropEq.subst (c <_))
-                  , (λ {c} → PropEq.subst (_< c))
+  ; <-resp-≈      = (λ {c} → ≡.subst (c <_))
+                  , (λ {c} → ≡.subst (_< c))
   }
 
 <-isStrictTotalOrder : IsStrictTotalOrder _≡_ _<_
@@ -142,20 +142,20 @@ _<?_ = On.decidable toℕ ℕ._<_ ℕ._<?_
 
 infix 4 _≤?_
 _≤?_ : Decidable _≤_
-_≤?_ = Reflₚ.decidable <-cmp
+_≤?_ = Refl.decidable <-cmp
 
 ≤-reflexive : _≡_ ⇒ _≤_
 ≤-reflexive = Refl.reflexive
 
 ≤-trans : Transitive _≤_
-≤-trans = Reflₚ.trans (λ {a} {b} {c} → <-trans {a} {b} {c})
+≤-trans = Refl.trans (λ {a} {b} {c} → <-trans {a} {b} {c})
 
 ≤-antisym : Antisymmetric _≡_ _≤_
-≤-antisym = Reflₚ.antisym _≡_ refl ℕ.<-asym
+≤-antisym = Refl.antisym _≡_ refl ℕ.<-asym
 
 ≤-isPreorder : IsPreorder _≡_ _≤_
 ≤-isPreorder = record
-  { isEquivalence = PropEq.isEquivalence
+  { isEquivalence = ≡.isEquivalence
   ; reflexive     = ≤-reflexive
   ; trans         = ≤-trans
   }

--- a/src/Data/Digit/Properties.agda
+++ b/src/Data/Digit/Properties.agda
@@ -7,13 +7,13 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 open import Data.Digit
-import Data.Char.Properties as Charₚ
+import Data.Char.Properties as Char
 open import Data.Nat.Base using (ℕ)
 open import Data.Nat.Properties using (_≤?_)
 open import Data.Fin.Properties using (inject≤-injective)
 open import Data.Product.Base using (_,_; proj₁)
 open import Data.Vec.Relation.Unary.Unique.Propositional using (Unique)
-import Data.Vec.Relation.Unary.Unique.Propositional.Properties as Uniqueₚ
+import Data.Vec.Relation.Unary.Unique.Propositional.Properties as Unique
 open import Data.Vec.Relation.Unary.AllPairs using (allPairs?)
 open import Relation.Nullary.Decidable.Core using (True; from-yes; ¬?)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
@@ -22,7 +22,7 @@ open import Function.Base using (_∘_)
 module Data.Digit.Properties where
 
 digitCharsUnique : Unique digitChars
-digitCharsUnique = from-yes (allPairs? (λ x y → ¬? (x Charₚ.≟ y)) digitChars)
+digitCharsUnique = from-yes (allPairs? (λ x y → ¬? (x Char.≟ y)) digitChars)
 
 module _ (base : ℕ) where
   module _ {base≥2 base≥2′ : True (2 ≤? base)} where
@@ -32,4 +32,4 @@ module _ (base : ℕ) where
 
   module _ {base≤16 base≤16′ : True (base ≤? 16)} where
     showDigit-injective : (n m : Digit base) → showDigit {base} {base≤16} n ≡ showDigit {base} {base≤16′} m → n ≡ m
-    showDigit-injective n m = inject≤-injective _ _ n m ∘ Uniqueₚ.lookup-injective digitCharsUnique _ _
+    showDigit-injective n m = inject≤-injective _ _ n m ∘ Unique.lookup-injective digitCharsUnique _ _

--- a/src/Data/Fin/Induction.agda
+++ b/src/Data/Fin/Induction.agda
@@ -16,7 +16,7 @@ import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (_,_)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Data.Vec.Relation.Unary.Linked as Linked using (Linked; [-]; _∷_)
-import Data.Vec.Relation.Unary.Linked.Properties as Linkedₚ
+import Data.Vec.Relation.Unary.Linked.Properties as Linked
 open import Function.Base using (flip; _$_)
 open import Induction
 open import Induction.WellFounded as WF
@@ -124,7 +124,7 @@ module _ {_≈_ : Rel (Fin n) ℓ} where
     pigeon : {xs : Vec (Fin n) n} → Linked (flip _⊏_) (i ∷ xs) → WellFounded _⊏_
     pigeon {xs} i∷xs↑ =
       let (i₁ , i₂ , i₁<i₂ , xs[i₁]≡xs[i₂]) = pigeonhole (n<1+n n) (Vec.lookup (i ∷ xs)) in
-      let xs[i₁]⊏xs[i₂] = Linkedₚ.lookup⁺ (Ord.transitive _⊏_ ⊏.trans) i∷xs↑ i₁<i₂ in
+      let xs[i₁]⊏xs[i₂] = Linked.lookup⁺ (Ord.transitive _⊏_ ⊏.trans) i∷xs↑ i₁<i₂ in
       let xs[i₁]⊏xs[i₁] = ⊏.<-respʳ-≈ (⊏.Eq.reflexive xs[i₁]≡xs[i₂]) xs[i₁]⊏xs[i₂] in
       contradiction xs[i₁]⊏xs[i₁] (⊏.irrefl ⊏.Eq.refl)
 

--- a/src/Data/Fin/Substitution/Lemmas.agda
+++ b/src/Data/Fin/Substitution/Lemmas.agda
@@ -12,9 +12,9 @@ open import Data.Fin.Substitution
 open import Data.Nat hiding (_⊔_; _/_)
 open import Data.Fin.Base using (Fin; zero; suc; lift)
 open import Data.Vec.Base
-import Data.Vec.Properties as VecProp
+import Data.Vec.Properties as Vec
 open import Function.Base as Fun using (_∘_; _$_; flip)
-open import Relation.Binary.PropositionalEquality.Core as PropEq
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; sym; cong; cong₂)
 open import Relation.Binary.PropositionalEquality.Properties
   using (module ≡-Reasoning)
@@ -68,9 +68,9 @@ record Lemmas₀ (T : Pred ℕ ℓ) : Set ℓ where
   lookup-map-weaken-↑⋆ zero    x           = refl
   lookup-map-weaken-↑⋆ (suc k) zero        = refl
   lookup-map-weaken-↑⋆ (suc k) (suc x) {ρ} = begin
-    lookup (map weaken (map weaken ρ ↑⋆ k)) x        ≡⟨ VecProp.lookup-map x weaken (map weaken ρ ↑⋆ k) ⟩
+    lookup (map weaken (map weaken ρ ↑⋆ k)) x        ≡⟨ Vec.lookup-map x weaken (map weaken ρ ↑⋆ k) ⟩
     weaken (lookup (map weaken ρ ↑⋆ k) x)            ≡⟨ cong weaken (lookup-map-weaken-↑⋆ k x) ⟩
-    weaken (lookup ((ρ ↑) ↑⋆ k) (lift k suc x))      ≡⟨ sym $ VecProp.lookup-map (lift k suc x) weaken ((ρ ↑) ↑⋆ k) ⟩
+    weaken (lookup ((ρ ↑) ↑⋆ k) (lift k suc x))      ≡⟨ sym $ Vec.lookup-map (lift k suc x) weaken ((ρ ↑) ↑⋆ k) ⟩
     lookup (map weaken ((ρ ↑) ↑⋆ k)) (lift k suc x)  ∎
 
 record Lemmas₁ (T : Pred ℕ ℓ) : Set ℓ where
@@ -85,7 +85,7 @@ record Lemmas₁ (T : Pred ℕ ℓ) : Set ℓ where
                       lookup             ρ  x ≡ var      y →
                       lookup (map weaken ρ) x ≡ var (suc y)
   lookup-map-weaken x {y} {ρ} hyp = begin
-    lookup (map weaken ρ) x  ≡⟨ VecProp.lookup-map x weaken ρ ⟩
+    lookup (map weaken ρ) x  ≡⟨ Vec.lookup-map x weaken ρ ⟩
     weaken (lookup ρ x)      ≡⟨ cong weaken hyp ⟩
     weaken (var y)           ≡⟨ weaken-var ⟩
     var (suc y)              ∎
@@ -153,7 +153,7 @@ record Lemmas₂ (T : Pred ℕ ℓ) : Set ℓ where
 
   lookup-⊙ : ∀ x {ρ₁ : Sub T m n} {ρ₂ : Sub T n o} →
              lookup (ρ₁ ⊙ ρ₂) x ≡ lookup ρ₁ x / ρ₂
-  lookup-⊙ x {ρ₁} {ρ₂} = VecProp.lookup-map x (λ t → t / ρ₂) ρ₁
+  lookup-⊙ x {ρ₁} {ρ₂} = Vec.lookup-map x (λ t → t / ρ₂) ρ₁
 
   lookup-⨀ : ∀ x (ρs : Subs T m n) →
              lookup (⨀ ρs) x ≡ var x /✶ ρs
@@ -239,8 +239,8 @@ record Lemmas₃ (T : Pred ℕ ℓ) : Set ℓ where
 
   ⊙-id : {ρ : Sub T m n} → ρ ⊙ id ≡ ρ
   ⊙-id {ρ = ρ} = begin
-    map (λ t → t / id) ρ  ≡⟨ VecProp.map-cong id-vanishes ρ ⟩
-    map Fun.id         ρ  ≡⟨ VecProp.map-id ρ ⟩
+    map (λ t → t / id) ρ  ≡⟨ Vec.map-cong id-vanishes ρ ⟩
+    map Fun.id         ρ  ≡⟨ Vec.map-id ρ ⟩
     ρ                     ∎
 
   open Lemmas₂ lemmas₂ public hiding (wk-⊙-sub′)
@@ -264,13 +264,13 @@ record Lemmas₄ (T : Pred ℕ ℓ) : Set ℓ where
       ρ₁ ↑ ⊙ ρ₂ ↑                             ∎
       where
       lemma = begin
-        map weaken (map (λ t → t / ρ₂) ρ₁)    ≡⟨ sym (VecProp.map-∘ _ _ _) ⟩
-        map (λ t → weaken (t / ρ₂)) ρ₁        ≡⟨ VecProp.map-cong (λ t → begin
+        map weaken (map (λ t → t / ρ₂) ρ₁)    ≡⟨ sym (Vec.map-∘ _ _ _) ⟩
+        map (λ t → weaken (t / ρ₂)) ρ₁        ≡⟨ Vec.map-cong (λ t → begin
                                                    weaken (t / ρ₂)  ≡⟨ sym /-wk ⟩
                                                    t / ρ₂ / wk      ≡⟨ hyp t ⟩
                                                    t / wk / ρ₂ ↑    ≡⟨ cong₂ _/_ /-wk refl ⟩
                                                    weaken t / ρ₂ ↑  ∎) ρ₁ ⟩
-        map (λ t → weaken t / ρ₂ ↑) ρ₁        ≡⟨ VecProp.map-∘ _ _ _ ⟩
+        map (λ t → weaken t / ρ₂ ↑) ρ₁        ≡⟨ Vec.map-∘ _ _ _ ⟩
         map (λ t → t / ρ₂ ↑) (map weaken ρ₁)  ∎
 
     ↑⋆-distrib′ : {ρ₁ : Sub T m n} {ρ₂ : Sub T n o} →
@@ -284,7 +284,7 @@ record Lemmas₄ (T : Pred ℕ ℓ) : Set ℓ where
 
   map-weaken : {ρ : Sub T m n} → map weaken ρ ≡ ρ ⊙ wk
   map-weaken {ρ = ρ} = begin
-    map weaken ρ          ≡⟨ VecProp.map-cong (λ _ → sym /-wk) ρ ⟩
+    map weaken ρ          ≡⟨ Vec.map-cong (λ _ → sym /-wk) ρ ⟩
     map (λ t → t / wk) ρ  ≡⟨ refl ⟩
     ρ ⊙ wk                ∎
 
@@ -324,8 +324,8 @@ record Lemmas₄ (T : Pred ℕ ℓ) : Set ℓ where
   ⊙-assoc : {ρ₁ : Sub T m n} {ρ₂ : Sub T n o} {ρ₃ : Sub T o p} →
             ρ₁ ⊙ (ρ₂ ⊙ ρ₃) ≡ (ρ₁ ⊙ ρ₂) ⊙ ρ₃
   ⊙-assoc {ρ₁ = ρ₁} {ρ₂} {ρ₃} = begin
-    map (λ t → t / ρ₂ ⊙ ρ₃) ρ₁                  ≡⟨ VecProp.map-cong /-⊙ ρ₁ ⟩
-    map (λ t → t / ρ₂ / ρ₃) ρ₁                  ≡⟨ VecProp.map-∘ _ _ _ ⟩
+    map (λ t → t / ρ₂ ⊙ ρ₃) ρ₁                  ≡⟨ Vec.map-cong /-⊙ ρ₁ ⟩
+    map (λ t → t / ρ₂ / ρ₃) ρ₁                  ≡⟨ Vec.map-∘ _ _ _ ⟩
     map (λ t → t / ρ₃) (map (λ t → t / ρ₂) ρ₁)  ∎
 
   map-weaken-⊙-sub : ∀ {ρ : Sub T m n} {t} → map weaken ρ ⊙ sub t ≡ ρ
@@ -560,7 +560,7 @@ record TermLemmas (T : ℕ → Set) : Set₁ where
              (∀ x → lookup ρ₂ x ≡ T.var (f x)) →
              map T.var ρ₁ ≡ ρ₂
   map-var≡ {ρ₁ = ρ₁} {ρ₂ = ρ₂} {f = f} hyp₁ hyp₂ = extensionality λ x →
-    lookup (map T.var ρ₁) x  ≡⟨ VecProp.lookup-map x _ ρ₁ ⟩
+    lookup (map T.var ρ₁) x  ≡⟨ Vec.lookup-map x _ ρ₁ ⟩
     T.var (lookup ρ₁ x)      ≡⟨ cong T.var $ hyp₁ x ⟩
     T.var (f x)              ≡⟨ sym $ hyp₂ x ⟩
     lookup ρ₂ x              ∎
@@ -577,7 +577,7 @@ record TermLemmas (T : ℕ → Set) : Set₁ where
   ↑≡↑ : {ρ : Sub Fin m n} → map T.var (ρ VarSubst.↑) ≡ map T.var ρ T.↑
   ↑≡↑ {ρ = ρ} = map-var≡
     (VarLemmas.lookup-↑⋆ (lookup ρ) (λ _ → refl) 1)
-    (lookup-↑⋆ (lookup ρ) (λ _ → VecProp.lookup-map _ _ ρ) 1)
+    (lookup-↑⋆ (lookup ρ) (λ _ → Vec.lookup-map _ _ ρ) 1)
 
   /Var≡/ : ∀ {ρ : Sub Fin m n} {t} → t /Var ρ ≡ t T./ map T.var ρ
   /Var≡/ {ρ = ρ} {t = t} =
@@ -585,7 +585,7 @@ record TermLemmas (T : ℕ → Set) : Set₁ where
       (λ k x →
          T.var x /Var ρ VarSubst.↑⋆ k        ≡⟨ app-var ⟩
          T.var (lookup (ρ VarSubst.↑⋆ k) x)  ≡⟨ cong T.var $ VarLemmas.lookup-↑⋆ _ (λ _ → refl) k _ ⟩
-         T.var (lift k (VarSubst._/ ρ) x)    ≡⟨ sym $ lookup-↑⋆ _ (λ _ → VecProp.lookup-map _ _ ρ) k _ ⟩
+         T.var (lift k (VarSubst._/ ρ) x)    ≡⟨ sym $ lookup-↑⋆ _ (λ _ → Vec.lookup-map _ _ ρ) k _ ⟩
          lookup (map T.var ρ T.↑⋆ k) x       ≡⟨ sym app-var ⟩
          T.var x T./ map T.var ρ T.↑⋆ k      ∎)
       zero t

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -24,7 +24,7 @@ open import Data.Nat.Solver
 open import Data.Product.Base using (proj₁; proj₂; _,_; _×_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Sign as Sign using (Sign) renaming (_*_ to _𝕊*_)
-import Data.Sign.Properties as 𝕊ₚ
+import Data.Sign.Properties as Sign
 open import Function.Base using (_∘_; _$_; id)
 open import Level using (0ℓ)
 open import Relation.Binary.Core using (_⇒_; _Preserves_⟶_; _Preserves₂_⟶_⟶_)
@@ -1597,7 +1597,7 @@ abs-* i j = abs-◃ _ _
 *-cancelʳ-≡ : ∀ i j k .{{_ : NonZero k}} → i * k ≡ j * k → i ≡ j
 *-cancelʳ-≡ i j k eq with sign-cong′ eq
 ... | inj₁ s[ik]≡s[jk] = ◃-cong
-  (𝕊ₚ.*-cancelʳ-≡ (sign k) (sign i) (sign j) s[ik]≡s[jk])
+  (Sign.*-cancelʳ-≡ (sign k) (sign i) (sign j) s[ik]≡s[jk])
   (ℕ.*-cancelʳ-≡ ∣ i ∣ ∣ j ∣ _ (abs-cong eq))
 ... | inj₂ (∣ik∣≡0 , ∣jk∣≡0) = trans
   (∣i∣≡0⇒i≡0 (ℕ.m*n≡0⇒m≡0 _ _ ∣ik∣≡0))
@@ -1709,7 +1709,7 @@ neg-distribʳ-* i j = begin
 ◃-distrib-* s t zero    (suc n) = refl
 ◃-distrib-* s t (suc m) zero    =
   trans
-    (cong₂ _◃_ (𝕊ₚ.*-comm s t) (ℕ.*-comm m 0))
+    (cong₂ _◃_ (Sign.*-comm s t) (ℕ.*-comm m 0))
     (*-comm (t ◃ zero) (s ◃ suc m))
 ◃-distrib-* s t (suc m) (suc n) =
   sym (cong₂ _◃_

--- a/src/Data/List/Countdown.agda
+++ b/src/Data/List/Countdown.agda
@@ -29,10 +29,10 @@ open import Data.Sum.Properties
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary
 open import Relation.Nullary.Decidable using (dec-true; dec-false)
-open import Relation.Binary.PropositionalEquality.Core as PropEq
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; _≢_; refl; cong)
-import Relation.Binary.PropositionalEquality.Properties as PropEq
-open PropEq.≡-Reasoning
+import Relation.Binary.PropositionalEquality.Properties as ≡
+open ≡.≡-Reasoning
 
 private
   open module D = DecSetoid D
@@ -124,12 +124,12 @@ record _⊕_ (counted : List Elem) (n : ℕ) : Set where
 
 -- A countdown can be initialised by proving that Elem is finite.
 
-empty : ∀ {n} → Injection D.setoid (PropEq.setoid (Fin n)) → [] ⊕ n
+empty : ∀ {n} → Injection D.setoid (≡.setoid (Fin n)) → [] ⊕ n
 empty inj =
   record { kind      = inj₂ ∘ to
          ; injective = λ {x} {y} {i} eq₁ eq₂ → injective (begin
              to x ≡⟨ inj₂-injective eq₁ ⟩
-             i    ≡⟨ PropEq.sym $ inj₂-injective eq₂ ⟩
+             i    ≡⟨ ≡.sym $ inj₂-injective eq₂ ⟩
              to y ∎)
          }
   where open Injection inj
@@ -199,7 +199,7 @@ insert {counted} {n} counted⊕1+n x x∉counted =
   inj eq₁ eq₂ | no  _ | no  _ | inj₂ i         | inj₂ _ | inj₂ _ | _ | _ | hlp =
     hlp _ refl refl $
       punchOut-injective {i = i} _ _ $
-        (PropEq.trans (inj₂-injective eq₁) (PropEq.sym (inj₂-injective eq₂)))
+        (≡.trans (inj₂-injective eq₁) (≡.sym (inj₂-injective eq₂)))
 
 -- Counts an element if it has not already been counted.
 

--- a/src/Data/List/Fresh/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Fresh/Membership/Setoid/Properties.agda
@@ -20,17 +20,16 @@ open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; fromInj₂)
 
 open import Function.Base using (id; _∘′_; _$_)
 open import Relation.Nullary
-open import Relation.Unary as U using (Pred)
-import Relation.Binary.Definitions as B
-import Relation.Binary.PropositionalEquality.Core as P
+open import Relation.Unary as Unary using (Pred)
+import Relation.Binary.Definitions as Binary
+import Relation.Binary.PropositionalEquality.Core as ≡
 open import Relation.Nary
 
 open import Data.List.Fresh
 open import Data.List.Fresh.Properties
 open import Data.List.Fresh.Membership.Setoid S
 open import Data.List.Fresh.Relation.Unary.Any using (Any; here; there; _─_)
-import Data.List.Fresh.Relation.Unary.Any.Properties as Anyₚ
-import Data.List.Fresh.Relation.Unary.All.Properties as Allₚ
+import Data.List.Fresh.Relation.Unary.Any.Properties as List#
 
 open Setoid S renaming (Carrier to A)
 
@@ -82,7 +81,7 @@ module _ {R : Rel A r} where
 module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) (≉⇒R : ∀[ _≉_ ⇒ R ]) where
 
   private
-    R≈ : R B.Respectsˡ _≈_
+    R≈ : R Binary.Respectsˡ _≈_
     R≈ x≈y Rxz = ≉⇒R (R⇒≉ Rxz ∘′ trans x≈y)
 
   fresh-remove : ∀ {x} {xs : List# A R} (x∈xs : x ∈ xs) → x # (xs ─ x∈xs)
@@ -103,7 +102,7 @@ module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) where
   injection {[]}                 {ys} inj = z≤n
   injection {xxs@(cons x xs pr)} {ys} inj = begin
     length xxs               ≤⟨ s≤s (injection step) ⟩
-    suc (length (ys ─ x∈ys)) ≡⟨ P.sym (Anyₚ.length-remove x∈ys) ⟩
+    suc (length (ys ─ x∈ys)) ≡⟨ ≡.sym (List#.length-remove x∈ys) ⟩
     length ys                ∎
 
     where
@@ -123,7 +122,7 @@ module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) where
    (∃ λ x → x ∈ ys × x ∉ xs) → length xs < length ys
   strict-injection {xs} {ys} inj (x , x∈ys , x∉xs) = begin
     suc (length xs)          ≤⟨ s≤s (injection step) ⟩
-    suc (length (ys ─ x∈ys)) ≡⟨ P.sym (Anyₚ.length-remove x∈ys) ⟩
+    suc (length (ys ─ x∈ys)) ≡⟨ ≡.sym (List#.length-remove x∈ys) ⟩
     length ys                ∎
 
     where
@@ -138,12 +137,12 @@ module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) where
 ------------------------------------------------------------------------
 -- proof irrelevance
 
-module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) (≈-irrelevant : B.Irrelevant _≈_) where
+module _ {R : Rel A r} (R⇒≉ : ∀[ R ⇒ _≉_ ]) (≈-irrelevant : Binary.Irrelevant _≈_) where
 
   ∈-irrelevant : ∀ {x} {xs : List# A R} → Irrelevant (x ∈ xs)
   -- positive cases
-  ∈-irrelevant (here x≈y₁)   (here x≈y₂)   = P.cong here (≈-irrelevant x≈y₁ x≈y₂)
-  ∈-irrelevant (there x∈xs₁) (there x∈xs₂) = P.cong there (∈-irrelevant x∈xs₁ x∈xs₂)
+  ∈-irrelevant (here x≈y₁)   (here x≈y₂)   = ≡.cong here (≈-irrelevant x≈y₁ x≈y₂)
+  ∈-irrelevant (there x∈xs₁) (there x∈xs₂) = ≡.cong there (∈-irrelevant x∈xs₁ x∈xs₂)
   -- absurd cases
   ∈-irrelevant {xs = cons x xs pr} (here x≈y)    (there x∈xs₂) =
     ⊥-elim (distinct x∈xs₂ (fresh⇒∉ R⇒≉ pr) x≈y)

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -16,7 +16,7 @@ open import Data.List.Base as List
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties
 open import Data.List.Membership.Propositional
-import Data.List.Membership.Setoid.Properties as Membershipₛ
+import Data.List.Membership.Setoid.Properties as Membership
 open import Data.List.Relation.Binary.Equality.Propositional
   using (_≋_; ≡⇒≋; ≋⇒≡)
 open import Data.List.Effectful using (monad)
@@ -35,8 +35,8 @@ open import Function.Related.TypeIsomorphisms
 open import Function.Construct.Identity using (↔-id)
 open import Level using (Level)
 open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Definitions as B hiding (Decidable)
-open import Relation.Binary.PropositionalEquality as P
+open import Relation.Binary.Definitions as Binary hiding (Decidable)
+open import Relation.Binary.PropositionalEquality as ≡
   using (_≡_; _≢_; refl; sym; trans; cong; subst; →-to-⟶; _≗_)
 import Relation.Binary.Properties.DecTotalOrder as DTOProperties
 open import Relation.Unary using (_⟨×⟩_; Decidable)
@@ -62,10 +62,10 @@ open import Data.List.Membership.Propositional.Properties.Core public
 -- Equality
 
 ∈-resp-≋ : ∀ {x : A} → (x ∈_) Respects _≋_
-∈-resp-≋ = Membershipₛ.∈-resp-≋ (P.setoid _)
+∈-resp-≋ = Membership.∈-resp-≋ (≡.setoid _)
 
 ∉-resp-≋ : ∀ {x : A} → (x ∉_) Respects _≋_
-∉-resp-≋ = Membershipₛ.∉-resp-≋ (P.setoid _)
+∉-resp-≋ = Membership.∉-resp-≋ (≡.setoid _)
 
 ------------------------------------------------------------------------
 -- mapWith∈
@@ -74,19 +74,19 @@ mapWith∈-cong : ∀ (xs : List A) → (f g : ∀ {x} → x ∈ xs → B) →
                 (∀ {x} → (x∈xs : x ∈ xs) → f x∈xs ≡ g x∈xs) →
                 mapWith∈ xs f ≡ mapWith∈ xs g
 mapWith∈-cong []       f g cong = refl
-mapWith∈-cong (x ∷ xs) f g cong = P.cong₂ _∷_ (cong (here refl))
+mapWith∈-cong (x ∷ xs) f g cong = ≡.cong₂ _∷_ (cong (here refl))
   (mapWith∈-cong xs (f ∘ there) (g ∘ there) (cong ∘ there))
 
 mapWith∈≗map : ∀ (f : A → B) xs → mapWith∈ xs (λ {x} _ → f x) ≡ map f xs
 mapWith∈≗map f xs =
-  ≋⇒≡ (Membershipₛ.mapWith∈≗map (P.setoid _) (P.setoid _) f xs)
+  ≋⇒≡ (Membership.mapWith∈≗map (≡.setoid _) (≡.setoid _) f xs)
 
 mapWith∈-id : (xs : List A) → mapWith∈ xs (λ {x} _ → x) ≡ xs
-mapWith∈-id = Membershipₛ.mapWith∈-id (P.setoid _)
+mapWith∈-id = Membership.mapWith∈-id (≡.setoid _)
 
 map-mapWith∈ : (xs : List A) (f : ∀ {x} → x ∈ xs → B) (g : B → C) →
                map g (mapWith∈ xs f) ≡ mapWith∈ xs (g ∘′ f)
-map-mapWith∈ = Membershipₛ.map-mapWith∈ (P.setoid _)
+map-mapWith∈ = Membership.map-mapWith∈ (≡.setoid _)
 
 ------------------------------------------------------------------------
 -- map
@@ -94,10 +94,10 @@ map-mapWith∈ = Membershipₛ.map-mapWith∈ (P.setoid _)
 module _ (f : A → B) where
 
   ∈-map⁺ : ∀ {x xs} → x ∈ xs → f x ∈ map f xs
-  ∈-map⁺ = Membershipₛ.∈-map⁺ (P.setoid A) (P.setoid B) (P.cong f)
+  ∈-map⁺ = Membership.∈-map⁺ (≡.setoid A) (≡.setoid B) (≡.cong f)
 
   ∈-map⁻ : ∀ {y xs} → y ∈ map f xs → ∃ λ x → x ∈ xs × y ≡ f x
-  ∈-map⁻ = Membershipₛ.∈-map⁻ (P.setoid A) (P.setoid B)
+  ∈-map⁻ = Membership.∈-map⁻ (≡.setoid A) (≡.setoid B)
 
   map-∈↔ : ∀ {y xs} → (∃ λ x → x ∈ xs × y ≡ f x) ↔ y ∈ map f xs
   map-∈↔ {y} {xs} =
@@ -112,19 +112,19 @@ module _ (f : A → B) where
 module _ {v : A} where
 
   ∈-++⁺ˡ : ∀ {xs ys} → v ∈ xs → v ∈ xs ++ ys
-  ∈-++⁺ˡ = Membershipₛ.∈-++⁺ˡ (P.setoid A)
+  ∈-++⁺ˡ = Membership.∈-++⁺ˡ (≡.setoid A)
 
   ∈-++⁺ʳ : ∀ xs {ys} → v ∈ ys → v ∈ xs ++ ys
-  ∈-++⁺ʳ = Membershipₛ.∈-++⁺ʳ (P.setoid A)
+  ∈-++⁺ʳ = Membership.∈-++⁺ʳ (≡.setoid A)
 
   ∈-++⁻ : ∀ xs {ys} → v ∈ xs ++ ys → (v ∈ xs) ⊎ (v ∈ ys)
-  ∈-++⁻ = Membershipₛ.∈-++⁻ (P.setoid A)
+  ∈-++⁻ = Membership.∈-++⁻ (≡.setoid A)
 
   ∈-insert : ∀ xs {ys} → v ∈ xs ++ [ v ] ++ ys
-  ∈-insert xs = Membershipₛ.∈-insert (P.setoid A) xs refl
+  ∈-insert xs = Membership.∈-insert (≡.setoid A) xs refl
 
   ∈-∃++ : ∀ {xs} → v ∈ xs → ∃₂ λ ys zs → xs ≡ ys ++ [ v ] ++ zs
-  ∈-∃++ v∈xs with Membershipₛ.∈-∃++ (P.setoid A) v∈xs
+  ∈-∃++ v∈xs with Membership.∈-∃++ (≡.setoid A) v∈xs
   ... | ys , zs , _ , refl , eq = ys , zs , ≋⇒≡ eq
 
 ------------------------------------------------------------------------
@@ -133,17 +133,17 @@ module _ {v : A} where
 module _ {v : A} where
 
   ∈-concat⁺ : ∀ {xss} → Any (v ∈_) xss → v ∈ concat xss
-  ∈-concat⁺ = Membershipₛ.∈-concat⁺ (P.setoid A)
+  ∈-concat⁺ = Membership.∈-concat⁺ (≡.setoid A)
 
   ∈-concat⁻ : ∀ xss → v ∈ concat xss → Any (v ∈_) xss
-  ∈-concat⁻ = Membershipₛ.∈-concat⁻ (P.setoid A)
+  ∈-concat⁻ = Membership.∈-concat⁻ (≡.setoid A)
 
   ∈-concat⁺′ : ∀ {vs xss} → v ∈ vs → vs ∈ xss → v ∈ concat xss
   ∈-concat⁺′ v∈vs vs∈xss =
-    Membershipₛ.∈-concat⁺′ (P.setoid A) v∈vs (Any.map ≡⇒≋ vs∈xss)
+    Membership.∈-concat⁺′ (≡.setoid A) v∈vs (Any.map ≡⇒≋ vs∈xss)
 
   ∈-concat⁻′ : ∀ xss → v ∈ concat xss → ∃ λ xs → v ∈ xs × xs ∈ xss
-  ∈-concat⁻′ xss v∈c with Membershipₛ.∈-concat⁻′ (P.setoid A) xss v∈c
+  ∈-concat⁻′ xss v∈c with Membership.∈-concat⁻′ (≡.setoid A) xss v∈c
   ... | xs , v∈xs , xs∈xss = xs , v∈xs , Any.map ≋⇒≡ xs∈xss
 
   concat-∈↔ : ∀ {xss : List (List A)} →
@@ -162,13 +162,13 @@ module _ (f : A → B → C) where
 
   ∈-cartesianProductWith⁺ : ∀ {xs ys a b} → a ∈ xs → b ∈ ys →
                             f a b ∈ cartesianProductWith f xs ys
-  ∈-cartesianProductWith⁺ = Membershipₛ.∈-cartesianProductWith⁺
-    (P.setoid A) (P.setoid B) (P.setoid C) (P.cong₂ f)
+  ∈-cartesianProductWith⁺ = Membership.∈-cartesianProductWith⁺
+    (≡.setoid A) (≡.setoid B) (≡.setoid C) (≡.cong₂ f)
 
   ∈-cartesianProductWith⁻ : ∀ xs ys {v} → v ∈ cartesianProductWith f xs ys →
                             ∃₂ λ a b → a ∈ xs × b ∈ ys × v ≡ f a b
-  ∈-cartesianProductWith⁻ = Membershipₛ.∈-cartesianProductWith⁻
-    (P.setoid A) (P.setoid B) (P.setoid C) f
+  ∈-cartesianProductWith⁻ = Membership.∈-cartesianProductWith⁻
+    (≡.setoid A) (≡.setoid B) (≡.setoid C) f
 
 ------------------------------------------------------------------------
 -- cartesianProduct
@@ -188,11 +188,11 @@ module _ (f : A → B → C) where
 module _ (f : ℕ → A) where
 
   ∈-applyUpTo⁺ : ∀ {i n} → i < n → f i ∈ applyUpTo f n
-  ∈-applyUpTo⁺ = Membershipₛ.∈-applyUpTo⁺ (P.setoid _) f
+  ∈-applyUpTo⁺ = Membership.∈-applyUpTo⁺ (≡.setoid _) f
 
   ∈-applyUpTo⁻ : ∀ {v n} → v ∈ applyUpTo f n →
                  ∃ λ i → i < n × v ≡ f i
-  ∈-applyUpTo⁻ = Membershipₛ.∈-applyUpTo⁻ (P.setoid _) f
+  ∈-applyUpTo⁻ = Membership.∈-applyUpTo⁻ (≡.setoid _) f
 
 ------------------------------------------------------------------------
 -- upTo
@@ -210,11 +210,11 @@ module _ (f : ℕ → A) where
 module _ (f : ℕ → A) where
 
   ∈-applyDownFrom⁺ : ∀ {i n} → i < n → f i ∈ applyDownFrom f n
-  ∈-applyDownFrom⁺ = Membershipₛ.∈-applyDownFrom⁺ (P.setoid _) f
+  ∈-applyDownFrom⁺ = Membership.∈-applyDownFrom⁺ (≡.setoid _) f
 
   ∈-applyDownFrom⁻ : ∀ {v n} → v ∈ applyDownFrom f n →
                      ∃ λ i → i < n × v ≡ f i
-  ∈-applyDownFrom⁻ = Membershipₛ.∈-applyDownFrom⁻ (P.setoid _) f
+  ∈-applyDownFrom⁻ = Membership.∈-applyDownFrom⁻ (≡.setoid _) f
 
 ------------------------------------------------------------------------
 -- downFrom
@@ -232,10 +232,10 @@ module _ (f : ℕ → A) where
 module _ {n} {f : Fin n → A} where
 
   ∈-tabulate⁺ : ∀ i → f i ∈ tabulate f
-  ∈-tabulate⁺ = Membershipₛ.∈-tabulate⁺ (P.setoid _)
+  ∈-tabulate⁺ = Membership.∈-tabulate⁺ (≡.setoid _)
 
   ∈-tabulate⁻ : ∀ {v} → v ∈ tabulate f → ∃ λ i → v ≡ f i
-  ∈-tabulate⁻ = Membershipₛ.∈-tabulate⁻ (P.setoid _)
+  ∈-tabulate⁻ = Membership.∈-tabulate⁻ (≡.setoid _)
 
 ------------------------------------------------------------------------
 -- filter
@@ -243,29 +243,29 @@ module _ {n} {f : Fin n → A} where
 module _ {p} {P : A → Set p} (P? : Decidable P) where
 
   ∈-filter⁺ : ∀ {x xs} → x ∈ xs → P x → x ∈ filter P? xs
-  ∈-filter⁺ = Membershipₛ.∈-filter⁺ (P.setoid A) P? (P.subst P)
+  ∈-filter⁺ = Membership.∈-filter⁺ (≡.setoid A) P? (≡.subst P)
 
   ∈-filter⁻ : ∀ {v xs} → v ∈ filter P? xs → v ∈ xs × P v
-  ∈-filter⁻ = Membershipₛ.∈-filter⁻ (P.setoid A) P? (P.subst P)
+  ∈-filter⁻ = Membership.∈-filter⁻ (≡.setoid A) P? (≡.subst P)
 
 ------------------------------------------------------------------------
 -- derun and deduplicate
 
-module _ {r} {R : Rel A r} (R? : B.Decidable R) where
+module _ {r} {R : Rel A r} (R? : Binary.Decidable R) where
 
   ∈-derun⁻ : ∀ xs {z} → z ∈ derun R? xs → z ∈ xs
-  ∈-derun⁻ xs z∈derun[R,xs] = Membershipₛ.∈-derun⁻ (P.setoid A) R? xs z∈derun[R,xs]
+  ∈-derun⁻ xs z∈derun[R,xs] = Membership.∈-derun⁻ (≡.setoid A) R? xs z∈derun[R,xs]
 
   ∈-deduplicate⁻ : ∀ xs {z} → z ∈ deduplicate R? xs → z ∈ xs
-  ∈-deduplicate⁻ xs z∈dedup[R,xs] = Membershipₛ.∈-deduplicate⁻ (P.setoid A) R? xs z∈dedup[R,xs]
+  ∈-deduplicate⁻ xs z∈dedup[R,xs] = Membership.∈-deduplicate⁻ (≡.setoid A) R? xs z∈dedup[R,xs]
 
-module _ (_≈?_ : B.Decidable {A = A} _≡_) where
+module _ (_≈?_ : Binary.Decidable {A = A} _≡_) where
 
   ∈-derun⁺ : ∀ {xs z} → z ∈ xs → z ∈ derun _≈?_ xs
-  ∈-derun⁺ z∈xs = Membershipₛ.∈-derun⁺ (P.setoid A) _≈?_ (flip trans) z∈xs
+  ∈-derun⁺ z∈xs = Membership.∈-derun⁺ (≡.setoid A) _≈?_ (flip trans) z∈xs
 
   ∈-deduplicate⁺ : ∀ {xs z} → z ∈ xs → z ∈ deduplicate _≈?_ xs
-  ∈-deduplicate⁺ z∈xs = Membershipₛ.∈-deduplicate⁺ (P.setoid A) _≈?_ (λ c≡b a≡b → trans a≡b (sym c≡b)) z∈xs
+  ∈-deduplicate⁺ z∈xs = Membership.∈-deduplicate⁺ (≡.setoid A) _≈?_ (λ c≡b a≡b → trans a≡b (sym c≡b)) z∈xs
 
 ------------------------------------------------------------------------
 -- _>>=_
@@ -307,13 +307,13 @@ module _ (_≈?_ : B.Decidable {A = A} _≡_) where
 -- length
 
 ∈-length : ∀ {x : A} {xs} → x ∈ xs → 1 ≤ length xs
-∈-length = Membershipₛ.∈-length (P.setoid _)
+∈-length = Membership.∈-length (≡.setoid _)
 
 ------------------------------------------------------------------------
 -- lookup
 
 ∈-lookup : ∀ {xs : List A} i → lookup xs i ∈ xs
-∈-lookup {xs = xs} i = Membershipₛ.∈-lookup (P.setoid _) xs i
+∈-lookup {xs = xs} i = Membership.∈-lookup (≡.setoid _) xs i
 
 ------------------------------------------------------------------------
 -- foldr
@@ -322,7 +322,7 @@ module _ {_•_ : Op₂ A} where
 
   foldr-selective : Selective _≡_ _•_ → ∀ e xs →
                     (foldr _•_ e xs ≡ e) ⊎ (foldr _•_ e xs ∈ xs)
-  foldr-selective = Membershipₛ.foldr-selective (P.setoid A)
+  foldr-selective = Membership.foldr-selective (≡.setoid A)
 
 ------------------------------------------------------------------------
 -- allFin
@@ -380,7 +380,7 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = ¬¬-excluded-middle helper
     f′-injective′ : Injective _≡_ _≡_ f′
     f′-injective′ {j} {k} eq with i ≤ᵇ j | Reflects.invert (≤ᵇ-reflects-≤ i j)
                                 | i ≤ᵇ k | Reflects.invert (≤ᵇ-reflects-≤ i k)
-    ... | true  | p | true  | q = P.cong pred (f-inj eq)
+    ... | true  | p | true  | q = ≡.cong pred (f-inj eq)
     ... | true  | p | false | q = contradiction (f-inj eq) (lemma p q)
     ... | false | p | true  | q = contradiction (f-inj eq) (lemma q p ∘ sym)
     ... | false | p | false | q = f-inj eq
@@ -388,7 +388,7 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = ¬¬-excluded-middle helper
     f′-inj : ℕ ↣ _
     f′-inj = record
       { to        = f′
-      ; cong      = P.cong f′
+      ; cong      = ≡.cong f′
       ; injective = f′-injective′
       }
 
@@ -398,4 +398,4 @@ finite inj (x ∷ xs) fᵢ∈x∷xs = ¬¬-excluded-middle helper
 there-injective-≢∈ : ∀ {xs} {x y z : A} {x∈xs : x ∈ xs} {y∈xs : y ∈ xs} →
                      there {x = z} x∈xs ≢∈ there y∈xs →
                      x∈xs ≢∈ y∈xs
-there-injective-≢∈ neq refl eq = neq refl (P.cong there eq)
+there-injective-≢∈ neq refl eq = neq refl (≡.cong there eq)

--- a/src/Data/List/Membership/Propositional/Properties/WithK.agda
+++ b/src/Data/List/Membership/Propositional/Properties/WithK.agda
@@ -12,9 +12,9 @@ module Data.List.Membership.Propositional.Properties.WithK where
 open import Data.List.Base
 open import Data.List.Relation.Unary.Unique.Propositional
 open import Data.List.Membership.Propositional
-import Data.List.Membership.Setoid.Properties as Membershipₛ
+import Data.List.Membership.Setoid.Properties as Membership
 open import Relation.Unary using (Irrelevant)
-open import Relation.Binary.PropositionalEquality.Properties as P
+open import Relation.Binary.PropositionalEquality.Properties as ≡
 open import Relation.Binary.PropositionalEquality.WithK
 
 ------------------------------------------------------------------------
@@ -22,4 +22,4 @@ open import Relation.Binary.PropositionalEquality.WithK
 
 unique⇒irrelevant : ∀ {a} {A : Set a} {xs : List A} →
                     Unique xs → Irrelevant (_∈ xs)
-unique⇒irrelevant = Membershipₛ.unique⇒irrelevant (P.setoid _) ≡-irrelevant
+unique⇒irrelevant = Membership.unique⇒irrelevant (≡.setoid _) ≡-irrelevant

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -28,10 +28,10 @@ open import Function.Base using (_$_; flip; _∘_; _∘′_; id)
 open import Function.Bundles using (_↔_)
 open import Level using (Level)
 open import Relation.Binary.Core using (Rel; _Preserves₂_⟶_⟶_; _Preserves_⟶_)
-open import Relation.Binary.Definitions as B hiding (Decidable)
+open import Relation.Binary.Definitions as Binary hiding (Decidable)
 open import Relation.Binary.Bundles using (Setoid)
-open import Relation.Binary.PropositionalEquality.Core as P using (_≡_)
-open import Relation.Unary as U using (Decidable; Pred)
+open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
+open import Relation.Unary as Unary using (Decidable; Pred)
 open import Relation.Nullary using (¬_; does; _because_; yes; no)
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary.Negation using (contradiction)
@@ -85,11 +85,11 @@ module _ (S : Setoid c ℓ) where
     ∉×∈⇒≉ : ∀ {x y xs} → All (y ≉_) xs → x ∈ xs → x ≉ y
     ∉×∈⇒≉ = All.lookupWith λ y≉z x≈z x≈y → y≉z (trans (sym x≈y) x≈z)
 
-  unique⇒irrelevant : B.Irrelevant _≈_ → ∀ {xs} → Unique xs → U.Irrelevant (_∈ xs)
+  unique⇒irrelevant : Binary.Irrelevant _≈_ → ∀ {xs} → Unique xs → Unary.Irrelevant (_∈ xs)
   unique⇒irrelevant ≈-irr _        (here p)  (here q)  =
-    P.cong here (≈-irr p q)
+    ≡.cong here (≈-irr p q)
   unique⇒irrelevant ≈-irr (_  ∷ u) (there p) (there q) =
-    P.cong there (unique⇒irrelevant ≈-irr u p q)
+    ≡.cong there (unique⇒irrelevant ≈-irr u p q)
   unique⇒irrelevant ≈-irr (≉s ∷ _) (here p)  (there q) =
     contradiction p (∉×∈⇒≉ ≉s q)
   unique⇒irrelevant ≈-irr (≉s ∷ _) (there p) (here q)  =
@@ -130,18 +130,18 @@ module _ (S : Setoid c ℓ) where
 
   length-mapWith∈ : ∀ {a} {A : Set a} xs {f : ∀ {x} → x ∈ xs → A} →
                     length (mapWith∈ xs f) ≡ length xs
-  length-mapWith∈ []       = P.refl
-  length-mapWith∈ (x ∷ xs) = P.cong suc (length-mapWith∈ xs)
+  length-mapWith∈ []       = ≡.refl
+  length-mapWith∈ (x ∷ xs) = ≡.cong suc (length-mapWith∈ xs)
 
   mapWith∈-id : ∀ xs → mapWith∈ xs (λ {x} _ → x) ≡ xs
-  mapWith∈-id []       = P.refl
-  mapWith∈-id (x ∷ xs) = P.cong (x ∷_) (mapWith∈-id xs)
+  mapWith∈-id []       = ≡.refl
+  mapWith∈-id (x ∷ xs) = ≡.cong (x ∷_) (mapWith∈-id xs)
 
   map-mapWith∈ : ∀ {a b} {A : Set a} {B : Set b} →
                  ∀ xs (f : ∀ {x} → x ∈ xs → A) (g : A → B) →
                  map g (mapWith∈ xs f) ≡ mapWith∈ xs (g ∘′ f)
-  map-mapWith∈ []       f g = P.refl
-  map-mapWith∈ (x ∷ xs) f g = P.cong (_ ∷_) (map-mapWith∈ xs (f ∘ there) g)
+  map-mapWith∈ []       f g = ≡.refl
+  map-mapWith∈ (x ∷ xs) f g = ≡.cong (_ ∷_) (map-mapWith∈ xs (f ∘ there) g)
 
 ------------------------------------------------------------------------
 -- map
@@ -164,8 +164,8 @@ module _ (S₁ : Setoid c₁ ℓ₁) (S₂ : Setoid c₂ ℓ₂) where
   map-∷= : ∀ {f} (f≈ : f Preserves _≈₁_ ⟶ _≈₂_)
            {xs x v} → (x∈xs : x ∈₁ xs) →
            map f (x∈xs M₁.∷= v) ≡ ∈-map⁺ f≈ x∈xs M₂.∷= f v
-  map-∷= f≈ (here x≈y)   = P.refl
-  map-∷= f≈ (there x∈xs) = P.cong (_ ∷_) (map-∷= f≈ x∈xs)
+  map-∷= f≈ (here x≈y)   = ≡.refl
+  map-∷= f≈ (there x∈xs) = ≡.cong (_ ∷_) (map-∷= f≈ x∈xs)
 
 ------------------------------------------------------------------------
 -- _++_
@@ -350,7 +350,7 @@ module _ (S : Setoid c ℓ) {P : Pred (Carrier S) p}
 ------------------------------------------------------------------------
 -- derun and deduplicate
 
-module _ (S : Setoid c ℓ) {R : Rel (Carrier S) ℓ₂} (R? : B.Decidable R) where
+module _ (S : Setoid c ℓ) {R : Rel (Carrier S) ℓ₂} (R? : Binary.Decidable R) where
 
   open Setoid S using (_≈_)
   open Membership S using (_∈_)

--- a/src/Data/List/Relation/Binary/BagAndSetEquality.agda
+++ b/src/Data/List/Relation/Binary/BagAndSetEquality.agda
@@ -15,7 +15,7 @@ open import Data.Empty
 open import Data.Fin.Base
 open import Data.List.Base
 open import Data.List.Effectful using (monad; module Applicative; module MonadProperties)
-import Data.List.Properties as LP
+import Data.List.Properties as List
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties hiding (++-comm)
 open import Data.List.Membership.Propositional using (_∈_)
@@ -232,7 +232,7 @@ commutativeMonoid {a} k A = record
         ; ∙-cong        = ++-cong
         }
       ; assoc         = λ xs ys zs →
-                          Eq.reflexive (LP.++-assoc xs ys zs)
+                          Eq.reflexive (List.++-assoc xs ys zs)
       }
     ; identityˡ = λ xs → K-refl
     ; comm      = λ xs ys → ↔⇒ (++↔++ xs ys)

--- a/src/Data/List/Relation/Binary/Infix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Infix/Heterogeneous/Properties.agda
@@ -27,7 +27,7 @@ open import Data.List.Relation.Binary.Pointwise.Base as Pointwise using (Pointwi
 open import Data.List.Relation.Binary.Infix.Heterogeneous
 open import Data.List.Relation.Binary.Prefix.Heterogeneous
   as Prefix using (Prefix; []; _∷_)
-import Data.List.Relation.Binary.Prefix.Heterogeneous.Properties as Prefixₚ
+import Data.List.Relation.Binary.Prefix.Heterogeneous.Properties as Prefix
 open import Data.List.Relation.Binary.Suffix.Heterogeneous
   as Suffix using (Suffix; here; there)
 
@@ -43,7 +43,7 @@ private
 -- Conversion functions
 
 fromPointwise : ∀ {as bs} → Pointwise R as bs → Infix R as bs
-fromPointwise pw = here (Prefixₚ.fromPointwise pw)
+fromPointwise pw = here (Prefix.fromPointwise pw)
 
 fromSuffix : ∀ {as bs} → Suffix R as bs → Infix R as bs
 fromSuffix (here pw) = fromPointwise pw
@@ -52,11 +52,11 @@ fromSuffix (there p) = there (fromSuffix p)
 module _ {c t} {C : Set c} {T : REL A C t} where
 
   fromPrefixSuffix : Trans R S T → Trans (Prefix R) (Suffix S) (Infix T)
-  fromPrefixSuffix tr p (here q)  = here (Prefixₚ.trans tr p (Prefixₚ.fromPointwise q))
+  fromPrefixSuffix tr p (here q)  = here (Prefix.trans tr p (Prefix.fromPointwise q))
   fromPrefixSuffix tr p (there q) = there (fromPrefixSuffix tr p q)
 
   fromSuffixPrefix : Trans R S T → Trans (Suffix R) (Prefix S) (Infix T)
-  fromSuffixPrefix tr (here p)  q       = here (Prefixₚ.trans tr (Prefixₚ.fromPointwise p) q)
+  fromSuffixPrefix tr (here p)  q       = here (Prefix.trans tr (Prefix.fromPointwise p) q)
   fromSuffixPrefix tr (there p) (_ ∷ q) = there (fromSuffixPrefix tr p q)
 
 ∷⁻ : ∀ {as b bs} → Infix R as (b ∷ bs) → Prefix R as (b ∷ bs) ⊎ Infix R as bs
@@ -67,7 +67,7 @@ module _ {c t} {C : Set c} {T : REL A C t} where
 -- length
 
 length-mono : ∀ {as bs} → Infix R as bs → length as ≤ length bs
-length-mono (here pref) = Prefixₚ.length-mono pref
+length-mono (here pref) = Prefix.length-mono pref
 length-mono (there p)   = ℕ.m≤n⇒m≤1+n (length-mono p)
 
 ------------------------------------------------------------------------
@@ -76,11 +76,11 @@ length-mono (there p)   = ℕ.m≤n⇒m≤1+n (length-mono p)
 module _ {c t} {C : Set c} {T : REL A C t} where
 
   Prefix-Infix-trans : Trans R S T → Trans (Prefix R) (Infix S) (Infix T)
-  Prefix-Infix-trans tr p (here q)  = here (Prefixₚ.trans tr p q)
+  Prefix-Infix-trans tr p (here q)  = here (Prefix.trans tr p q)
   Prefix-Infix-trans tr p (there q) = there (Prefix-Infix-trans tr p q)
 
   Infix-Prefix-trans : Trans R S T → Trans (Infix R) (Prefix S) (Infix T)
-  Infix-Prefix-trans tr (here p)  q       = here (Prefixₚ.trans tr p q)
+  Infix-Prefix-trans tr (here p)  q       = here (Prefix.trans tr p q)
   Infix-Prefix-trans tr (there p) (_ ∷ q) = there (Infix-Prefix-trans tr p q)
 
   Suffix-Infix-trans : Trans R S T → Trans (Suffix R) (Infix S) (Infix T)
@@ -88,7 +88,7 @@ module _ {c t} {C : Set c} {T : REL A C t} where
   Suffix-Infix-trans tr p (there q) = there (Suffix-Infix-trans tr p q)
 
   Infix-Suffix-trans : Trans R S T → Trans (Infix R) (Suffix S) (Infix T)
-  Infix-Suffix-trans tr p (here q)  = Infix-Prefix-trans tr p (Prefixₚ.fromPointwise q)
+  Infix-Suffix-trans tr p (here q)  = Infix-Prefix-trans tr p (Prefix.fromPointwise q)
   Infix-Suffix-trans tr p (there q) = there (Infix-Suffix-trans tr p q)
 
   trans : Trans R S T → Trans (Infix R) (Infix S) (Infix T)
@@ -96,7 +96,7 @@ module _ {c t} {C : Set c} {T : REL A C t} where
   trans tr p (there q) = there (trans tr p q)
 
   antisym : Antisym R S T → Antisym (Infix R) (Infix S) (Pointwise T)
-  antisym asym (here p) (here q) = Prefixₚ.antisym asym p q
+  antisym asym (here p) (here q) = Prefix.antisym asym p q
   antisym asym {i = a ∷ as} {j = bs} p@(here _) (there q)
     = ⊥-elim $′ ℕ.<-irrefl refl $′ begin-strict
       length as <⟨ length-mono p ⟩
@@ -121,14 +121,14 @@ module _ {c d r} {C : Set c} {D : Set d} {R : REL C D r} where
   map⁺ : ∀ {as bs} (f : A → C) (g : B → D) →
          Infix (λ a b → R (f a) (g b)) as bs →
          Infix R (List.map f as) (List.map g bs)
-  map⁺ f g (here p)  = here (Prefixₚ.map⁺ f g p)
+  map⁺ f g (here p)  = here (Prefix.map⁺ f g p)
   map⁺ f g (there p) = there (map⁺ f g p)
 
   map⁻ : ∀ {as bs} (f : A → C) (g : B → D) →
          Infix R (List.map f as) (List.map g bs) →
          Infix (λ a b → R (f a) (g b)) as bs
-  map⁻ {bs = []}     f g (here p)  = here (Prefixₚ.map⁻ f g p)
-  map⁻ {bs = b ∷ bs} f g (here p)  = here (Prefixₚ.map⁻ f g p)
+  map⁻ {bs = []}     f g (here p)  = here (Prefix.map⁻ f g p)
+  map⁻ {bs = b ∷ bs} f g (here p)  = here (Prefix.map⁻ f g p)
   map⁻ {bs = b ∷ bs} f g (there p) = there (map⁻ f g p)
 
 ------------------------------------------------------------------------
@@ -139,7 +139,7 @@ module _ {p q} {P : Pred A p} {Q : Pred B q} (P? : U.Decidable P) (Q? : U.Decida
          where
 
   filter⁺ : ∀ {as bs} → Infix R as bs → Infix R (filter P? as) (filter Q? bs)
-  filter⁺ (here p) = here (Prefixₚ.filter⁺ P? Q? (λ _ → P⇒Q) (λ _ → Q⇒P) p)
+  filter⁺ (here p) = here (Prefix.filter⁺ P? Q? (λ _ → P⇒Q) (λ _ → Q⇒P) p)
   filter⁺ {bs = b ∷ bs} (there p) with does (Q? b)
   ... | true = there (filter⁺ p)
   ... | false = filter⁺ p
@@ -149,12 +149,12 @@ module _ {p q} {P : Pred A p} {Q : Pred B q} (P? : U.Decidable P) (Q? : U.Decida
 
 replicate⁺ : ∀ {m n a b} → m ≤ n → R a b →
              Infix R (replicate m a) (replicate n b)
-replicate⁺ m≤n r = here (Prefixₚ.replicate⁺ m≤n r)
+replicate⁺ m≤n r = here (Prefix.replicate⁺ m≤n r)
 
 replicate⁻ : ∀ {m n a b} → m ≢ 0 →
              Infix R (replicate m a) (replicate n b) → R a b
-replicate⁻ {m = m} {n = zero}  m≢0 (here p)  = Prefixₚ.replicate⁻ m≢0 p
-replicate⁻ {m = m} {n = suc n} m≢0 (here p)  = Prefixₚ.replicate⁻ m≢0 p
+replicate⁻ {m = m} {n = zero}  m≢0 (here p)  = Prefix.replicate⁻ m≢0 p
+replicate⁻ {m = m} {n = suc n} m≢0 (here p)  = Prefix.replicate⁻ m≢0 p
 replicate⁻ {m = m} {n = suc n} m≢0 (there p) = replicate⁻ m≢0 p
 
 ------------------------------------------------------------------------
@@ -165,4 +165,4 @@ infix? R? [] [] = yes (here [])
 infix? R? (a ∷ as) [] = no (λ where (here ()))
 infix? R? as bbs@(_ ∷ bs) =
   map′ [ here , there ]′ ∷⁻
-  (Prefixₚ.prefix? R? as bbs ⊎-dec infix? R? as bs)
+  (Prefix.prefix? R? as bbs ⊎-dec infix? R? as bs)

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -15,13 +15,13 @@ open import Data.Empty
 open import Data.List.Relation.Unary.All using (Null; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Base as List hiding (map; _∷ʳ_)
-import Data.List.Properties as Lₚ
+import Data.List.Properties as List
 open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
 open import Data.List.Relation.Binary.Pointwise as Pw using (Pointwise; []; _∷_)
 open import Data.List.Relation.Binary.Sublist.Heterogeneous
 
-open import Data.Maybe.Relation.Unary.All as MAll using (nothing; just)
+open import Data.Maybe.Relation.Unary.All as Maybe using (nothing; just)
 open import Data.Nat.Base using (ℕ; _≤_; _≥_); open ℕ; open _≤_
 import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (∃₂; _×_; _,_; <_,_>; proj₂; uncurry)
@@ -90,9 +90,9 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   tail-Sublist : ∀ {as bs} → Sublist R as bs →
-                 MAll.All (λ as → Sublist R as bs) (tail as)
+                 Maybe.All (λ as → Sublist R as bs) (tail as)
   tail-Sublist []        = nothing
-  tail-Sublist (b ∷ʳ ps) = MAll.map (b ∷ʳ_) (tail-Sublist ps)
+  tail-Sublist (b ∷ʳ ps) = Maybe.map (b ∷ʳ_) (tail-Sublist ps)
   tail-Sublist (p ∷ ps)  = just (_ ∷ʳ ps)
 
   take-Sublist : ∀ {as bs} n → Sublist R as bs → Sublist R (take n as) bs
@@ -308,7 +308,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   reverse⁻ : ∀ {as bs} → Sublist R (reverse as) (reverse bs) → Sublist R as bs
   reverse⁻ {as} {bs} p = cast (reverse⁺ p) where
-    cast = P.subst₂ (Sublist R) (Lₚ.reverse-involutive as) (Lₚ.reverse-involutive bs)
+    cast = P.subst₂ (Sublist R) (List.reverse-involutive as) (List.reverse-involutive bs)
 
 ------------------------------------------------------------------------
 -- Inversion lemmas

--- a/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
@@ -21,7 +21,7 @@ open import Data.List.Effectful
 open import Data.List.Relation.Unary.Any using (Any)
 open import Data.List.Membership.Propositional
 open import Data.List.Membership.Propositional.Properties
-import Data.List.Relation.Binary.Subset.Setoid.Properties as Setoidₚ
+import Data.List.Relation.Binary.Subset.Setoid.Properties as Subset
 open import Data.List.Relation.Binary.Subset.Propositional
 open import Data.List.Relation.Binary.Permutation.Propositional
 import Data.List.Relation.Binary.Permutation.Propositional.Properties as Permutation
@@ -79,7 +79,7 @@ module _ (A : Set a) where
 ------------------------------------------------------------------------
 -- Relational properties with _↭_ (permutation)
 ------------------------------------------------------------------------
--- See issue #1354 for why these proofs can't be taken from `Setoidₚ`
+-- See issue #1354 for why these proofs can't be taken from `Subset`
 
 ⊆-reflexive-↭ : _↭_ {A = A} ⇒ _⊆_
 ⊆-reflexive-↭ xs↭ys = Permutation.∈-resp-↭ xs↭ys
@@ -109,7 +109,7 @@ module _ (A : Set a) where
 ------------------------------------------------------------------------
 
 module ⊆-Reasoning (A : Set a) where
-  open Setoidₚ.⊆-Reasoning (setoid A) public
+  open Subset.⊆-Reasoning (setoid A) public
     hiding (step-≋; step-≋˘)
 
 ------------------------------------------------------------------------
@@ -117,10 +117,10 @@ module ⊆-Reasoning (A : Set a) where
 ------------------------------------------------------------------------
 
 Any-resp-⊆ : ∀ {P : Pred A p} → (Any P) Respects _⊆_
-Any-resp-⊆ = Setoidₚ.Any-resp-⊆ (setoid _) (subst _)
+Any-resp-⊆ = Subset.Any-resp-⊆ (setoid _) (subst _)
 
 All-resp-⊇ : ∀ {P : Pred A p} → (All P) Respects _⊇_
-All-resp-⊇ = Setoidₚ.All-resp-⊇ (setoid _) (subst _)
+All-resp-⊇ = Subset.All-resp-⊇ (setoid _) (subst _)
 
 ------------------------------------------------------------------------
 -- Properties relating _⊆_ to various list functions
@@ -137,31 +137,31 @@ map⁺ f xs⊆ys =
 -- ∷
 
 xs⊆x∷xs : ∀ (xs : List A) x → xs ⊆ x ∷ xs
-xs⊆x∷xs = Setoidₚ.xs⊆x∷xs (setoid _)
+xs⊆x∷xs = Subset.xs⊆x∷xs (setoid _)
 
 ∷⁺ʳ : ∀ x → xs ⊆ ys → x ∷ xs ⊆ x ∷ ys
-∷⁺ʳ = Setoidₚ.∷⁺ʳ (setoid _)
+∷⁺ʳ = Subset.∷⁺ʳ (setoid _)
 
 ∈-∷⁺ʳ : ∀ {x} → x ∈ ys → xs ⊆ ys → x ∷ xs ⊆ ys
-∈-∷⁺ʳ = Setoidₚ.∈-∷⁺ʳ (setoid _)
+∈-∷⁺ʳ = Subset.∈-∷⁺ʳ (setoid _)
 
 ------------------------------------------------------------------------
 -- _++_
 
 xs⊆xs++ys : ∀ (xs ys : List A) → xs ⊆ xs ++ ys
-xs⊆xs++ys = Setoidₚ.xs⊆xs++ys (setoid _)
+xs⊆xs++ys = Subset.xs⊆xs++ys (setoid _)
 
 xs⊆ys++xs : ∀ (xs ys : List A) → xs ⊆ ys ++ xs
-xs⊆ys++xs = Setoidₚ.xs⊆ys++xs (setoid _)
+xs⊆ys++xs = Subset.xs⊆ys++xs (setoid _)
 
 ++⁺ʳ : ∀ zs → xs ⊆ ys → zs ++ xs ⊆ zs ++ ys
-++⁺ʳ = Setoidₚ.++⁺ʳ (setoid _)
+++⁺ʳ = Subset.++⁺ʳ (setoid _)
 
 ++⁺ˡ : ∀ zs → xs ⊆ ys → xs ++ zs ⊆ ys ++ zs
-++⁺ˡ = Setoidₚ.++⁺ˡ (setoid _)
+++⁺ˡ = Subset.++⁺ˡ (setoid _)
 
 ++⁺ : ws ⊆ xs → ys ⊆ zs → ws ++ ys ⊆ xs ++ zs
-++⁺ = Setoidₚ.++⁺ (setoid _)
+++⁺ = Subset.++⁺ (setoid _)
 
 ------------------------------------------------------------------------
 -- concat
@@ -178,7 +178,7 @@ module _ {xss yss : List (List A)} where
 -- applyUpTo
 
 applyUpTo⁺ : ∀ (f : ℕ → A) {m n} → m ≤ n → applyUpTo f m ⊆ applyUpTo f n
-applyUpTo⁺ = Setoidₚ.applyUpTo⁺ (setoid _)
+applyUpTo⁺ = Subset.applyUpTo⁺ (setoid _)
 
 ------------------------------------------------------------------------
 -- _>>=_
@@ -248,12 +248,12 @@ module _ {xs : List A} {f : ∀ {x} → x ∈ xs → B}
 module _ {P : Pred A p} (P? : Decidable P) where
 
   filter-⊆ : ∀ xs → filter P? xs ⊆ xs
-  filter-⊆ = Setoidₚ.filter-⊆ (setoid A) P?
+  filter-⊆ = Subset.filter-⊆ (setoid A) P?
 
   module _ {Q : Pred A q} (Q? : Decidable Q) where
 
     filter⁺′ : P ⋐ Q → ∀ {xs ys} → xs ⊆ ys → filter P? xs ⊆ filter Q? ys
-    filter⁺′ = Setoidₚ.filter⁺′ (setoid A) P? (resp P) Q? (resp Q)
+    filter⁺′ = Subset.filter⁺′ (setoid A) P? (resp P) Q? (resp Q)
 
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Suffix/Heterogeneous/Properties.agda
@@ -30,8 +30,8 @@ open import Relation.Binary.Definitions as B
 open import Relation.Binary.PropositionalEquality.Core as P
   using (_≡_; _≢_; refl; sym; subst; subst₂)
 
-import Data.List.Properties as Listₚ
-import Data.List.Relation.Binary.Prefix.Heterogeneous.Properties as Prefixₚ
+import Data.List.Properties as List
+import Data.List.Relation.Binary.Prefix.Heterogeneous.Properties as Prefix
 
 ------------------------------------------------------------------------
 -- Suffix and Prefix are linked via reverse
@@ -43,15 +43,15 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   fromPrefix {as} {bs} p with Prefix.toView p
   ... | Prefix._++_ {cs} rs ds =
     subst (Suffix R (reverse as))
-      (sym (Listₚ.reverse-++ cs ds))
+      (sym (List.reverse-++ cs ds))
       (Suffix.fromView (reverse ds Suffix.++ Pw.reverse⁺ rs))
 
   fromPrefix-rev : ∀ {as bs} → Prefix R (reverse as) (reverse bs) →
                    Suffix R as bs
   fromPrefix-rev pre =
     subst₂ (Suffix R)
-      (Listₚ.reverse-involutive _)
-      (Listₚ.reverse-involutive _)
+      (List.reverse-involutive _)
+      (List.reverse-involutive _)
       (fromPrefix pre)
 
   toPrefix-rev : ∀ {as bs} → Suffix R as bs →
@@ -59,15 +59,15 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
   toPrefix-rev {as} {bs} s with Suffix.toView s
   ... | Suffix._++_ cs {ds} rs =
     subst (Prefix R (reverse as))
-      (sym (Listₚ.reverse-++ cs ds))
+      (sym (List.reverse-++ cs ds))
       (Prefix.fromView (Pw.reverse⁺ rs Prefix.++ reverse cs))
 
   toPrefix : ∀ {as bs} → Suffix R (reverse as) (reverse bs) →
              Prefix R as bs
   toPrefix suf =
     subst₂ (Prefix R)
-      (Listₚ.reverse-involutive _)
-      (Listₚ.reverse-involutive _)
+      (List.reverse-involutive _)
+      (List.reverse-involutive _)
       (toPrefix-rev suf)
 
 ------------------------------------------------------------------------
@@ -139,7 +139,7 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
     ds<cs = begin-strict
       length ds                   ≤⟨ m≤n+m (length ds) (length bs) ⟩
       length bs + length ds       <⟨ ≤-refl ⟩
-      suc (length bs + length ds) ≡⟨ sym $ Listₚ.length-++ (b ∷ bs) ⟩
+      suc (length bs + length ds) ≡⟨ sym $ List.length-++ (b ∷ bs) ⟩
       length (b ∷ bs ++ ds)       ≡⟨ sym $ Pointwise-length rs ⟩
       length cs                   ∎
 
@@ -209,4 +209,4 @@ module _ {a b r} {A : Set a} {B : Set b} {R : REL A B r} where
 
   suffix? : B.Decidable R → B.Decidable (Suffix R)
   suffix? R? as bs = Dec.map′ fromPrefix-rev toPrefix-rev
-                   $ Prefixₚ.prefix? R? (reverse as) (reverse bs)
+                   $ Prefix.prefix? R? (reverse as) (reverse bs)

--- a/src/Data/List/Relation/Ternary/Appending/Propositional.agda
+++ b/src/Data/List/Relation/Ternary/Appending/Propositional.agda
@@ -13,14 +13,14 @@ module Data.List.Relation.Ternary.Appending.Propositional
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.Product.Base using (_,_)
 
-import Data.List.Properties as Listₚ
+import Data.List.Properties as List
 import Data.List.Relation.Binary.Pointwise as Pw using (≡⇒Pointwise-≡; Pointwise-≡⇒≡)
 open import Relation.Binary.PropositionalEquality
   using (_≡_; setoid; refl; trans; cong₂; module ≡-Reasoning)
 
 import Data.List.Relation.Ternary.Appending.Setoid (setoid A) as General
 import Data.List.Relation.Ternary.Appending.Setoid.Properties (setoid A)
-  as Appendingₚ
+  as Appending
 
 ------------------------------------------------------------------------
 -- Re-export the basic combinators
@@ -37,7 +37,7 @@ _++_ : (as bs : List A) → Appending as bs (as List.++ bs)
 as ++ bs = Pw.≡⇒Pointwise-≡ refl General.++ Pw.≡⇒Pointwise-≡ refl
 
 _++[] : (as : List A) → Appending as [] as
-as ++[] = Appendingₚ.respʳ-≋ (as ++ []) (Pw.≡⇒Pointwise-≡ (Listₚ.++-identityʳ as))
+as ++[] = Appending.respʳ-≋ (as ++ []) (Pw.≡⇒Pointwise-≡ (List.++-identityʳ as))
 
 break : ∀ {as bs cs} → Appending as bs cs → as List.++ bs ≡ cs
 break {as} {bs} {cs} lrs = let (cs₁ , cs₂ , eq , acs , bcs) = General.break lrs in begin

--- a/src/Data/List/Relation/Ternary/Appending/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Ternary/Appending/Propositional/Properties.agda
@@ -9,7 +9,6 @@
 module Data.List.Relation.Ternary.Appending.Propositional.Properties {a} {A : Set a} where
 
 open import Data.List.Base as List using (List; [])
-import Data.List.Properties as Listₚ
 import Data.List.Relation.Binary.Pointwise as Pw using (Pointwise-≡⇒≡)
 open import Data.List.Relation.Binary.Equality.Propositional using (_≋_)
 open import Data.List.Relation.Ternary.Appending.Propositional {A = A}
@@ -18,7 +17,7 @@ open import Relation.Binary.PropositionalEquality.Core using (_≡_)
 open import Relation.Binary.PropositionalEquality.Properties using (setoid)
 
 import Data.List.Relation.Ternary.Appending.Setoid.Properties (setoid A)
-  as Appendingₚ
+  as Appending
 
 private
   variable
@@ -27,14 +26,14 @@ private
 ------------------------------------------------------------------------
 -- Re-export existing properties
 
-open Appendingₚ public
+open Appending public
   hiding ([]++⁻¹; ++[]⁻¹)
 
 ------------------------------------------------------------------------
 -- Prove propositional-specific ones
 
 []++⁻¹ : Appending [] bs cs → bs ≡ cs
-[]++⁻¹ = Pw.Pointwise-≡⇒≡ ∘′ Appendingₚ.[]++⁻¹
+[]++⁻¹ = Pw.Pointwise-≡⇒≡ ∘′ Appending.[]++⁻¹
 
 ++[]⁻¹ : Appending as [] cs → as ≡ cs
-++[]⁻¹ = Pw.Pointwise-≡⇒≡ ∘′ Appendingₚ.++[]⁻¹
+++[]⁻¹ = Pw.Pointwise-≡⇒≡ ∘′ Appending.++[]⁻¹

--- a/src/Data/String/Properties.agda
+++ b/src/Data/String/Properties.agda
@@ -9,8 +9,8 @@
 module Data.String.Properties where
 
 open import Data.Bool.Base using (Bool)
-import Data.Char.Properties as Charₚ
-import Data.List.Properties as Listₚ
+import Data.Char.Properties as Char
+import Data.List.Properties as List
 import Data.List.Relation.Binary.Pointwise as Pointwise
 import Data.List.Relation.Binary.Lex.Strict as StrictLex
 open import Data.String.Base
@@ -59,7 +59,7 @@ open import Agda.Builtin.String.Properties public
 
 infix 4 _≈?_
 _≈?_ : Decidable _≈_
-x ≈? y = Pointwise.decidable Charₚ._≟_ (toList x) (toList y)
+x ≈? y = Pointwise.decidable Char._≟_ (toList x) (toList y)
 
 ≈-isEquivalence : IsEquivalence _≈_
 ≈-isEquivalence = record
@@ -103,54 +103,54 @@ x ≟ y = map′ ≈⇒≡ ≈-reflexive $ x ≈? y
 
 infix 4 _<?_
 _<?_ : Decidable _<_
-x <? y = StrictLex.<-decidable Charₚ._≟_ Charₚ._<?_ (toList x) (toList y)
+x <? y = StrictLex.<-decidable Char._≟_ Char._<?_ (toList x) (toList y)
 
 <-isStrictPartialOrder-≈ : IsStrictPartialOrder _≈_ _<_
 <-isStrictPartialOrder-≈ =
   On.isStrictPartialOrder
     toList
-    (StrictLex.<-isStrictPartialOrder Charₚ.<-isStrictPartialOrder)
+    (StrictLex.<-isStrictPartialOrder Char.<-isStrictPartialOrder)
 
 <-isStrictTotalOrder-≈ : IsStrictTotalOrder _≈_ _<_
 <-isStrictTotalOrder-≈ =
   On.isStrictTotalOrder
     toList
-    (StrictLex.<-isStrictTotalOrder Charₚ.<-isStrictTotalOrder)
+    (StrictLex.<-isStrictTotalOrder Char.<-isStrictTotalOrder)
 
 <-strictPartialOrder-≈ : StrictPartialOrder _ _ _
 <-strictPartialOrder-≈ =
   On.strictPartialOrder
-    (StrictLex.<-strictPartialOrder Charₚ.<-strictPartialOrder)
+    (StrictLex.<-strictPartialOrder Char.<-strictPartialOrder)
     toList
 
 <-strictTotalOrder-≈ : StrictTotalOrder _ _ _
 <-strictTotalOrder-≈ =
   On.strictTotalOrder
-    (StrictLex.<-strictTotalOrder Charₚ.<-strictTotalOrder)
+    (StrictLex.<-strictTotalOrder Char.<-strictTotalOrder)
     toList
 
 ≤-isDecPartialOrder-≈ : IsDecPartialOrder _≈_ _≤_
 ≤-isDecPartialOrder-≈ =
   On.isDecPartialOrder
     toList
-    (StrictLex.≤-isDecPartialOrder Charₚ.<-isStrictTotalOrder)
+    (StrictLex.≤-isDecPartialOrder Char.<-isStrictTotalOrder)
 
 ≤-isDecTotalOrder-≈ : IsDecTotalOrder _≈_ _≤_
 ≤-isDecTotalOrder-≈ =
   On.isDecTotalOrder
     toList
-    (StrictLex.≤-isDecTotalOrder Charₚ.<-isStrictTotalOrder)
+    (StrictLex.≤-isDecTotalOrder Char.<-isStrictTotalOrder)
 
 ≤-decTotalOrder-≈ :  DecTotalOrder _ _ _
 ≤-decTotalOrder-≈ =
   On.decTotalOrder
-    (StrictLex.≤-decTotalOrder Charₚ.<-strictTotalOrder)
+    (StrictLex.≤-decTotalOrder Char.<-strictTotalOrder)
     toList
 
 ≤-decPoset-≈ : DecPoset _ _ _
 ≤-decPoset-≈ =
   On.decPoset
-    (StrictLex.≤-decPoset Charₚ.<-strictTotalOrder)
+    (StrictLex.≤-decPoset Char.<-strictTotalOrder)
     toList
 
 ------------------------------------------------------------------------

--- a/src/Data/Tree/Rose/Properties.agda
+++ b/src/Data/Tree/Rose/Properties.agda
@@ -12,7 +12,7 @@ open import Level using (Level)
 open import Size
 open import Data.List.Base as List using (List)
 open import Data.List.Extrema.Nat
-import Data.List.Properties as Listₚ
+import Data.List.Properties as List
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Tree.Rose
 open import Function.Base
@@ -33,14 +33,14 @@ private
 map-∘ : (f : A → B) (g : B → C) →
               map {i = i} (g ∘′ f) ≗ map {i = i} g ∘′ map {i = i} f
 map-∘ f g (node a ts) = cong (node (g (f a))) $ begin
-  List.map (map (g ∘′ f)) ts             ≡⟨ Listₚ.map-cong (map-∘ f g) ts ⟩
-  List.map (map g ∘ map f) ts            ≡⟨ Listₚ.map-∘ ts ⟩
+  List.map (map (g ∘′ f)) ts             ≡⟨ List.map-cong (map-∘ f g) ts ⟩
+  List.map (map g ∘ map f) ts            ≡⟨ List.map-∘ ts ⟩
   List.map (map g) (List.map (map f) ts) ∎
 
 depth-map : (f : A → B) (t : Rose A i) → depth {i = i} (map {i = i} f t) ≡ depth {i = i} t
 depth-map f (node a ts) = cong (suc ∘′ max 0) $ begin
-  List.map depth (List.map (map f) ts) ≡⟨ Listₚ.map-∘ ts ⟨
-  List.map (depth ∘′ map f) ts         ≡⟨ Listₚ.map-cong (depth-map f) ts ⟩
+  List.map depth (List.map (map f) ts) ≡⟨ List.map-∘ ts ⟨
+  List.map (depth ∘′ map f) ts         ≡⟨ List.map-cong (depth-map f) ts ⟩
   List.map depth ts ∎
 
 ------------------------------------------------------------------------
@@ -49,8 +49,8 @@ depth-map f (node a ts) = cong (suc ∘′ max 0) $ begin
 foldr-map : (f : A → B) (n : B → List C → C) (ts : Rose A i) →
             foldr {i = i} n (map {i = i} f ts) ≡ foldr {i = i} (n ∘′ f) ts
 foldr-map f n (node a ts) = cong (n (f a)) $ begin
-  List.map (foldr n) (List.map (map f) ts) ≡⟨ Listₚ.map-∘ ts ⟨
-  List.map (foldr n ∘′ map f) ts           ≡⟨ Listₚ.map-cong (foldr-map f n) ts ⟩
+  List.map (foldr n) (List.map (map f) ts) ≡⟨ List.map-∘ ts ⟨
+  List.map (foldr n ∘′ map f) ts           ≡⟨ List.map-cong (foldr-map f n) ts ⟩
   List.map (foldr (n ∘′ f)) ts             ∎
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -13,11 +13,11 @@ open import Data.Bool.Base using (true; false)
 open import Data.Fin.Base as Fin
   using (Fin; zero; suc; toℕ; fromℕ<; _↑ˡ_; _↑ʳ_)
 open import Data.List.Base as List using (List)
-import Data.List.Properties as Listₚ
+import Data.List.Properties as List
 open import Data.Nat.Base
 open import Data.Nat.Properties
   using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; ≤-irrelevant; ≤⇒≤″; suc-injective; +-comm; +-suc)
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_×_; _,_; proj₁; proj₂; <_,_>; uncurry)
 open import Data.Sum.Base using ([_,_]′)
 open import Data.Sum.Properties using ([,]-map)
@@ -689,7 +689,7 @@ map-<,>-zip f g []       = refl
 map-<,>-zip f g (x ∷ xs) = cong (_ ∷_) (map-<,>-zip f g xs)
 
 map-zip : ∀ (f : A → B) (g : C → D) (xs : Vec A n) (ys : Vec C n) →
-          map (Prod.map f g) (zip xs ys) ≡ zip (map f xs) (map g ys)
+          map (Product.map f g) (zip xs ys) ≡ zip (map f xs) (map g ys)
 map-zip f g []       []       = refl
 map-zip f g (x ∷ xs) (y ∷ ys) = cong (_ ∷_) (map-zip f g xs ys)
 
@@ -705,10 +705,10 @@ lookup-unzip (suc i) ((x , y) ∷ xys) = lookup-unzip i xys
 
 map-unzip : ∀ (f : A → B) (g : C → D) (xys : Vec (A × C) n) →
             let xs , ys = unzip xys
-            in (map f xs , map g ys) ≡ unzip (map (Prod.map f g) xys)
+            in (map f xs , map g ys) ≡ unzip (map (Product.map f g) xys)
 map-unzip f g []              = refl
 map-unzip f g ((x , y) ∷ xys) =
-  cong (Prod.map (f x ∷_) (g y ∷_)) (map-unzip f g xys)
+  cong (Product.map (f x ∷_) (g y ∷_)) (map-unzip f g xys)
 
 -- Products of vectors are isomorphic to vectors of products.
 
@@ -716,7 +716,7 @@ unzip∘zip : ∀ (xs : Vec A n) (ys : Vec B n) →
             unzip (zip xs ys) ≡ (xs , ys)
 unzip∘zip [] []             = refl
 unzip∘zip (x ∷ xs) (y ∷ ys) =
-  cong (Prod.map (x ∷_) (y ∷_)) (unzip∘zip xs ys)
+  cong (Product.map (x ∷_) (y ∷_)) (unzip∘zip xs ys)
 
 zip∘unzip : ∀ (xys : Vec (A × B) n) → uncurry zip (unzip xys) ≡ xys
 zip∘unzip []         = refl
@@ -869,7 +869,7 @@ unfold-∷ʳ eq x (y ∷ xs) = cong (y ∷_) (unfold-∷ʳ (cong pred eq) x xs)
 ∷ʳ-injective : ∀ (xs ys : Vec A n) → xs ∷ʳ x ≡ ys ∷ʳ y → xs ≡ ys × x ≡ y
 ∷ʳ-injective []       []        refl = (refl , refl)
 ∷ʳ-injective (x ∷ xs) (y  ∷ ys) eq   with ∷-injective eq
-... | refl , eq′ = Prod.map₁ (cong (x ∷_)) (∷ʳ-injective xs ys eq′)
+... | refl , eq′ = Product.map₁ (cong (x ∷_)) (∷ʳ-injective xs ys eq′)
 
 ∷ʳ-injectiveˡ : ∀ (xs ys : Vec A n) → xs ∷ʳ x ≡ ys ∷ʳ y → xs ≡ ys
 ∷ʳ-injectiveˡ xs ys eq = proj₁ (∷ʳ-injective xs ys eq)
@@ -1294,29 +1294,29 @@ cast-fromList : ∀ {xs ys : List A} (eq : xs ≡ ys) →
                 cast (cong List.length eq) (fromList xs) ≡ fromList ys
 cast-fromList {xs = List.[]}     {ys = List.[]}     eq = refl
 cast-fromList {xs = x List.∷ xs} {ys = y List.∷ ys} eq =
-  let x≡y , xs≡ys = Listₚ.∷-injective eq in begin
+  let x≡y , xs≡ys = List.∷-injective eq in begin
   x ∷ cast (cong (pred ∘ List.length) eq) (fromList xs) ≡⟨ cong (_ ∷_) (cast-fromList xs≡ys) ⟩
   x ∷ fromList ys                                       ≡⟨ cong (_∷ _) x≡y ⟩
   y ∷ fromList ys                                       ∎
   where open ≡-Reasoning
 
 fromList-map : ∀ (f : A → B) (xs : List A) →
-               cast (Listₚ.length-map f xs) (fromList (List.map f xs)) ≡ map f (fromList xs)
+               cast (List.length-map f xs) (fromList (List.map f xs)) ≡ map f (fromList xs)
 fromList-map f List.[]       = refl
 fromList-map f (x List.∷ xs) = cong (f x ∷_) (fromList-map f xs)
 
 fromList-++ : ∀ (xs : List A) {ys : List A} →
-              cast (Listₚ.length-++ xs) (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
+              cast (List.length-++ xs) (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
 fromList-++ List.[]       {ys} = cast-is-id refl (fromList ys)
 fromList-++ (x List.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
 
-fromList-reverse : (xs : List A) → cast (Listₚ.length-reverse xs) (fromList (List.reverse xs)) ≡ reverse (fromList xs)
+fromList-reverse : (xs : List A) → cast (List.length-reverse xs) (fromList (List.reverse xs)) ≡ reverse (fromList xs)
 fromList-reverse List.[] = refl
 fromList-reverse (x List.∷ xs) = begin
-  fromList (List.reverse (x List.∷ xs))         ≈⟨ cast-fromList (Listₚ.ʳ++-defn xs) ⟩
+  fromList (List.reverse (x List.∷ xs))         ≈⟨ cast-fromList (List.ʳ++-defn xs) ⟩
   fromList (List.reverse xs List.++ List.[ x ]) ≈⟨ fromList-++ (List.reverse xs) ⟩
   fromList (List.reverse xs) ++ [ x ]           ≈⟨ unfold-∷ʳ (+-comm 1 _) x (fromList (List.reverse xs)) ⟨
-  fromList (List.reverse xs) ∷ʳ x               ≈⟨ ≈-cong (_∷ʳ x) (cast-∷ʳ (cong suc (Listₚ.length-reverse xs)) _ _)
+  fromList (List.reverse xs) ∷ʳ x               ≈⟨ ≈-cong (_∷ʳ x) (cast-∷ʳ (cong suc (List.length-reverse xs)) _ _)
                                                           (fromList-reverse xs) ⟩
   reverse (fromList xs) ∷ʳ x                    ≂⟨ reverse-∷ x (fromList xs) ⟨
   reverse (x ∷ fromList xs)                     ≈⟨⟩

--- a/src/Data/Vec/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/All/Properties.agda
@@ -12,9 +12,8 @@ open import Data.Nat.Base using (ℕ; zero; suc; _+_)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base using ([]; _∷_)
 open import Data.List.Relation.Unary.All as List using ([]; _∷_)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry; uncurry′)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry; uncurry′)
 open import Data.Vec.Base as Vec
-import Data.Vec.Properties as Vecₚ
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
 open import Level using (Level)
 open import Function.Base using (_∘_; id)
@@ -82,7 +81,7 @@ gmap g = map⁺ ∘ All.map g
 ++⁻ : (xs : Vec A m) {ys : Vec A n} →
       All P (xs ++ ys) → All P xs × All P ys
 ++⁻ []       p          = [] , p
-++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map₁ (px ∷_) (++⁻ _ pxs)
+++⁻ (x ∷ xs) (px ∷ pxs) = Product.map₁ (px ∷_) (++⁻ _ pxs)
 
 ++⁺∘++⁻ : (xs : Vec A m) {ys : Vec A n} →
           (p : All P (xs ++ ys)) →

--- a/src/Data/Vec/Relation/Unary/AllPairs/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/AllPairs/Properties.agda
@@ -9,9 +9,9 @@
 module Data.Vec.Relation.Unary.AllPairs.Properties where
 
 open import Data.Vec
-import Data.Vec.Properties as Vecₚ
+import Data.Vec.Properties as Vec
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
-import Data.Vec.Relation.Unary.All.Properties as Allₚ
+import Data.Vec.Relation.Unary.All.Properties as All
 open import Data.Vec.Relation.Unary.AllPairs as AllPairs using (AllPairs; []; _∷_)
 open import Data.Bool.Base using (true; false)
 open import Data.Fin.Base using (Fin)
@@ -39,7 +39,7 @@ module _ {R : Rel A ℓ} {f : B → A} where
   map⁺ : ∀ {n xs} → AllPairs (λ x y → R (f x) (f y)) {n} xs →
          AllPairs R {n} (map f xs)
   map⁺ []           = []
-  map⁺ (x∉xs ∷ xs!) = Allₚ.map⁺ x∉xs ∷ map⁺ xs!
+  map⁺ (x∉xs ∷ xs!) = All.map⁺ x∉xs ∷ map⁺ xs!
 
 ------------------------------------------------------------------------
 -- ++
@@ -49,7 +49,7 @@ module _ {R : Rel A ℓ} where
   ++⁺ : ∀ {n m xs ys} → AllPairs R {n} xs → AllPairs R {m} ys →
         All (λ x → All (R x) ys) xs → AllPairs R (xs ++ ys)
   ++⁺ []         Rys _              = Rys
-  ++⁺ (px ∷ Rxs) Rys (Rxys ∷ Rxsys) = Allₚ.++⁺ px Rxys ∷ ++⁺ Rxs Rys Rxsys
+  ++⁺ (px ∷ Rxs) Rys (Rxys ∷ Rxsys) = All.++⁺ px Rxys ∷ ++⁺ Rxs Rys Rxsys
 
 ------------------------------------------------------------------------
 -- concat
@@ -61,7 +61,7 @@ module _ {R : Rel A ℓ} where
             AllPairs R (concat xss)
   concat⁺ []           []              = []
   concat⁺ (pxs ∷ pxss) (Rxsxss ∷ Rxss) = ++⁺ pxs (concat⁺ pxss Rxss)
-    (All.map Allₚ.concat⁺ (Allₚ.All-swap Rxsxss))
+    (All.map All.concat⁺ (All.All-swap Rxsxss))
 
 ------------------------------------------------------------------------
 -- take and drop
@@ -70,7 +70,7 @@ module _ {R : Rel A ℓ} where
 
   take⁺ : ∀ {n} m {xs} → AllPairs R {m + n} xs → AllPairs R {m} (take m xs)
   take⁺ zero pxs = []
-  take⁺ (suc m) {x ∷ xs} (px ∷ pxs) = Allₚ.take⁺ m px ∷ take⁺ m pxs
+  take⁺ (suc m) {x ∷ xs} (px ∷ pxs) = All.take⁺ m px ∷ take⁺ m pxs
 
   drop⁺ : ∀ {n} m {xs} → AllPairs R {m + n} xs → AllPairs R {n} (drop m xs)
   drop⁺ zero pxs = pxs
@@ -85,5 +85,5 @@ module _ {R : Rel A ℓ} where
               AllPairs R (tabulate f)
   tabulate⁺ {zero}  fᵢ~fⱼ = []
   tabulate⁺ {suc n} fᵢ~fⱼ =
-    Allₚ.tabulate⁺ (λ j → fᵢ~fⱼ λ()) ∷
+    All.tabulate⁺ (λ j → fᵢ~fⱼ λ()) ∷
     tabulate⁺ (fᵢ~fⱼ ∘ (_∘ suc-injective))

--- a/src/Data/Vec/Relation/Unary/Linked/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Linked/Properties.agda
@@ -10,7 +10,7 @@ module Data.Vec.Relation.Unary.Linked.Properties where
 
 open import Data.Vec.Base as Vec
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
-import Data.Vec.Relation.Unary.All.Properties as Allₚ
+import Data.Vec.Relation.Unary.All.Properties as All
 open import Data.Vec.Relation.Unary.Linked as Linked
   using (Linked; []; [-]; _∷_)
 open import Data.Fin.Base using (zero; suc; _<_)
@@ -43,7 +43,7 @@ module _ (trans : Transitive R) where
   lookup⁺ : ∀ {i j} {xs : Vec _ n} →
            Linked R xs → i < j →
            R (lookup xs i) (lookup xs j)
-  lookup⁺ {i = zero}  {j = suc j} (rx ∷ rxs) i<j = Allₚ.lookup⁺ (Linked⇒All rx rxs) j
+  lookup⁺ {i = zero}  {j = suc j} (rx ∷ rxs) i<j = All.lookup⁺ (Linked⇒All rx rxs) j
   lookup⁺ {i = suc i} {j = suc j} (_  ∷ rxs) i<j = lookup⁺ rxs (s<s⁻¹ i<j)
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Relation/Unary/Unique/Setoid/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Unique/Setoid/Properties.agda
@@ -11,10 +11,10 @@ module Data.Vec.Relation.Unary.Unique.Setoid.Properties where
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Vec.Base as Vec
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
-import Data.Vec.Relation.Unary.All.Properties as Allₚ
+import Data.Vec.Relation.Unary.All.Properties as All
 open import Data.Vec.Relation.Unary.AllPairs as AllPairs using (AllPairs)
 open import Data.Vec.Relation.Unary.Unique.Setoid
-import Data.Vec.Relation.Unary.AllPairs.Properties as AllPairsₚ
+import Data.Vec.Relation.Unary.AllPairs.Properties as AllPairs
 open import Data.Nat.Base using (ℕ; _+_)
 open import Function.Base using (_∘_; id)
 open import Level using (Level)
@@ -39,7 +39,7 @@ module _ (S : Setoid a ℓ₁) (R : Setoid b ℓ₂) where
 
   map⁺ : ∀ {f} → (∀ {x y} → f x ≈₂ f y → x ≈₁ y) →
          ∀ {n xs} → Unique S {n} xs → Unique R {n} (map f xs)
-  map⁺ inj xs! = AllPairsₚ.map⁺ (AllPairs.map (contraposition inj) xs!)
+  map⁺ inj xs! = AllPairs.map⁺ (AllPairs.map (contraposition inj) xs!)
 
 ------------------------------------------------------------------------
 -- take & drop
@@ -47,10 +47,10 @@ module _ (S : Setoid a ℓ₁) (R : Setoid b ℓ₂) where
 module _ (S : Setoid a ℓ) where
 
   drop⁺ : ∀ {n} m {xs} → Unique S {m + n} xs → Unique S {n} (drop m xs)
-  drop⁺ = AllPairsₚ.drop⁺
+  drop⁺ = AllPairs.drop⁺
 
   take⁺ : ∀ {n} m {xs} → Unique S {m + n} xs → Unique S {m} (take m xs)
-  take⁺ = AllPairsₚ.take⁺
+  take⁺ = AllPairs.take⁺
 
 ------------------------------------------------------------------------
 -- tabulate
@@ -61,7 +61,7 @@ module _ (S : Setoid a ℓ) where
 
   tabulate⁺ : ∀ {n} {f : Fin n → A} → (∀ {i j} → f i ≈ f j → i ≡ j) →
               Unique S (tabulate f)
-  tabulate⁺ f-inj = AllPairsₚ.tabulate⁺ (_∘ f-inj)
+  tabulate⁺ f-inj = AllPairs.tabulate⁺ (_∘ f-inj)
 
 ------------------------------------------------------------------------
 -- lookup
@@ -72,6 +72,6 @@ module _ (S : Setoid a ℓ) where
 
   lookup-injective : ∀ {n xs} → Unique S {n} xs → ∀ i j → lookup xs i ≈ lookup xs j → i ≡ j
   lookup-injective (px ∷ pxs) zero zero eq = P.refl
-  lookup-injective (px ∷ pxs) zero (suc j) eq = contradiction eq (Allₚ.lookup⁺ px j)
-  lookup-injective (px ∷ pxs) (suc i) zero eq = contradiction (sym eq) (Allₚ.lookup⁺ px i)
+  lookup-injective (px ∷ pxs) zero (suc j) eq = contradiction eq (All.lookup⁺ px j)
+  lookup-injective (px ∷ pxs) (suc i) zero eq = contradiction (sym eq) (All.lookup⁺ px i)
   lookup-injective (px ∷ pxs) (suc i) (suc j) eq = P.cong suc (lookup-injective pxs i j eq)

--- a/src/System/Clock.agda
+++ b/src/System/Clock.agda
@@ -14,7 +14,7 @@ open import Data.Fin.Base using (Fin; toℕ)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_; _∸_; _^_; _<ᵇ_)
 import Data.Nat.Show as ℕ using (show)
 open import Data.Nat.DivMod using (_/_)
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.String.Base using (String; _++_; padLeft)
 
 open import IO.Base
@@ -104,5 +104,5 @@ show : Time →   -- Time in seconds and nanoseconds
 show (mkTime s ns) prec = secs ++ "s" ++ padLeft '0' decimals nsecs where
   decimals = toℕ prec
   secs     = ℕ.show s
-  prf      = ℕₚ.m^n≢0 10 (9 ∸ decimals)
+  prf      = ℕ.m^n≢0 10 (9 ∸ decimals)
   nsecs    = ℕ.show ((ns / (10 ^ (9 ∸ decimals))) {{prf}})

--- a/src/Text/Pretty/Core.agda
+++ b/src/Text/Pretty/Core.agda
@@ -23,15 +23,15 @@ import Data.Product.Relation.Unary.All as Allᴾ
 open import Data.Tree.Binary as Tree using (Tree; leaf; node; #nodes; mapₙ)
 open import Data.Tree.Binary.Relation.Unary.All as Allᵀ using (leaf; node)
 open import Data.Unit using (⊤; tt)
-import Data.Tree.Binary.Relation.Unary.All.Properties as Allᵀₚ
-import Data.Tree.Binary.Properties as Treeₚ
+import Data.Tree.Binary.Relation.Unary.All.Properties as Allᵀ
+import Data.Tree.Binary.Properties as Tree
 
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; maybe′)
 open import Data.Maybe.Relation.Unary.All as Allᴹ using (nothing; just)
 
 open import Data.String.Base as String
   using (String; length; replicate; _++_; unlines)
-open import Data.String.Unsafe as Stringₚ
+open import Data.String.Unsafe as String
 open import Function.Base
 open import Relation.Nullary.Decidable using (Dec)
 open import Relation.Unary using (IUniversal; _⇒_; U)
@@ -162,10 +162,10 @@ private
 
     size-indents : ∀ ma t → #nodes (indents ma t) ≡ #nodes t
     size-indents nothing    t = refl
-    size-indents (just pad) t = Treeₚ.#nodes-mapₙ (pad ++_) t
+    size-indents (just pad) t = Tree.#nodes-mapₙ (pad ++_) t
 
     unfold-indents : ∀ ma t → indents ma t ≡ mapₙ (indent ma) t
-    unfold-indents nothing    t = sym (Treeₚ.map-id t)
+    unfold-indents nothing    t = sym (Tree.map-id t)
     unfold-indents (just pad) t = refl
 
     vContent : Content × String
@@ -250,7 +250,7 @@ private
       All≤-node? (≤-Content (m≤m⊔n _ _) ∣xs∣)
                  middle
                  (subst (Allᵀ.All _ U) (sym $ unfold-indents pad tl)
-                 $ Allᵀₚ.mapₙ⁺ (indent pad) (Allᵀ.mapₙ (indented _) ∣tl∣))
+                 $ Allᵀ.mapₙ⁺ (indent pad) (Allᵀ.mapₙ (indented _) ∣tl∣))
       where
 
       middle : length (lastx ++ hd) ≤ vMaxWidth

--- a/src/Text/Regex/String.agda
+++ b/src/Text/Regex/String.agda
@@ -8,9 +8,9 @@
 
 module Text.Regex.String where
 
-import Data.Char.Properties as Charₚ
+import Data.Char.Properties as Char
 
 ------------------------------------------------------------------------
 -- Re-exporting definitions
 
-open import Text.Regex Charₚ.≤-decPoset public
+open import Text.Regex Char.≤-decPoset public

--- a/src/Text/Tabular/List.agda
+++ b/src/Text/Tabular/List.agda
@@ -10,7 +10,7 @@ module Text.Tabular.List where
 
 open import Data.String.Base using (String)
 open import Data.List.Base
-import Data.Nat.Properties as ℕₚ
+import Data.Nat.Properties as ℕ
 open import Data.Product.Base using (-,_; proj₂)
 open import Data.Vec.Base as Vec using (Vec)
 open import Data.Vec.Bounded.Base as Vec≤ using (Vec≤)
@@ -24,7 +24,7 @@ display c a rows = Show.display c alignment rectangle
   where
   alignment : Vec Alignment _
   alignment = Vec≤.padRight Left
-            $ Vec≤.≤-cast (ℕₚ.m⊓n≤m _ _)
+            $ Vec≤.≤-cast (ℕ.m⊓n≤m _ _)
             $ Vec≤.take _ (Vec≤.fromList a)
 
   rectangle : Vec (Vec String _) _


### PR DESCRIPTION
Outstanding issues:
* disambiguation problem wrt `Permutation` in `Data.List.Relation.Binary.Subset.Setoid.Properties`;
* ditto. in `Data.Tree.AVL.Map.Membership.Propositional.Properties` wrt `IAny`
* use of `Pw` (etc.) vs. `Pointwise` for the qualified name of `Pointwise` modules? 
* ... ditto: `Membership`, `Subset`, `Sublist`, `Setoid`, `All`, `Any`, ...under `Data.List.Relation.*`
* not being able to use the datatype root name in some cases, esp. `List` for those above

Intermittent fixing of `U` to `Unary`, `B` to `Binary` ahead of tackling that task more systematically downstream