### PR TITLE
Make `_<″_`/`_≤″_` inversions more lazy

### DIFF
--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -435,7 +435,7 @@ pattern <″-offset k = k , refl
 "Warning: <″-offset was deprecated in v2.1. Please match directly on proofs of ≤″ using pattern (_, refl) from Algebra.Definitions.RawMagma._∣ˡ_ instead. "
 #-}
 
--- Smart destructors of _<″_
+-- Smart destructor of _≤″_
 
 s≤″s⁻¹ : ∀ {m n} → suc m ≤″ suc n → m ≤″ n
 s≤″s⁻¹ (k , eq) = k , cong pred eq

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -18,7 +18,7 @@ open import Data.Parity.Base using (Parity; 0ℙ; 1ℙ)
 open import Level using (0ℓ)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; _≢_; refl)
+  using (_≡_; _≢_; refl; cong)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Unary using (Pred)
 
@@ -375,7 +375,7 @@ m >″ n = n <″ m
 -- Smart destructor of _<″_
 
 s<″s⁻¹ : ∀ {m n} → suc m <″ suc n → m <″ n
-s<″s⁻¹ (k , refl) = k , refl
+s<″s⁻¹ (k , eq) = k , cong pred eq
 
 -- _≤‴_: this definition is useful for induction with an upper bound.
 
@@ -438,7 +438,7 @@ pattern <″-offset k = k , refl
 -- Smart destructors of _<″_
 
 s≤″s⁻¹ : ∀ {m n} → suc m ≤″ suc n → m ≤″ n
-s≤″s⁻¹ (k , refl) = k , refl
+s≤″s⁻¹ (k , eq) = k , cong pred eq
 {-# WARNING_ON_USAGE s≤″s⁻¹
 "Warning: s≤″s⁻¹ was deprecated in v2.1. Please match directly on proofs of ≤″ using pattern (_, refl) from Algebra.Definitions.RawMagma._∣ˡ_ instead. "
 #-}

--- a/src/Data/Nat/Base.agda
+++ b/src/Data/Nat/Base.agda
@@ -440,5 +440,5 @@ pattern <″-offset k = k , refl
 s≤″s⁻¹ : ∀ {m n} → suc m ≤″ suc n → m ≤″ n
 s≤″s⁻¹ (k , eq) = k , cong pred eq
 {-# WARNING_ON_USAGE s≤″s⁻¹
-"Warning: s≤″s⁻¹ was deprecated in v2.1. Please match directly on proofs of ≤″ using pattern (_, refl) from Algebra.Definitions.RawMagma._∣ˡ_ instead. "
+"Warning: s≤″s⁻¹ was deprecated in v2.1. Please match directly on proofs of ≤″ using constructor Algebra.Definitions.RawMagma._∣ˡ_._,_ instead. "
 #-}


### PR DESCRIPTION
Extracted from the discussion on [this Zulip thread](https://agda.zulipchat.com/#narrow/stream/259644-newcomers/topic/What.20is.20going.20on.20with.20this.20proof.20normalization.20performance.3F)

NB:
* no `CHANGELOG`: only a potential performance improvement
* should become redundant if we manage to deprecate these relations entirely