### PR TITLE
Typo in `Data.List.Relation.Unary.All`

### DIFF
--- a/src/Data/List/Relation/Unary/All.agda
+++ b/src/Data/List/Relation/Unary/All.agda
@@ -115,7 +115,7 @@ zip = zipWith id
 unzip : All (P ∩ Q) ⊆ All P ∩ All Q
 unzip = unzipWith id
 
-module _(S : Setoid a ℓ) {P : Pred (Setoid.Carrier S) p} where
+module _ (S : Setoid a ℓ) {P : Pred (Setoid.Carrier S) p} where
   open Setoid S renaming (refl to ≈-refl)
   open SetoidMembership S
 


### PR DESCRIPTION
Fixes #2467

No `CHANGELOG`.

Applies to `master` as well as to `v2.1.1`.