### PR TITLE
Refactor `List.Membership.*` and `List.Relation.Unary.Any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,12 @@ Additions to existing modules
   pattern divides k eq = Data.Nat.Divisibility.divides k eq
   ```
 
+* In `Data.List.Membership.Propositional.Properties.Core`:
+  ```agda
+  find∘∃∈-Any : (p : ∃∈ P xs) → find (∃∈-Any p) ≡ p
+  ∃∈-Any∘find : (p : Any P xs) → ∃∈-Any (find p) ≡ p
+  ```
+
 * In `Data.List.Membership.Setoid`: two abbreviations for predicate transformers
   ```agda
   ∃∈ P xs = ∃ λ x → x ∈ xs × P x
@@ -250,6 +256,11 @@ Additions to existing modules
   reverse-upTo          : reverse (upTo n) ≡ downFrom n
   reverse-applyDownFrom : reverse (applyDownFrom f n) ≡ applyUpTo f n
   reverse-downFrom      : reverse (downFrom n) ≡ upTo n
+  ```
+
+* In `Data.List.Relation.Unary.All`:
+  ```agda
+  universal-U : Universal (All U)
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ Additions to existing modules
   quasigroup      : Quasigroup _ _
   isLoop          : IsLoop _∙_ _\\_ _//_ ε
   loop            : Loop _ _
-  
+
   \\-leftDividesˡ  : LeftDividesˡ _∙_ _\\_
   \\-leftDividesʳ  : LeftDividesʳ _∙_ _\\_
   \\-leftDivides   : LeftDivides _∙_ _\\_
@@ -189,7 +189,7 @@ Additions to existing modules
   identityʳ-unique : x ∙ y ≈ x → y ≈ ε
   identity-unique  : Identity x _∙_ → x ≈ ε
   ```
- 
+
 * In `Algebra.Construct.Terminal`:
   ```agda
   rawNearSemiring : RawNearSemiring c ℓ
@@ -218,7 +218,7 @@ Additions to existing modules
   _\\_ : Op₂ A
   x \\ y = (x ⁻¹) ∙ y
   ```
- 
+
 * In `Data.Container.Indexed.Core`:
   ```agda
   Subtrees o c = (r : Response c) → X (next c r)
@@ -229,9 +229,15 @@ Additions to existing modules
   nonZeroIndex : Fin n → ℕ.NonZero n
   ```
 
-* In `Data.Integer.Divisisbility`: introduce `divides` as an explicit pattern synonym
+* In `Data.Integer.Divisibility`: introduce `divides` as an explicit pattern synonym
   ```agda
   pattern divides k eq = Data.Nat.Divisibility.divides k eq
+  ```
+
+* In `Data.List.Membership.Setoid`: two abbreviations for predicate transformers
+  ```agda
+  ∃∈ P xs = ∃ λ x → x ∈ xs × P x
+  ∀∈ P xs = ∀ {x} → x ∈ xs → P x
   ```
 
 * In `Data.List.Properties`:
@@ -320,7 +326,7 @@ Additions to existing modules
   pred-injective : .{{NonZero m}} → .{{NonZero n}} → pred m ≡ pred n → m ≡ n
   pred-cancel-≡ : pred m ≡ pred n → ((m ≡ 0 × n ≡ 1) ⊎ (m ≡ 1 × n ≡ 0)) ⊎ m ≡ n
   ```
-  
+
 * Added new proofs to `Data.Nat.Primality`:
   ```agda
   rough∧square>⇒prime : .{{NonTrivial n}} → m Rough n → m * m > n → Prime n

--- a/src/Data/List/Membership/Propositional.agda
+++ b/src/Data/List/Membership/Propositional.agda
@@ -10,7 +10,7 @@
 module Data.List.Membership.Propositional {a} {A : Set a} where
 
 open import Data.List.Relation.Unary.Any using (Any)
-open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; subst)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; resp; subst)
 open import Relation.Binary.PropositionalEquality.Properties using (setoid)
 
 import Data.List.Membership.Setoid as SetoidMembership
@@ -32,4 +32,4 @@ _≢∈_ x∈xs y∈xs = ∀ x≡y → subst (_∈ _) x≡y x∈xs ≢ y∈xs
 -- Other operations
 
 lose : ∀ {p} {P : A → Set p} {x xs} → x ∈ xs → P x → Any P xs
-lose = SetoidMembership.lose (setoid A) (subst _)
+lose = SetoidMembership.lose (setoid A) (resp _)

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -55,7 +55,7 @@ private
 ------------------------------------------------------------------------
 -- Publicly re-export properties from Core
 
-open import Data.List.Membership.Propositional.Properties.CoreNEW public
+open import Data.List.Membership.Propositional.Properties.Core public
 
 ------------------------------------------------------------------------
 -- Equality

--- a/src/Data/List/Membership/Propositional/Properties/Core.agda
+++ b/src/Data/List/Membership/Propositional/Properties/Core.agda
@@ -13,8 +13,8 @@
 module Data.List.Membership.Propositional.Properties.Core where
 
 open import Data.List.Base using (List)
-open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional
+open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.Product.Base as Product using (_,_)
 open import Function.Base using (flip; id; _∘_)
 open import Function.Bundles using (_↔_; mk↔ₛ′)

--- a/src/Data/List/Membership/Propositional/Properties/Core.agda
+++ b/src/Data/List/Membership/Propositional/Properties/Core.agda
@@ -62,12 +62,12 @@ module _ {P : Pred A p} where
   ∃∈-Any : ∃∈ P xs → Any P xs
   ∃∈-Any (x , x∈xs , px) = lose {P = P} x∈xs px
 
+  ∃∈-Any∘find : (p : Any P xs) → ∃∈-Any (find p) ≡ p
+  ∃∈-Any∘find p = map∘find p refl
+
   find∘∃∈-Any : (p : ∃∈ P xs) → find (∃∈-Any p) ≡ p
   find∘∃∈-Any p@(x , x∈xs , px)
     rewrite find∘map x∈xs (flip (resp P) px) | find-∈ x∈xs = refl
-
-  ∃∈-Any∘find : (p : Any P xs) → ∃∈-Any (find p) ≡ p
-  ∃∈-Any∘find p = map∘find p refl
 
   Any↔ : ∃∈ P xs ↔ Any P xs
   Any↔ = mk↔ₛ′ ∃∈-Any find ∃∈-Any∘find find∘∃∈-Any

--- a/src/Data/List/Membership/Propositional/Properties/Core.agda
+++ b/src/Data/List/Membership/Propositional/Properties/Core.agda
@@ -12,75 +12,73 @@
 
 module Data.List.Membership.Propositional.Properties.Core where
 
-open import Function.Base using (flip; id; _∘_)
-open import Function.Bundles
 open import Data.List.Base using (List)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional
-open import Data.Product.Base as Product
-  using (_,_; proj₁; proj₂; uncurry′; ∃; _×_)
+open import Data.Product.Base as Product using (_,_)
+open import Function.Base using (flip; id; _∘_)
+open import Function.Bundles using (_↔_; mk↔ₛ′)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; refl; cong; subst)
+  using (_≡_; refl; cong; resp)
 open import Relation.Unary using (Pred; _⊆_)
 
 private
   variable
     a p q : Level
     A : Set a
-
-------------------------------------------------------------------------
--- Lemmas relating map and find.
-
-map∘find : ∀ {P : Pred A p} {xs}
-           (p : Any P xs) → let p′ = find p in
-           {f : _≡_ (proj₁ p′) ⊆ P} →
-           f refl ≡ proj₂ (proj₂ p′) →
-           Any.map f (proj₁ (proj₂ p′)) ≡ p
-map∘find (here  p) hyp = cong here  hyp
-map∘find (there p) hyp = cong there (map∘find p hyp)
-
-find∘map : ∀ {P : Pred A p} {Q : Pred A q}
-           {xs : List A} (p : Any P xs) (f : P ⊆ Q) →
-           find (Any.map f p) ≡ Product.map id (Product.map id f) (find p)
-find∘map (here  p) f = refl
-find∘map (there p) f rewrite find∘map p f = refl
+    x : A
+    xs : List A
 
 ------------------------------------------------------------------------
 -- find satisfies a simple equality when the predicate is a
 -- propositional equality.
 
-find-∈ : ∀ {x : A} {xs : List A} (x∈xs : x ∈ xs) →
-         find x∈xs ≡ (x , x∈xs , refl)
+find-∈ : (x∈xs : x ∈ xs) → find x∈xs ≡ (x , x∈xs , refl)
 find-∈ (here refl)  = refl
 find-∈ (there x∈xs) rewrite find-∈ x∈xs = refl
 
 ------------------------------------------------------------------------
--- find and lose are inverses (more or less).
+-- Lemmas relating map and find.
 
-lose∘find : ∀ {P : Pred A p} {xs : List A}
-            (p : Any P xs) →
-            uncurry′ lose (proj₂ (find p)) ≡ p
-lose∘find p = map∘find p refl
+module _ {P : Pred A p} where
 
-find∘lose : ∀ (P : Pred A p) {x xs}
-            (x∈xs : x ∈ xs) (pp : P x) →
-            find {P = P} (lose x∈xs pp) ≡ (x , x∈xs , pp)
-find∘lose P x∈xs p
-  rewrite find∘map x∈xs (flip (subst P) p)
-        | find-∈ x∈xs
-        = refl
+  map∘find : (p : Any P xs) → let x , x∈xs , px = find p in
+             {f : (x ≡_) ⊆ P} → f refl ≡ px →
+             Any.map f x∈xs ≡ p
+  map∘find (here  p) hyp = cong here  hyp
+  map∘find (there p) hyp = cong there (map∘find p hyp)
+
+  find∘map : ∀ {Q : Pred A q} {xs} (p : Any P xs) (f : P ⊆ Q) →
+             find (Any.map f p) ≡ Product.map id (Product.map id f) (find p)
+  find∘map (here  p) f = refl
+  find∘map (there p) f rewrite find∘map p f = refl
 
 ------------------------------------------------------------------------
 -- Any can be expressed using _∈_
 
 module _ {P : Pred A p} where
 
-  ∃∈-Any : ∀  {xs} → (∃ λ x → x ∈ xs × P x) → Any P xs
-  ∃∈-Any = uncurry′ lose ∘ proj₂
+  ∃∈-Any : ∃∈ P xs → Any P xs
+  ∃∈-Any (x , x∈xs , px) = lose {P = P} x∈xs px
 
-  Any↔ : ∀ {xs} → (∃ λ x → x ∈ xs × P x) ↔ Any P xs
-  Any↔ = mk↔ₛ′ ∃∈-Any find lose∘find from∘to
-    where
-    from∘to : ∀ v → find (∃∈-Any v) ≡ v
-    from∘to p = find∘lose _ (proj₁ (proj₂ p)) (proj₂ (proj₂ p))
+  find∘∃∈-Any : (p : ∃∈ P xs) → find (∃∈-Any p) ≡ p
+  find∘∃∈-Any p@(x , x∈xs , px)
+    rewrite find∘map x∈xs (flip (resp P) px) | find-∈ x∈xs = refl
+
+  ∃∈-Any∘find : (p : Any P xs) → ∃∈-Any (find p) ≡ p
+  ∃∈-Any∘find p = map∘find p refl
+
+  Any↔ : ∃∈ P xs ↔ Any P xs
+  Any↔ = mk↔ₛ′ ∃∈-Any find ∃∈-Any∘find find∘∃∈-Any
+
+------------------------------------------------------------------------
+-- Hence, find and lose are inverses (more or less).
+
+lose∘find : ∀ {P : Pred A p} {xs} (p : Any P xs) → ∃∈-Any (find p) ≡ p
+lose∘find = ∃∈-Any∘find
+
+find∘lose : ∀ (P : Pred A p) {x xs}
+            (x∈xs : x ∈ xs) (px : P x) →
+            find (lose {P = P} x∈xs px) ≡ (x , x∈xs , px)
+find∘lose P {x} x∈xs px = find∘∃∈-Any (x , x∈xs , px)

--- a/src/Data/List/Membership/Setoid.agda
+++ b/src/Data/List/Membership/Setoid.agda
@@ -9,7 +9,7 @@
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Definitions using (_Respects_)
 
-module Data.List.Membership.SetoidNEW {c ℓ} (S : Setoid c ℓ) where
+module Data.List.Membership.Setoid {c ℓ} (S : Setoid c ℓ) where
 
 open import Function.Base using (_∘_; id; flip; const)
 open import Data.List.Base as List using (List; []; _∷_; length; lookup)

--- a/src/Data/List/Membership/Setoid.agda
+++ b/src/Data/List/Membership/Setoid.agda
@@ -7,17 +7,17 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 open import Relation.Binary.Bundles using (Setoid)
-open import Relation.Binary.Definitions using (_Respects_)
 
 module Data.List.Membership.Setoid {c ℓ} (S : Setoid c ℓ) where
 
-open import Function.Base using (_∘_; id; flip; const)
-open import Data.List.Base as List using (List; []; _∷_; length; lookup)
+open import Data.List.Base using (List; []; _∷_; length; lookup)
 open import Data.List.Relation.Unary.Any as Any
   using (Any; index; map; here; there)
 open import Data.Product.Base as Product using (∃; _×_; _,_)
-open import Relation.Unary using (Pred)
+open import Function.Base using (_∘_; id; flip; const)
+open import Relation.Binary.Definitions using (_Respects_)
 open import Relation.Nullary.Negation using (¬_)
+open import Relation.Unary using (Pred)
 
 open Setoid S renaming (Carrier to A)
 
@@ -57,7 +57,7 @@ module _ {p} {P : Pred A p} where
   find : ∀ {xs} → Any P xs → ∃∈ P xs
   find (here px)   = _ , here refl , px
   find (there pxs) = Product.map id (Product.map there id) (find pxs)
-  -- let x , x∈xs , px = find pxs in x , there x∈xs , px
+  -- better? let x , x∈xs , px = find pxs in x , there x∈xs , px
 
   lose : P Respects _≈_ →  ∀ {x xs} → x ∈ xs → P x → Any P xs
   lose resp x∈xs px = map (flip resp px) x∈xs

--- a/src/Data/List/Membership/Setoid.agda
+++ b/src/Data/List/Membership/Setoid.agda
@@ -9,9 +9,9 @@
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Definitions using (_Respects_)
 
-module Data.List.Membership.Setoid {c ℓ} (S : Setoid c ℓ) where
+module Data.List.Membership.SetoidNEW {c ℓ} (S : Setoid c ℓ) where
 
-open import Function.Base using (_∘_; id; flip)
+open import Function.Base using (_∘_; id; flip; const)
 open import Data.List.Base as List using (List; []; _∷_; length; lookup)
 open import Data.List.Relation.Unary.Any as Any
   using (Any; index; map; here; there)
@@ -32,6 +32,12 @@ x ∈ xs = Any (x ≈_) xs
 _∉_ : A → List A → Set _
 x ∉ xs = ¬ x ∈ xs
 
+∃∈ : ∀ {p} (P : Pred A p) → Pred (List A) _
+∃∈ P xs = ∃ λ x → x ∈ xs × P x
+
+∀∈ : ∀ {p} (P : Pred A p) → Pred (List A) _
+∀∈ P xs = ∀ {x} → x ∈ xs → P x
+
 ------------------------------------------------------------------------
 -- Operations
 
@@ -39,7 +45,7 @@ _∷=_ = Any._∷=_ {A = A}
 _─_ = Any._─_ {A = A}
 
 mapWith∈ : ∀ {b} {B : Set b}
-           (xs : List A) → (∀ {x} → x ∈ xs → B) → List B
+           (xs : List A) → (∀∈ (const B) xs) → List B
 mapWith∈ []       f = []
 mapWith∈ (x ∷ xs) f = f (here refl) ∷ mapWith∈ xs (f ∘ there)
 
@@ -48,9 +54,10 @@ mapWith∈ (x ∷ xs) f = f (here refl) ∷ mapWith∈ xs (f ∘ there)
 
 module _ {p} {P : Pred A p} where
 
-  find : ∀ {xs} → Any P xs → ∃ λ x → x ∈ xs × P x
-  find (here px)   = (_ , here refl , px)
+  find : ∀ {xs} → Any P xs → ∃∈ P xs
+  find (here px)   = _ , here refl , px
   find (there pxs) = Product.map id (Product.map there id) (find pxs)
+  -- let x , x∈xs , px = find pxs in x , there x∈xs , px
 
   lose : P Respects _≈_ →  ∀ {x xs} → x ∈ xs → P x → Any P xs
   lose resp x∈xs px = map (flip resp px) x∈xs

--- a/src/Data/List/Membership/Setoid/Properties.agda
+++ b/src/Data/List/Membership/Setoid/Properties.agda
@@ -13,15 +13,14 @@ open import Data.Bool.Base using (true; false)
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.Fin.Properties using (suc-injective)
 open import Data.List.Base hiding (find)
-open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
-open import Data.List.Relation.Unary.All as All using (All)
-import Data.List.Relation.Unary.Any.Properties as Any
 import Data.List.Membership.Setoid as Membership
 import Data.List.Relation.Binary.Equality.Setoid as Equality
+open import Data.List.Relation.Unary.All as All using (All)
+open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
+import Data.List.Relation.Unary.Any.Properties as Any
 import Data.List.Relation.Unary.Unique.Setoid as Unique
-open import Data.Nat.Base using (suc; z≤n; s≤s; _≤_; _<_)
-open import Data.Nat.Properties using (≤-trans; n≤1+n)
-open import Data.Product.Base as Product using (∃; _×_; _,_ ; ∃₂; proj₁; proj₂)
+open import Data.Nat.Base using (suc; z<s; _<_)
+open import Data.Product.Base as Product using (∃; _×_; _,_ ; ∃₂)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent using (_×ₛ_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_]′)
 open import Function.Base using (_$_; flip; _∘_; _∘′_; id)
@@ -31,11 +30,11 @@ open import Relation.Binary.Core using (Rel; _Preserves₂_⟶_⟶_; _Preserves_
 open import Relation.Binary.Definitions as Binary hiding (Decidable)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
-open import Relation.Unary as Unary using (Decidable; Pred)
-open import Relation.Nullary using (¬_; does; _because_; yes; no)
+open import Relation.Nullary.Decidable using (does; _because_; yes; no)
+open import Relation.Nullary.Negation using (¬_; contradiction)
 open import Relation.Nullary.Reflects using (invert)
-open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Nullary.Decidable using (¬?)
+open import Relation.Unary as Unary using (Decidable; Pred)
+
 open Setoid using (Carrier)
 
 private
@@ -148,24 +147,24 @@ module _ (S : Setoid c ℓ) where
 
 module _ (S₁ : Setoid c₁ ℓ₁) (S₂ : Setoid c₂ ℓ₂) where
 
-  open Setoid S₁ renaming (Carrier to A₁; _≈_ to _≈₁_; refl to refl₁)
-  open Setoid S₂ renaming (Carrier to A₂; _≈_ to _≈₂_)
+  open Setoid S₁ renaming (_≈_ to _≈₁_)
+  open Setoid S₂ renaming (_≈_ to _≈₂_)
   private module M₁ = Membership S₁; open M₁ using (find) renaming (_∈_ to _∈₁_)
   private module M₂ = Membership S₂; open M₂ using () renaming (_∈_ to _∈₂_)
 
-  ∈-map⁺ : ∀ {f} → f Preserves _≈₁_ ⟶ _≈₂_ → ∀ {v xs} →
-            v ∈₁ xs → f v ∈₂ map f xs
+  ∈-map⁺ : ∀ {f} → f Preserves _≈₁_ ⟶ _≈₂_ →
+           ∀ {v xs} → v ∈₁ xs → f v ∈₂ map f xs
   ∈-map⁺ pres x∈xs = Any.map⁺ (Any.map pres x∈xs)
 
   ∈-map⁻ : ∀ {v xs f} → v ∈₂ map f xs →
            ∃ λ x → x ∈₁ xs × v ≈₂ f x
   ∈-map⁻ x∈map = find (Any.map⁻ x∈map)
 
-  map-∷= : ∀ {f} (f≈ : f Preserves _≈₁_ ⟶ _≈₂_)
-           {xs x v} → (x∈xs : x ∈₁ xs) →
-           map f (x∈xs M₁.∷= v) ≡ ∈-map⁺ f≈ x∈xs M₂.∷= f v
-  map-∷= f≈ (here x≈y)   = ≡.refl
-  map-∷= f≈ (there x∈xs) = ≡.cong (_ ∷_) (map-∷= f≈ x∈xs)
+  map-∷= : ∀ {f} (pres : f Preserves _≈₁_ ⟶ _≈₂_) →
+           ∀ {xs x v} → (x∈xs : x ∈₁ xs) →
+           map f (x∈xs M₁.∷= v) ≡ ∈-map⁺ pres x∈xs M₂.∷= f v
+  map-∷= pres (here x≈y)   = ≡.refl
+  map-∷= pres (there x∈xs) = ≡.cong (_ ∷_) (map-∷= pres x∈xs)
 
 ------------------------------------------------------------------------
 -- _++_
@@ -211,9 +210,9 @@ module _ (S : Setoid c ℓ) where
 
   ∈-∃++ : ∀ {v xs} → v ∈ xs → ∃₂ λ ys zs → ∃ λ w →
           v ≈ w × xs ≋ ys ++ [ w ] ++ zs
-  ∈-∃++ (here px)                  = [] , _ , _ , px , ≋-refl
-  ∈-∃++ (there {d} v∈xs) with ∈-∃++ v∈xs
-  ... | hs , _ , _ , v≈v′ , eq = d ∷ hs , _ , _ , v≈v′ , refl ∷ eq
+  ∈-∃++ (here px)        = [] , _ , _ , px , ≋-refl
+  ∈-∃++ (there {d} v∈xs) with hs , _ , _ , v≈v′ , eq ← ∈-∃++ v∈xs
+                         = d ∷ hs , _ , _ , v≈v′ , refl ∷ eq
 
 ------------------------------------------------------------------------
 -- concat
@@ -235,8 +234,8 @@ module _ (S : Setoid c ℓ) where
   ∈-concat⁺′ v∈vs = ∈-concat⁺ ∘ Any.map (flip (∈-resp-≋ S) v∈vs)
 
   ∈-concat⁻′ : ∀ {v} xss → v ∈ concat xss → ∃ λ xs → v ∈ xs × xs ∈ₗ xss
-  ∈-concat⁻′ xss v∈c[xss] with find (∈-concat⁻ xss v∈c[xss])
-  ... | xs , t , s = xs , s , t
+  ∈-concat⁻′ xss v∈c[xss]
+    with xs , xs∈xss , v∈xs ← find (∈-concat⁻ xss v∈c[xss]) = xs , v∈xs , xs∈xss
 
 ------------------------------------------------------------------------
 -- cartesianProductWith
@@ -375,9 +374,9 @@ module _ (S : Setoid c ℓ) where
 
   open Membership S using (_∈_)
 
-  ∈-length : ∀ {x xs} → x ∈ xs → 1 ≤ length xs
-  ∈-length (here px)    = s≤s z≤n
-  ∈-length (there x∈xs) = ≤-trans (∈-length x∈xs) (n≤1+n _)
+  ∈-length : ∀ {x xs} → x ∈ xs → 0 < length xs
+  ∈-length (here px)    = z<s
+  ∈-length (there x∈xs) = z<s
 
 ------------------------------------------------------------------------
 -- lookup

--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -8,9 +8,6 @@
 
 module Data.List.Relation.Unary.All where
 
-open import Effect.Applicative
-open import Effect.Monad
-open import Data.Empty using (⊥)
 open import Data.List.Base as List using (List; []; _∷_)
 open import Data.List.Relation.Unary.Any as Any using (Any; here; there)
 open import Data.List.Membership.Propositional renaming (_∈_ to _∈ₚ_; ∀∈ to ∀∈ₚ)
@@ -18,6 +15,8 @@ import Data.List.Membership.Setoid as SetoidMembership
 open import Data.Product.Base as Product
   using (∃; -,_; _×_; _,_; proj₁; proj₂; uncurry)
 open import Data.Sum.Base as Sum using (inj₁; inj₂)
+open import Effect.Applicative
+open import Effect.Monad
 open import Function.Base using (_∘_; _∘′_; id; const)
 open import Level using (Level; _⊔_)
 open import Relation.Nullary hiding (Irrelevant)

--- a/src/Data/List/Relation/Unary/Any.agda
+++ b/src/Data/List/Relation/Unary/Any.agda
@@ -8,7 +8,6 @@
 
 module Data.List.Relation.Unary.Any where
 
-open import Data.Empty
 open import Data.Fin.Base using (Fin; zero; suc)
 open import Data.List.Base as List using (List; []; [_]; _∷_; removeAt)
 open import Data.Product.Base as Product using (∃; _,_)
@@ -46,7 +45,7 @@ head ¬pxs (here px)   = px
 head ¬pxs (there pxs) = contradiction pxs ¬pxs
 
 tail : ¬ P x → Any P (x ∷ xs) → Any P xs
-tail ¬px (here  px)  = ⊥-elim (¬px px)
+tail ¬px (here  px)  = contradiction px ¬px
 tail ¬px (there pxs) = pxs
 
 map : P ⊆ Q → Any P ⊆ Any Q

--- a/src/Data/List/Relation/Unary/Any.agda
+++ b/src/Data/List/Relation/Unary/Any.agda
@@ -16,7 +16,7 @@ open import Level using (Level; _⊔_)
 open import Relation.Nullary using (¬_; yes; no; _⊎-dec_)
 import Relation.Nullary.Decidable as Dec
 open import Relation.Nullary.Negation using (contradiction)
-open import Relation.Unary hiding (_∈_)
+open import Relation.Unary using (Pred; _⊆_; Decidable; Satisfiable)
 
 private
   variable


### PR DESCRIPTION
By contrast with #2323 this adds to the `List.*` API, and extensively refactors proofs about `Membership` and `Any` in the light of the addition of two 'obviously missing' combinators.

Highlights of the refactoring:
* extensive debugging of `import` dependencies throughout
* revision of qualified imports in accordance with the new style guidelines #2280 
* revision of `with` usage in favour of 'irrefutable' style #2123 

The changes are mostly cosmetic, although there were some interesting pain points around eta-conversion (or lack of it!?), wrt strictness in (the structure of) values of dependent `Σ`-types. 