### PR TITLE
Fix standard-library.agda-lib

### DIFF
--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -1,5 +1,4 @@
-name: standard-library-tbt
+name: standard-library-2.1
 include: src
 flags:
   --warning=noUnsupportedIndexedMatch
---   --type-based-termination


### PR DESCRIPTION
I accidentially introduce a modification in `standard-library.agda-lib` which I revert here.