### PR TITLE
CI: use v2-install for happy

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -32,7 +32,7 @@ on:
 ## To be experimented with again in the future to see if things have
 ## gotten better.
 ##
-## We use `v1-install` rather than `install` as Agda as a community
+## We mostly use `v1-install` rather than `install` as Agda as a community
 ## hasn't figured out how to manage dependencies with the new local
 ## style builds (see agda/agda#4627 for details). Once this is resolved
 ## we should upgrade to `install`.
@@ -50,8 +50,8 @@ on:
 env:
   GHC_VERSION: 9.8.2
   CABAL_VERSION: 3.10.3.0
-  CABAL_INSTALL: cabal v1-install --ghc-options='-O1 +RTS -M6G -RTS'
-  # CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
+  CABAL_V1_INSTALL: cabal v1-install --ghc-options='-O1 +RTS -M6G -RTS'
+  CABAL_INSTALL: cabal install --overwrite-policy=always --ghc-options='-O1 +RTS -M6G -RTS'
   AGDA: agda -Werror +RTS -M5G -H3.5G -A128M -RTS -i. -isrc -idoc
 
 jobs:
@@ -121,13 +121,15 @@ jobs:
           cabal-update: true
 
       - name: Put cabal programs in PATH
-        run: echo "~/.cabal/bin" >> "${GITHUB_PATH}"
+        run: echo ~/.cabal/bin >> "${GITHUB_PATH}"
 
       - name: Install alex & happy
         if: steps.cache-cabal.outputs.cache-hit != 'true'
         run: |
           ${{ env.CABAL_INSTALL }} alex
           ${{ env.CABAL_INSTALL }} happy
+          # happy>=2.0 cannot be v1-installed: https://github.com/haskell/happy/issues/315
+          # Since we only need the executable, it is fine to use v2-install here.
 
       - name: Download and install Agda from github
         if: steps.cache-cabal.outputs.cache-hit != 'true'
@@ -137,7 +139,7 @@ jobs:
           git checkout ${{ env.AGDA_COMMIT }}
           mkdir -p doc
           touch doc/user-manual.pdf
-          ${{ env.CABAL_INSTALL }}
+          ${{ env.CABAL_V1_INSTALL }}
           cd ..
 
 ########################################################################
@@ -167,7 +169,7 @@ jobs:
 
       - name: Golden testing
         run: |
-          ${{ env.CABAL_INSTALL }} clock
+          ${{ env.CABAL_V1_INSTALL }} clock
           make testsuite INTERACTIVE='' AGDA_EXEC='~/.cabal/bin/agda'
 
 


### PR DESCRIPTION
`cabal v1-install happy` does not work any longer:
https://github.com/haskell/happy/issues/315
