### PR TITLE
Fix type for ≡-syntax in heterogeneous equality

### DIFF
--- a/src/Relation/Binary/HeterogeneousEquality.agda
+++ b/src/Relation/Binary/HeterogeneousEquality.agda
@@ -240,16 +240,16 @@ module ≅-Reasoning where
   start : ∀ {x : A} {y : B} → x IsRelatedTo y → x ≅ y
   start (relTo x≅y) = x≅y
 
-  ≡-go : ∀ {A : Set a} → Trans {A = A} {C = A} _≡_ _IsRelatedTo_ _IsRelatedTo_
+  ≡-go : ∀ {A : Set ℓ} {B : Set ℓ} → Trans {A = A} {C = B} _≡_ _IsRelatedTo_ _IsRelatedTo_
   ≡-go x≡y (relTo y≅z) = relTo (trans (reflexive x≡y) y≅z)
 
   -- Combinators with one heterogeneous relation
   module _ {A : Set ℓ} {B : Set ℓ} where
     open begin-syntax (_IsRelatedTo_ {A = A} {B}) start public
+    open ≡-syntax (_IsRelatedTo_ {A = A} {B}) ≡-go public
 
   -- Combinators with homogeneous relations
   module _ {A : Set ℓ} where
-    open ≡-syntax (_IsRelatedTo_ {A = A}) ≡-go public
     open end-syntax (_IsRelatedTo_ {A = A}) (relTo refl) public
 
   -- Can't create syntax in the standard `Syntax` module for


### PR DESCRIPTION
The original definition forces LHS and RHS of the result type to be the same. I do not find any reason for this restriction, and it prevents writing the following code (which I believe is intention of `≡-syntax` operators):
```agda
example = begin
  some expression        ≡⟨⟩
  some other expression  ≡⟨⟩
  ...
```
where `some expression` and `some other expression` are definitionally equal.

I have verified locally that the modified code type-checks with Agda 2.7.0.1.