### PR TITLE
`README.Data.*` manual fix for #1380

### DIFF
--- a/src/Data/Bool/Solver.agda
+++ b/src/Data/Bool/Solver.agda
@@ -4,7 +4,7 @@
 -- Automatic solvers for equations over booleans
 ------------------------------------------------------------------------
 
--- See README.Nat for examples of how to use similar solvers
+-- See README.Data.Nat for examples of how to use similar solvers
 
 {-# OPTIONS --cubical-compatible --safe #-}
 

--- a/src/Data/Integer/Solver.agda
+++ b/src/Data/Integer/Solver.agda
@@ -4,7 +4,7 @@
 -- Automatic solvers for equations over integers
 ------------------------------------------------------------------------
 
--- See README.Integer for examples of how to use this solver
+-- See README.Data.Integer for examples of how to use this solver
 
 {-# OPTIONS --cubical-compatible --safe #-}
 

--- a/src/Data/Integer/Tactic/RingSolver.agda
+++ b/src/Data/Integer/Tactic/RingSolver.agda
@@ -4,7 +4,7 @@
 -- Automatic solvers for equations over integers
 ------------------------------------------------------------------------
 
--- See README.Integer for examples of how to use this solver
+-- See README.Tactic.RingSolver for examples of how to use this solver
 
 {-# OPTIONS --cubical-compatible --safe #-}
 

--- a/src/Data/Nat/Solver.agda
+++ b/src/Data/Nat/Solver.agda
@@ -4,7 +4,7 @@
 -- Automatic solvers for equations over naturals
 ------------------------------------------------------------------------
 
--- See README.Nat for examples of how to use this solver
+-- See README.Data.Nat for examples of how to use this solver
 
 {-# OPTIONS --cubical-compatible --safe #-}
 


### PR DESCRIPTION
Anent @gallais 's #1380 : a purely manual fix, so doesn't close the issue ... 

... because, as with the recent #2278 / #2279 we still need to observe a 'better' discipline about (checking the) linking to `README`s on the one hand, and ensuring that new `README.*` are in fact imported by `doc/README`.

Nevertheless, the dead links seem (at the time of writing) only to arise from the historical move from the 'simple' `*.Solver.solve`s to the more sophisticated `*.Tactic.RingSolver.solve-∀`, so this is a 'stable' fix:
* `Data/Bool/Solver.agda`:-- See README.~~Nat~~.Data.Nat for examples of how to use similar solvers
* `Data/Integer/Solver.agda`:-- See README.~~Integer~~.Data.Integer ...
* `Data/Integer/Tactic/RingSolver.agda`:-- See README.~~Integer~~Tactic.Ringsolver ...
* `Data/Nat/Solver.agda`:-- See README.~~Nat~~.Data.Nat ...
