### PR TITLE
A tweak for the cong! tactic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,4 +283,4 @@ Additions to existing modules
   ```
 
 * `Tactic.Cong` now provides a marker function, `⌞_⌟`, for user-guided
-  anti-unification.
+  anti-unification. See README.Tactic.Cong for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ New modules
   ```agda
   Algebra.Module.Construct.Idealization
   ```
-  
+
 * `Function.Relation.Binary.Equality`
   ```agda
   setoid : Setoid a₁ a₂ → Setoid b₁ b₂ → Setoid _ _
@@ -269,3 +269,6 @@ Additions to existing modules
   ↭-sym       : Symmetric (Vector A) _↭_
   ↭-trans     : Transitive (Vector A) _↭_
   ```
+
+* `Tactic.Cong` now provides a marker function, `⌞_⌟`, for user-guided
+  anti-unification.

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -8,7 +8,7 @@ open import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality as Eq
 import Relation.Binary.Reasoning.Preorder as PR
 
-open import Tactic.Cong using (cong! ; ⌞_⌟)
+open import Tactic.Cong
 
 ----------------------------------------------------------------------
 -- Usage
@@ -77,18 +77,18 @@ marker-example₁ m n o p =
   let open Eq.≡-Reasoning in
   begin
     ⌞ m + n ⌟ + (o + p)
-  ≡⟨ cong! (+-comm m n) ⟩
+  ≡⟨! +-comm m n ⟩
     n + m + ⌞ o + p ⌟
-  ≡⟨ cong! (+-comm o p) ⟩
+  ≡⟨! +-comm p o ⟨
     n + m + (p + o)
   ∎
 
 marker-example₂ : ∀ m n → m + n + (m + n) ≡ n + m + (n + m)
 marker-example₂ m n =
-  let open Eq.≡-Reasoning in
-  begin
+  let open ≤-Reasoning in
+  begin-equality
     ⌞ m + n ⌟ + ⌞ m + n ⌟
-  ≡⟨ cong! (+-comm m n) ⟩
+  ≡⟨! +-comm m n ⟩
     n + m + (n + m)
   ∎
 

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -8,7 +8,7 @@ open import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality as Eq
 import Relation.Binary.Reasoning.Preorder as PR
 
-open import Tactic.Cong using (cong!)
+open import Tactic.Cong using (cong! ; ⌞_⌟)
 
 ----------------------------------------------------------------------
 -- Usage
@@ -68,6 +68,29 @@ succinct-example m n eq =
 -- to deduce where to generalize. When presented with two sides
 -- of an equality like 'm + n ≡ n + m', it will anti-unify to
 -- 'ϕ + ϕ', which is too specific.
+--
+-- In these cases, you may explicitly mark the subterms to be
+-- generalized by wrapping them in the marker function, ⌞_⌟.
+
+marker-example₁ : ∀ m n o p → m + n + (o + p) ≡ n + m + (p + o)
+marker-example₁ m n o p =
+  let open Eq.≡-Reasoning in
+  begin
+    ⌞ m + n ⌟ + (o + p)
+  ≡⟨ cong! (+-comm m n) ⟩
+    n + m + ⌞ o + p ⌟
+  ≡⟨ cong! (+-comm o p) ⟩
+    n + m + (p + o)
+  ∎
+
+marker-example₂ : ∀ m n → m + n + (m + n) ≡ n + m + (n + m)
+marker-example₂ m n =
+  let open Eq.≡-Reasoning in
+  begin
+    ⌞ m + n ⌟ + ⌞ m + n ⌟
+  ≡⟨ cong! (+-comm m n) ⟩
+    n + m + (n + m)
+  ∎
 
 ----------------------------------------------------------------------
 -- Unit Tests

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -74,13 +74,13 @@ succinct-example m n eq =
 
 marker-example₁ : ∀ m n o p → m + n + (o + p) ≡ n + m + (p + o)
 marker-example₁ m n o p =
-  let open Eq.≡-Reasoning in
+  let open ≡-Reasoning in
   begin
     ⌞ m + n ⌟ + (o + p)
   ≡⟨ cong! (+-comm m n) ⟩
     n + m + ⌞ o + p ⌟
   ≡⟨ cong! (+-comm p o) ⟨
-     + m + (p + o)
+    n + m + (p + o)
   ∎
 
 marker-example₂ : ∀ m n → m + n + (m + n) ≡ n + m + (n + m)

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -56,7 +56,7 @@ succinct-example m n eq =
   ∎
 
 ----------------------------------------------------------------------
--- Limitations
+-- Explicit markings
 ----------------------------------------------------------------------
 
 -- The 'cong!' tactic can handle simple cases, but will

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -69,8 +69,8 @@ succinct-example m n eq =
 -- of an equality like 'm + n ≡ n + m', it will anti-unify to
 -- 'ϕ + ϕ', which is too specific.
 --
--- In these cases, you may explicitly mark the subterms to be
--- generalized by wrapping them in the marker function, ⌞_⌟.
+-- In cases like these, you may explicitly mark the subterms to
+-- be generalized by wrapping them in the marker function, ⌞_⌟.
 
 marker-example₁ : ∀ m n o p → m + n + (o + p) ≡ n + m + (p + o)
 marker-example₁ m n o p =

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -8,7 +8,7 @@ open import Data.Nat.Properties
 open import Relation.Binary.PropositionalEquality as Eq
 import Relation.Binary.Reasoning.Preorder as PR
 
-open import Tactic.Cong
+open import Tactic.Cong using (cong! ; ⌞_⌟)
 
 ----------------------------------------------------------------------
 -- Usage
@@ -77,10 +77,10 @@ marker-example₁ m n o p =
   let open Eq.≡-Reasoning in
   begin
     ⌞ m + n ⌟ + (o + p)
-  ≡⟨! +-comm m n ⟩
+  ≡⟨ cong! (+-comm m n) ⟩
     n + m + ⌞ o + p ⌟
-  ≡⟨! +-comm p o ⟨
-    n + m + (p + o)
+  ≡⟨ cong! (+-comm p o) ⟨
+     + m + (p + o)
   ∎
 
 marker-example₂ : ∀ m n → m + n + (m + n) ≡ n + m + (n + m)
@@ -88,7 +88,7 @@ marker-example₂ m n =
   let open ≤-Reasoning in
   begin-equality
     ⌞ m + n ⌟ + ⌞ m + n ⌟
-  ≡⟨! +-comm m n ⟩
+  ≡⟨ cong! (+-comm m n) ⟩
     n + m + (n + m)
   ∎
 

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -236,6 +236,12 @@ macro
     withNormalisation false $ do
       goal ← inferType hole
       eqGoal ← destructEqualityGoal goal
-      let cong-lam = antiUnify 0 (EqualityGoal.lhs eqGoal) (EqualityGoal.rhs eqGoal)
-      cong-tm ← `cong eqGoal cong-lam x≡y
-      unify cong-tm hole
+      let uni = do
+        let cong-lam = antiUnify 0 (EqualityGoal.lhs eqGoal) (EqualityGoal.rhs eqGoal)
+        cong-tm ← `cong eqGoal cong-lam x≡y
+        unify cong-tm hole
+      let uni' = do
+        let cong-lam = antiUnify 0 (EqualityGoal.rhs eqGoal) (EqualityGoal.lhs eqGoal)
+        cong-tm ← `cong eqGoal cong-lam x≡y
+        unify cong-tm hole
+      catchTC uni uni'

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -242,6 +242,6 @@ macro
         unify cong-tm hole
       let lhs = EqualityGoal.lhs eqGoal
       let rhs = EqualityGoal.rhs eqGoal
-      -- When using ⌞_⌟ with ≡˘⟨ ... ⟩, (uni lhs rhs) fails and
+      -- When using ⌞_⌟ with ≡⟨ ... ⟨, (uni lhs rhs) fails and
       -- (uni rhs lhs) succeeds.
       catchTC (uni lhs rhs) (uni rhs lhs)

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -18,6 +18,8 @@
 --   ≡⟨ cong! (+-identityʳ n) ⟨
 --     suc (suc n) + (n + 0)
 --   ∎
+--
+-- Please see README.Tactic.Cong for more details.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --cubical-compatible --safe #-}
@@ -55,6 +57,17 @@ open import Reflection.AST.Term                 as Term
 
 open import Reflection.TCM.Syntax
 
+-- Marker to keep anti-unification from descending into the wrapped
+-- subterm.
+--
+-- For instance, anti-unification of ⌞ a + b ⌟ + c and b + a + c
+-- yields λ ϕ → ϕ + c, as opposed to λ ϕ → ϕ + ϕ + c without ⌞_⌟.
+--
+-- The marker is only visible to the cong! tactic, which inhibits
+-- normalisation. Anywhere else, ⌞ a + b ⌟ reduces to a + b.
+--
+-- Thus, proving ⌞ a + b ⌟ + c ≡ b + a + c via cong! (+-comm a b)
+-- also proves a + b + c ≡ b + a + c.
 ⌞_⌟ : ∀ {a} {A : Set a} → A → A
 ⌞_⌟ x = x
 

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -282,6 +282,10 @@ private
     args' ← dropArgs args
     -- Assume that the step function has arguments args' followed by
     -- {x} {y} {z} x≡y yRz. We skip {y} and {z}, which we don't know.
+    -- We must specify {x}, because the x we have at hand had
+    -- normalisation inhibited and thus still contains the markers,
+    -- ⌞_⌟. If we let Agda figure out {x} instead, then any markers
+    -- would be lost.
     pure $ def go $ args' ++ `x ⟅∷⟆ inner ⟨∷⟩ `yRz ⟨∷⟩ []
 
   makeGoal : ∀ {a r} {A : Set a} {R : Set r} → A → R → Term → TC Term

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -241,7 +241,9 @@ macro
         cong-tm ← `cong eqGoal cong-lam x≡y
         unify cong-tm hole
       let uni' = do
+        -- Like uni, but with RHS and LHS swapped.
         let cong-lam = antiUnify 0 (EqualityGoal.rhs eqGoal) (EqualityGoal.lhs eqGoal)
         cong-tm ← `cong eqGoal cong-lam x≡y
         unify cong-tm hole
+      -- When using ⌞_⌟ with ≡˘⟨ ... ⟩, uni fails and uni' succeeds.
       catchTC uni uni'

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -240,8 +240,8 @@ macro
         let cong-lam = antiUnify 0 lhs rhs
         cong-tm ← `cong eqGoal cong-lam x≡y
         unify cong-tm hole
-      let lhs = EqualityGoal.rhs eqGoal
-      let rhs = EqualityGoal.lhs eqGoal
+      let lhs = EqualityGoal.lhs eqGoal
+      let rhs = EqualityGoal.rhs eqGoal
       -- When using ⌞_⌟ with ≡˘⟨ ... ⟩, (uni lhs rhs) fails and
       -- (uni rhs lhs) succeeds.
       catchTC (uni lhs rhs) (uni rhs lhs)

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -55,6 +55,9 @@ open import Reflection.AST.Term                 as Term
 
 open import Reflection.TCM.Syntax
 
+⌞_⌟ : ∀ {a} {A : Set a} → A → A
+⌞_⌟ x = x
+
 ------------------------------------------------------------------------
 -- Utilities
 ------------------------------------------------------------------------
@@ -136,6 +139,8 @@ private
   antiUnifyClauses : ℕ → Clauses → Clauses → Maybe Clauses
   antiUnifyClause  : ℕ → Clause → Clause → Maybe Clause
 
+  pattern apply-⌞⌟ t = (def (quote ⌞_⌟) (_ ∷ _ ∷ arg _ t ∷ []))
+
   antiUnify ϕ (var x args) (var y args') with x ℕ.≡ᵇ y | antiUnifyArgs ϕ args args'
   ... | _     | nothing    = var ϕ []
   ... | false | just uargs = var ϕ uargs
@@ -144,6 +149,7 @@ private
   ... | _     | nothing    = var ϕ []
   ... | false | just uargs = var ϕ []
   ... | true  | just uargs = con c uargs
+  antiUnify ϕ (def f args) (apply-⌞⌟ t) = antiUnify ϕ (def f args) t
   antiUnify ϕ (def f args) (def f' args') with f Name.≡ᵇ f' | antiUnifyArgs ϕ args args'
   ... | _     | nothing    = var ϕ []
   ... | false | just uargs = var ϕ []

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -236,14 +236,12 @@ macro
     withNormalisation false $ do
       goal ← inferType hole
       eqGoal ← destructEqualityGoal goal
-      let uni = do
-        let cong-lam = antiUnify 0 (EqualityGoal.lhs eqGoal) (EqualityGoal.rhs eqGoal)
+      let uni = λ lhs rhs → do
+        let cong-lam = antiUnify 0 lhs rhs
         cong-tm ← `cong eqGoal cong-lam x≡y
         unify cong-tm hole
-      let uni' = do
-        -- Like uni, but with RHS and LHS swapped.
-        let cong-lam = antiUnify 0 (EqualityGoal.rhs eqGoal) (EqualityGoal.lhs eqGoal)
-        cong-tm ← `cong eqGoal cong-lam x≡y
-        unify cong-tm hole
-      -- When using ⌞_⌟ with ≡˘⟨ ... ⟩, uni fails and uni' succeeds.
-      catchTC uni uni'
+      let lhs = EqualityGoal.rhs eqGoal
+      let rhs = EqualityGoal.lhs eqGoal
+      -- When using ⌞_⌟ with ≡˘⟨ ... ⟩, (uni lhs rhs) fails and
+      -- (uni rhs lhs) succeeds.
+      catchTC (uni lhs rhs) (uni rhs lhs)


### PR DESCRIPTION
Hello there.

It's known that the  `cong!` tactic's anti-unification is a tad too granular for some use cases. In the following, for example, it descends past the application of `_+_` in `b + c` and `c + b`, so that the following definition doesn't type-check.

```
proof : ∀ a b c → a + (b + c) ≡ a + (c + b)
proof a b c =
  a + (b + c) ≡⟨ cong! (+-comm b c) ⟩
  a + (c + b) ∎
```
Note, however, that the following does type-check. (Note the added application of `id` to `b + c`.)

```
proof : ∀ a b c → a + (b + c) ≡ a + (c + b)
proof a b c =
  a + id (b + c) ≡⟨ cong! (+-comm b c) ⟩
  a + (c + b)    ∎
```

It works, because the `cong!` tactic inhibits normalisation, the application of `id` isn't reduced, anti-unification finds that `id (b + c)` is different from `(c + b)` (because `id` is different from `_+_`) - and doesn't descend further.

Unfortunately, this hack falls apart, when using `cong!` multiple times in a row. The following, for example, doesn't type-check.

```
proof : ∀ a b c d → a + b + (c + d) ≡ b + a + (d + c)
proof a b c d =
  a + b + id (c + d)   ≡⟨ cong! (+-comm c d) ⟩
  id (a + b) + (d + c) ≡⟨ cong! (+-comm a b) ⟩
  b + a + (d + c)      ∎
```

I think that this can be worked around, however, by slightly tweaking the `cong!` tactic to replace any `id x` on the right-hand side of the equality with `x`, i.e., by manually reducing `id x` to `x` on the RHS.

The modifications contemplated in this pull request do two things:

* They add `⌞_⌟` as an alias for `id`. (Name choice inspired by #1136.)
* They tweak the anti-unification algorithm to skip past any application of `⌞_⌟` on the right-hand side of the equality.

As a result, the following example type-checks:

```
module Demo where

open import Data.Nat
open import Data.Nat.Properties
open import Relation.Binary.PropositionalEquality
open import Tactic.Cong

proof : ∀ a b c d → a + b + (c + d) ≡ b + a + (d + c)
proof a b c d =
  a + b + ⌞ c + d ⌟   ≡⟨ cong! (+-comm c d) ⟩
  ⌞ a + b ⌟ + (d + c) ≡⟨ cong! (+-comm a b) ⟩
  b + a + (d + c)     ∎
  where open ≡-Reasoning

proof′ : ∀ a b → a + b + (a + b) ≡ b + a + (b + a)
proof′ a b =
  ⌞ a + b ⌟ + ⌞ a + b ⌟   ≡⟨ cong! (+-comm a b) ⟩
  b + a + (b + a)         ∎
  where open ≡-Reasoning
```
This could be a useful tweak to the `cong!` tactic, no? Or am I missing something?