### PR TITLE
Improve `Data.List.Base.unfold` (#2359; deprecate use of `with` #2123)

### DIFF
--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -253,12 +253,8 @@ unfold : ∀ (P : ℕ → Set b)
          (f : ∀ {n} → P (suc n) → Maybe (A × P n)) →
          ∀ {n} → P n → List A
 unfold P f {n = zero}  s = []
-unfold P f {n = suc n} s = maybe′ {!λ (x , s′) → x ∷ unfold P f s′!} [] (f s)
-{-
-with f s
-... | nothing       = []
-... | just (x , s′) = x ∷ unfold P f s′
--}
+unfold P f {n = suc n} s = maybe′ (λ (x , s′) → x ∷ unfold P f s′) [] (f s)
+
 ------------------------------------------------------------------------
 -- Operations for reversing lists
 

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -253,10 +253,12 @@ unfold : ∀ (P : ℕ → Set b)
          (f : ∀ {n} → P (suc n) → Maybe (A × P n)) →
          ∀ {n} → P n → List A
 unfold P f {n = zero}  s = []
-unfold P f {n = suc n} s with f s
+unfold P f {n = suc n} s = maybe′ {!λ (x , s′) → x ∷ unfold P f s′!} [] (f s)
+{-
+with f s
 ... | nothing       = []
 ... | just (x , s′) = x ∷ unfold P f s′
-
+-}
 ------------------------------------------------------------------------
 -- Operations for reversing lists
 


### PR DESCRIPTION
NB There are *no* lemmas about this in `Data.List.Properties`!?