### PR TITLE
Fix `sized-types` error in `README.Data.Tree.Binary`

### DIFF
--- a/doc/README/Data/Tree/Binary.agda
+++ b/doc/README/Data/Tree/Binary.agda
@@ -4,7 +4,7 @@
 -- Some examples showing how the Binary tree module can be used
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical-compatible --safe --sized-types #-}
+{-# OPTIONS --cubical-compatible --sized-types #-}
 
 module README.Data.Tree.Binary where
 


### PR DESCRIPTION
Corrects another orphan module under `doc/README`: use of `--sized-types` is no longer `--safe` ... cf. #2278 #1380 