### PR TITLE
Proof that `pred` is right adjoint to `suc` on `ℕ._≤_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,8 @@ Additions to existing modules
 
 * New lemmas in `Data.Nat.Properties`: adjunction between `suc` and `pred`
   ```agda
-  sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
-  m≤pn⇒sm≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
+  suc[m]≤n⇒m≤pred[n] : suc m ≤ n → m ≤ pred n
+  m≤pred[n]⇒suc[m]≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
   ```
 
 * New lemma in `Data.Vec.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ New modules
 Additions to existing modules
 -----------------------------
 
+* New lemma in `Data.Nat.Properties`:
+  ```agda
+  sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
+  ```
+
 * New lemma in `Data.Vec.Properties`:
   ```agda
   map-concat : map f (concat xss) ≡ concat (map (map f) xss)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,10 @@ New modules
 Additions to existing modules
 -----------------------------
 
-* New lemma in `Data.Nat.Properties`:
+* New lemmas in `Data.Nat.Properties`: adjunction between `suc` and `pred`
   ```agda
   sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
+  m≤pn⇒sm≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
   ```
 
 * New lemma in `Data.Vec.Properties`:

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -272,8 +272,11 @@ _≥?_ = flip _≤?_
 s≤s-injective : {p q : m ≤ n} → s≤s p ≡ s≤s q → p ≡ q
 s≤s-injective refl = refl
 
+sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
+sm≤n⇒m≤pn {n = suc _} = s≤s⁻¹
+
 ≤-pred : suc m ≤ suc n → m ≤ n
-≤-pred = s≤s⁻¹
+≤-pred = sm≤n⇒m≤pn
 
 m≤n⇒m≤1+n : m ≤ n → m ≤ 1 + n
 m≤n⇒m≤1+n z≤n       = z≤n

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -272,14 +272,14 @@ _≥?_ = flip _≤?_
 s≤s-injective : {p q : m ≤ n} → s≤s p ≡ s≤s q → p ≡ q
 s≤s-injective refl = refl
 
-sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
-sm≤n⇒m≤pn {n = suc _} = s≤s⁻¹
+suc[m]≤n⇒m≤pred[n] : suc m ≤ n → m ≤ pred n
+suc[m]≤n⇒m≤pred[n] {n = suc _} = s≤s⁻¹
 
-m≤pn⇒sm≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
-m≤pn⇒sm≤n {n = suc _} = s≤s
+m≤pred[n]⇒suc[m]≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
+m≤pred[n]⇒suc[m]≤n {n = suc _} = s≤s
 
 ≤-pred : suc m ≤ suc n → m ≤ n
-≤-pred = sm≤n⇒m≤pn
+≤-pred = suc[m]≤n⇒m≤pred[n]
 
 m≤n⇒m≤1+n : m ≤ n → m ≤ 1 + n
 m≤n⇒m≤1+n z≤n       = z≤n

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -275,6 +275,9 @@ s≤s-injective refl = refl
 sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
 sm≤n⇒m≤pn {n = suc _} = s≤s⁻¹
 
+m≤pn⇒sm≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
+m≤pn⇒sm≤n {n = suc _} = {!s≤s!}
+
 ≤-pred : suc m ≤ suc n → m ≤ n
 ≤-pred = sm≤n⇒m≤pn
 

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -276,7 +276,7 @@ sm≤n⇒m≤pn : suc m ≤ n → m ≤ pred n
 sm≤n⇒m≤pn {n = suc _} = s≤s⁻¹
 
 m≤pn⇒sm≤n : .{{NonZero n}} → m ≤ pred n → suc m ≤ n
-m≤pn⇒sm≤n {n = suc _} = {!s≤s!}
+m≤pn⇒sm≤n {n = suc _} = s≤s
 
 ≤-pred : suc m ≤ suc n → m ≤ n
 ≤-pred = sm≤n⇒m≤pn


### PR DESCRIPTION
I'm reluctant to add yet more to `Data.Nat.Properties`, but these lemmas seemed missing, and offered a sweet-spot in an application I've been working on, and as a by-product the left-to-right direction permits a possibly useful refactoring of `≤-pred`.