### PR TITLE
Run CI tests on release branches as well

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - experimental
+      - 'v*-branch'
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
       - experimental
-      - 'v*-branch'
+      - 'v*-release'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
So I can test for the release of v2.1.1 for compatibility with Agda 2.7.0