### PR TITLE
Another tweak to cong!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -426,5 +426,7 @@ Additions to existing modules
   WeaklyDecidable : Pred A ℓ → Set _
   ```
 
-* `Tactic.Cong` now provides a marker function, `⌞_⌟`, for user-guided
-  anti-unification. See README.Tactic.Cong for details.
+* Enhancements to `Tactic.Cong` - see `README.Tactic.Cong` for details.
+  - Provide a marker function, `⌞_⌟`, for user-guided anti-unification.
+  - Improved support for equalities between terms with instance arguments,
+    such as terms that contain `_/_` or `_%_`.

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -3,6 +3,7 @@
 module README.Tactic.Cong where
 
 open import Data.Nat
+open import Data.Nat.DivMod
 open import Data.Nat.Properties
 
 open import Relation.Binary.PropositionalEquality
@@ -160,4 +161,35 @@ module EquationalReasoningTests where
       suc (n + n)
     ≤⟨ n≤1+n _ ⟩
       suc (suc (n + n))
+    ∎
+
+module MetaTests where
+  test₁ : ∀ m n o → .⦃ _ : NonZero o ⦄ → (m + n) / o ≡ (n + m) / o
+  test₁ m n o =
+    let open ≤-Reasoning in
+    begin-equality
+      ⌞ m + n ⌟ / o
+     ≡⟨ cong! (+-comm m n) ⟩
+      (n + m) / o
+    ∎
+
+  test₂ : ∀ m n o p q r → .⦃ _ : NonZero o ⦄ → .⦃ _ : NonZero p ⦄ →
+          .⦃ _ : NonZero q ⦄ → p ≡ q ^ r → (m + n) % o % p ≡ (n + m) % o % p
+  test₂ m n o p q r eq =
+    let
+      open ≤-Reasoning
+      instance q^r≢0 = m^n≢0 q r
+    in
+    begin-equality
+      (m + n) % o % p
+     ≡⟨ %-congʳ eq ⟩
+      ⌞ m + n ⌟ % o % q ^ r
+     ≡⟨ cong! (+-comm m n) ⟩
+      ⌞ n + m ⌟ % o % q ^ r
+     ≡⟨ cong! (+-comm m n) ⟨
+      ⌞ m + n ⌟ % o % q ^ r
+     ≡⟨ cong! (+-comm m n) ⟩
+      (n + m) % o % q ^ r
+     ≡⟨ %-congʳ eq ⟨
+      (n + m) % o % p
     ∎

--- a/doc/README/Tactic/Cong.agda
+++ b/doc/README/Tactic/Cong.agda
@@ -164,6 +164,7 @@ module EquationalReasoningTests where
     ∎
 
 module MetaTests where
+
   test₁ : ∀ m n o → .⦃ _ : NonZero o ⦄ → (m + n) / o ≡ (n + m) / o
   test₁ m n o =
     let open ≤-Reasoning in

--- a/src/Reflection/TCM/Utilities.agda
+++ b/src/Reflection/TCM/Utilities.agda
@@ -1,0 +1,33 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Reflection utilities
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Reflection.TCM.Utilities where
+
+open import Data.List using (List; []; _∷_; _++_; map)
+open import Data.Unit using (⊤; tt)
+open import Effect.Applicative using (RawApplicative; mkRawApplicative)
+open import Function using (case_of_)
+open import Reflection.AST.Meta using (Meta)
+open import Reflection.AST.Term using (Term)
+open import Reflection.TCM using (TC; pure; blockTC; blockerAll; blockerMeta)
+
+import Reflection.AST.Traversal as Traversal
+
+blockOnMetas : Term → TC ⊤
+blockOnMetas t =
+  case traverseTerm actions (0 , []) t of λ where
+    []         → pure tt
+    xs@(_ ∷ _) → blockTC (blockerAll (map blockerMeta xs))
+  where
+  applicative : ∀ {ℓ} → RawApplicative {ℓ} (λ _ → List Meta)
+  applicative = mkRawApplicative (λ _ → List Meta) (λ _ → []) _++_
+
+  open Traversal applicative
+
+  actions : Actions
+  actions = record defaultActions { onMeta = λ _ x → x ∷ [] }

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -31,13 +31,12 @@ open import Function.Base using (_$_)
 open import Data.Bool.Base            using (true; false; if_then_else_; _∧_)
 open import Data.Char.Base   as Char  using (toℕ)
 open import Data.Float.Base  as Float using (_≡ᵇ_)
-open import Data.List.Base   as List  using (List; []; _∷_; _++_)
+open import Data.List.Base   as List  using ([]; _∷_)
 open import Data.Maybe.Base  as Maybe using (Maybe; just; nothing)
 open import Data.Nat.Base    as ℕ     using (ℕ; zero; suc; _≡ᵇ_; _+_)
-open import Data.Unit.Base            using (⊤; tt)
+open import Data.Unit.Base            using (⊤)
 open import Data.Word.Base   as Word  using (toℕ)
 open import Data.Product.Base         using (_×_; map₁; _,_)
-open import Effect.Applicative        using (RawApplicative; mkRawApplicative)
 open import Function                  using (flip; case_of_)
 
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; cong)
@@ -60,6 +59,7 @@ open import Reflection.AST.Term                 as Term
 import Reflection.AST.Traversal                 as Traversal
 
 open import Reflection.TCM.Syntax
+open import Reflection.TCM.Utilities
 
 -- Marker to keep anti-unification from descending into the wrapped
 -- subterm.
@@ -145,21 +145,6 @@ private
     `x ← quoteTC x
     `y ← quoteTC y
     pure $ def (quote cong) $ `a ⟅∷⟆ `A ⟅∷⟆ level ⟅∷⟆ type ⟅∷⟆ vLam "ϕ" f ⟨∷⟩ `x ⟅∷⟆ `y ⟅∷⟆ eq ⟨∷⟩ []
-
-  module _ where
-    private
-      applicative : ∀ {ℓ} → RawApplicative {ℓ} λ _ → List Meta
-      applicative = mkRawApplicative (λ _ → List Meta) (λ _ → []) _++_
-
-      open Traversal applicative
-
-      actions : Actions
-      actions = record defaultActions { onMeta = λ _ x → x ∷ [] }
-
-    blockOnMetas : Term → TC ⊤
-    blockOnMetas t with traverseTerm actions (0 , []) t
-    ... | []         = pure tt
-    ... | xs@(_ ∷ _) = blockTC (blockerAll (List.map blockerMeta xs))
 
 ------------------------------------------------------------------------
 -- Anti-Unification

--- a/src/Tactic/Cong.agda
+++ b/src/Tactic/Cong.agda
@@ -271,10 +271,10 @@ macro
       let term = makeTerm lhs rhs
       let symTerm = makeTerm rhs lhs
       let uni = _>>= flip unify hole
-      catchTC
-        -- When using ⌞_⌟ with ≡⟨ ... ⟨, (uni term) fails and
-        -- (uni symTerm) succeeds.
-        (catchTC (uni term) (uni symTerm)) $ do
+      -- When using ⌞_⌟ with ≡⟨ ... ⟨, (uni term) fails and
+      -- (uni symTerm) succeeds.
+      catchTC (uni term) $
+        catchTC (uni symTerm) $ do
           -- If we failed because of unresolved metas, restart.
           blockOnMetas goal
           -- If we failed for a different reason, show an error.


### PR DESCRIPTION
Hello there.

I do a lot of equational reasoning with `_/_` and `_%_`. This means `NonZero` instance arguments on both sides of my equalities. Sometimes, when `cong!` runs, the metas for the instance arguments are already resolved. But sometimes they aren't. Or one of them is, but the other isn't. It depends on how things fall into place during type-checking.

When there are such unresolved metas, `cong!` fails. For example, even an identical instance argument gets a different meta on the LHS vs. the RHS. So, anti-unification considers them a difference and places a phi. Same for an unresolved meta on one side and a resolved meta on the other.

The solution that I would like to propose is to wait for the meta variables to be resolved, before doing anti-unification. However, checking the goal for the existence of metas comes with a cost: the goal needs to be traversed, which impacts `cong!` performance.

This proposal thus only checks for metas once unification failed. The idea is to avoid burdening other people with the meta check, who might not use `_/_` and `_%_` as much as I do, and who thus might not have this problem.

In addition to the meta check, this proposal tries to make the error message issued by a failing `cong!` more meaningful to the user. `cong!` now tells them which term it tried, so that the user can troubleshoot the situation. Consider the following:
```
lemma : ∀ m n o → m + n + o ≡ n + m + o
lemma m n o = begin-equality
  m + n + o ≡⟨ cong! (+-comm m n) ⟩
  n + m + o ∎
  where open ≤-Reasoning
```
This now yields the following error:
```
cong! failed, tried:
cong (λ ϕ → ϕ + ϕ + o) (+-comm m n)
```
Previously the error was the following, which I've always found confusing:
```
m != m + n of type ℕ
```