### PR TITLE
[DRY] Refactor `Data.List.Relation.Binary.Equality.Setoid` exports

### DIFF
--- a/src/Data/List/Relation/Binary/Equality/DecSetoid.agda
+++ b/src/Data/List/Relation/Binary/Equality/DecSetoid.agda
@@ -7,33 +7,24 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 open import Relation.Binary.Bundles using (DecSetoid)
-open import Relation.Binary.Structures using (IsDecEquivalence)
-open import Relation.Binary.Definitions using (Decidable)
 
 module Data.List.Relation.Binary.Equality.DecSetoid
   {a ℓ} (DS : DecSetoid a ℓ) where
 
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
-import Data.List.Relation.Binary.Pointwise as PW
-open import Level
-open import Relation.Binary.Definitions using (Decidable)
-open DecSetoid DS
+open import Data.List.Relation.Binary.Pointwise using (decSetoid)
+
+------------------------------------------------------------------------
+-- Additional properties
+
+≋-decSetoid : DecSetoid _ _
+≋-decSetoid = decSetoid DS
+
+open DecSetoid ≋-decSetoid public
+  using (setoid)
+  renaming (isDecEquivalence to ≋-isDecEquivalence; _≟_ to _≋?_)
 
 ------------------------------------------------------------------------
 -- Make all definitions from setoid equality available
 
 open SetoidEquality setoid public
-
-------------------------------------------------------------------------
--- Additional properties
-
-infix 4 _≋?_
-
-_≋?_ : Decidable _≋_
-_≋?_ = PW.decidable _≟_
-
-≋-isDecEquivalence : IsDecEquivalence _≋_
-≋-isDecEquivalence = PW.isDecEquivalence isDecEquivalence
-
-≋-decSetoid : DecSetoid a (a ⊔ ℓ)
-≋-decSetoid = PW.decSetoid DS

--- a/src/Data/List/Relation/Binary/Equality/DecSetoid.agda
+++ b/src/Data/List/Relation/Binary/Equality/DecSetoid.agda
@@ -13,6 +13,7 @@ module Data.List.Relation.Binary.Equality.DecSetoid
 
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
 open import Data.List.Relation.Binary.Pointwise using (decSetoid)
+open DecSetoid DS using (setoid)
 
 ------------------------------------------------------------------------
 -- Additional properties
@@ -21,7 +22,7 @@ open import Data.List.Relation.Binary.Pointwise using (decSetoid)
 ≋-decSetoid = decSetoid DS
 
 open DecSetoid ≋-decSetoid public
-  using (setoid)
+  using ()
   renaming (isDecEquivalence to ≋-isDecEquivalence; _≟_ to _≋?_)
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Binary/Equality/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Equality/Setoid.agda
@@ -48,23 +48,16 @@ open PW public
 -- Relational properties
 ------------------------------------------------------------------------
 
-≋-refl : Reflexive _≋_
-≋-refl = PW.refl refl
-
-≋-reflexive : _≡_ ⇒ _≋_
-≋-reflexive ≡.refl = ≋-refl
-
-≋-sym : Symmetric _≋_
-≋-sym = PW.symmetric sym
-
-≋-trans : Transitive _≋_
-≋-trans = PW.transitive trans
-
-≋-isEquivalence : IsEquivalence _≋_
-≋-isEquivalence = PW.isEquivalence isEquivalence
-
 ≋-setoid : Setoid _ _
 ≋-setoid = PW.setoid S
+
+open Setoid ≋-setoid public
+  using ()
+  renaming ( refl to ≋-refl
+           ; reflexive to ≋-reflexive
+           ; sym to ≋-sym
+           ; trans to ≋-trans
+           ; isEquivalence to ≋-isEquivalence)
 
 ------------------------------------------------------------------------
 -- Relationships to predicates

--- a/src/Data/List/Relation/Binary/Subset/DecSetoid.agda
+++ b/src/Data/List/Relation/Binary/Subset/DecSetoid.agda
@@ -14,10 +14,10 @@ open import Function.Base using (_∘_)
 open import Data.List.Base using ([]; _∷_)
 open import Data.List.Relation.Unary.Any using (here; there; map)
 open import Relation.Binary.Definitions using (Decidable)
-open import Relation.Nullary using (yes; no)
-open DecSetoid S
-open import Data.List.Relation.Binary.Equality.DecSetoid S
-open import Data.List.Membership.DecSetoid S
+open import Relation.Nullary.Decidable.Core using (yes; no)
+
+open DecSetoid S using (setoid; refl; trans)
+open import Data.List.Membership.DecSetoid S using (_∈?_)
 
 -- Re-export definitions
 open import Data.List.Relation.Binary.Subset.Setoid setoid public


### PR DESCRIPTION
Addresses the two examples of the general issue #2391 , but leaving that open for further downstream instances to be tackled.

NB.:
* no `CHANGELOG` required, as a 'pure' refactoring