### PR TITLE
Reconciles `Data.Vec.Relation.Binary.Equality.DecPropositional` with `List`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,8 @@ New modules
 
 Additions to existing modules
 -----------------------------
+
+* In `Data.Vec.Relation.Binary.Equality.DecPropositional`:
+  ```agda
+  _≡?_ : DecidableEquality (Vec A n)
+  ```

--- a/src/Data/Vec/Relation/Binary/Equality/DecPropositional.agda
+++ b/src/Data/Vec/Relation/Binary/Equality/DecPropositional.agda
@@ -11,6 +11,8 @@ open import Relation.Binary.Definitions using (DecidableEquality)
 module Data.Vec.Relation.Binary.Equality.DecPropositional
   {a} {A : Set a} (_≟_ : DecidableEquality A) where
 
+open import Data.Vec.Base using (Vec)
+open import Data.Vec.Properties using (≡-dec)
 import Data.Vec.Relation.Binary.Equality.Propositional as PEq
 import Data.Vec.Relation.Binary.Equality.DecSetoid as DSEq
 open import Relation.Binary.PropositionalEquality.Properties using (decSetoid)
@@ -22,3 +24,11 @@ open import Relation.Binary.PropositionalEquality.Properties using (decSetoid)
 open PEq public
 open DSEq (decSetoid _≟_) public
   using (_≋?_; ≋-isDecEquivalence; ≋-decSetoid)
+
+------------------------------------------------------------------------
+-- Additional proofs
+
+infix 4 _≡?_
+
+_≡?_ : ∀ {n} → DecidableEquality (Vec A n)
+_≡?_ = ≡-dec _≟_


### PR DESCRIPTION
Adds an 'obvious' missing property to make the API uniform with that for `Data.List.Relation.Binary.Equality.DecPropositional`.

NB.
* It seems as though these are each of these lemmas are redundant recodings of `Data.{List|Vec}.Properties.≡-dec`, so an alternative PR would be to *remove* the version for `List` instead of adding the one for `Vec`.
* On balance, I think the addition is preferable?