### PR TITLE
Improve `Data.List.Base.mapMaybe` (#2359; deprecate use of `with` #2123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,7 @@ Additions to existing modules
 
 * In `Data.List.Properties`:
   ```agda
+  length-catMaybes      : length (catMaybes xs) ≤ length xs
   applyUpTo-∷ʳ          : applyUpTo f n ∷ʳ f n ≡ applyUpTo f (suc n)
   applyDownFrom-∷ʳ      : applyDownFrom (f ∘ suc) n ∷ʳ f 0 ≡ applyDownFrom f (suc n)
   upTo-∷ʳ               : upTo n ∷ʳ n ≡ upTo (suc n)

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -49,6 +49,14 @@ map : (A → B) → List A → List B
 map f []       = []
 map f (x ∷ xs) = f x ∷ map f xs
 
+catMaybes′ : List (Maybe A) → List A
+catMaybes′ []             = []
+catMaybes′ (nothing ∷ xs) = catMaybes′ xs
+catMaybes′ (just x  ∷ xs) = x ∷ catMaybes′ xs
+
+mapMaybe′ : (A → Maybe B) → List A → List B
+mapMaybe′ p = catMaybes′ ∘ map p
+
 mapMaybe : (A → Maybe B) → List A → List B
 mapMaybe p []       = []
 mapMaybe p (x ∷ xs) with p x


### PR DESCRIPTION
Initial commits do side-by-side comparison of new with old.
Also: misc. tidying up. 
If we're happy with the new versions not being a breaking change, then I'll remove the old definitions/proofs.