### PR TITLE
Add proofs to Data.List.Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,8 @@ Additions to existing modules
   zip-unzip             : uncurry′ zip ∘ unzip ≗ id
   unzipWith-zipWith     : f ∘ uncurry′ g ≗ id → length xs ≡ length ys → unzipWith f (zipWith g xs ys) ≡ (xs , ys)
   unzip-zip             : length xs ≡ length ys → unzip (zip xs ys) ≡ (xs , ys)
+  mapMaybe-++           : mapMaybe f (xs ++ ys) ≡ mapMaybe f xs ++ mapMaybe f ys
+  unzipWith-++          : unzipWith f (xs ++ ys) ≡ zip _++_ _++_ (unzipWith f xs) (unzipWith f ys)
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,17 @@ Additions to existing modules
   reverse-upTo          : reverse (upTo n) ≡ downFrom n
   reverse-applyDownFrom : reverse (applyDownFrom f n) ≡ applyUpTo f n
   reverse-downFrom      : reverse (downFrom n) ≡ upTo n
+  mapMaybe-map          : mapMaybe f ∘ map g ≗ mapMaybe (f ∘ g)
+  map-mapMaybe          : map g ∘ mapMaybe f ≗ mapMaybe (Maybe.map g ∘ f)
+  align-map             : align (map f xs) (map g ys) ≡ map (map f g) (align xs ys)
+  zip-map               : zip (map f xs) (map g ys) ≡ map (map f g) (zip xs ys)
+  unzipWith-map         : unzipWith f ∘ map g ≗ unzipWith (f ∘ g)
+  map-unzipWith         : map (map g) (map h) ∘ unzipWith f ≗ unzipWith (map g h ∘ f)
+  unzip-map             : unzip ∘ map (map f g) ≗ map (map f) (map g) ∘ unzip
+  splitAt-map           : splitAt n ∘ map f ≗ map (map f) (map f) ∘ splitAt n
+  uncons-map            : uncons ∘ map f ≗ map (map f (map f)) ∘ uncons
+  last-map              : last ∘ map f ≗ map f ∘ last
+  tail-map              : tail ∘ map f ≗ map (map f) ∘ tail
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,8 @@ Additions to existing modules
   zip-flip              : zip xs ys ≡ map swap (zip ys xs)
   unzipWith-swap        : unzipWith (swap ∘ f) ≗ swap ∘ unzipWith f
   unzip-swap            : unzip ∘ map swap ≗ swap ∘ unzip
+  take-take             : take n (take m xs) ≡ take (n ⊓ m) xs
+  take-drop             : take n (drop m xs) ≡ drop m (take (m + n) xs)
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,7 +308,7 @@ Additions to existing modules
   take-take             : take n (take m xs) ≡ take (n ⊓ m) xs
   take-drop             : take n (drop m xs) ≡ drop m (take (m + n) xs)
   zip-unzip             : uncurry′ zip ∘ unzip ≗ id
-  unzipWith-zipWith     : length xs ≡ length ys → unzipWith f (zipWith g xs ys) ≡ (xs , ys)
+  unzipWith-zipWith     : f ∘ uncurry′ g ≗ id → length xs ≡ length ys → unzipWith f (zipWith g xs ys) ≡ (xs , ys)
   unzip-zip             : length xs ≡ length ys → unzip (zip xs ys) ≡ (xs , ys)
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,9 @@ Additions to existing modules
   unzip-zip             : length xs ≡ length ys → unzip (zip xs ys) ≡ (xs , ys)
   mapMaybe-++           : mapMaybe f (xs ++ ys) ≡ mapMaybe f xs ++ mapMaybe f ys
   unzipWith-++          : unzipWith f (xs ++ ys) ≡ zip _++_ _++_ (unzipWith f xs) (unzipWith f ys)
+  catMaybes-concatMap   : catMaybes ≗ concatMap fromMaybe
+  catMaybes-++          : catMaybes (xs ++ ys) ≡ catMaybes xs ++ catMaybes ys
+  map-catMaybes         : map f ∘ catMaybes ≗ catMaybes ∘ map (Maybe.map f)
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,7 +323,7 @@ Additions to existing modules
   mapMaybe-cong         : f ≗ g → mapMaybe f ≗ mapMaybe g
   zipWith-cong          : (∀ a b → f a b ≡ g a b) → ∀ as → zipWith f as ≗ zipWith g as
   unzipWith-cong        : f ≗ g → unzipWith f ≗ unzipWith g
-  foldl-cong            : (∀ x y → f x y ≡ g x y) → d ≡ e → foldl f d ≗ foldl g e
+  foldl-cong            : (∀ x y → f x y ≡ g x y) → ∀ x → foldl f x ≗ foldl g x
   alignWith-flip        : alignWith f xs ys ≡ alignWith (f ∘ swap) ys xs
   alignWith-comm        : f ∘ swap ≗ f → alignWith f xs ys ≡ alignWith f ys xs
   align-flip            : align xs ys ≡ map swap (align ys xs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,10 @@ Additions to existing modules
   uncons-map            : uncons ∘ map f ≗ map (map f (map f)) ∘ uncons
   last-map              : last ∘ map f ≗ map f ∘ last
   tail-map              : tail ∘ map f ≗ map (map f) ∘ tail
+  mapMaybe-cong         : f ≗ g → mapMaybe f ≗ mapMaybe g
+  zipWith-cong          : (∀ a b → f a b ≡ g a b) → ∀ as → zipWith f as ≗ zipWith g as
+  unzipWith-cong        : f ≗ g → unzipWith f ≗ unzipWith g
+  foldl-cong            : (∀ x y → f x y ≡ g x y) → d ≡ e → foldl f d ≗ foldl g e
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,9 @@ Additions to existing modules
   unzip-swap            : unzip ∘ map swap ≗ swap ∘ unzip
   take-take             : take n (take m xs) ≡ take (n ⊓ m) xs
   take-drop             : take n (drop m xs) ≡ drop m (take (m + n) xs)
+  zip-unzip             : uncurry′ zip ∘ unzip ≗ id
+  unzipWith-zipWith     : length xs ≡ length ys → unzipWith f (zipWith g xs ys) ≡ (xs , ys)
+  unzip-zip             : length xs ≡ length ys → unzip (zip xs ys) ≡ (xs , ys)
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,12 @@ Additions to existing modules
   zipWith-cong          : (∀ a b → f a b ≡ g a b) → ∀ as → zipWith f as ≗ zipWith g as
   unzipWith-cong        : f ≗ g → unzipWith f ≗ unzipWith g
   foldl-cong            : (∀ x y → f x y ≡ g x y) → d ≡ e → foldl f d ≗ foldl g e
+  alignWith-flip        : alignWith f xs ys ≡ alignWith (f ∘ swap) ys xs
+  alignWith-comm        : f ∘ swap ≗ f → alignWith f xs ys ≡ alignWith f ys xs
+  align-flip            : align xs ys ≡ map swap (align ys xs)
+  zip-flip              : zip xs ys ≡ map swap (zip ys xs)
+  unzipWith-swap        : unzipWith (swap ∘ f) ≗ swap ∘ unzipWith f
+  unzip-swap            : unzip ∘ map swap ≗ swap ∘ unzip
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Bug-fixes
 * Module `Data.List.Relation.Ternary.Appending.Setoid.Properties` no longer
   exports the `Setoid` module under the alias `S`.
 
+* Remove unbound parameter from `Data.List.Properties.length-alignWith`,
+  `alignWith-map` and `map-alignWith`.
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -154,6 +154,13 @@ module _ (f : A → Maybe B) where
   ... | just y  = s≤s ih
   ... | nothing = m≤n⇒m≤1+n ih
 
+  mapMaybe-++ : ∀ xs ys →
+                mapMaybe f (xs ++ ys) ≡ mapMaybe f xs ++ mapMaybe f ys
+  mapMaybe-++ []       ys = refl
+  mapMaybe-++ (x ∷ xs) ys with ih ← mapMaybe-++ xs ys | f x
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
 module _ (f : B → Maybe C) (g : A → B) where
 
   mapMaybe-map : mapMaybe f ∘ map g ≗ mapMaybe (f ∘ g)
@@ -564,6 +571,13 @@ module _ (f : A → B × C) where
   unzipWith-swap []       = refl
   unzipWith-swap (x ∷ xs) =
     cong (Product.zip _∷_ _∷_ _) (unzipWith-swap xs)
+
+  unzipWith-++ : ∀ xs ys →
+                 unzipWith f (xs ++ ys) ≡
+                 Product.zip _++_ _++_ (unzipWith f xs) (unzipWith f ys)
+  unzipWith-++ []       ys = refl
+  unzipWith-++ (x ∷ xs) ys =
+    cong (Product.zip _∷_ _∷_ (f x)) (unzipWith-++ xs ys)
 
 ------------------------------------------------------------------------
 -- unzip

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -122,6 +122,15 @@ map-injective finj {x ∷ xs} {y ∷ ys} eq =
 ------------------------------------------------------------------------
 -- mapMaybe
 
+module _ {f g : A → Maybe B} where
+
+  mapMaybe-cong : f ≗ g → mapMaybe f ≗ mapMaybe g
+  mapMaybe-cong f≗g [] = refl
+  mapMaybe-cong f≗g (x ∷ xs) rewrite f≗g x
+    with ih ← mapMaybe-cong f≗g xs | g x
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
 mapMaybe-just : (xs : List A) → mapMaybe just xs ≡ xs
 mapMaybe-just []       = refl
 mapMaybe-just (x ∷ xs) = cong (x ∷_) (mapMaybe-just xs)
@@ -346,6 +355,14 @@ align-map f g xs ys = trans
 ------------------------------------------------------------------------
 -- zipWith
 
+module _ {f g : A → B → C} where
+
+  zipWith-cong : (∀ a b → f a b ≡ g a b) → ∀ as → zipWith f as ≗ zipWith g as
+  zipWith-cong f≗g []         bs       = refl
+  zipWith-cong f≗g as@(_ ∷ _) []       = refl
+  zipWith-cong f≗g (a ∷ as)   (b ∷ bs) =
+    cong₂ _∷_ (f≗g a b) (zipWith-cong f≗g as bs)
+
 module _ (f : A → A → B) where
 
   zipWith-comm : (∀ x y → f x y ≡ f y x) →
@@ -457,6 +474,13 @@ module _ (f : C → These A B) where
 
 ------------------------------------------------------------------------
 -- unzipWith
+
+module _ {f g : A → B × C} where
+
+  unzipWith-cong : f ≗ g → unzipWith f ≗ unzipWith g
+  unzipWith-cong f≗g [] = refl
+  unzipWith-cong f≗g (x ∷ xs) =
+    cong₂ (Product.zip _∷_ _∷_) (f≗g x) (unzipWith-cong f≗g xs)
 
 module _ (f : A → B × C) where
 
@@ -584,6 +608,12 @@ module _ {P : Pred A p} {f : A → A → A} where
 
 ------------------------------------------------------------------------
 -- foldl
+
+foldl-cong : ∀ {f g : B → A → B} {d e : B} →
+             (∀ x y → f x y ≡ g x y) → d ≡ e →
+             foldl f d ≗ foldl g e
+foldl-cong f≗g refl []      = refl
+foldl-cong f≗g d≡e (x ∷ xs) rewrite d≡e = foldl-cong f≗g (f≗g _ x) xs
 
 foldl-++ : ∀ (f : A → B → A) x ys zs →
            foldl f x (ys ++ zs) ≡ foldl f (foldl f x ys) zs

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -369,12 +369,11 @@ align-map f g xs ys = trans
   (alignWith-map f g xs ys)
   (sym (map-alignWith (These.map f g) xs ys))
 
-module _ (xs : List A) (ys : List B) where
-
-  align-flip : align xs ys ≡ map These.swap (align ys xs)
-  align-flip = trans
-    (alignWith-flip xs ys)
-    (sym (map-alignWith These.swap ys xs))
+align-flip : ∀ (xs : List A) (ys : List B) →
+             align xs ys ≡ map These.swap (align ys xs)
+align-flip xs ys = trans
+  (alignWith-flip xs ys)
+  (sym (map-alignWith These.swap ys xs))
 
 ------------------------------------------------------------------------
 -- zipWith
@@ -446,12 +445,11 @@ zip-map f g xs ys = trans
   (zipWith-map _,_ f g xs ys)
   (sym (map-zipWith _,_ (Product.map f g) xs ys))
 
-module _ (xs : List A) (ys : List B) where
-
-  zip-flip : zip xs ys ≡ map Product.swap (zip ys xs)
-  zip-flip = trans
-    (zipWith-flip _,_ xs ys)
-    (sym (map-zipWith _,_ Product.swap ys xs))
+zip-flip : ∀ (xs : List A) (ys : List B) →
+           zip xs ys ≡ map Product.swap (zip ys xs)
+zip-flip xs ys = trans
+  (zipWith-flip _,_ xs ys)
+  (sym (map-zipWith _,_ Product.swap ys xs))
 
 ------------------------------------------------------------------------
 -- unalignWith

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -531,9 +531,17 @@ module _ (f : A → B × C) where
 
   zipWith-unzipWith : (g : B → C → A) → uncurry′ g ∘ f ≗ id →
                       uncurry′ (zipWith g) ∘ (unzipWith f)  ≗ id
-  zipWith-unzipWith g f∘g≗id []       = refl
-  zipWith-unzipWith g f∘g≗id (x ∷ xs) =
-    cong₂ _∷_ (f∘g≗id x) (zipWith-unzipWith g f∘g≗id xs)
+  zipWith-unzipWith g g∘f≗id []       = refl
+  zipWith-unzipWith g g∘f≗id (x ∷ xs) =
+    cong₂ _∷_ (g∘f≗id x) (zipWith-unzipWith g g∘f≗id xs)
+
+  unzipWith-zipWith : (g : B → C → A) → f ∘ uncurry′ g ≗ id →
+                      ∀ xs ys → length xs ≡ length ys →
+                      unzipWith f (zipWith g xs ys) ≡ (xs , ys)
+  unzipWith-zipWith g f∘g≗id []       []       l≡l = refl
+  unzipWith-zipWith g f∘g≗id (x ∷ xs) (y ∷ ys) l≡l  =
+    cong₂ (Product.zip _∷_ _∷_) (f∘g≗id (x , y))
+          (unzipWith-zipWith g f∘g≗id xs ys (suc-injective l≡l))
 
   unzipWith-map : (g : D → A) → unzipWith f ∘ map g ≗ unzipWith (f ∘ g)
   unzipWith-map g []       = refl
@@ -567,6 +575,13 @@ unzip-swap : unzip ∘ map Product.swap ≗ Product.swap ∘ unzip {A = A} {B = 
 unzip-swap xs = trans
   (unzipWith-map id Product.swap xs)
   (unzipWith-swap id xs)
+
+zip-unzip : uncurry′ zip ∘ unzip ≗ id {A = List (A × B)}
+zip-unzip = zipWith-unzipWith id _,_ λ _ → refl
+
+unzip-zip : ∀ (xs : List A) (ys : List B) →
+            length xs ≡ length ys → unzip (zip xs ys) ≡ (xs , ys)
+unzip-zip = unzipWith-zipWith id _,_ λ _ → refl
 
 ------------------------------------------------------------------------
 -- foldr

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -696,11 +696,10 @@ module _ {P : Pred A p} {f : A → A → A} where
 ------------------------------------------------------------------------
 -- foldl
 
-foldl-cong : ∀ {f g : B → A → B} {d e : B} →
-             (∀ x y → f x y ≡ g x y) → d ≡ e →
-             foldl f d ≗ foldl g e
-foldl-cong f≗g refl []      = refl
-foldl-cong f≗g d≡e (x ∷ xs) rewrite d≡e = foldl-cong f≗g (f≗g _ x) xs
+foldl-cong : ∀ {f g : B → A → B} → (∀ x y → f x y ≡ g x y) →
+             ∀ x → foldl f x ≗ foldl g x
+foldl-cong f≗g x []       = refl
+foldl-cong f≗g x (y ∷ xs) rewrite f≗g x y = foldl-cong f≗g _ xs
 
 foldl-++ : ∀ (f : A → B → A) x ys zs →
            foldl f x (ys ++ zs) ≡ foldl f (foldl f x ys) zs

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -355,9 +355,10 @@ module _ {f : These A A → B} where
 
   alignWith-comm : f ∘ These.swap ≗ f →
                  ∀ xs ys → alignWith f xs ys ≡ alignWith f ys xs
-  alignWith-comm f-comm xs ys = trans
-    (alignWith-flip xs ys)
-    (alignWith-cong f-comm ys xs)
+  alignWith-comm f-comm xs ys = begin
+    alignWith f xs ys                ≡⟨ alignWith-flip xs ys ⟩
+    alignWith (f ∘ These.swap) ys xs ≡⟨ alignWith-cong f-comm ys xs ⟩
+    alignWith f ys xs                ∎
 
 ------------------------------------------------------------------------
 -- align
@@ -365,15 +366,17 @@ module _ {f : These A A → B} where
 align-map : ∀ (f : A → B) (g : C → D) →
             ∀ xs ys → align (map f xs) (map g ys) ≡
                       map (These.map f g) (align xs ys)
-align-map f g xs ys = trans
-  (alignWith-map f g xs ys)
-  (sym (map-alignWith (These.map f g) xs ys))
+align-map f g xs ys = begin
+  align (map f xs) (map g ys)       ≡⟨ alignWith-map f g xs ys ⟩
+  alignWith (These.map f g) xs ys   ≡⟨ sym (map-alignWith (These.map f g) xs ys) ⟩
+  map (These.map f g) (align xs ys) ∎
 
 align-flip : ∀ (xs : List A) (ys : List B) →
              align xs ys ≡ map These.swap (align ys xs)
-align-flip xs ys = trans
-  (alignWith-flip xs ys)
-  (sym (map-alignWith These.swap ys xs))
+align-flip xs ys = begin
+  align xs ys                  ≡⟨ alignWith-flip xs ys ⟩
+  alignWith These.swap ys xs   ≡⟨ sym (map-alignWith These.swap ys xs) ⟩
+  map These.swap (align ys xs) ∎
 
 ------------------------------------------------------------------------
 -- zipWith
@@ -431,9 +434,10 @@ module _ (f : A → A → B) where
 
   zipWith-comm : (∀ x y → f x y ≡ f y x) →
                  ∀ xs ys → zipWith f xs ys ≡ zipWith f ys xs
-  zipWith-comm f-comm xs ys = trans
-    (zipWith-flip f xs ys)
-    (zipWith-cong (flip f-comm) ys xs)
+  zipWith-comm f-comm xs ys = begin
+    zipWith f xs ys        ≡⟨ zipWith-flip f xs ys ⟩
+    zipWith (flip f) ys xs ≡⟨ zipWith-cong (flip f-comm) ys xs ⟩
+    zipWith f ys xs        ∎
 
 ------------------------------------------------------------------------
 -- zip
@@ -441,15 +445,17 @@ module _ (f : A → A → B) where
 zip-map : ∀ (f : A → B) (g : C → D) →
           ∀ xs ys → zip (map f xs) (map g ys) ≡
                     map (Product.map f g) (zip xs ys)
-zip-map f g xs ys = trans
-  (zipWith-map _,_ f g xs ys)
-  (sym (map-zipWith _,_ (Product.map f g) xs ys))
+zip-map f g xs ys = begin
+  zip (map f xs) (map g ys)         ≡⟨ zipWith-map _,_ f g xs ys ⟩
+  zipWith (λ x y → f x , g y) xs ys ≡⟨ sym (map-zipWith _,_ (Product.map f g) xs ys) ⟩
+  map (Product.map f g) (zip xs ys) ∎
 
 zip-flip : ∀ (xs : List A) (ys : List B) →
            zip xs ys ≡ map Product.swap (zip ys xs)
-zip-flip xs ys = trans
-  (zipWith-flip _,_ xs ys)
-  (sym (map-zipWith _,_ Product.swap ys xs))
+zip-flip xs ys = begin
+  zip xs ys                    ≡⟨ zipWith-flip _,_ xs ys ⟩
+  zipWith (flip _,_) ys xs     ≡⟨ sym (map-zipWith _,_ Product.swap ys xs) ⟩
+  map Product.swap (zip ys xs) ∎
 
 ------------------------------------------------------------------------
 -- unalignWith
@@ -565,14 +571,16 @@ module _ (f : A → B × C) where
 unzip-map : ∀ (f : A → B) (g : C → D) →
             unzip ∘ map (Product.map f g) ≗
             Product.map (map f) (map g) ∘ unzip
-unzip-map f g xs = trans
-  (unzipWith-map id (Product.map f g) xs)
-  (sym (map-unzipWith id f g xs))
+unzip-map f g xs = begin
+  unzip (map (Product.map f g) xs)       ≡⟨ unzipWith-map id (Product.map f g) xs ⟩
+  unzipWith (Product.map f g) xs         ≡⟨ sym (map-unzipWith id f g xs) ⟩
+  Product.map (map f) (map g) (unzip xs) ∎
 
 unzip-swap : unzip ∘ map Product.swap ≗ Product.swap ∘ unzip {A = A} {B = B}
-unzip-swap xs = trans
-  (unzipWith-map id Product.swap xs)
-  (unzipWith-swap id xs)
+unzip-swap xs = begin
+  unzip (map Product.swap xs) ≡⟨ unzipWith-map id Product.swap xs ⟩
+  unzipWith Product.swap xs   ≡⟨ unzipWith-swap id xs ⟩
+  Product.swap (unzip xs)     ∎
 
 zip-unzip : uncurry′ zip ∘ unzip ≗ id {A = List (A × B)}
 zip-unzip = zipWith-unzipWith id _,_ λ _ → refl

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -146,65 +146,6 @@ module _ (f : A → B) where
   map-catMaybes (nothing ∷ xs) = map-catMaybes xs
 
 ------------------------------------------------------------------------
--- mapMaybe
-
-module _ {f g : A → Maybe B} where
-
-  mapMaybe-cong : f ≗ g → mapMaybe f ≗ mapMaybe g
-  mapMaybe-cong f≗g [] = refl
-  mapMaybe-cong f≗g (x ∷ xs) rewrite f≗g x
-    with ih ← mapMaybe-cong f≗g xs | g x
-  ... | just y  = cong (y ∷_) ih
-  ... | nothing = ih
-
-mapMaybe-just : (xs : List A) → mapMaybe just xs ≡ xs
-mapMaybe-just []       = refl
-mapMaybe-just (x ∷ xs) = cong (x ∷_) (mapMaybe-just xs)
-
-mapMaybe-nothing : (xs : List A) →
-                   mapMaybe {B = B} (λ _ → nothing) xs ≡ []
-mapMaybe-nothing []       = refl
-mapMaybe-nothing (x ∷ xs) = mapMaybe-nothing xs
-
-module _ (f : A → Maybe B) where
-
-  mapMaybe-concatMap : mapMaybe f ≗ concatMap (fromMaybe ∘ f)
-  mapMaybe-concatMap []       = refl
-  mapMaybe-concatMap (x ∷ xs) with ih ← mapMaybe-concatMap xs | f x
-  ... | just y  = cong (y ∷_) ih
-  ... | nothing = ih
-
-  length-mapMaybe : ∀ xs → length (mapMaybe f xs) ≤ length xs
-  length-mapMaybe xs = ≤-begin
-    length (mapMaybe f xs)      ≤⟨ length-catMaybes (map f xs) ⟩
-    length (map f xs)           ≤⟨ ≤-reflexive (length-map f xs) ⟩
-    length xs                   ≤-∎
-    where open ≤-Reasoning renaming (begin_ to ≤-begin_; _∎ to _≤-∎)
-
-  mapMaybe-++ : ∀ xs ys →
-                mapMaybe f (xs ++ ys) ≡ mapMaybe f xs ++ mapMaybe f ys
-  mapMaybe-++ []       ys = refl
-  mapMaybe-++ (x ∷ xs) ys with ih ← mapMaybe-++ xs ys | f x
-  ... | just y  = cong (y ∷_) ih
-  ... | nothing = ih
-
-module _ (f : B → Maybe C) (g : A → B) where
-
-  mapMaybe-map : mapMaybe f ∘ map g ≗ mapMaybe (f ∘ g)
-  mapMaybe-map []       = refl
-  mapMaybe-map (x ∷ xs) with ih ← mapMaybe-map xs | f (g x)
-  ... | just y  = cong (y ∷_) ih
-  ... | nothing = ih
-
-module _ (g : B → C) (f : A → Maybe B) where
-
-  map-mapMaybe : map g ∘ mapMaybe f ≗ mapMaybe (Maybe.map g ∘ f)
-  map-mapMaybe []       = refl
-  map-mapMaybe (x ∷ xs) with ih ← map-mapMaybe xs | f x
-  ... | just y  = cong (g y ∷_) ih
-  ... | nothing = ih
-
-------------------------------------------------------------------------
 -- _++_
 
 length-++ : ∀ (xs : List A) {ys} →
@@ -795,6 +736,65 @@ map-concatMap f g xs = begin
     ≡⟨⟩
   concatMap (map f ∘′ g) xs
     ∎
+
+------------------------------------------------------------------------
+-- mapMaybe
+
+module _ {f g : A → Maybe B} where
+
+  mapMaybe-cong : f ≗ g → mapMaybe f ≗ mapMaybe g
+  mapMaybe-cong f≗g [] = refl
+  mapMaybe-cong f≗g (x ∷ xs) rewrite f≗g x
+    with ih ← mapMaybe-cong f≗g xs | g x
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
+mapMaybe-just : (xs : List A) → mapMaybe just xs ≡ xs
+mapMaybe-just []       = refl
+mapMaybe-just (x ∷ xs) = cong (x ∷_) (mapMaybe-just xs)
+
+mapMaybe-nothing : (xs : List A) →
+                   mapMaybe {B = B} (λ _ → nothing) xs ≡ []
+mapMaybe-nothing []       = refl
+mapMaybe-nothing (x ∷ xs) = mapMaybe-nothing xs
+
+module _ (f : A → Maybe B) where
+
+  mapMaybe-concatMap : mapMaybe f ≗ concatMap (fromMaybe ∘ f)
+  mapMaybe-concatMap []       = refl
+  mapMaybe-concatMap (x ∷ xs) with ih ← mapMaybe-concatMap xs | f x
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
+  length-mapMaybe : ∀ xs → length (mapMaybe f xs) ≤ length xs
+  length-mapMaybe xs = ≤-begin
+    length (mapMaybe f xs)      ≤⟨ length-catMaybes (map f xs) ⟩
+    length (map f xs)           ≤⟨ ≤-reflexive (length-map f xs) ⟩
+    length xs                   ≤-∎
+    where open ≤-Reasoning renaming (begin_ to ≤-begin_; _∎ to _≤-∎)
+
+  mapMaybe-++ : ∀ xs ys →
+                mapMaybe f (xs ++ ys) ≡ mapMaybe f xs ++ mapMaybe f ys
+  mapMaybe-++ []       ys = refl
+  mapMaybe-++ (x ∷ xs) ys with ih ← mapMaybe-++ xs ys | f x
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
+module _ (f : B → Maybe C) (g : A → B) where
+
+  mapMaybe-map : mapMaybe f ∘ map g ≗ mapMaybe (f ∘ g)
+  mapMaybe-map []       = refl
+  mapMaybe-map (x ∷ xs) with ih ← mapMaybe-map xs | f (g x)
+  ... | just y  = cong (y ∷_) ih
+  ... | nothing = ih
+
+module _ (g : B → C) (f : A → Maybe B) where
+
+  map-mapMaybe : map g ∘ mapMaybe f ≗ mapMaybe (Maybe.map g ∘ f)
+  map-mapMaybe []       = refl
+  map-mapMaybe (x ∷ xs) with ih ← map-mapMaybe xs | f x
+  ... | just y  = cong (g y ∷_) ih
+  ... | nothing = ih
 
 ------------------------------------------------------------------------
 -- sum

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -956,6 +956,21 @@ take-[] : ∀ m → take {A = A} m [] ≡ []
 take-[] zero = refl
 take-[] (suc m) = refl
 
+-- Taking twice takes the minimum of both counts.
+take-take : ∀ n m (xs : List A) → take n (take m xs) ≡ take (n ⊓ m) xs
+take-take zero    m       xs       = refl
+take-take (suc n) zero    xs       = refl
+take-take (suc n) (suc m) []       = refl
+take-take (suc n) (suc m) (x ∷ xs) = cong (x ∷_) (take-take n m xs)
+
+-- Dropping m elements and then taking n is the same as
+-- taking n + m elements and then dropping m.
+take-drop : ∀ n m (xs : List A) →
+            take n (drop m xs) ≡ drop m (take (m + n) xs)
+take-drop n zero    xs       = refl
+take-drop n (suc m) []       = take-[] n
+take-drop n (suc m) (x ∷ xs) = take-drop n m xs
+
 ------------------------------------------------------------------------
 -- drop
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -120,6 +120,32 @@ map-injective finj {x ∷ xs} {y ∷ ys} eq =
   cong₂ _∷_ (finj fx≡fy) (map-injective finj fxs≡fys)
 
 ------------------------------------------------------------------------
+-- catMaybes
+
+catMaybes-concatMap : catMaybes {A = A} ≗ concatMap fromMaybe
+catMaybes-concatMap []             = refl
+catMaybes-concatMap (just x  ∷ xs) = cong (x ∷_) (catMaybes-concatMap xs)
+catMaybes-concatMap (nothing ∷ xs) = catMaybes-concatMap xs
+
+length-catMaybes : ∀ xs → length (catMaybes {A = A} xs) ≤ length xs
+length-catMaybes []             = ≤-refl
+length-catMaybes (just x  ∷ xs) = s≤s (length-catMaybes xs)
+length-catMaybes (nothing ∷ xs) = m≤n⇒m≤1+n (length-catMaybes xs)
+
+catMaybes-++ : (xs ys : List (Maybe A)) →
+               catMaybes (xs ++ ys) ≡ catMaybes xs ++ catMaybes ys
+catMaybes-++ []             ys = refl
+catMaybes-++ (just x  ∷ xs) ys = cong (x ∷_) (catMaybes-++ xs ys)
+catMaybes-++ (nothing ∷ xs) ys = catMaybes-++ xs ys
+
+module _ (f : A → B) where
+
+  map-catMaybes : map f ∘ catMaybes ≗ catMaybes ∘ map (Maybe.map f)
+  map-catMaybes []             = refl
+  map-catMaybes (just x  ∷ xs) = cong (f x ∷_) (map-catMaybes xs)
+  map-catMaybes (nothing ∷ xs) = map-catMaybes xs
+
+------------------------------------------------------------------------
 -- mapMaybe
 
 module _ {f g : A → Maybe B} where
@@ -130,11 +156,6 @@ module _ {f g : A → Maybe B} where
     with ih ← mapMaybe-cong f≗g xs | g x
   ... | just y  = cong (y ∷_) ih
   ... | nothing = ih
-
-length-catMaybes : ∀ xs → length (catMaybes {A = A} xs) ≤ length xs
-length-catMaybes []        = ≤-refl
-length-catMaybes (just x ∷ xs) = s≤s (length-catMaybes xs)
-length-catMaybes (nothing ∷ xs) = m≤n⇒m≤1+n (length-catMaybes xs)
 
 mapMaybe-just : (xs : List A) → mapMaybe just xs ≡ xs
 mapMaybe-just []       = refl

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -320,6 +320,8 @@ module _ {f g : These A B → C} where
   alignWith-cong f≗g (a ∷ as)   (b ∷ bs) =
     cong₂ _∷_ (f≗g (these a b)) (alignWith-cong f≗g as bs)
 
+module _ {f : These A B → C} where
+
   length-alignWith : ∀ xs ys →
                    length (alignWith f xs ys) ≡ length xs ⊔ length ys
   length-alignWith []         ys       = length-map (f ∘′ that) ys


### PR DESCRIPTION
Hi! This is my first PR, apologies if I'm missing something.

This adds a series of proofs to `Data.List.Properties` that I consider general enough to be in the stdlib, and in most cases already exist for other list operations. This proves, in order:

 - interaction with `map`, for list operations where it makes sense and was missing
 - congruence for higher order operations, where missing (except for those acting on `Decidable`s, which I am still working on, and `unsnoc` which is challenging because of the indexed datatype)
 - for `alignWith` / `align`, `zipWith` / `zip` and `unzipWith` / `unzip`:
   - effect of swapping function arguments / inputs
   - equivalence of swapping function arguments if function is commutative
 - interaction of `take` with itself and with `drop`
 - `unzipWith` + `zipWith` being inverses (with particular cases for the non-With versions)
 - interaction with `++`, for operations where it makes sense and was missing

It also fixes a `module` that was defining a parameter that was not used in the proofs.
I've tried to respect conventions of that file where possible, please tell me if there's anything that could be improved :)