### PR TITLE
Qualified import of `Data.Product.Base` fixing #2280

### DIFF
--- a/src/Algebra/Construct/Flip/Op.agda
+++ b/src/Algebra/Construct/Flip/Op.agda
@@ -10,7 +10,7 @@
 module Algebra.Construct.Flip.Op where
 
 open import Algebra
-import Data.Product.Base as Prod
+import Data.Product.Base as Product
 import Data.Sum.Base as Sum
 open import Function.Base using (flip)
 open import Level using (Level)
@@ -39,7 +39,7 @@ module _ (≈ : Rel A ℓ) (∙ : Op₂ A) where
   associative sym assoc x y z = sym (assoc z y x)
 
   identity : Identity ≈ ε ∙ → Identity ≈ ε (flip ∙)
-  identity id = Prod.swap id
+  identity id = Product.swap id
 
   commutative : Commutative ≈ ∙ → Commutative ≈ (flip ∙)
   commutative comm = flip comm
@@ -51,7 +51,7 @@ module _ (≈ : Rel A ℓ) (∙ : Op₂ A) where
   idempotent idem = idem
 
   inverse : Inverse ≈ ε ⁻¹ ∙ → Inverse ≈ ε ⁻¹ (flip ∙)
-  inverse inv = Prod.swap inv
+  inverse inv = Product.swap inv
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Algebra/Construct/Subst/Equality.agda
+++ b/src/Algebra/Construct/Subst/Equality.agda
@@ -9,7 +9,7 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Relation.Binary.Core
 
 module Algebra.Construct.Subst.Equality
@@ -45,13 +45,13 @@ sel : ∀ {∙} → Selective ≈₁ ∙ → Selective ≈₂ ∙
 sel sel x y = Sum.map to to (sel x y)
 
 identity : ∀ {∙ e} → Identity ≈₁ e ∙ → Identity ≈₂ e ∙
-identity = Prod.map (to ∘_) (to ∘_)
+identity = Product.map (to ∘_) (to ∘_)
 
 inverse : ∀ {∙ e ⁻¹} → Inverse ≈₁ ⁻¹ ∙ e → Inverse ≈₂ ⁻¹ ∙ e
-inverse = Prod.map (to ∘_) (to ∘_)
+inverse = Product.map (to ∘_) (to ∘_)
 
 absorptive : ∀ {∙ ◦} → Absorptive ≈₁ ∙ ◦ → Absorptive ≈₂ ∙ ◦
-absorptive = Prod.map (λ f x y → to (f x y)) (λ f x y → to (f x y))
+absorptive = Product.map (λ f x y → to (f x y)) (λ f x y → to (f x y))
 
 distribˡ : ∀ {∙ ◦} → _DistributesOverˡ_ ≈₁ ∙ ◦ → _DistributesOverˡ_ ≈₂ ∙ ◦
 distribˡ distribˡ x y z = to (distribˡ x y z)
@@ -60,7 +60,7 @@ distribʳ : ∀ {∙ ◦} → _DistributesOverʳ_ ≈₁ ∙ ◦ → _Distribute
 distribʳ distribʳ x y z = to (distribʳ x y z)
 
 distrib : ∀ {∙ ◦} → _DistributesOver_ ≈₁ ∙ ◦ → _DistributesOver_ ≈₂ ∙ ◦
-distrib {∙} {◦} = Prod.map (distribˡ {∙} {◦}) (distribʳ {∙} {◦})
+distrib {∙} {◦} = Product.map (distribˡ {∙} {◦}) (distribʳ {∙} {◦})
 
 ------------------------------------------------------------------------
 -- Structures
@@ -92,7 +92,7 @@ isSelectiveMagma S = record
 isMonoid : ∀ {∙ ε} → IsMonoid ≈₁ ∙ ε → IsMonoid ≈₂ ∙ ε
 isMonoid S = record
   { isSemigroup = isSemigroup S.isSemigroup
-  ; identity    = Prod.map (to ∘_) (to ∘_) S.identity
+  ; identity    = Product.map (to ∘_) (to ∘_) S.identity
   } where module S = IsMonoid S
 
 isCommutativeMonoid : ∀ {∙ ε} →
@@ -113,7 +113,7 @@ isIdempotentCommutativeMonoid {∙} S = record
 isGroup : ∀ {∙ ε ⁻¹} → IsGroup ≈₁ ∙ ε ⁻¹ → IsGroup ≈₂ ∙ ε ⁻¹
 isGroup S = record
   { isMonoid = isMonoid S.isMonoid
-  ; inverse  = Prod.map (to ∘_) (to ∘_) S.inverse
+  ; inverse  = Product.map (to ∘_) (to ∘_) S.inverse
   ; ⁻¹-cong  = cong₁ S.⁻¹-cong
   } where module S = IsGroup S
 
@@ -141,7 +141,7 @@ isSemiringWithoutOne {+} {*} S = record
   ; *-cong                = cong₂ S.*-cong
   ; *-assoc               = assoc {*} S.*-assoc
   ; distrib               = distrib {*} {+} S.distrib
-  ; zero                  = Prod.map (to ∘_) (to ∘_) S.zero
+  ; zero                  = Product.map (to ∘_) (to ∘_) S.zero
   } where module S = IsSemiringWithoutOne S
 
 isCommutativeSemiringWithoutOne : ∀ {+ * 0#} →

--- a/src/Algebra/Lattice/Construct/Subst/Equality.agda
+++ b/src/Algebra/Lattice/Construct/Subst/Equality.agda
@@ -12,7 +12,7 @@
 open import Algebra.Core using (Op₂)
 open import Algebra.Definitions
 open import Algebra.Lattice.Structures
-open import Data.Product.Base as Prod
+open import Data.Product.Base using (_,_)
 open import Function.Base
 open import Relation.Binary.Core
 

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -21,7 +21,7 @@ open import Data.Maybe.Relation.Unary.Any using (just)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.NonEmpty using (List⁺; _∷_)
-open import Data.Product.Base as Prod using (∃; _×_; _,_)
+open import Data.Product.Base as Product using (∃; _×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Vec.Bounded as Vec≤ using (Vec≤)
 open import Function.Base
@@ -108,7 +108,7 @@ Any-∈ {P = P} = mk↔ₛ′
   where
   to : ∀ {xs} → Any P xs → ∃ λ x → x ∈ xs × P x
   to (here  p) = _ , here P.refl , p
-  to (there p) = Prod.map id (Prod.map there id) (to p)
+  to (there p) = Product.map id (Product.map there id) (to p)
 
   from : ∀ {x xs} → x ∈ xs → P x → Any P xs
   from (here P.refl) p = here p
@@ -118,7 +118,7 @@ Any-∈ {P = P} = mk↔ₛ′
             to (from x∈xs p) ≡ (x , x∈xs , p)
   to∘from (here P.refl) p = P.refl
   to∘from (there x∈xs)  p =
-    P.cong (Prod.map id (Prod.map there id)) (to∘from x∈xs p)
+    P.cong (Product.map id (Product.map there id)) (to∘from x∈xs p)
 
   from∘to : ∀ {xs} (p : Any P xs) →
             let (x , x∈xs , px) = to p in from x∈xs px ≡ p

--- a/src/Codata/Musical/Colist/Infinite-merge.agda
+++ b/src/Codata/Musical/Colist/Infinite-merge.agda
@@ -13,7 +13,7 @@ open import Codata.Musical.Colist as Colist hiding (_⋎_)
 open import Data.Nat.Base
 open import Data.Nat.Induction using (<′-wellFounded)
 open import Data.Nat.Properties
-open import Data.Product.Base as Prod using (_×_; _,_; ∃; ∃₂; proj₁; proj₂)
+open import Data.Product.Base as Product using (_×_; _,_; ∃; ∃₂; proj₁; proj₂)
 open import Data.Sum.Base
 open import Data.Sum.Properties
 open import Data.Sum.Function.Propositional using (_⊎-cong_)
@@ -195,7 +195,7 @@ Any-merge {P = P} xss = mk↔ₛ′ (proj₁ ∘ to xss) from to∘from (proj₂
          | index-Any-⋎P xs p
     ... | inj₁ q | P.refl | _   = here (inj₂ q) , P.refl
     ... | inj₂ q | P.refl | q≤p =
-      Prod.map there
+      Product.map there
                (P.cong (there ∘ (Inverse.from (Any-⋎P xs)) ∘ inj₂))
                (rec (s≤′s q≤p))
 

--- a/src/Codata/Sized/Colist/Properties.agda
+++ b/src/Codata/Sized/Colist/Properties.agda
@@ -27,7 +27,7 @@ open import Data.Maybe.Base as Maybe using (Maybe; nothing; just)
 import Data.Maybe.Properties as Maybeₚ
 open import Data.Maybe.Relation.Unary.All using (All; nothing; just)
 open import Data.Nat.Base as ℕ using (zero; suc; z≤n; s≤s)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry)
 open import Data.These.Base as These using (These; this; that; these)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Function.Base
@@ -106,7 +106,7 @@ lookup-replicate (suc k) (suc n) a = lookup-replicate k (n .force) a
 -- Properties of unfold
 
 map-unfold : ∀ (f : B → C) (alg : A → Maybe (A × B)) a →
-             i ⊢ map f (unfold alg a) ≈ unfold (Maybe.map (Prod.map₂ f) ∘ alg) a
+             i ⊢ map f (unfold alg a) ≈ unfold (Maybe.map (Product.map₂ f) ∘ alg) a
 map-unfold f alg a with alg a
 ... | nothing       = []
 ... | just (a′ , b) = Eq.refl ∷ λ where .force → map-unfold f alg a′

--- a/src/Codata/Sized/Cowriter.agda
+++ b/src/Codata/Sized/Cowriter.agda
@@ -18,7 +18,7 @@ open import Data.Unit.Base
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.NonEmpty.Base using (List⁺; _∷_)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc)
-open import Data.Product.Base as Prod using (_×_; _,_)
+open import Data.Product.Base as Product using (_×_; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Data.Vec.Base using (Vec; []; _∷_)
 open import Data.Vec.Bounded.Base as Vec≤ using (Vec≤; _,_)
@@ -68,11 +68,11 @@ length (w ∷ cw) = suc λ where .force → length (cw .force)
 splitAt : ∀ (n : ℕ) → Cowriter W A ∞ → (Vec W n × Cowriter W A ∞) ⊎ (Vec≤ W n × A)
 splitAt zero    cw       = inj₁ ([] , cw)
 splitAt (suc n) [ a ]    = inj₂ (Vec≤.[] , a)
-splitAt (suc n) (w ∷ cw) = Sum.map (Prod.map₁ (w ∷_)) (Prod.map₁ (w Vec≤.∷_))
+splitAt (suc n) (w ∷ cw) = Sum.map (Product.map₁ (w ∷_)) (Product.map₁ (w Vec≤.∷_))
                          $ splitAt n (cw .force)
 
 take : ∀ (n : ℕ) → Cowriter W A ∞ → Vec W n ⊎ (Vec≤ W n × A)
-take n = Sum.map₁ Prod.proj₁ ∘′ splitAt n
+take n = Sum.map₁ Product.proj₁ ∘′ splitAt n
 
 infixr 5 _++_ _⁺++_
 _++_ : ∀ {i} → List W → Cowriter W A i → Cowriter W A i

--- a/src/Codata/Sized/M/Properties.agda
+++ b/src/Codata/Sized/M/Properties.agda
@@ -15,7 +15,7 @@ open import Codata.Sized.M
 open import Codata.Sized.M.Bisimilarity
 open import Data.Container.Core as C hiding (map)
 import Data.Container.Morphism as Mp
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Data.Product.Properties hiding (map-cong)
 open import Function.Base using (_$′_; _∘′_)
 import Relation.Binary.PropositionalEquality.Core as P

--- a/src/Codata/Sized/Stream/Properties.agda
+++ b/src/Codata/Sized/Stream/Properties.agda
@@ -20,7 +20,7 @@ open import Data.Nat.GeneralisedArithmetic using (fold; fold-pull)
 open import Data.List.Base as List using ([]; _∷_)
 open import Data.List.NonEmpty as List⁺ using (List⁺; _∷_)
 import Data.List.Relation.Binary.Equality.Propositional as Eq
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Data.Vec.Base as Vec using (_∷_)
 
 open import Function.Base using (id; _$_; _∘′_; const)
@@ -49,7 +49,7 @@ take-repeat-identity (suc n) a = P.cong (a Vec.∷_) (take-repeat-identity n a)
 
 splitAt-repeat-identity : (n : ℕ) (a : A) → splitAt n (repeat a) ≡ (Vec.replicate n a , repeat a)
 splitAt-repeat-identity zero    a = P.refl
-splitAt-repeat-identity (suc n) a = P.cong (Prod.map₁ (a ∷_)) (splitAt-repeat-identity n a)
+splitAt-repeat-identity (suc n) a = P.cong (Product.map₁ (a ∷_)) (splitAt-repeat-identity n a)
 
 replicate-repeat : ∀ {i} (n : ℕ) (a : A) → i ⊢ List.replicate n a ++ repeat a ≈ repeat a
 replicate-repeat zero    a = refl
@@ -103,10 +103,10 @@ map-∘ f g (a ∷ as) = P.refl ∷ λ where .force → map-∘ f g (as .force)
 -- splitAt
 
 splitAt-map : ∀ n (f : A → B) xs →
-  splitAt n (map f xs) ≡ Prod.map (Vec.map f) (map f) (splitAt n xs)
+  splitAt n (map f xs) ≡ Product.map (Vec.map f) (map f) (splitAt n xs)
 splitAt-map zero    f xs       = P.refl
 splitAt-map (suc n) f (x ∷ xs) =
-  P.cong (Prod.map₁ (f x Vec.∷_)) (splitAt-map n f (xs .force))
+  P.cong (Product.map₁ (f x Vec.∷_)) (splitAt-map n f (xs .force))
 
 ------------------------------------------------------------------------
 -- iterate

--- a/src/Data/Container/Core.agda
+++ b/src/Data/Container/Core.agda
@@ -9,7 +9,7 @@
 module Data.Container.Core where
 
 open import Level
-open import Data.Product.Base as Prod using (Σ-syntax)
+open import Data.Product.Base as Product using (Σ-syntax)
 open import Function.Base
 open import Function using (Inverse; _↔_)
 open import Relation.Unary using (Pred; _⊆_)
@@ -33,7 +33,7 @@ open Container public
 
 map : ∀ {s p x y} {C : Container s p} {X : Set x} {Y : Set y} →
       (X → Y) → ⟦ C ⟧ X → ⟦ C ⟧ Y
-map f = Prod.map₂ (f ∘_)
+map f = Product.map₂ (f ∘_)
 
 -- Representation of container morphisms.
 
@@ -47,7 +47,7 @@ record _⇒_ {s₁ s₂ p₁ p₂} (C₁ : Container s₁ p₁) (C₂ : Containe
     position : ∀ {s} → Position C₂ (shape s) → Position C₁ s
 
   ⟪_⟫ : ∀ {x} {X : Set x} → ⟦ C₁ ⟧ X → ⟦ C₂ ⟧ X
-  ⟪_⟫ = Prod.map shape (_∘′ position)
+  ⟪_⟫ = Product.map shape (_∘′ position)
 
 open _⇒_ public
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -23,7 +23,7 @@ open import Data.Nat.Base as ℕ
 import Data.Nat.Properties as ℕ
 open import Data.Nat.Solver
 open import Data.Unit using (⊤; tt)
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (∃; ∃₂; _×_; _,_; map; proj₁; proj₂; uncurry; <_,_>)
 open import Data.Product.Properties using (,-injective)
 open import Data.Product.Algebra using (×-cong)
@@ -644,7 +644,7 @@ splitAt-≥ (suc m) (suc i) i≥m = cong (Sum.map suc id) (splitAt-≥ m i (ℕ.
 remQuot-combine : ∀ {n k} (i : Fin n) j → remQuot k (combine i j) ≡ (i , j)
 remQuot-combine {suc n} {k} zero    j rewrite splitAt-↑ˡ k j (n ℕ.* k) = refl
 remQuot-combine {suc n} {k} (suc i) j rewrite splitAt-↑ʳ k   (n ℕ.* k) (combine i j) =
-  cong (Prod.map₁ suc) (remQuot-combine i j)
+  cong (Product.map₁ suc) (remQuot-combine i j)
 
 combine-remQuot : ∀ {n} k (i : Fin (n ℕ.* k)) → uncurry combine (remQuot {n} k i) ≡ i
 combine-remQuot {suc n} k i with splitAt k i in eq

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -17,7 +17,7 @@ open import Data.Bool.Base as Bool
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; maybe′)
 open import Data.Nat.Base as ℕ using (ℕ; zero; suc; _+_; _*_ ; _≤_ ; s≤s)
-open import Data.Product.Base as Prod using (_×_; _,_; map₁; map₂′)
+open import Data.Product.Base as Product using (_×_; _,_; map₁; map₂′)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Data.These.Base as These using (These; this; that; these)
 open import Function.Base
@@ -96,13 +96,13 @@ zipWith f _        _        = []
 unalignWith : (A → These B C) → List A → List B × List C
 unalignWith f []       = [] , []
 unalignWith f (a ∷ as) with f a
-... | this b    = Prod.map₁ (b ∷_) (unalignWith f as)
-... | that c    = Prod.map₂ (c ∷_) (unalignWith f as)
-... | these b c = Prod.map (b ∷_) (c ∷_) (unalignWith f as)
+... | this b    = Product.map₁ (b ∷_) (unalignWith f as)
+... | that c    = Product.map₂ (c ∷_) (unalignWith f as)
+... | these b c = Product.map (b ∷_) (c ∷_) (unalignWith f as)
 
 unzipWith : (A → B × C) → List A → List B × List C
 unzipWith f []         = [] , []
-unzipWith f (xy ∷ xys) = Prod.zip _∷_ _∷_ (f xy) (unzipWith f xys)
+unzipWith f (xy ∷ xys) = Product.zip _∷_ _∷_ (f xy) (unzipWith f xys)
 
 partitionSumsWith : (A → B ⊎ C) → List A → List B × List C
 partitionSumsWith f = unalignWith (These.fromSum ∘′ f)
@@ -340,7 +340,7 @@ drop (suc n) (x ∷ xs) = drop n xs
 splitAt : ℕ → List A → List A × List A
 splitAt zero    xs       = ([] , xs)
 splitAt (suc n) []       = ([] , [])
-splitAt (suc n) (x ∷ xs) = Prod.map₁ (x ∷_) (splitAt n xs)
+splitAt (suc n) (x ∷ xs) = Product.map₁ (x ∷_) (splitAt n xs)
 
 removeAt : (xs : List A) → Fin (length xs) → List A
 removeAt (x ∷ xs) zero     = xs
@@ -406,7 +406,7 @@ partitionᵇ p = partition (T? ∘ p)
 span : ∀ {P : Pred A p} → Decidable P → List A → (List A × List A)
 span P? []       = ([] , [])
 span P? ys@(x ∷ xs) with does (P? x)
-... | true  = Prod.map (x ∷_) id (span P? xs)
+... | true  = Product.map (x ∷_) id (span P? xs)
 ... | false = ([] , ys)
 
 

--- a/src/Data/List/Membership/Propositional/Properties/Core.agda
+++ b/src/Data/List/Membership/Propositional/Properties/Core.agda
@@ -17,7 +17,7 @@ open import Function.Bundles
 open import Data.List.Base using (List)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_,_; proj₁; proj₂; uncurry′; ∃; _×_)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality.Core as P
@@ -42,7 +42,7 @@ map∘find (there p) hyp = P.cong there (map∘find p hyp)
 
 find∘map : ∀ {P : Pred A p} {Q : Pred A q}
            {xs : List A} (p : Any P xs) (f : P ⊆ Q) →
-           find (Any.map f p) ≡ Prod.map id (Prod.map id f) (find p)
+           find (Any.map f p) ≡ Product.map id (Product.map id f) (find p)
 find∘map (here  p) f = refl
 find∘map (there p) f rewrite find∘map p f = refl
 

--- a/src/Data/List/Membership/Setoid.agda
+++ b/src/Data/List/Membership/Setoid.agda
@@ -15,7 +15,7 @@ open import Function.Base using (_∘_; id; flip)
 open import Data.List.Base as List using (List; []; _∷_; length; lookup)
 open import Data.List.Relation.Unary.Any as Any
   using (Any; index; map; here; there)
-open import Data.Product.Base as Prod using (∃; _×_; _,_)
+open import Data.Product.Base as Product using (∃; _×_; _,_)
 open import Relation.Unary using (Pred)
 open import Relation.Nullary.Negation using (¬_)
 
@@ -50,7 +50,7 @@ module _ {p} {P : Pred A p} where
 
   find : ∀ {xs} → Any P xs → ∃ λ x → x ∈ xs × P x
   find (here px)   = (_ , here refl , px)
-  find (there pxs) = Prod.map id (Prod.map there id) (find pxs)
+  find (there pxs) = Product.map id (Product.map there id) (find pxs)
 
   lose : P Respects _≈_ →  ∀ {x xs} → x ∈ xs → P x → Any P xs
   lose resp x∈xs px = map (flip resp px) x∈xs

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -21,7 +21,7 @@ import Data.List.Relation.Binary.Equality.Setoid as Equality
 import Data.List.Relation.Unary.Unique.Setoid as Unique
 open import Data.Nat.Base using (suc; z≤n; s≤s; _≤_; _<_)
 open import Data.Nat.Properties using (≤-trans; n≤1+n)
-open import Data.Product.Base as Prod using (∃; _×_; _,_ ; ∃₂; proj₁; proj₂)
+open import Data.Product.Base as Product using (∃; _×_; _,_ ; ∃₂; proj₁; proj₂)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent using (_×ₛ_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Function.Base using (_$_; flip; _∘_; _∘′_; id)
@@ -342,10 +342,10 @@ module _ (S : Setoid c ℓ) {P : Pred (Carrier S) p}
 
   ∈-filter⁻ : ∀ {v xs} → v ∈ filter P? xs → v ∈ xs × P v
   ∈-filter⁻ {xs = x ∷ xs} v∈f[x∷xs] with P? x
-  ... | false because  _   = Prod.map there id (∈-filter⁻ v∈f[x∷xs])
+  ... | false because  _   = Product.map there id (∈-filter⁻ v∈f[x∷xs])
   ... |  true because [Px] with v∈f[x∷xs]
   ...   | here  v≈x   = here v≈x , resp (sym v≈x) (invert [Px])
-  ...   | there v∈fxs = Prod.map there id (∈-filter⁻ v∈fxs)
+  ...   | there v∈fxs = Product.map there id (∈-filter⁻ v∈fxs)
 
 ------------------------------------------------------------------------
 -- derun and deduplicate

--- a/src/Data/List/Nary/NonDependent.agda
+++ b/src/Data/List/Nary/NonDependent.agda
@@ -10,7 +10,7 @@ module Data.List.Nary.NonDependent where
 
 open import Data.Nat.Base using (zero; suc)
 open import Data.List.Base as List using (List; []; _∷_)
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Data.Product.Nary.NonDependent using (Product)
 open import Function.Base using ()
 open import Function.Nary.NonDependent.Base
@@ -37,7 +37,7 @@ zipWith : ∀ n {ls} {as : Sets n ls} {r} {R : Set r} →
 zipWith 0               f       = []
 zipWith 1               f xs    = List.map f xs
 zipWith (suc n@(suc _)) f xs ys =
-  zipWith n (Prod.uncurry f) (List.zipWith _,_ xs ys)
+  zipWith n (Product.uncurry f) (List.zipWith _,_ xs ys)
 
 unzipWith : ∀ n {ls} {as : Sets n ls} {a} {A : Set a} →
             (A → Product n as) → (List A → Product n (List <$> as))

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -25,9 +25,9 @@ open import Data.Maybe.Base as Maybe using (Maybe; just; nothing)
 open import Data.Nat.Base
 open import Data.Nat.Divisibility
 open import Data.Nat.Properties
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_×_; _,_; uncurry; uncurry′; proj₁; proj₂; <_,_>)
-import Data.Product.Relation.Unary.All as Prod using (All)
+import Data.Product.Relation.Unary.All as Product using (All)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Data.These.Base as These using (These; this; that; these)
 open import Data.Fin.Properties using (toℕ-cast)
@@ -370,20 +370,20 @@ module _ (f : A → B → C) where
 
 unalignWith-this : unalignWith ((A → These A B) ∋ this) ≗ (_, [])
 unalignWith-this []       = refl
-unalignWith-this (a ∷ as) = cong (Prod.map₁ (a ∷_)) (unalignWith-this as)
+unalignWith-this (a ∷ as) = cong (Product.map₁ (a ∷_)) (unalignWith-this as)
 
 unalignWith-that : unalignWith ((B → These A B) ∋ that) ≗ ([] ,_)
 unalignWith-that []       = refl
-unalignWith-that (b ∷ bs) = cong (Prod.map₂ (b ∷_)) (unalignWith-that bs)
+unalignWith-that (b ∷ bs) = cong (Product.map₂ (b ∷_)) (unalignWith-that bs)
 
 module _ {f g : C → These A B} where
 
   unalignWith-cong : f ≗ g → unalignWith f ≗ unalignWith g
   unalignWith-cong f≗g []       = refl
   unalignWith-cong f≗g (c ∷ cs) with f c | g c | f≗g c
-  ... | this a    | ._ | refl = cong (Prod.map₁ (a ∷_)) (unalignWith-cong f≗g cs)
-  ... | that b    | ._ | refl = cong (Prod.map₂ (b ∷_)) (unalignWith-cong f≗g cs)
-  ... | these a b | ._ | refl = cong (Prod.map (a ∷_) (b ∷_)) (unalignWith-cong f≗g cs)
+  ... | this a    | ._ | refl = cong (Product.map₁ (a ∷_)) (unalignWith-cong f≗g cs)
+  ... | that b    | ._ | refl = cong (Product.map₂ (b ∷_)) (unalignWith-cong f≗g cs)
+  ... | these a b | ._ | refl = cong (Product.map (a ∷_) (b ∷_)) (unalignWith-cong f≗g cs)
 
 module _ (f : C → These A B) where
 
@@ -391,17 +391,17 @@ module _ (f : C → These A B) where
                     unalignWith f (map g ds) ≡ unalignWith (f ∘′ g) ds
   unalignWith-map g []       = refl
   unalignWith-map g (d ∷ ds) with f (g d)
-  ... | this a    = cong (Prod.map₁ (a ∷_)) (unalignWith-map g ds)
-  ... | that b    = cong (Prod.map₂ (b ∷_)) (unalignWith-map g ds)
-  ... | these a b = cong (Prod.map (a ∷_) (b ∷_)) (unalignWith-map g ds)
+  ... | this a    = cong (Product.map₁ (a ∷_)) (unalignWith-map g ds)
+  ... | that b    = cong (Product.map₂ (b ∷_)) (unalignWith-map g ds)
+  ... | these a b = cong (Product.map (a ∷_) (b ∷_)) (unalignWith-map g ds)
 
   map-unalignWith : (g : A → D) (h : B → E) →
-    Prod.map (map g) (map h) ∘′ unalignWith f ≗ unalignWith (These.map g h ∘′ f)
+    Product.map (map g) (map h) ∘′ unalignWith f ≗ unalignWith (These.map g h ∘′ f)
   map-unalignWith g h []       = refl
   map-unalignWith g h (c ∷ cs) with f c
-  ... | this a    = cong (Prod.map₁ (g a ∷_)) (map-unalignWith g h cs)
-  ... | that b    = cong (Prod.map₂ (h b ∷_)) (map-unalignWith g h cs)
-  ... | these a b = cong (Prod.map (g a ∷_) (h b ∷_)) (map-unalignWith g h cs)
+  ... | this a    = cong (Product.map₁ (g a ∷_)) (map-unalignWith g h cs)
+  ... | that b    = cong (Product.map₂ (h b ∷_)) (map-unalignWith g h cs)
+  ... | these a b = cong (Product.map (g a ∷_) (h b ∷_)) (map-unalignWith g h cs)
 
   unalignWith-alignWith : (g : These A B → C) → f ∘′ g ≗ id → ∀ as bs →
                           unalignWith f (alignWith g as bs) ≡ (as , bs)
@@ -417,7 +417,7 @@ module _ (f : C → These A B) where
     as , []                            ∎
   unalignWith-alignWith g g∘f≗id (a ∷ as)   (b ∷ bs)
     rewrite g∘f≗id (these a b) =
-    cong (Prod.map (a ∷_) (b ∷_)) (unalignWith-alignWith g g∘f≗id as bs)
+    cong (Product.map (a ∷_) (b ∷_)) (unalignWith-alignWith g g∘f≗id as bs)
 
 ------------------------------------------------------------------------
 -- unzipWith
@@ -896,7 +896,7 @@ lookup-iterate f x (suc n) (suc i) = lookup-iterate f (f x) n i
 splitAt-defn : ∀ n → splitAt {A = A} n ≗ < take n , drop n >
 splitAt-defn zero    xs       = refl
 splitAt-defn (suc n) []       = refl
-splitAt-defn (suc n) (x ∷ xs) = cong (Prod.map (x ∷_) id) (splitAt-defn n xs)
+splitAt-defn (suc n) (x ∷ xs) = cong (Product.map (x ∷_) id) (splitAt-defn n xs)
 
 ------------------------------------------------------------------------
 -- takeWhile, dropWhile, and span
@@ -912,7 +912,7 @@ module _ {P : Pred A p} (P? : Decidable P) where
   span-defn : span P? ≗ < takeWhile P? , dropWhile P? >
   span-defn []       = refl
   span-defn (x ∷ xs) with does (P? x)
-  ... | true  = cong (Prod.map (x ∷_) id) (span-defn xs)
+  ... | true  = cong (Product.map (x ∷_) id) (span-defn xs)
   ... | false = refl
 
 ------------------------------------------------------------------------
@@ -1023,15 +1023,15 @@ module _ {P : Pred A p} (P? : Decidable P) where
   partition-defn : partition P? ≗ < filter P? , filter (∁? P?) >
   partition-defn []       = refl
   partition-defn (x ∷ xs) with ih ← partition-defn xs | does (P? x)
-  ...  | true  = cong (Prod.map (x ∷_) id) ih
-  ...  | false = cong (Prod.map id (x ∷_)) ih
+  ...  | true  = cong (Product.map (x ∷_) id) ih
+  ...  | false = cong (Product.map id (x ∷_)) ih
 
   length-partition : ∀ xs → (let (ys , zs) = partition P? xs) →
                      length ys ≤ length xs × length zs ≤ length xs
   length-partition []       = z≤n , z≤n
   length-partition (x ∷ xs) with ih ← length-partition xs | does (P? x)
-  ...  | true  = Prod.map s≤s m≤n⇒m≤1+n ih
-  ...  | false = Prod.map m≤n⇒m≤1+n s≤s ih
+  ...  | true  = Product.map s≤s m≤n⇒m≤1+n ih
+  ...  | false = Product.map m≤n⇒m≤1+n s≤s ih
 
 ------------------------------------------------------------------------
 -- _ʳ++_
@@ -1181,7 +1181,7 @@ module _ {x y : A} where
   ∷ʳ-injective : ∀ xs ys → xs ∷ʳ x ≡ ys ∷ʳ y → xs ≡ ys × x ≡ y
   ∷ʳ-injective []          []          refl = (refl , refl)
   ∷ʳ-injective (x ∷ xs)    (y  ∷ ys)   eq   with refl , eq′  ← ∷-injective eq
-    = Prod.map (cong (x ∷_)) id (∷ʳ-injective xs ys eq′)
+    = Product.map (cong (x ∷_)) id (∷ʳ-injective xs ys eq′)
   ∷ʳ-injective []          (_ ∷ _ ∷ _) ()
   ∷ʳ-injective (_ ∷ _ ∷ _) []          ()
 

--- a/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Prefix/Heterogeneous/Properties.agda
@@ -19,7 +19,7 @@ open import Data.List.Relation.Binary.Pointwise.Base using (Pointwise; []; _∷_
 open import Data.List.Relation.Binary.Prefix.Heterogeneous as Prefix hiding (PrefixView; _++_)
 open import Data.Nat.Base using (ℕ; zero; suc; _≤_; z≤n; s≤s)
 open import Data.Nat.Properties using (suc-injective)
-open import Data.Product.Base as Prod using (_×_; _,_; proj₁; proj₂; uncurry)
+open import Data.Product.Base as Product using (_×_; _,_; proj₁; proj₂; uncurry)
 open import Function.Base
 
 open import Relation.Nullary.Negation using (¬_)

--- a/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Subset/Propositional/Properties.agda
@@ -26,7 +26,7 @@ open import Data.List.Relation.Binary.Subset.Propositional
 open import Data.List.Relation.Binary.Permutation.Propositional
 import Data.List.Relation.Binary.Permutation.Propositional.Properties as Permutation
 open import Data.Nat using (ℕ; _≤_)
-import Data.Product.Base as Prod
+import Data.Product.Base as Product
 import Data.Sum.Base as Sum
 open import Effect.Monad
 open import Function.Base using (_∘_; _∘′_; id; _$_)
@@ -130,7 +130,7 @@ All-resp-⊇ = Setoidₚ.All-resp-⊇ (setoid _) (subst _)
 map⁺ : ∀ (f : A → B) → xs ⊆ ys → map f xs ⊆ map f ys
 map⁺ f xs⊆ys =
   Inverse.to (map-∈↔ f) ∘
-  Prod.map₂ (Prod.map₁ xs⊆ys) ∘
+  Product.map₂ (Product.map₁ xs⊆ys) ∘
   Inverse.from (map-∈↔ f)
 
 ------------------------------------------------------------------------
@@ -171,7 +171,7 @@ module _ {xss yss : List (List A)} where
   concat⁺ : xss ⊆ yss → concat xss ⊆ concat yss
   concat⁺ xss⊆yss =
     Inverse.to concat-∈↔ ∘
-    Prod.map₂ (Prod.map₂ xss⊆yss) ∘
+    Product.map₂ (Product.map₂ xss⊆yss) ∘
     Inverse.from concat-∈↔
 
 ------------------------------------------------------------------------
@@ -188,7 +188,7 @@ module _ {A B : Set a} (f g : A → List B) where
   >>=⁺ : xs ⊆ ys → (∀ {x} → f x ⊆ g x) → (xs >>= f) ⊆ (ys >>= g)
   >>=⁺ xs⊆ys f⊆g =
     Inverse.to >>=-∈↔ ∘
-    Prod.map₂ (Prod.map xs⊆ys f⊆g) ∘
+    Product.map₂ (Product.map xs⊆ys f⊆g) ∘
     Inverse.from >>=-∈↔
 
 ------------------------------------------------------------------------
@@ -199,7 +199,7 @@ module _ {A B : Set a} {fs gs : List (A → B)} where
   ⊛⁺ : fs ⊆ gs → xs ⊆ ys → (fs ⊛ xs) ⊆ (gs ⊛ ys)
   ⊛⁺ fs⊆gs xs⊆ys =
     (Inverse.to $ ⊛-∈↔ gs) ∘
-    Prod.map₂ (Prod.map₂ (Prod.map fs⊆gs (Prod.map₁ xs⊆ys))) ∘
+    Product.map₂ (Product.map₂ (Product.map fs⊆gs (Product.map₁ xs⊆ys))) ∘
     (Inverse.from $ ⊛-∈↔ fs)
 
 ------------------------------------------------------------------------
@@ -210,7 +210,7 @@ module _ {A B : Set a} {ws xs : List A} {ys zs : List B} where
   ⊗⁺ : ws ⊆ xs → ys ⊆ zs → (ws ⊗ ys) ⊆ (xs ⊗ zs)
   ⊗⁺ ws⊆xs ys⊆zs =
     Inverse.to ⊗-∈↔ ∘
-    Prod.map ws⊆xs ys⊆zs ∘
+    Product.map ws⊆xs ys⊆zs ∘
     Inverse.from ⊗-∈↔
 
 ------------------------------------------------------------------------
@@ -235,7 +235,7 @@ module _ {xs : List A} {f : ∀ {x} → x ∈ xs → B}
                 mapWith∈ xs f ⊆ mapWith∈ ys g
   mapWith∈⁺ xs⊆ys f≈g {x} =
     Inverse.to Any.mapWith∈↔ ∘
-    Prod.map₂ (Prod.map xs⊆ys (λ {x∈xs} x≡fx∈xs → begin
+    Product.map₂ (Product.map xs⊆ys (λ {x∈xs} x≡fx∈xs → begin
       x               ≡⟨ x≡fx∈xs ⟩
       f x∈xs          ≡⟨ f≈g x∈xs ⟩
       g (xs⊆ys x∈xs)  ∎)) ∘

--- a/src/Data/List/Relation/Ternary/Interleaving.agda
+++ b/src/Data/List/Relation/Ternary/Interleaving.agda
@@ -12,7 +12,7 @@ module Data.List.Relation.Ternary.Interleaving where
 open import Level
 open import Data.List.Base as List using (List; []; _∷_; _++_)
 open import Data.List.Relation.Binary.Pointwise.Base using (Pointwise; []; _∷_)
-open import Data.Product.Base as Prod using (∃; ∃₂; _×_; uncurry; _,_; -,_; proj₂)
+open import Data.Product.Base as Product using (∃; ∃₂; _×_; uncurry; _,_; -,_; proj₂)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base
 open import Relation.Binary.Core using (REL; _⇒_)
@@ -95,11 +95,11 @@ module _ {a b l r} {A : Set a} {B : Set b} {L : REL A B l} {R : REL A B r} where
   split : ∀ {as bs} → Pointwise (λ a b → L a b ⊎ R a b) as bs →
           ∃₂ λ asr asl → Interleaving L R asl asr bs
   split []            = [] , [] , []
-  split (inj₁ l ∷ pw) = Prod.map _ (Prod.map _ (l ∷ˡ_)) (split pw)
-  split (inj₂ r ∷ pw) = Prod.map _ (Prod.map _ (r ∷ʳ_)) (split pw)
+  split (inj₁ l ∷ pw) = Product.map _ (Product.map _ (l ∷ˡ_)) (split pw)
+  split (inj₂ r ∷ pw) = Product.map _ (Product.map _ (r ∷ʳ_)) (split pw)
 
   unsplit : ∀ {l r as} → Interleaving L R l r as →
             ∃ λ bs → Pointwise (λ a b → L a b ⊎ R a b) bs as
   unsplit []        = -, []
-  unsplit (l ∷ˡ sp) = Prod.map _ (inj₁ l ∷_) (unsplit sp)
-  unsplit (r ∷ʳ sp) = Prod.map _ (inj₂ r ∷_) (unsplit sp)
+  unsplit (l ∷ˡ sp) = Product.map _ (inj₁ l ∷_) (unsplit sp)
+  unsplit (r ∷ʳ sp) = Product.map _ (inj₂ r ∷_) (unsplit sp)

--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -15,7 +15,7 @@ open import Data.List.Base as List using (List; []; _∷_)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional renaming (_∈_ to _∈ₚ_)
 import Data.List.Membership.Setoid as SetoidMembership
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (∃; -,_; _×_; _,_; proj₁; proj₂; uncurry)
 open import Data.Sum.Base as Sum using (inj₁; inj₂)
 open import Function.Base using (_∘_; _∘′_; id; const)
@@ -88,7 +88,7 @@ reduce f (px ∷ pxs) = f px ∷ reduce f pxs
 
 construct : (f : B → ∃ P) (xs : List B) → ∃ (All P)
 construct f []       = [] , []
-construct f (x ∷ xs) = Prod.zip _∷_ _∷_ (f x) (construct f xs)
+construct f (x ∷ xs) = Product.zip _∷_ _∷_ (f x) (construct f xs)
 
 fromList : (xs : List (∃ P)) → All P (List.map proj₁ xs)
 fromList []              = []
@@ -107,7 +107,7 @@ zipWith f (px ∷ pxs , qx ∷ qxs) = f (px , qx) ∷ zipWith f (pxs , qxs)
 
 unzipWith : R ⊆ P ∩ Q → All R ⊆ All P ∩ All Q
 unzipWith f []         = [] , []
-unzipWith f (rx ∷ rxs) = Prod.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
+unzipWith f (rx ∷ rxs) = Product.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
 
 zip : All P ∩ All Q ⊆ All (P ∩ Q)
 zip = zipWith id
@@ -189,7 +189,7 @@ lookupAny (px ∷ pxs) (here qx) = px , qx
 lookupAny (px ∷ pxs) (there i) = lookupAny pxs i
 
 lookupWith : ∀[ P ⇒ Q ⇒ R ] → All P xs → (i : Any Q xs) → R (Any.lookup i)
-lookupWith f pxs i = Prod.uncurry f (lookupAny pxs i)
+lookupWith f pxs i = Product.uncurry f (lookupAny pxs i)
 
 lookup : All P xs → (∀ {x} → x ∈ₚ xs → P x)
 lookup pxs = lookupWith (λ { px refl → px }) pxs

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -32,7 +32,7 @@ open import Data.Maybe.Relation.Unary.All as Maybe using (just; nothing; fromAny
 open import Data.Maybe.Relation.Unary.Any as Maybe using (just)
 open import Data.Nat.Base using (zero; suc; s≤s; _<_; z<s; s<s)
 open import Data.Nat.Properties using (≤-refl; m≤n⇒m≤1+n)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry; uncurry′)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry; uncurry′)
 open import Function.Base
 open import Function.Bundles
 open import Level using (Level)
@@ -417,7 +417,7 @@ Any-catMaybes⁺ = All-catMaybes⁺ ∘ All.map fromAny
 
 ++⁻ : ∀ xs {ys} → All P (xs ++ ys) → All P xs × All P ys
 ++⁻ []       p          = [] , p
-++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map (px ∷_) id (++⁻ _ pxs)
+++⁻ (x ∷ xs) (px ∷ pxs) = Product.map (px ∷_) id (++⁻ _ pxs)
 
 ++↔ : (All P xs × All P ys) ↔ All P (xs ++ ys)
 ++↔ {xs = zs} = mk↔ₛ′ (uncurry ++⁺) (++⁻ zs) (++⁺∘++⁻ zs) ++⁻∘++⁺
@@ -448,7 +448,7 @@ concat⁻ {xss = xs ∷ xss} pxs = ++⁻ˡ xs pxs ∷ concat⁻ (++⁻ʳ xs pxs)
 ∷ʳ⁺ pxs px = ++⁺ pxs (px ∷ [])
 
 ∷ʳ⁻ : All P (xs ∷ʳ x) → All P xs × P x
-∷ʳ⁻ pxs = Prod.map₂ singleton⁻ $ ++⁻ _ pxs
+∷ʳ⁻ pxs = Product.map₂ singleton⁻ $ ++⁻ _ pxs
 
 -- unsnoc
 
@@ -656,7 +656,7 @@ module _ {R : A → A → Set q} (R? : B.Decidable R) where
     where
     aux : ∀ {z} → z ∈ filter (¬? ∘ ¬? ∘ R? x) (deduplicate R? xs) → P z
     aux {z = z} z∈filter = resp (decidable-stable (R? x z)
-      (Prod.proj₂ (∈-filter⁻ (¬? ∘ ¬? ∘ R? x) {z} {deduplicate R? xs} z∈filter))) px
+      (Product.proj₂ (∈-filter⁻ (¬? ∘ ¬? ∘ R? x) {z} {deduplicate R? xs} z∈filter))) px
 
 ------------------------------------------------------------------------
 -- zipWith

--- a/src/Data/List/Relation/Unary/Any.agda
+++ b/src/Data/List/Relation/Unary/Any.agda
@@ -11,7 +11,7 @@ module Data.List.Relation.Unary.Any where
 open import Data.Empty
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List; []; [_]; _∷_; removeAt)
-open import Data.Product.Base as Prod using (∃; _,_)
+open import Data.Product.Base as Product using (∃; _,_)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary using (¬_; yes; no; _⊎-dec_)

--- a/src/Data/List/Relation/Unary/Any/Properties.agda
+++ b/src/Data/List/Relation/Unary/Any/Properties.agda
@@ -25,7 +25,7 @@ open import Data.Nat using (zero; suc; _<_; z<s; s<s; s≤s)
 open import Data.Nat.Properties using (_≟_; ≤∧≢⇒<; ≤-refl; m<n⇒m<1+n)
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Maybe.Relation.Unary.Any as MAny using (just)
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_×_; _,_; ∃; ∃₂; proj₁; proj₂; uncurry′)
 open import Data.Product.Properties
 open import Data.Product.Function.NonDependent.Propositional
@@ -214,7 +214,7 @@ Any-×⁺ (p , q) = Any.map (λ p → Any.map (λ q → (p , q)) q) p
 
 Any-×⁻ : Any (λ x → Any (λ y → P x × Q y) ys) xs →
          Any P xs × Any Q ys
-Any-×⁻ pq with Prod.map₂ (Prod.map₂ find) (find pq)
+Any-×⁻ pq with Product.map₂ (Product.map₂ find) (find pq)
 ... | (x , x∈xs , y , y∈ys , p , q) = lose x∈xs p , lose y∈ys q
 
 ×↔ : ∀ {xs ys} →
@@ -286,7 +286,7 @@ module _ {_~_ : REL A B r} where
 
   Any-Σ⁻ʳ : Any (∃ ∘ _~_) xs → ∃ λ x → Any (_~ x) xs
   Any-Σ⁻ʳ (here (b , x)) = b , here x
-  Any-Σ⁻ʳ (there xs) = Prod.map₂ there $ Any-Σ⁻ʳ xs
+  Any-Σ⁻ʳ (there xs) = Product.map₂ there $ Any-Σ⁻ʳ xs
 
 ------------------------------------------------------------------------
 -- Invertible introduction (⁺) and elimination (⁻) rules for various
@@ -514,7 +514,7 @@ tabulate⁺ (suc i) p = there (tabulate⁺ i p)
 
 tabulate⁻ : ∀ {n} {f : Fin n → A} → Any P (tabulate f) → ∃ λ i → P (f i)
 tabulate⁻ {n = suc _} (here p)  = zero , p
-tabulate⁻ {n = suc _} (there p) = Prod.map suc id (tabulate⁻ p)
+tabulate⁻ {n = suc _} (there p) = Product.map suc id (tabulate⁻ p)
 
 ------------------------------------------------------------------------
 -- filter
@@ -593,7 +593,7 @@ module _ {P : B → Set p} where
                 ∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)
   mapWith∈⁻ (y ∷ xs) f (here  p) = (y , here refl , p)
   mapWith∈⁻ (y ∷ xs) f (there p) =
-    Prod.map₂ (Prod.map there id) $ mapWith∈⁻ xs (f ∘ there) p
+    Product.map₂ (Product.map there id) $ mapWith∈⁻ xs (f ∘ there) p
 
   mapWith∈↔ : ∀ {xs : List A} {f : ∀ {x} → x ∈ xs → B} →
                 (∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)) ↔ Any P (mapWith∈ xs f)

--- a/src/Data/List/Sort/MergeSort.agda
+++ b/src/Data/List/Sort/MergeSort.agda
@@ -24,7 +24,7 @@ open import Relation.Nullary.Decidable using (does)
 open import Data.Nat.Base using (_<_; _>_; z<s; s<s)
 open import Data.Nat.Induction
 open import Data.Nat.Properties using (m<n⇒m<1+n)
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Function.Base using (_∘_)
 open import Relation.Binary.Bundles using (DecTotalOrder)
 open import Relation.Nullary.Negation using (¬_)

--- a/src/Data/Maybe/Relation/Unary/All.agda
+++ b/src/Data/Maybe/Relation/Unary/All.agda
@@ -12,7 +12,7 @@ open import Effect.Applicative
 open import Effect.Monad
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Maybe.Relation.Unary.Any using (Any; just)
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Function.Base using (id; _∘′_)
 open import Function.Bundles using (_⇔_; mk⇔)
 open import Level
@@ -56,7 +56,7 @@ module _ {a p q r} {A : Set a} {P : Pred A p} {Q : Pred A q} {R : Pred A r} wher
   zipWith f (nothing , nothing) = nothing
 
   unzipWith : P ⊆ Q ∩ R → All P ⊆ All Q ∩ All R
-  unzipWith f (just px) = Prod.map just just (f px)
+  unzipWith f (just px) = Product.map just just (f px)
   unzipWith f nothing   = nothing , nothing
 
 module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where

--- a/src/Data/Maybe/Relation/Unary/Any.agda
+++ b/src/Data/Maybe/Relation/Unary/Any.agda
@@ -9,7 +9,7 @@
 module Data.Maybe.Relation.Unary.Any where
 
 open import Data.Maybe.Base using (Maybe; just; nothing)
-open import Data.Product.Base as Prod using (∃; _,_; -,_)
+open import Data.Product.Base as Product using (∃; _,_; -,_)
 open import Function.Base using (id)
 open import Function.Bundles using (_⇔_; mk⇔)
 open import Level
@@ -50,7 +50,7 @@ module _ {a p q r} {A : Set a} {P : Pred A p} {Q : Pred A q} {R : Pred A r} wher
   zipWith f (just px , just qx) = just (f (px , qx))
 
   unzipWith : P ⊆ Q ∩ R → Any P ⊆ Any Q ∩ Any R
-  unzipWith f (just px) = Prod.map just just (f px)
+  unzipWith f (just px) = Product.map just just (f px)
 
 module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
 
@@ -73,4 +73,4 @@ module _ {a p} {A : Set a} {P : Pred A p} where
   irrelevant P-irrelevant (just p) (just q) = cong just (P-irrelevant p q)
 
   satisfiable : Satisfiable P → Satisfiable (Any P)
-  satisfiable P-satisfiable = Prod.map just just P-satisfiable
+  satisfiable P-satisfiable = Product.map just just P-satisfiable

--- a/src/Data/Product/Function/Dependent/Propositional.agda
+++ b/src/Data/Product/Function/Dependent/Propositional.agda
@@ -9,7 +9,7 @@
 
 module Data.Product.Function.Dependent.Propositional where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Data.Product.Function.NonDependent.Setoid using ()
 open import Data.Product.Relation.Binary.Pointwise.NonDependent using ()
 open import Data.Product.Properties using (Σ-≡,≡→≡; Σ-≡,≡↔≡; Σ-≡,≡←≡)
@@ -41,7 +41,7 @@ module _ where
   Σ-⟶ : (I⟶J : I ⟶ J) →
          (∀ {i} → A i ⟶ B (to I⟶J i)) →
          Σ I A ⟶ Σ J B
-  Σ-⟶ I⟶J A⟶B = mk⟶ $ Prod.map (to I⟶J) (to A⟶B)
+  Σ-⟶ I⟶J A⟶B = mk⟶ $ Product.map (to I⟶J) (to A⟶B)
 
 ------------------------------------------------------------------------
 -- Equivalences
@@ -117,7 +117,7 @@ module _ where
     open Injection
 
     to′ : Σ I A → Σ J B
-    to′ = Prod.map (_≃_.to I≃J) (to A↣B)
+    to′ = Product.map (_≃_.to I≃J) (to A↣B)
 
     to-injective : Injective _≡_ _≡_ to′
     to-injective {(x₁ , x₂)} {(y₁ , y₂)} =

--- a/src/Data/Product/Function/NonDependent/Setoid.agda
+++ b/src/Data/Product/Function/NonDependent/Setoid.agda
@@ -9,7 +9,7 @@
 
 module Data.Product.Function.NonDependent.Setoid where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Data.Product.Relation.Binary.Pointwise.NonDependent
 open import Level using (Level)
 open import Relation.Binary
@@ -44,8 +44,8 @@ swapₛ = < proj₂ₛ , proj₁ₛ >ₛ
 
 _×-function_ : Func A B → Func C D → Func (A ×ₛ C) (B ×ₛ D)
 f ×-function g = record
-  { to    = Prod.map (to f) (to g)
-  ; cong  = Prod.map (cong f) (cong g)
+  { to    = Product.map (to f) (to g)
+  ; cong  = Product.map (cong f) (cong g)
   } where open Func
 
 infixr 2 _×-equivalence_ _×-injection_ _×-left-inverse_
@@ -53,54 +53,54 @@ infixr 2 _×-equivalence_ _×-injection_ _×-left-inverse_
 _×-equivalence_ : Equivalence A B → Equivalence C D →
                   Equivalence (A ×ₛ C) (B ×ₛ D)
 _×-equivalence_ f g = record
-  { to        = Prod.map (to f) (to g)
-  ; from      = Prod.map (from f) (from g)
-  ; to-cong   = Prod.map (to-cong f) (to-cong g)
-  ; from-cong = Prod.map (from-cong f) (from-cong g)
+  { to        = Product.map (to f) (to g)
+  ; from      = Product.map (from f) (from g)
+  ; to-cong   = Product.map (to-cong f) (to-cong g)
+  ; from-cong = Product.map (from-cong f) (from-cong g)
   } where open Equivalence
 
 _×-injection_ : Injection A B → Injection C D →
                 Injection (A ×ₛ C) (B ×ₛ D)
 f ×-injection g = record
-  { to        = Prod.map (to f) (to g)
-  ; cong      = Prod.map (cong f) (cong g)
-  ; injective = Prod.map (injective f) (injective g)
+  { to        = Product.map (to f) (to g)
+  ; cong      = Product.map (cong f) (cong g)
+  ; injective = Product.map (injective f) (injective g)
   } where open Injection
 
 _×-surjection_ : Surjection A B → Surjection C D →
                  Surjection (A ×ₛ C) (B ×ₛ D)
 f ×-surjection g = record
-  { to         = Prod.map (to f) (to g)
-  ; cong       = Prod.map (cong f) (cong g)
-  ; surjective = λ y → Prod.zip _,_ (λ ff gg x₂ → (ff (proj₁ x₂)) , (gg (proj₂ x₂))) (surjective f (proj₁ y)) (surjective g (proj₂ y))
+  { to         = Product.map (to f) (to g)
+  ; cong       = Product.map (cong f) (cong g)
+  ; surjective = λ y → Product.zip _,_ (λ ff gg x₂ → (ff (proj₁ x₂)) , (gg (proj₂ x₂))) (surjective f (proj₁ y)) (surjective g (proj₂ y))
   } where open Surjection
 
 _×-bijection_ : Bijection A B → Bijection C D →
                 Bijection (A ×ₛ C) (B ×ₛ D)
 f ×-bijection g = record
-  { to         = Prod.map (to f) (to g)
-  ; cong       = Prod.map (cong f) (cong g)
-  ; bijective  = Prod.map (injective f) (injective g) ,
-                 λ { (y₀ , y₁) → Prod.zip _,_ (λ {ff gg (x₀ , x₁) → ff x₀ , gg x₁}) (surjective f y₀) (surjective g y₁)}
+  { to         = Product.map (to f) (to g)
+  ; cong       = Product.map (cong f) (cong g)
+  ; bijective  = Product.map (injective f) (injective g) ,
+                 λ { (y₀ , y₁) → Product.zip _,_ (λ {ff gg (x₀ , x₁) → ff x₀ , gg x₁}) (surjective f y₀) (surjective g y₁)}
   } where open Bijection
 
 _×-leftInverse_ : LeftInverse A B → LeftInverse C D →
                   LeftInverse (A ×ₛ C) (B ×ₛ D)
 f ×-leftInverse g = record
-  { to        = Prod.map (to f) (to g)
-  ; from      = Prod.map (from f) (from g)
-  ; to-cong   = Prod.map (to-cong f) (to-cong g)
-  ; from-cong = Prod.map (from-cong f) (from-cong g)
+  { to        = Product.map (to f) (to g)
+  ; from      = Product.map (from f) (from g)
+  ; to-cong   = Product.map (to-cong f) (to-cong g)
+  ; from-cong = Product.map (from-cong f) (from-cong g)
   ; inverseˡ   = λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)
   } where open LeftInverse
 
 _×-rightInverse_ : RightInverse A B → RightInverse C D →
                    RightInverse (A ×ₛ C) (B ×ₛ D)
 f ×-rightInverse g = record
-  { to        = Prod.map (to f) (to g)
-  ; from      = Prod.map (from f) (from g)
-  ; to-cong   = Prod.map (to-cong f) (to-cong g)
-  ; from-cong = Prod.map (from-cong f) (from-cong g)
+  { to        = Product.map (to f) (to g)
+  ; from      = Product.map (from f) (from g)
+  ; to-cong   = Product.map (to-cong f) (to-cong g)
+  ; from-cong = Product.map (from-cong f) (from-cong g)
   ; inverseʳ   = λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x)
   } where open RightInverse
 
@@ -109,10 +109,10 @@ infixr 2 _×-surjection_ _×-inverse_
 _×-inverse_ : Inverse A B → Inverse C D →
               Inverse (A ×ₛ C) (B ×ₛ D)
 f ×-inverse g = record
-  { to        = Prod.map (to f) (to g)
-  ; from      = Prod.map (from f) (from g)
-  ; to-cong   = Prod.map (to-cong f) (to-cong g)
-  ; from-cong = Prod.map (from-cong f) (from-cong g)
+  { to        = Product.map (to f) (to g)
+  ; from      = Product.map (from f) (from g)
+  ; to-cong   = Product.map (to-cong f) (to-cong g)
+  ; from-cong = Product.map (from-cong f) (from-cong g)
   ; inverse   = (λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)) ,
                 (λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x))
   } where open Inverse

--- a/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
@@ -8,7 +8,7 @@
 
 module Data.Product.Relation.Binary.Pointwise.Dependent where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Level
 open import Function.Base
 open import Relation.Binary.Core using (Rel; REL; _⇒_)

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -8,7 +8,7 @@
 
 module Data.Product.Relation.Binary.Pointwise.NonDependent where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Data.Product.Properties using (≡-dec)
 open import Data.Sum.Base
 open import Data.Unit.Base using (⊤)
@@ -35,7 +35,7 @@ Pointwise R S = (R on proj₁) -×- (S on proj₂)
 -- Pointwise preserves many relational properties
 
 ×-reflexive : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-×-reflexive refl₁ refl₂ = Prod.map refl₁ refl₂
+×-reflexive refl₁ refl₂ = Product.map refl₁ refl₂
 
 ×-refl : Reflexive R → Reflexive S → Reflexive (Pointwise R S)
 ×-refl refl₁ refl₂ = refl₁ , refl₂
@@ -49,14 +49,14 @@ Pointwise R S = (R on proj₁) -×- (S on proj₂)
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric sym₁ sym₂ = Prod.map sym₁ sym₂
+×-symmetric sym₁ sym₂ = Product.map sym₁ sym₂
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
-×-transitive trans₁ trans₂ = Prod.zip trans₁ trans₂
+×-transitive trans₁ trans₂ = Product.zip trans₁ trans₂
 
 ×-antisymmetric : Antisymmetric ≈₁ R → Antisymmetric ≈₂ S →
                   Antisymmetric (Pointwise ≈₁ ≈₂) (Pointwise R S)
-×-antisymmetric antisym₁ antisym₂ = Prod.zip antisym₁ antisym₂
+×-antisymmetric antisym₁ antisym₂ = Product.zip antisym₁ antisym₂
 
 ×-asymmetric₁ : Asymmetric R → Asymmetric (Pointwise R S)
 ×-asymmetric₁ asym₁ x<y y<x = asym₁ (proj₁ x<y) (proj₁ y<x)
@@ -66,15 +66,15 @@ Pointwise R S = (R on proj₁) -×- (S on proj₂)
 
 ×-respectsʳ : R Respectsʳ ≈₁ → S Respectsʳ ≈₂ →
              (Pointwise R S) Respectsʳ (Pointwise ≈₁ ≈₂)
-×-respectsʳ resp₁ resp₂ = Prod.zip resp₁ resp₂
+×-respectsʳ resp₁ resp₂ = Product.zip resp₁ resp₂
 
 ×-respectsˡ : R Respectsˡ ≈₁ → S Respectsˡ ≈₂ →
              (Pointwise R S) Respectsˡ (Pointwise ≈₁ ≈₂)
-×-respectsˡ resp₁ resp₂ = Prod.zip resp₁ resp₂
+×-respectsˡ resp₁ resp₂ = Product.zip resp₁ resp₂
 
 ×-respects₂ : R Respects₂ ≈₁ → S Respects₂ ≈₂ →
               (Pointwise R S) Respects₂ (Pointwise ≈₁ ≈₂)
-×-respects₂ = Prod.zip ×-respectsʳ ×-respectsˡ
+×-respects₂ = Product.zip ×-respectsʳ ×-respectsˡ
 
 ×-total : Symmetric R → Total R → Total S → Total (Pointwise R S)
 ×-total sym₁ total₁ total₂ (x₁ , x₂) (y₁ , y₂)

--- a/src/Data/Sum/Function/Setoid.agda
+++ b/src/Data/Sum/Function/Setoid.agda
@@ -8,7 +8,7 @@
 
 module Data.Sum.Function.Setoid where
 
-open import Data.Product.Base as Prod using (_,_)
+open import Data.Product.Base as Product using (_,_)
 open import Data.Sum.Base as Sum
 open import Data.Sum.Relation.Binary.Pointwise as Pointwise
 open import Relation.Binary
@@ -60,8 +60,8 @@ swapₛ = [ inj₂ₛ , inj₁ₛ ]ₛ
               StrictlySurjective ≈₂ g →
               StrictlySurjective (Pointwise ≈₁ ≈₂) (Sum.map f g)
 ⊎-strictlySurjective f-sur g-sur =
-  [ Prod.map inj₁ inj₁ ∘ f-sur
-  , Prod.map inj₂ inj₂ ∘ g-sur
+  [ Product.map inj₁ inj₁ ∘ f-sur
+  , Product.map inj₂ inj₂ ∘ g-sur
   ]
 
 ⊎-surjective : ∀ {f : A → B} {g : C → D} →
@@ -69,8 +69,8 @@ swapₛ = [ inj₂ₛ , inj₁ₛ ]ₛ
               Surjective ≈₃ ≈₄ g →
               Surjective (Pointwise ≈₁ ≈₃) (Pointwise ≈₂ ≈₄) (Sum.map f g)
 ⊎-surjective f-sur g-sur =
-  [ Prod.map inj₁ (λ { fwd (inj₁ x) → inj₁ (fwd x)}) ∘ f-sur
-  , Prod.map inj₂ (λ { fwd (inj₂ y) → inj₂ (fwd y)}) ∘ g-sur
+  [ Product.map inj₁ (λ { fwd (inj₁ x) → inj₁ (fwd x)}) ∘ f-sur
+  , Product.map inj₂ (λ { fwd (inj₂ y) → inj₂ (fwd y)}) ∘ g-sur
   ]
 
 

--- a/src/Data/Tree/AVL/Map/Membership/Propositional/Properties.agda
+++ b/src/Data/Tree/AVL/Map/Membership/Propositional/Properties.agda
@@ -15,7 +15,7 @@ module Data.Tree.AVL.Map.Membership.Propositional.Properties
 
 open import Data.Bool.Base using (true; false)
 open import Data.Maybe.Base using (just; nothing; is-just)
-open import Data.Product.Base as Prod using (_×_; ∃-syntax; _,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (_×_; ∃-syntax; _,_; proj₁; proj₂)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent renaming (Pointwise to _×ᴿ_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base using (_∘_; _∘′_)
@@ -37,7 +37,7 @@ import Data.Tree.AVL.Indexed.Relation.Unary.Any strictTotalOrder as IAny
 import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties strictTotalOrder as IAnyₚ
 open import Data.Tree.AVL.Key strictTotalOrder using (⊥⁺<[_]<⊤⁺)
 open import Data.Tree.AVL.Map strictTotalOrder
-open import Data.Tree.AVL.Map.Relation.Unary.Any strictTotalOrder as Mapₚ using (Any)
+open import Data.Tree.AVL.Map.Relation.Unary.Any strictTotalOrder as Map using (Any)
 open import Data.Tree.AVL.Map.Membership.Propositional strictTotalOrder
 open import Data.Tree.AVL.Relation.Unary.Any strictTotalOrder as Any using (tree)
 
@@ -113,7 +113,7 @@ private
 
 ∈ₖᵥ-lookup⁻ : lookup m k ≡ just x → (k , x) ∈ₖᵥ m
 ∈ₖᵥ-lookup⁻ {m = tree t} {k = k} {x = x} eq
-  = tree (IAny.map (Prod.map sym ≡-sym) (IAnyₚ.lookup⁻ t k x (⊥⁺<[ _ ]<⊤⁺) eq))
+  = tree (IAny.map (Product.map sym ≡-sym) (IAnyₚ.lookup⁻ t k x (⊥⁺<[ _ ]<⊤⁺) eq))
 
 ∈ₖᵥ-lookup-nothing⁺ : (∀ x → (k , x) ∉ₖᵥ m) → lookup m k ≡ nothing
 ∈ₖᵥ-lookup-nothing⁺ {k = k} {m = m@(tree t)} k∉m with lookup m k in eq

--- a/src/Data/Tree/AVL/Map/Relation/Unary/Any.agda
+++ b/src/Data/Tree/AVL/Map/Relation/Unary/Any.agda
@@ -12,7 +12,7 @@ module Data.Tree.AVL.Map.Relation.Unary.Any
   {a ℓ₁ ℓ₂} (strictTotalOrder : StrictTotalOrder a ℓ₁ ℓ₂)
   where
 
-open import Data.Product.Base as Prod using (_×_; ∃; _,_)
+open import Data.Product.Base as Product using (_×_; ∃; _,_)
 open import Function.Base using (_∘_; _∘′_; id)
 open import Level using (Level; _⊔_)
 
@@ -21,7 +21,7 @@ open import Relation.Unary
 open StrictTotalOrder strictTotalOrder renaming (Carrier to Key)
 open import Data.Tree.AVL.Map strictTotalOrder using (Map)
 open import Data.Tree.AVL.Indexed strictTotalOrder using (toPair)
-import Data.Tree.AVL.Relation.Unary.Any strictTotalOrder as Mapₚ
+import Data.Tree.AVL.Relation.Unary.Any strictTotalOrder as Map
 
 private
   variable
@@ -39,30 +39,30 @@ private
 -- See `Relation.Unary` for an explanation of predicates.
 
 Any : {V : Set v} → Pred (Key × V) p → Pred (Map V) (a ⊔ ℓ₂ ⊔ v ⊔ p)
-Any P = Mapₚ.Any (P ∘′ toPair)
+Any P = Map.Any (P ∘′ toPair)
 
 ------------------------------------------------------------------------
 -- Operations on Any
 
 map : P ⊆ Q → Any P ⊆ Any Q
-map f = Mapₚ.map f
+map f = Map.map f
 
 lookup : Any {V = V} P m → Key × V
-lookup = toPair ∘′ Mapₚ.lookup
+lookup = toPair ∘′ Map.lookup
 
 lookupKey : Any P m → Key
-lookupKey = Mapₚ.lookupKey
+lookupKey = Map.lookupKey
 
 -- If any element satisfies P, then P is satisfied.
 
 satisfied : Any P m → ∃ P
-satisfied = Prod.map toPair id ∘′ Mapₚ.satisfied
+satisfied = Product.map toPair id ∘′ Map.satisfied
 
 ------------------------------------------------------------------------
 -- Properties of predicates preserved by Any
 
 any? : Decidable P → Decidable (Any P)
-any? P? = Mapₚ.any? (P? ∘ toPair)
+any? P? = Map.any? (P? ∘ toPair)
 
 satisfiable : Satisfiable P → Satisfiable (Any P)
-satisfiable ((k , v) , p) = Mapₚ.satisfiable k (v , p)
+satisfiable ((k , v) , p) = Map.satisfiable k (v , p)

--- a/src/Data/Tree/AVL/Relation/Unary/Any.agda
+++ b/src/Data/Tree/AVL/Relation/Unary/Any.agda
@@ -12,7 +12,7 @@ module Data.Tree.AVL.Relation.Unary.Any
   {a ℓ₁ ℓ₂} (strictTotalOrder : StrictTotalOrder a ℓ₁ ℓ₂)
   where
 
-open import Data.Product.Base as Prod using (∃)
+open import Data.Product.Base as Product using (∃)
 open import Function.Base using (_∘_; _$_)
 open import Level using (Level; _⊔_)
 
@@ -68,5 +68,5 @@ any? : Decidable P → Decidable (Any {V = V} P)
 any? P? (tree p) = map′ tree (λ where (tree p) → p) (AVLₚ.any? P? p)
 
 satisfiable : (k : Key) → Satisfiable (P ∘ (k ,_)) → Satisfiable (Any {V = V} P)
-satisfiable k sat = Prod.map tree tree
+satisfiable k sat = Product.map tree tree
                   $ AVLₚ.satisfiable Indexed.⊥⁺<[ k ] Indexed.[ k ]<⊤⁺ sat

--- a/src/Data/Tree/AVL/Sets.agda
+++ b/src/Data/Tree/AVL/Sets.agda
@@ -16,7 +16,7 @@ open import Data.Bool.Base using (Bool)
 open import Data.List.Base as List using (List)
 open import Data.Maybe.Base as Maybe
 open import Data.Nat.Base using (ℕ)
-open import Data.Product.Base as Prod using (_×_; _,_; proj₁)
+open import Data.Product.Base as Product using (_×_; _,_; proj₁)
 open import Data.Unit.Base
 open import Function.Base
 open import Level using (Level; _⊔_)
@@ -54,10 +54,10 @@ member : A → ⟨Set⟩ → Bool
 member = AVL.member
 
 headTail : ⟨Set⟩ → Maybe (A × ⟨Set⟩)
-headTail s = Maybe.map (Prod.map₁ proj₁) (AVL.headTail s)
+headTail s = Maybe.map (Product.map₁ proj₁) (AVL.headTail s)
 
 initLast : ⟨Set⟩ → Maybe (⟨Set⟩ × A)
-initLast s = Maybe.map (Prod.map₂ proj₁) (AVL.initLast s)
+initLast s = Maybe.map (Product.map₂ proj₁) (AVL.initLast s)
 
 fromList : List A → ⟨Set⟩
 fromList = AVL.fromList ∘ List.map (_, _)

--- a/src/Data/Tree/AVL/Sets/Membership.agda
+++ b/src/Data/Tree/AVL/Sets/Membership.agda
@@ -13,7 +13,7 @@ module Data.Tree.AVL.Sets.Membership
   where
 
 open import Data.Bool.Base using (true; false)
-open import Data.Product.Base as Prod using (_,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (_,_; proj₁; proj₂)
 open import Data.Sum.Base as Sum using (_⊎_)
 open import Data.Unit.Base using (tt)
 open import Function.Base using (_∘_; _∘′_; const)

--- a/src/Data/Tree/AVL/Sets/Membership/Properties.agda
+++ b/src/Data/Tree/AVL/Sets/Membership/Properties.agda
@@ -13,7 +13,7 @@ module Data.Tree.AVL.Sets.Membership.Properties
   where
 
 open import Data.Bool.Base using (true; false)
-open import Data.Product.Base as Prod using (_,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (_,_; proj₁; proj₂)
 open import Data.Sum.Base as Sum using (_⊎_)
 open import Data.Unit.Base using (tt)
 open import Function.Base using (_∘_; _∘′_; const)

--- a/src/Data/Trie/NonEmpty.agda
+++ b/src/Data/Trie/NonEmpty.agda
@@ -13,7 +13,7 @@ module Data.Trie.NonEmpty {k e r} (S : StrictTotalOrder k e r) where
 open import Level
 open import Size
 open import Effect.Monad
-open import Data.Product.Base as Prod using (∃; uncurry; -,_)
+open import Data.Product.Base as Product using (∃; uncurry; -,_)
 open import Data.List.Base as List using (List; []; _∷_; _++_)
 open import Data.List.NonEmpty as List⁺ using (List⁺; [_]; concatMap)
 open import Data.Maybe.Base as Maybe using (Maybe; nothing; just; maybe′) hiding (module Maybe)
@@ -125,7 +125,7 @@ toList⁺ (node nd) = These.mergeThese List⁺._⁺++⁺_
   where
 
   fromVal    = [_] ∘′ -,_
-  fromTrie⁺  = λ (k , v) → List⁺.map (Prod.map (k ∷_) id) (toList⁺ v)
+  fromTrie⁺  = λ (k , v) → List⁺.map (Product.map (k ∷_) id) (toList⁺ v)
   fromTries⁺ = concatMap fromTrie⁺ ∘′ Tree⁺.toList⁺
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Base.agda
+++ b/src/Data/Vec/Base.agda
@@ -12,7 +12,7 @@ open import Data.Bool.Base using (Bool; true; false; if_then_else_)
 open import Data.Nat.Base
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List)
-open import Data.Product.Base as Prod using (∃; ∃₂; _×_; _,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (∃; ∃₂; _×_; _,_; proj₁; proj₂)
 open import Data.These.Base as These using (These; this; that; these)
 open import Function.Base using (const; _∘′_; id; _∘_)
 open import Level using (Level)
@@ -131,7 +131,7 @@ zipWith f (x ∷ xs) (y ∷ ys) = f x y ∷ zipWith f xs ys
 
 unzipWith : (A → B × C) → Vec A n → Vec B n × Vec C n
 unzipWith f []       = [] , []
-unzipWith f (a ∷ as) = Prod.zip _∷_ _∷_ (f a) (unzipWith f as)
+unzipWith f (a ∷ as) = Product.zip _∷_ _∷_ (f a) (unzipWith f as)
 
 align : Vec A m → Vec B n → Vec (These A B) (m ⊔ n)
 align = alignWith id
@@ -282,7 +282,7 @@ group (suc n) k xs  =
 split : Vec A n → Vec A ⌈ n /2⌉ × Vec A ⌊ n /2⌋
 split []           = ([]     , [])
 split (x ∷ [])     = (x ∷ [] , [])
-split (x ∷ y ∷ xs) = Prod.map (x ∷_) (y ∷_) (split xs)
+split (x ∷ y ∷ xs) = Product.map (x ∷_) (y ∷_) (split xs)
 
 uncons : Vec A (suc n) → A × Vec A n
 uncons (x ∷ xs) = x , xs

--- a/src/Data/Vec/N-ary.agda
+++ b/src/Data/Vec/N-ary.agda
@@ -11,7 +11,7 @@ module Data.Vec.N-ary where
 open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Function.Bundles using (_↔_; Inverse; mk↔ₛ′)
 open import Data.Nat.Base hiding (_⊔_)
-open import Data.Product.Base as Prod using (∃; _,_)
+open import Data.Product.Base as Product using (∃; _,_)
 open import Data.Vec.Base using (Vec; []; _∷_; head; tail)
 open import Function.Base using (_∘_; id; flip; constᵣ)
 open import Function.Bundles using (_⇔_; mk⇔)
@@ -126,7 +126,7 @@ uncurry-∃ⁿ {a} {A} {ℓ} n = mk⇔ (⇒ n) (⇐ n)
   ⇒ : ∀ n {P : N-ary n A (Set ℓ)} →
       ∃ⁿ n P → (∃ λ (xs : Vec A n) → P $ⁿ xs)
   ⇒ zero    p       = ([] , p)
-  ⇒ (suc n) (x , p) = Prod.map (_∷_ x) id (⇒ n p)
+  ⇒ (suc n) (x , p) = Product.map (_∷_ x) id (⇒ n p)
 
   ⇐ : ∀ n {P : N-ary n A (Set ℓ)} →
       (∃ λ (xs : Vec A n) → P $ⁿ xs) → ∃ⁿ n P

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -17,7 +17,7 @@ import Data.List.Properties as Listₚ
 open import Data.Nat.Base
 open import Data.Nat.Properties
   using (+-assoc; m≤n⇒m≤1+n; m≤m+n; ≤-refl; ≤-trans; ≤-irrelevant; ≤⇒≤″; suc-injective; +-comm; +-suc)
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_×_; _,_; proj₁; proj₂; <_,_>; uncurry)
 open import Data.Sum.Base using ([_,_]′)
 open import Data.Sum.Properties using ([,]-map)
@@ -689,7 +689,7 @@ map-<,>-zip f g []       = refl
 map-<,>-zip f g (x ∷ xs) = cong (_ ∷_) (map-<,>-zip f g xs)
 
 map-zip : ∀ (f : A → B) (g : C → D) (xs : Vec A n) (ys : Vec C n) →
-          map (Prod.map f g) (zip xs ys) ≡ zip (map f xs) (map g ys)
+          map (Product.map f g) (zip xs ys) ≡ zip (map f xs) (map g ys)
 map-zip f g []       []       = refl
 map-zip f g (x ∷ xs) (y ∷ ys) = cong (_ ∷_) (map-zip f g xs ys)
 
@@ -705,10 +705,10 @@ lookup-unzip (suc i) ((x , y) ∷ xys) = lookup-unzip i xys
 
 map-unzip : ∀ (f : A → B) (g : C → D) (xys : Vec (A × C) n) →
             let xs , ys = unzip xys
-            in (map f xs , map g ys) ≡ unzip (map (Prod.map f g) xys)
+            in (map f xs , map g ys) ≡ unzip (map (Product.map f g) xys)
 map-unzip f g []              = refl
 map-unzip f g ((x , y) ∷ xys) =
-  cong (Prod.map (f x ∷_) (g y ∷_)) (map-unzip f g xys)
+  cong (Product.map (f x ∷_) (g y ∷_)) (map-unzip f g xys)
 
 -- Products of vectors are isomorphic to vectors of products.
 
@@ -716,7 +716,7 @@ unzip∘zip : ∀ (xs : Vec A n) (ys : Vec B n) →
             unzip (zip xs ys) ≡ (xs , ys)
 unzip∘zip [] []             = refl
 unzip∘zip (x ∷ xs) (y ∷ ys) =
-  cong (Prod.map (x ∷_) (y ∷_)) (unzip∘zip xs ys)
+  cong (Product.map (x ∷_) (y ∷_)) (unzip∘zip xs ys)
 
 zip∘unzip : ∀ (xys : Vec (A × B) n) → uncurry zip (unzip xys) ≡ xys
 zip∘unzip []         = refl
@@ -869,7 +869,7 @@ unfold-∷ʳ eq x (y ∷ xs) = cong (y ∷_) (unfold-∷ʳ (cong pred eq) x xs)
 ∷ʳ-injective : ∀ (xs ys : Vec A n) → xs ∷ʳ x ≡ ys ∷ʳ y → xs ≡ ys × x ≡ y
 ∷ʳ-injective []       []        refl = (refl , refl)
 ∷ʳ-injective (x ∷ xs) (y  ∷ ys) eq   with ∷-injective eq
-... | refl , eq′ = Prod.map₁ (cong (x ∷_)) (∷ʳ-injective xs ys eq′)
+... | refl , eq′ = Product.map₁ (cong (x ∷_)) (∷ʳ-injective xs ys eq′)
 
 ∷ʳ-injectiveˡ : ∀ (xs ys : Vec A n) → xs ∷ʳ x ≡ ys ∷ʳ y → xs ≡ ys
 ∷ʳ-injectiveˡ xs ys eq = proj₁ (∷ʳ-injective xs ys eq)

--- a/src/Data/Vec/Recursive.agda
+++ b/src/Data/Vec/Recursive.agda
@@ -21,7 +21,7 @@ open import Data.Nat.Properties using (+-comm; *-comm)
 open import Data.Empty.Polymorphic
 open import Data.Fin.Base as Fin using (Fin; zero; suc)
 open import Data.Fin.Properties using (1↔⊤; *↔×)
-open import Data.Product.Base as Prod using (_×_; _,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (_×_; _,_; proj₁; proj₂)
 open import Data.Product.Algebra using (×-cong)
 open import Data.Sum.Base as Sum using (_⊎_)
 open import Data.Unit.Base using (tt)
@@ -146,7 +146,7 @@ zipWith f ((suc n@(suc _))) (a , as) (b , bs) = f a b , zipWith f n as bs
 unzipWith : (A → B × C) → ∀ n → A ^ n → B ^ n × C ^ n
 unzipWith f 0               as       = [] , []
 unzipWith f 1               a        = f a
-unzipWith f (suc n@(suc _)) (a , as) = Prod.zip _,_ _,_ (f a) (unzipWith f n as)
+unzipWith f (suc n@(suc _)) (a , as) = Product.zip _,_ _,_ (f a) (unzipWith f n as)
 
 zip : ∀ n → A ^ n → B ^ n → (A × B) ^ n
 zip = zipWith _,_

--- a/src/Data/Vec/Relation/Unary/All.agda
+++ b/src/Data/Vec/Relation/Unary/All.agda
@@ -9,7 +9,7 @@
 module Data.Vec.Relation.Unary.All where
 
 open import Data.Nat.Base using (ℕ; zero; suc; NonZero)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry; <_,_>)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry; <_,_>)
 open import Data.Sum.Base as Sum using (inj₁; inj₂)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Data.Vec.Relation.Unary.Any as Any using (Any; here; there)
@@ -71,7 +71,7 @@ zip (px ∷ pxs , qx ∷ qxs) = (px , qx) ∷ zip (pxs , qxs)
 
 unzip : All (P ∩ Q) {n} ⊆ All P ∩ All Q
 unzip []           = [] , []
-unzip (pqx ∷ pqxs) = Prod.zip _∷_ _∷_ pqx (unzip pqxs)
+unzip (pqx ∷ pqxs) = Product.zip _∷_ _∷_ pqx (unzip pqxs)
 
 module _ {P : Pred A p} {Q : Pred B q} {R : Pred C r} where
 
@@ -91,7 +91,7 @@ lookupAny (px ∷ pxs) (here qx) = px , qx
 lookupAny (px ∷ pxs) (there i) = lookupAny pxs i
 
 lookupWith : ∀[ P ⇒ Q ⇒ R ] → All P xs → (i : Any Q xs) → R (Any.lookup i)
-lookupWith f pxs i = Prod.uncurry f (lookupAny pxs i)
+lookupWith f pxs i = Product.uncurry f (lookupAny pxs i)
 
 lookup : All P xs → (∀ {x} → x ∈ₚ xs → P x)
 lookup pxs = lookupWith (λ { px P.refl → px }) pxs
@@ -121,7 +121,7 @@ irrelevant irr (px₁ ∷ pxs₁) (px₂ ∷ pxs₂) =
 
 satisfiable : Satisfiable P → ∀ {n} → Satisfiable (All P {n})
 satisfiable (x , p) {zero}  = [] , []
-satisfiable (x , p) {suc n} = Prod.map (x ∷_) (p ∷_) (satisfiable (x , p))
+satisfiable (x , p) {suc n} = Product.map (x ∷_) (p ∷_) (satisfiable (x , p))
 
 ------------------------------------------------------------------------
 -- Generalised decidability procedure

--- a/src/Data/Vec/Relation/Unary/All/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/All/Properties.agda
@@ -12,7 +12,7 @@ open import Data.Nat.Base using (ℕ; zero; suc; _+_)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base using ([]; _∷_)
 open import Data.List.Relation.Unary.All as List using ([]; _∷_)
-open import Data.Product.Base as Prod using (_×_; _,_; uncurry; uncurry′)
+open import Data.Product.Base as Product using (_×_; _,_; uncurry; uncurry′)
 open import Data.Vec.Base as Vec
 import Data.Vec.Properties as Vecₚ
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
@@ -82,7 +82,7 @@ gmap g = map⁺ ∘ All.map g
 ++⁻ : (xs : Vec A m) {ys : Vec A n} →
       All P (xs ++ ys) → All P xs × All P ys
 ++⁻ []       p          = [] , p
-++⁻ (x ∷ xs) (px ∷ pxs) = Prod.map₁ (px ∷_) (++⁻ _ pxs)
+++⁻ (x ∷ xs) (px ∷ pxs) = Product.map₁ (px ∷_) (++⁻ _ pxs)
 
 ++⁺∘++⁻ : (xs : Vec A m) {ys : Vec A n} →
           (p : All P (xs ++ ys)) →

--- a/src/Data/Vec/Relation/Unary/Any.agda
+++ b/src/Data/Vec/Relation/Unary/Any.agda
@@ -13,7 +13,7 @@ open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Nat.Base using (ℕ; zero; suc; NonZero)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Vec.Base as Vec using (Vec; []; [_]; _∷_)
-open import Data.Product.Base as Prod using (∃; _,_)
+open import Data.Product.Base as Product using (∃; _,_)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary.Negation using (¬_; contradiction)
 open import Relation.Nullary.Decidable as Dec using (yes; no; _⊎-dec_)
@@ -80,7 +80,7 @@ any? P? (x ∷ xs) = Dec.map′ fromSum toSum (P? x ⊎-dec any? P? xs)
 
 satisfiable : Satisfiable P → ∀ {n} → Satisfiable (Any P {suc n})
 satisfiable (x , p) {zero}  = x ∷ [] , here p
-satisfiable (x , p) {suc n} = Prod.map (x ∷_) there (satisfiable (x , p))
+satisfiable (x , p) {suc n} = Product.map (x ∷_) there (satisfiable (x , p))
 
 any = any?
 {-# WARNING_ON_USAGE any

--- a/src/Data/Vec/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Vec/Relation/Unary/Any/Properties.agda
@@ -15,7 +15,7 @@ open import Data.List.Base using ([]; _∷_)
 import Data.List.Relation.Unary.Any as List
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Data.Sum.Function.Propositional using (_⊎-cong_)
-open import Data.Product.Base as Prod using (∃; ∃₂; _×_; _,_; proj₁; proj₂)
+open import Data.Product.Base as Product using (∃; ∃₂; _×_; _,_; proj₁; proj₂)
 open import Data.Vec.Base hiding (here; there)
 open import Data.Vec.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.Vec.Membership.Propositional
@@ -365,7 +365,7 @@ module _ {P : Pred A p} where
   tabulate⁻ : ∀ {n} {f : Fin n → A} →
               Any P (tabulate f) → ∃ λ i → P (f i)
   tabulate⁻ (here p)  = zero , p
-  tabulate⁻ (there p) = Prod.map suc id (tabulate⁻ p)
+  tabulate⁻ (there p) = Product.map suc id (tabulate⁻ p)
 
 ------------------------------------------------------------------------
 -- mapWith∈
@@ -384,7 +384,7 @@ module _ {P : Pred B p} where
               ∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)
   mapWith∈⁻ (y ∷ xs) f (here  p) = (y , here refl , p)
   mapWith∈⁻ (y ∷ xs) f (there p) =
-    Prod.map id (Prod.map there id) $ mapWith∈⁻ xs (f ∘ there) p
+    Product.map id (Product.map there id) $ mapWith∈⁻ xs (f ∘ there) p
 
   mapWith∈↔ : ∀ {n} {xs : Vec A n} {f : ∀ {x} → x ∈ xs → B} →
     (∃₂ λ x (x∈xs : x ∈ xs) → P (f x∈xs)) ↔ Any P (mapWith∈ xs f)

--- a/src/Data/Vec/Relation/Unary/Linked.agda
+++ b/src/Data/Vec/Relation/Unary/Linked.agda
@@ -11,7 +11,7 @@ module Data.Vec.Relation.Unary.Linked {a} {A : Set a} where
 open import Data.Nat.Base using (ℕ; zero; suc; _+_)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Data.Vec.Relation.Unary.All as All using (All; []; _∷_)
-open import Data.Product.Base as Prod using (_,_; _×_; uncurry; <_,_>)
+open import Data.Product.Base as Product using (_,_; _×_; uncurry; <_,_>)
 open import Function.Base using (id; _∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Binary.Core using (Rel; _⇒_)
@@ -66,7 +66,7 @@ zipWith f (px ∷ pxs , qx ∷ qxs) = f (px , qx) ∷ zipWith f (pxs , qxs)
 unzipWith : R ⇒ P ∩ᵇ Q → Linked R {n} ⊆ Linked P ∩ᵘ Linked Q
 unzipWith f []         = [] , []
 unzipWith f [-]        = [-] , [-]
-unzipWith f (rx ∷ rxs) = Prod.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
+unzipWith f (rx ∷ rxs) = Product.zip _∷_ _∷_ (f rx) (unzipWith f rxs)
 
 zip : Linked P {n} ∩ᵘ Linked Q ⊆ Linked (P ∩ᵇ Q)
 zip = zipWith id

--- a/src/Function/Consequences.agda
+++ b/src/Function/Consequences.agda
@@ -10,7 +10,7 @@
 
 module Function.Consequences where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Function.Definitions
 open import Level using (Level)
 open import Relation.Binary.Core using (Rel)
@@ -72,14 +72,14 @@ surjective⇒strictlySurjective : ∀ (≈₂ : Rel B ℓ₂) →
                                  Surjective ≈₁ ≈₂ f →
                                  StrictlySurjective ≈₂ f
 surjective⇒strictlySurjective _ refl surj x =
-  Prod.map₂ (λ v → v refl) (surj x)
+  Product.map₂ (λ v → v refl) (surj x)
 
 strictlySurjective⇒surjective : Transitive ≈₂ →
                                  Congruent ≈₁ ≈₂ f →
                                  StrictlySurjective ≈₂ f →
                                  Surjective ≈₁ ≈₂ f
 strictlySurjective⇒surjective trans cong surj x =
-  Prod.map₂ (λ fy≈x z≈y → trans (cong z≈y) fy≈x) (surj x)
+  Product.map₂ (λ fy≈x z≈y → trans (cong z≈y) fy≈x) (surj x)
 
 ------------------------------------------------------------------------
 -- StrictlyInverseˡ

--- a/src/Function/Related/TypeIsomorphisms.agda
+++ b/src/Function/Related/TypeIsomorphisms.agda
@@ -15,7 +15,7 @@ open import Axiom.Extensionality.Propositional using (Extensionality)
 open import Data.Bool.Base using (true; false)
 open import Data.Empty using (⊥-elim)
 open import Data.Empty.Polymorphic using (⊥) renaming (⊥-elim to ⊥ₚ-elim)
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
   using (_×_; Σ; curry; uncurry; _,_; -,_; <_,_>; proj₁; proj₂; ∃₂; ∃)
 open import Data.Product.Function.NonDependent.Propositional
 open import Data.Sum.Base as Sum
@@ -47,12 +47,12 @@ private
 -- Σ is associative
 Σ-assoc : ∀ {A : Set a} {B : A → Set b} {C : (a : A) → B a → Set c} →
           Σ (Σ A B) (uncurry C) ↔ Σ A (λ a → Σ (B a) (C a))
-Σ-assoc = mk↔ₛ′ Prod.assocʳ Prod.assocˡ (λ _ → P.refl) (λ _ → P.refl)
+Σ-assoc = mk↔ₛ′ Product.assocʳ Product.assocˡ (λ _ → P.refl) (λ _ → P.refl)
 
 -- × is commutative
 
 ×-comm : ∀ (A : Set a) (B : Set b) → (A × B) ↔ (B × A)
-×-comm _ _ = mk↔ₛ′ Prod.swap Prod.swap (λ _ → P.refl) λ _ → P.refl
+×-comm _ _ = mk↔ₛ′ Product.swap Product.swap (λ _ → P.refl) λ _ → P.refl
 
 -- × has ⊤ as its identity
 
@@ -114,14 +114,14 @@ private
 ×-distribˡ-⊎ : ∀ ℓ → _DistributesOverˡ_ {ℓ = ℓ} _↔_ _×_ _⊎_
 ×-distribˡ-⊎ ℓ _ _ _ = mk↔ₛ′
   (uncurry λ x → [ inj₁ ∘′ (x ,_) , inj₂ ∘′ (x ,_) ]′)
-  [ Prod.map₂ inj₁ , Prod.map₂ inj₂ ]′
+  [ Product.map₂ inj₁ , Product.map₂ inj₂ ]′
   [ (λ _ → P.refl) , (λ _ → P.refl) ]
   (uncurry λ _ → [ (λ _ → P.refl) , (λ _ → P.refl) ])
 
 ×-distribʳ-⊎ : ∀ ℓ → _DistributesOverʳ_ {ℓ = ℓ} _↔_ _×_ _⊎_
 ×-distribʳ-⊎ ℓ _ _ _ = mk↔ₛ′
   (uncurry [ curry inj₁ , curry inj₂ ]′)
-  [ Prod.map₁ inj₁ , Prod.map₁ inj₂ ]′
+  [ Product.map₁ inj₁ , Product.map₁ inj₂ ]′
   [ (λ _ → P.refl) , (λ _ → P.refl) ]
   (uncurry [ (λ _ _ → P.refl) , (λ _ _ → P.refl) ])
 

--- a/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
+++ b/src/Relation/Binary/Construct/Closure/Reflexive/Properties.agda
@@ -8,7 +8,7 @@
 
 module Relation.Binary.Construct.Closure.Reflexive.Properties where
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base as Product
 open import Data.Sum.Base as Sum
 open import Function.Bundles using (_⇔_; mk⇔)
 open import Function.Base using (id)
@@ -103,7 +103,7 @@ module _ {_~_ : Rel A ℓ} {P : Pred A p} where
 module _ {_~_ : Rel A ℓ} {P : Rel A p} where
 
   resp₂ : P Respects₂ _~_ → P Respects₂ (ReflClosure _~_)
-  resp₂ = Prod.map respˡ respʳ
+  resp₂ = Product.map respˡ respʳ
 
 ------------------------------------------------------------------------
 -- Structures

--- a/src/Relation/Binary/Construct/Subst/Equality.agda
+++ b/src/Relation/Binary/Construct/Subst/Equality.agda
@@ -9,7 +9,7 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Data.Product.Base as Prod
+open import Data.Product.Base using (_,_)
 open import Relation.Binary.Core using (Rel; _⇔_)
 open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Binary.Definitions using (Reflexive; Symmetric; Transitive)

--- a/src/Relation/Binary/Properties/Preorder.agda
+++ b/src/Relation/Binary/Properties/Preorder.agda
@@ -13,7 +13,7 @@ module Relation.Binary.Properties.Preorder
   {p₁ p₂ p₃} (P : Preorder p₁ p₂ p₃) where
 
 open import Function.Base using (flip)
-open import Data.Product.Base as Prod using (_×_; _,_; swap)
+open import Data.Product.Base as Product using (_×_; _,_; swap)
 import Relation.Binary.Construct.Flip.EqAndOrd as EqAndOrd
 
 open Preorder P
@@ -37,7 +37,7 @@ InducedEquivalence = record
   ; isEquivalence = record
     { refl  = (refl , refl)
     ; sym   = swap
-    ; trans = Prod.zip trans (flip trans)
+    ; trans = Product.zip trans (flip trans)
     }
   }
 

--- a/src/Relation/Nary.agda
+++ b/src/Relation/Nary.agda
@@ -19,7 +19,7 @@ open import Data.Unit.Base
 open import Data.Bool.Base using (true; false)
 open import Data.Empty
 open import Data.Nat.Base using (zero; suc)
-open import Data.Product.Base as Prod using (_×_; _,_)
+open import Data.Product.Base as Product using (_×_; _,_)
 open import Data.Product.Nary.NonDependent
 open import Data.Sum.Base using (_⊎_)
 open import Function.Base using (_$_; _∘′_)

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -11,7 +11,7 @@ module Relation.Nullary.Negation where
 open import Effect.Monad using (RawMonad; mkRawMonad)
 open import Data.Bool.Base using (Bool; false; true; if_then_else_; not)
 open import Data.Empty using (⊥-elim)
-open import Data.Product.Base as Prod using (_,_; Σ; Σ-syntax; ∃; curry; uncurry)
+open import Data.Product.Base as Product using (_,_; Σ; Σ-syntax; ∃; curry; uncurry)
 open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_])
 open import Function.Base using (flip; _∘_; const; _∘′_)
 open import Level using (Level)
@@ -82,7 +82,7 @@ independence-of-premise : A → (B → Σ A P) → DoubleNegation (Σ[ x ∈ A ]
 independence-of-premise {A = A} {B = B} {P = P} q f = ¬¬-map helper ¬¬-excluded-middle
   where
   helper : Dec B → Σ[ x ∈ A ] (B → P x)
-  helper (yes p) = Prod.map₂ const (f p)
+  helper (yes p) = Product.map₂ const (f p)
   helper (no ¬p) = (q , ⊥-elim ∘′ ¬p)
 
 -- The independence of premise rule for binary sums.

--- a/src/Relation/Nullary/Universe.agda
+++ b/src/Relation/Nullary/Universe.agda
@@ -19,7 +19,7 @@ import Relation.Binary.Indexed.Heterogeneous.Construct.Trivial
   as Trivial
 open import Data.Sum.Base as Sum  hiding (map)
 open import Data.Sum.Relation.Binary.Pointwise using (_⊎ₛ_; inj₁; inj₂)
-open import Data.Product.Base as Prod hiding (map)
+open import Data.Product.Base as Product hiding (map)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent using (_×ₛ_)
 open import Function.Base using (_∘_; id)
 open import Function.Indexed.Relation.Binary.Equality using (≡-setoid)
@@ -69,7 +69,7 @@ map : ∀ {p} (F : PropF p) {P Q} → (P → Q) → ⟦ F ⟧ P → ⟦ F ⟧ Q
 map Id        f  p = f p
 map (K P)     f  p = p
 map (F₁ ∨ F₂) f FP = Sum.map  (map F₁ f) (map F₂ f) FP
-map (F₁ ∧ F₂) f FP = Prod.map (map F₁ f) (map F₂ f) FP
+map (F₁ ∧ F₂) f FP = Product.map (map F₁ f) (map F₂ f) FP
 map (P₁ ⇒ F₂) f FP = map F₂ f ∘ FP
 map (¬¬ F)    f FP = ¬¬-map (map F f) FP
 


### PR DESCRIPTION
Outstanding issues:
* disambiguation in `Data.Container.*` wrt product structure on containers vs. that on types (both at the level of the type constructor, and at that of (internal) module naming)
* ...

(And with this being the third PR tackling #2280 , starting to feel diminishing returns without a bit more thought about how to deliver on the `style-guide` recommendations)