### PR TITLE
[DRY] refactor #2479

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,11 +59,6 @@ Deprecated names
   normalise-correct  ↦  Algebra.Solver.Monoid.Normal.correct
   ```
 
-* In `Data.List.Membership.Propositional.Properties`:
-  ```agda
-  map∷-decomp  ↦  map∷⁻
-  ```
-
 * In `Data.Vec.Properties`:
   ```agda
   ++-assoc _      ↦  ++-assoc-eqFree

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ Deprecated names
   normalise-correct  ↦  Algebra.Solver.Monoid.Normal.correct
   ```
 
+* In `Data.List.Membership.Propositional.Properties`:
+  ```agda
+  map∷-decomp  ↦  map∷⁻
+  ```
+
 * In `Data.Vec.Properties`:
   ```agda
   ++-assoc _      ↦  ++-assoc-eqFree
@@ -146,8 +151,8 @@ Additions to existing modules
   ∈-concatMap⁻   : y ∈ concatMap f xs → Any ((y ∈_) ∘ f) xs
   ++-∈⇔          : v ∈ xs ++ ys ⇔ (v ∈ xs ⊎ v ∈ ys)
   []∉map∷        : [] ∉ map (x ∷_) xss
+  map∷⁻          : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × xs ≡ y ∷ ys
   map∷-decomp∈   : (x ∷ xs) ∈ map (y ∷_) xss → x ≡ y × xs ∈ xss
-  map∷-decomp    : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × y ∷ ys ≡ xs
   ∈-map∷⁻        : xs ∈ map (x ∷_) xss → x ∈ xs
   ∉[]            : x ∉ []
   deduplicate-∈⇔ : z ∈ xs ⇔ z ∈ deduplicate _≈?_ xs

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -465,19 +465,3 @@ map∷-decomp∈ p with _ , xs∈xss , refl ← map∷⁻ p = refl , xs∈xss
 
 ∈-map∷⁻ : xs ∈ map (x ∷_) xss → x ∈ xs
 ∈-map∷⁻ p with _ , _ , refl ← map∷⁻ p = here refl
-
-
-------------------------------------------------------------------------
--- DEPRECATED NAMES
-------------------------------------------------------------------------
--- Please use the new names as continuing support for the old names is
--- not guaranteed.
-
--- Version 2.2
-
-map∷-decomp : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × y ∷ ys ≡ xs
-map∷-decomp p = let ys , ys∈xss , eq = map∷⁻ p in ys , ys∈xss , sym eq
-{-# WARNING_ON_USAGE map∷-decomp
-"Warning: map∷-decomp was deprecated in v2.2.
-Please use map∷⁻ instead."
-#-}

--- a/src/Data/List/Membership/Propositional/Properties.agda
+++ b/src/Data/List/Membership/Propositional/Properties.agda
@@ -454,22 +454,30 @@ module _ {R : A → A → Set ℓ} where
 ------------------------------------------------------------------------
 -- nested lists
 
+map∷⁻ : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × xs ≡ y ∷ ys
+map∷⁻ = ∈-map⁻ (_ ∷_)
+
 []∉map∷ : (List A ∋ []) ∉ map (x ∷_) xss
-[]∉map∷ {xss = _ ∷ _} (there p) = []∉map∷ p
+[]∉map∷ p with () ← map∷⁻ p
 
 map∷-decomp∈ : (List A ∋ x ∷ xs) ∈ map (y ∷_) xss → x ≡ y × xs ∈ xss
-map∷-decomp∈ {xss = _ ∷ _} = λ where
-  (here refl) → refl , here refl
-  (there p)   → map₂ there $ map∷-decomp∈ p
-
-map∷-decomp : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × y ∷ ys ≡ xs
-map∷-decomp               {xss = _  ∷ _} (here refl) = -, here refl , refl
-map∷-decomp {xs = []}     {xss = _  ∷ _} (there xs∈) = contradiction xs∈ []∉map∷
-map∷-decomp {xs = x ∷ xs} {xss = _  ∷ _} (there xs∈) =
-  let eq , p = map∷-decomp∈ xs∈
-  in -, there p , cong (_∷ _) (sym eq)
+map∷-decomp∈ p with _ , xs∈xss , refl ← map∷⁻ p = refl , xs∈xss
 
 ∈-map∷⁻ : xs ∈ map (x ∷_) xss → x ∈ xs
-∈-map∷⁻ {xss = _ ∷ _} = λ where
-  (here refl) → here refl
-  (there p)   → ∈-map∷⁻ p
+∈-map∷⁻ p with _ , _ , refl ← map∷⁻ p = here refl
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.2
+
+map∷-decomp : xs ∈ map (y ∷_) xss → ∃[ ys ] ys ∈ xss × y ∷ ys ≡ xs
+map∷-decomp p = let ys , ys∈xss , eq = map∷⁻ p in ys , ys∈xss , sym eq
+{-# WARNING_ON_USAGE map∷-decomp
+"Warning: map∷-decomp was deprecated in v2.2.
+Please use map∷⁻ instead."
+#-}


### PR DESCRIPTION
This refactors the (very!) recent additions to `Data.List.Membership.Propositional.Properties` for nested lists in favour of delegation to existing functionality.

NB:
* I should have seen this during my review of #2479 , but ... l'esprit de l'escalier, I guess ;-)
* the deprecation of `map∷-decomp` is possibly redundant/excessive, given how recently introduced was that name/definition
* the newly introduced replacement name/definition `map∷⁻` is likewise arguably redundant, in favour of inlining its definition, but useful perhaps for its type which enforces the `variable = complex` refinement of our existing heuristic for writing library rewrite lemmas in the form `complex = simpler`
* I have only done a back-of-the-envelope analysis to conjecture that the refactored definitions have the same computational behaviour esp. wrt strict-/lazi-ness as the originals, but separate confirmation might be welcome!

I'd be happy either way if this were merged or not, but it struck me as a useful reminder to be careful (and: more careful than I had been) about reviewing contributions against possible DRY violations.