### PR TITLE
fixes #2411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,8 +498,8 @@ Additions to existing modules
 
 * In `Data.List.Base` redefine `inits` and `tails` in terms of:
   ```agda
-  initsTail : List A → List (List A)
-  tailsTail : List A → List (List A)
+  Inits.tail : List A → List (List A)
+  Tails.tail : List A → List (List A)
   ```
 
 * In `Data.List.Membership.Propositional.Properties.Core`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,8 +498,8 @@ Additions to existing modules
 
 * In `Data.List.Base` redefine `inits` and `tails` in terms of:
   ```agda
-  tail∘inits : List A → List (List A)
-  tail∘tails : List A → List (List A)
+  initsTail : List A → List (List A)
+  tailsTail : List A → List (List A)
   ```
 
 * In `Data.List.Membership.Propositional.Properties.Core`:

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -189,19 +189,19 @@ iterate : (A → A) → A → ℕ → List A
 iterate f e zero    = []
 iterate f e (suc n) = e ∷ iterate f (f e) n
 
-tail∘inits : List A → List (List A)
-tail∘inits []       = []
-tail∘inits (x ∷ xs) = [ x ] ∷ map (x ∷_) (tail∘inits xs)
+initsTail : List A → List (List A)
+initsTail []       = []
+initsTail (x ∷ xs) = [ x ] ∷ map (x ∷_) (initsTail xs)
 
 inits : List A → List (List A)
-inits xs = [] ∷ tail∘inits xs
+inits xs = [] ∷ initsTail xs
 
-tail∘tails : List A → List (List A)
-tail∘tails []       = []
-tail∘tails (_ ∷ xs) = xs ∷ tail∘tails xs
+tailsTail : List A → List (List A)
+tailsTail []       = []
+tailsTail (_ ∷ xs) = xs ∷ tailsTail xs
 
 tails : List A → List (List A)
-tails xs = xs ∷ tail∘tails xs
+tails xs = xs ∷ tailsTail xs
 
 insertAt : (xs : List A) → Fin (suc (length xs)) → A → List A
 insertAt xs       zero    v = v ∷ xs

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -189,19 +189,19 @@ iterate : (A → A) → A → ℕ → List A
 iterate f e zero    = []
 iterate f e (suc n) = e ∷ iterate f (f e) n
 
-initsTail : List A → List (List A)
-initsTail []       = []
-initsTail (x ∷ xs) = [ x ] ∷ map (x ∷_) (initsTail xs)
-
 inits : List A → List (List A)
-inits xs = [] ∷ initsTail xs
-
-tailsTail : List A → List (List A)
-tailsTail []       = []
-tailsTail (_ ∷ xs) = xs ∷ tailsTail xs
+inits {A = A} = λ xs → [] ∷ tail xs
+  module Inits where
+    tail : List A → List (List A)
+    tail []       = []
+    tail (x ∷ xs) = [ x ] ∷ map (x ∷_) (tail xs)
 
 tails : List A → List (List A)
-tails xs = xs ∷ tailsTail xs
+tails {A = A} = λ xs → xs ∷ tail xs
+  module Tails where
+    tail : List A → List (List A)
+    tail []       = []
+    tail (_ ∷ xs) = xs ∷ tail xs
 
 insertAt : (xs : List A) → Fin (suc (length xs)) → A → List A
 insertAt xs       zero    v = v ∷ xs

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -146,12 +146,12 @@ ap fs as = concatMap (λ f → map f as) fs
 -- Inits
 
 inits : List A → List⁺ (List A)
-inits xs = [] ∷ List.tail∘inits xs
+inits xs = [] ∷ List.initsTail xs
 
 -- Tails
 
 tails : List A → List⁺ (List A)
-tails xs = xs ∷ List.tail∘tails xs
+tails xs = xs ∷ List.tailsTail xs
 
 -- Reverse
 

--- a/src/Data/List/NonEmpty/Base.agda
+++ b/src/Data/List/NonEmpty/Base.agda
@@ -146,12 +146,12 @@ ap fs as = concatMap (λ f → map f as) fs
 -- Inits
 
 inits : List A → List⁺ (List A)
-inits xs = [] ∷ List.initsTail xs
+inits xs = [] ∷ List.Inits.tail xs
 
 -- Tails
 
 tails : List A → List⁺ (List A)
-tails xs = xs ∷ List.tailsTail xs
+tails xs = xs ∷ List.Tails.tail xs
 
 -- Reverse
 


### PR DESCRIPTION
NB. I haven't tried doing this with local named module defining an auxiliary function cf. #2411 because the scoping of such modules means that I end up having to write:
```agda
inits : List A → List (List A)
inits {A = A} = ([] ∷_) ∘ tail
  module Inits where
    tail : List A → List (List A)
    tail []       = []
    tail (x ∷ xs) = [ x ] ∷ map (x ∷_) (tail xs)

tails : List A → List (List A)
tails {A = A} = λ (xs : List A) → xs ∷ tail xs
  module Tails where
    tail : List A → List (List A)
    tail []       = []
    tail (_ ∷ xs) = xs ∷ tail xs
```
which isn't obviously more readable/intelligible because of the artificiality of introducing an explicit `λ ...` on the RHS?

UPDATED: have gone with (a cleaned-up version of) this style now!