### PR TITLE
[refactor] Relation.Nulllary.Decidable.Core

### DIFF
--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -13,14 +13,14 @@ module Relation.Nullary.Decidable.Core where
 
 open import Level using (Level; Lift)
 open import Data.Bool.Base using (Bool; T; false; true; not; _∧_; _∨_)
-open import Data.Unit.Base using (⊤)
-open import Data.Empty using (⊥)
+open import Data.Unit.Polymorphic.Base using (⊤)
 open import Data.Empty.Irrelevant using (⊥-elim)
 open import Data.Product.Base using (_×_)
 open import Data.Sum.Base using (_⊎_)
 open import Function.Base using (_∘_; const; _$_; flip)
 open import Relation.Nullary.Reflects
 open import Relation.Nullary.Negation.Core
+  using (¬_; Stable; negated-stable; contradiction; DoubleNegation)
 
 private
   variable
@@ -58,11 +58,11 @@ module _ {A : Set a} where
 
   From-yes : Dec A → Set a
   From-yes (true  because _) = A
-  From-yes (false because _) = Lift a ⊤
+  From-yes (false because _) = ⊤
 
   From-no : Dec A → Set a
   From-no (false because _) = ¬ A
-  From-no (true  because _) = Lift a ⊤
+  From-no (true  because _) = ⊤
 
 ------------------------------------------------------------------------
 -- Recompute

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -171,7 +171,7 @@ proof (map′ A→B B→A (false because [¬a])) = ofⁿ (invert [¬a] ∘ B→A
 
 decidable-stable : Dec A → Stable A
 decidable-stable (yes a) ¬¬a = a
-decidable-stable (no ¬a) ¬¬a = ⊥-elim (¬¬a ¬a)
+decidable-stable (no ¬a) ¬¬a = contradiction ¬a ¬¬a
 
 ¬-drop-Dec : Dec (¬ ¬ A) → Dec (¬ A)
 ¬-drop-Dec ¬¬a? = map′ negated-stable contradiction (¬? ¬¬a?)


### PR DESCRIPTION
- Use `Data.Unit.Polymorphic` instead of an explicit `Lift` in a couple of places
- Use `contradiction` instead of explicit `⊥-elim` in one place (other can't because of irrelevance)
- Tighten imports a bit

No need for CHANGELOG as these are all internal changes with no external effects.