### PR TITLE
Added AVL.Map suggestion, explanation of MkValue args.

### DIFF
--- a/doc/README/Data/Tree/AVL.agda
+++ b/doc/README/Data/Tree/AVL.agda
@@ -28,20 +28,20 @@ open import Relation.Binary.PropositionalEquality
 open Data.Tree.AVL <-strictTotalOrder renaming (Tree to Tree′)
 Tree = Tree′ (MkValue (Vec String) (subst (Vec String)))
 
--- The first argument to MkValue should be a function from a key
--- (a ℕ in this case) to a value type (a String vector type).
--- [Since (Vec String) is missing Vec's second parameter, a ℕ,
--- it's the required kind of function.]
+-- The first argument to `MkValue` should be a function from a key
+-- (a `ℕ` in this case) to a value type (a `String` vector type).
+-- Since `(Vec String)` is missing `Vec`'s second parameter, a `ℕ`,
+-- it's equivalent to `λ n → Vec String n`.
 
--- The second argument to MkValue is a function that can accept
+-- The second argument to `MkValue` is a function that can accept
 -- a proof that two keys are equal, and then substitute a unique key
---  for an equivalent key that is passed in.  Applying subst to the
--- key-to-value-type function passed as MkValue's first argument is
+-- for an equivalent key that is passed in.  Applying `subst` to the
+-- key-to-value-type function passed as `MkValue`'s first argument is
 -- a normal way to create such a function.
 
 -- Note that there is no need to define the type of keys separately:
--- Passing a key-to-value-type function to MkValue and providing
--- the result of MkValue to Data.Tree.AVL.Tree is enough.
+-- passing a key-to-value-type function to `MkValue` and providing
+-- the result of `MkValue` to `Data.Tree.AVL.Tree` is enough.
 
 ------------------------------------------------------------------------
 -- Construction of trees

--- a/doc/README/Data/Tree/AVL.agda
+++ b/doc/README/Data/Tree/AVL.agda
@@ -39,6 +39,10 @@ Tree = Tree′ (MkValue (Vec String) (subst (Vec String)))
 -- key-to-value-type function passed as MkValue's first argument is
 -- a normal way to create such a function.
 
+-- Note that there is no need to define the type of keys separately:
+-- Passing a key-to-value-type function to MkValue and providing
+-- the result of MkValue to Data.Tree.AVL.Tree is enough.
+
 ------------------------------------------------------------------------
 -- Construction of trees
 

--- a/doc/README/Data/Tree/AVL.agda
+++ b/doc/README/Data/Tree/AVL.agda
@@ -28,6 +28,17 @@ open import Relation.Binary.PropositionalEquality
 open Data.Tree.AVL <-strictTotalOrder renaming (Tree to Tree′)
 Tree = Tree′ (MkValue (Vec String) (subst (Vec String)))
 
+-- The first argument to MkValue should be a function from a key
+-- (a ℕ in this case) to a value type (a String vector type).
+-- [Since (Vec String) is missing Vec's second parameter, a ℕ,
+-- it's the required kind of function.]
+
+-- The second argument to MkValue is a function that can accept
+-- a proof that two keys are equal, and then substitute a unique key
+--  for an equivalent key that is passed in.  Applying subst to the
+-- key-to-value-type function passed as MkValue's first argument is
+-- a normal way to create such a function.
+
 ------------------------------------------------------------------------
 -- Construction of trees
 
@@ -126,6 +137,10 @@ v₉ = refl
 -- Further reading
 
 -- Variations of the AVL tree module are available:
+
+-- • Finite maps in which types of values don't depend on keys.
+
+import Data.Tree.AVL.Map
 
 -- • Finite maps with indexed keys and values.
 


### PR DESCRIPTION
I had trouble understanding `MkValue` in the example `Tree` definition.  The proposed addition after the `Tree` definition briefly summarize what I learned (for future readers with ignorance like mine), without going into what I thought might be unnecessary detail.

I also added a suggestion and note about `Data.Tree.AVL.Map` in the "Further reading" section at the end.  I feel that `AVL.Map` satisfies the simplest use cases for the `Data.Tree.AVL`, so it's worth mentioning here.

(Sorry about the two commits with the same message.  I think I did something wrong when I tried to rebase them into one commit.  If it bothers anyone, I'll figure out how to fix it.)