### PR TITLE
New Maybe Unary definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,3 +187,8 @@ Additions to existing modules
   ```agda
   ⌊⌋-map′ : (a? : Dec A) → ⌊ map′ t f a? ⌋ ≡ ⌊ a? ⌋
   ```
+
+* Added new definition in `Data.Maybe.Relation.Unary.AllBoth`:
+  ```agda
+  data AllBoth (P : Pred A p) (Q : Set q) : Pred (Maybe A) (a ⊔ p ⊔ q)
+  ```

--- a/src/Data/Maybe/Relation/Unary/AllBoth.agda
+++ b/src/Data/Maybe/Relation/Unary/AllBoth.agda
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Maybes where all the elements satisfy a given property and nothing another property
+--------------------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Data.Maybe.Relation.Unary.AllBoth where
+
+open import Data.Maybe.Base using (Maybe; just; nothing)
+open import Level
+open import Relation.Unary
+
+------------------------------------------------------------------------
+-- Definition
+
+data AllBoth {a p q} {A : Set a} (P : Pred A p) (Q : Set q) : Pred (Maybe A) (a ⊔ p ⊔ q) where
+  just    : ∀ {x} → P x → AllBoth P Q (just x)
+  nothing : Q → AllBoth P Q nothing


### PR DESCRIPTION
I created this definition because it is a new kind of relation different from the other definitions we already have. It is the same as `Data.Sum.Relation.Unary.All` when used with the unit type.