### PR TITLE
add `¬First⇒All` lemma to `Data.List.Relation.Unary.First.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,6 +415,6 @@ Additions to existing modules
 
 * In `Data.List.Relation.Unary.First.Properties`:
   ```agda
-  ¬First⇒All : ∁ Q ⊆ P → ∀ xs → ∁ (First P Q) xs → All P xs
+  ¬First⇒All : ∁ Q ⊆ P → ∁ (First P Q) ⊆ All P
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -412,3 +412,9 @@ Additions to existing modules
   does-≐ : P ≐ Q → (P? : Decidable P) → (Q? : Decidable Q) → does ∘ P? ≗ does ∘ Q?
   does-≡ : (P? P?′ : Decidable P) → does ∘ P? ≗ does ∘ P?′
   ```
+
+* In `Data.List.Relation.Unary.First.Properties`:
+  ```agda
+  ¬First⇒All : ∁ Q ⊆ P → ∀ xs → ∁ (First P Q) xs → All P xs
+  ```
+

--- a/src/Data/List/Relation/Unary/First/Properties.agda
+++ b/src/Data/List/Relation/Unary/First/Properties.agda
@@ -59,6 +59,12 @@ module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
   First⇒¬All q⇒¬p [ qx ]     (px ∷ pxs) = q⇒¬p qx px
   First⇒¬All q⇒¬p (_ ∷ pqxs) (_ ∷ pxs)  = First⇒¬All q⇒¬p pqxs pxs
 
+  ¬First⇒All : ∁ Q ⊆ P → ∀ xs → ∁ (First P Q) xs → All P xs
+  ¬First⇒All ¬q⇒p []       _      = []
+  ¬First⇒All ¬q⇒p (x ∷ xs) ¬pqxxs =
+    let px = ¬q⇒p (¬pqxxs ∘ [_]) in
+    px ∷ ¬First⇒All ¬q⇒p xs (¬pqxxs ∘ (px ∷_))
+
 ------------------------------------------------------------------------
 -- Irrelevance
 

--- a/src/Data/List/Relation/Unary/First/Properties.agda
+++ b/src/Data/List/Relation/Unary/First/Properties.agda
@@ -59,11 +59,11 @@ module _ {a p q} {A : Set a} {P : Pred A p} {Q : Pred A q} where
   First⇒¬All q⇒¬p [ qx ]     (px ∷ pxs) = q⇒¬p qx px
   First⇒¬All q⇒¬p (_ ∷ pqxs) (_ ∷ pxs)  = First⇒¬All q⇒¬p pqxs pxs
 
-  ¬First⇒All : ∁ Q ⊆ P → ∀ xs → ∁ (First P Q) xs → All P xs
-  ¬First⇒All ¬q⇒p []       _      = []
-  ¬First⇒All ¬q⇒p (x ∷ xs) ¬pqxxs =
+  ¬First⇒All : ∁ Q ⊆ P → ∁ (First P Q) ⊆ All P
+  ¬First⇒All ¬q⇒p {[]}     _      = []
+  ¬First⇒All ¬q⇒p {x ∷ xs} ¬pqxxs =
     let px = ¬q⇒p (¬pqxxs ∘ [_]) in
-    px ∷ ¬First⇒All ¬q⇒p xs (¬pqxxs ∘ (px ∷_))
+    px ∷ ¬First⇒All ¬q⇒p (¬pqxxs ∘ (px ∷_))
 
 ------------------------------------------------------------------------
 -- Irrelevance


### PR DESCRIPTION
This PR adds a `¬Any⇒All¬` counterpart for `First`:
```agda
¬First⇒All : ∁ Q ⊆ P → ∀ xs → ∁ (First P Q) xs → All P xs

-- cf.
-- In Data.List.Relation.Unary.All.Properties.Core
¬Any⇒All¬ : ∀ xs → ¬ Any P xs → All (¬_ ∘ P) xs
```

Issues
- Should `xs` be an explicit argument or implicit?
  - Explicit for consistency with `¬Any⇒All¬` for now
- Is`∁ (First P Q) xs` preferable over `¬ First P Q xs`?
