### PR TITLE
[ add ] lemma relating `Propositional` and `Setoid` versions of `Sublist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,11 @@ Additions to existing modules
                                             ([] , [])
   ```
 
+* In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
+  ```agda
+  ⊆⇒⊆~ : IsEquivalence ≈  → ∀ {as bs} → as ⊆ bs → Setoid._⊆_ setoid≈ as bs
+  ```
+
 * In `Data.List.Relation.Unary.Any.Properties`:
   ```agda
   concatMap⁺ : Any (Any P ∘ f) xs → Any P (concatMap f xs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,9 +192,9 @@ Additions to existing modules
                                             ([] , [])
   ```
 
-* In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
+* In `Data.List.Relation.Binary.Sublist.Setoid.Properties`:
   ```agda
-  ⊆⇒⊆~ : IsEquivalence ≈  → ∀ {as bs} → as ⊆ bs → Setoid._⊆_ setoid≈ as bs
+  ⊆ₚ⇒⊆ : as PropositionalSublist.⊆ bs → as ⊆ bs
   ```
 
 * In `Data.List.Relation.Unary.Any.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -322,11 +322,6 @@ Additions to existing modules
   ⊆⇒⊆ₛ : (S : Setoid a ℓ) → as ⊆ bs → as (SetoidSublist.⊆ S) bs
   ```
 
-* In `Data.List.Relation.Binary.Sublist.Setoid.Properties`:
-  ```agda
-  ⊆ₚ⇒⊆ : as PropositionalSublist.⊆ bs → as ⊆ bs
-  ```
-
 * In `Data.List.Relation.Unary.All.Properties`:
   ```agda
   all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,11 @@ Additions to existing modules
                                             ([] , [])
   ```
 
+* In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
+  ```agda
+  ⊆⇒⊆ₛ : (S : Setoid a ℓ) → as ⊆ bs → as (SetoidSublist.⊆ S) bs
+  ```
+
 * In `Data.List.Relation.Binary.Sublist.Setoid.Properties`:
   ```agda
   ⊆ₚ⇒⊆ : as PropositionalSublist.⊆ bs → as ⊆ bs

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -10,7 +10,6 @@ module Data.List.Relation.Binary.Sublist.Propositional.Properties
   {a} {A : Set a} where
 
 open import Data.List.Base using (List; []; _∷_;  map)
-open import Data.List.Properties using (map-id)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -10,6 +10,7 @@ module Data.List.Relation.Binary.Sublist.Propositional.Properties
   {a} {A : Set a} where
 
 open import Data.List.Base using (List; []; _∷_;  map)
+open import Data.List.Properties using (map-id)
 open import Data.List.Membership.Propositional using (_∈_)
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
@@ -17,16 +18,21 @@ open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
 open import Data.List.Relation.Binary.Sublist.Propositional
   hiding (map)
+import Data.List.Relation.Binary.Sublist.Setoid
+  as Setoid
 import Data.List.Relation.Binary.Sublist.Setoid.Properties
   as SetoidProperties
 open import Data.Product.Base using (∃; _,_; proj₂)
 open import Function.Base using (id; _∘_; _∘′_)
 open import Level using (Level)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Definitions using (_Respects_)
 open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; cong; _≗_; trans)
 open import Relation.Binary.PropositionalEquality.Properties
   using (setoid; subst-injective; trans-reflʳ; trans-assoc)
+open import Relation.Binary.Structures using (IsEquivalence)
+open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Unary using (Pred)
 
 private
@@ -42,6 +48,20 @@ open SetoidProperties (setoid A) public
 
 map⁺ : ∀ {as bs} (f : A → B) → as ⊆ bs → map f as ⊆ map f bs
 map⁺ {B = B} f = SetoidProperties.map⁺ (setoid A) (setoid B) (cong f)
+
+module _ {≈ : Rel A ℓ} (isEquivalence : IsEquivalence ≈) where
+
+  private
+    setoid≈ : Setoid _ _
+    setoid≈ = record { isEquivalence = isEquivalence }
+
+  open IsEquivalence isEquivalence using (reflexive)
+
+  ⊆⇒⊆~ : ∀ {as bs} → as ⊆ bs → Setoid._⊆_ setoid≈ as bs
+  ⊆⇒⊆~ {as} {bs} as⊆bs
+    with p ← SetoidProperties.map⁺ (setoid A) setoid≈ reflexive as⊆bs
+    rewrite map-id as | map-id bs
+    = p
 
 ------------------------------------------------------------------------
 -- Category laws for _⊆_

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -51,11 +51,11 @@ module _ {A : Set a} where
 
 module _ (S : Setoid a ℓ) where
 
-  open Setoid S using (Carrier; reflexive)
+  open Setoid S using (reflexive)
   open SetoidSublist S using () renaming (_⊆_ to _⊆ₛ_)
 
   ⊆⇒⊆ₛ : ∀ {as bs} → as ⊆ bs → as ⊆ₛ bs
-  ⊆⇒⊆ₛ = SetoidSublist.map (setoid Carrier) reflexive
+  ⊆⇒⊆ₛ = SetoidSublist.map (setoid _) reflexive
 
 ------------------------------------------------------------------------
 -- Functoriality of map

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -49,20 +49,6 @@ open SetoidProperties (setoid A) public
 map⁺ : ∀ {as bs} (f : A → B) → as ⊆ bs → map f as ⊆ map f bs
 map⁺ {B = B} f = SetoidProperties.map⁺ (setoid A) (setoid B) (cong f)
 
-module _ {≈ : Rel A ℓ} (isEquivalence : IsEquivalence ≈) where
-
-  private
-    setoid≈ : Setoid _ _
-    setoid≈ = record { isEquivalence = isEquivalence }
-
-  open IsEquivalence isEquivalence using (reflexive)
-
-  ⊆⇒⊆~ : ∀ {as bs} → as ⊆ bs → Setoid._⊆_ setoid≈ as bs
-  ⊆⇒⊆~ {as} {bs} as⊆bs
-    with p ← SetoidProperties.map⁺ (setoid A) setoid≈ reflexive as⊆bs
-    rewrite map-id as | map-id bs
-    = p
-
 ------------------------------------------------------------------------
 -- Category laws for _⊆_
 

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -18,21 +18,16 @@ open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
 open import Data.List.Relation.Binary.Sublist.Propositional
   hiding (map)
-import Data.List.Relation.Binary.Sublist.Setoid
-  as Setoid
 import Data.List.Relation.Binary.Sublist.Setoid.Properties
   as SetoidProperties
 open import Data.Product.Base using (∃; _,_; proj₂)
 open import Function.Base using (id; _∘_; _∘′_)
 open import Level using (Level)
-open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Definitions using (_Respects_)
 open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; cong; _≗_; trans)
 open import Relation.Binary.PropositionalEquality.Properties
   using (setoid; subst-injective; trans-reflʳ; trans-assoc)
-open import Relation.Binary.Structures using (IsEquivalence)
-open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Unary using (Pred)
 
 private

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -51,7 +51,7 @@ module _ {A : Set a} where
 
 module _ (S : Setoid a ℓ) where
 
-  open Setoid S using (Carrier; _≈_; reflexive)
+  open Setoid S using (Carrier; reflexive)
   open SetoidSublist S using () renaming (_⊆_ to _⊆ₛ_)
 
   ⊆⇒⊆ₛ : ∀ {as bs} → as ⊆ bs → as ⊆ₛ bs

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -16,11 +16,14 @@ open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
 open import Data.List.Relation.Binary.Sublist.Propositional
   hiding (map)
+import Data.List.Relation.Binary.Sublist.Setoid
+  as SetoidSublist
 import Data.List.Relation.Binary.Sublist.Setoid.Properties
   as SetoidProperties
 open import Data.Product.Base using (∃; _,_; proj₂)
 open import Function.Base using (id; _∘_; _∘′_)
 open import Level using (Level)
+open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Definitions using (_Respects_)
 open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; cong; _≗_; trans)
@@ -39,8 +42,23 @@ private
 -- Re-exporting setoid properties
 
 module _ {A : Set a} where
-  open SetoidProperties  (setoid A) public
+  open SetoidProperties (setoid A) public
     hiding (map⁺; ⊆-trans-idˡ; ⊆-trans-idʳ; ⊆-trans-assoc)
+
+------------------------------------------------------------------------
+-- Relationship between _⊆_ and Setoid._⊆_
+------------------------------------------------------------------------
+
+module _ (S : Setoid a ℓ) where
+
+  open Setoid S using (Carrier; _≈_; reflexive)
+  open SetoidSublist S using () renaming (_⊆_ to _⊆ₛ_)
+
+  ⊆⇒⊆ₛ : ∀ {as bs} → as ⊆ bs → as ⊆ₛ bs
+  ⊆⇒⊆ₛ = SetoidSublist.map (setoid Carrier) reflexive
+
+------------------------------------------------------------------------
+-- Functoriality of map
 
 map⁺ : (f : A → B) → xs ⊆ ys → map f xs ⊆ map f ys
 map⁺ f = SetoidProperties.map⁺ (setoid _) (setoid _) (cong f)

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -30,7 +30,6 @@ open import Relation.Nullary.Negation using (¬_)
 open import Relation.Nullary.Decidable using (¬?; yes; no)
 
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
-import Data.List.Relation.Binary.Sublist.Propositional as PropositionalSublist
 import Data.List.Relation.Binary.Sublist.Setoid as SetoidSublist
 import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeteroProperties
@@ -67,13 +66,6 @@ module _ where
 
   ∷ʳ-injective : ∀ {pxs qxs : xs ⊆ ys} → y ∷ʳ pxs ≡ y ∷ʳ qxs → pxs ≡ qxs
   ∷ʳ-injective refl = refl
-
-------------------------------------------------------------------------
--- Relationship between Propositional._⊆_ and _⊆_
-------------------------------------------------------------------------
-
-⊆ₚ⇒⊆ : as PropositionalSublist.⊆ bs → as ⊆ bs
-⊆ₚ⇒⊆ = SetoidSublist.map (setoid _) reflexive
 
 ------------------------------------------------------------------------
 -- Categorical properties

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -23,7 +23,6 @@ open import Function.Bundles using (_⇔_; _⤖_)
 open import Level
 open import Relation.Binary.Definitions using () renaming (Decidable to Decidable₂)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_; refl; cong; cong₂)
-open import Relation.Binary.PropositionalEquality.Properties as ≡ using (setoid)
 open import Relation.Binary.Structures using (IsDecTotalOrder)
 open import Relation.Unary using (Pred; Decidable; Universal; Irrelevant)
 open import Relation.Nullary.Negation using (¬_)
@@ -35,7 +34,7 @@ import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeteroProperties
 import Data.List.Membership.Setoid as SetoidMembership
 
-open Setoid S using (_≈_; trans; reflexive) renaming (Carrier to A; refl to ≈-refl)
+open Setoid S using (_≈_; trans) renaming (Carrier to A; refl to ≈-refl)
 open SetoidEquality S using (_≋_; ≋-refl)
 open SetoidSublist S hiding (map)
 open SetoidMembership S using (_∈_)

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -72,7 +72,7 @@ module _ where
 -- Relationship between Propositional._⊆_ and _⊆_
 ------------------------------------------------------------------------
 
-⊆ₚ⇒⊆ : ∀ {as bs} → as PropositionalSublist.⊆ bs → as ⊆ bs
+⊆ₚ⇒⊆ : as PropositionalSublist.⊆ bs → as ⊆ bs
 ⊆ₚ⇒⊆ = SetoidSublist.map (setoid _) reflexive
 
 ------------------------------------------------------------------------

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -23,18 +23,20 @@ open import Function.Bundles using (_⇔_; _⤖_)
 open import Level
 open import Relation.Binary.Definitions using () renaming (Decidable to Decidable₂)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_; refl; cong; cong₂)
+open import Relation.Binary.PropositionalEquality.Properties as ≡ using (setoid)
 open import Relation.Binary.Structures using (IsDecTotalOrder)
 open import Relation.Unary using (Pred; Decidable; Universal; Irrelevant)
 open import Relation.Nullary.Negation using (¬_)
 open import Relation.Nullary.Decidable using (¬?; yes; no)
 
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
+import Data.List.Relation.Binary.Sublist.Propositional as PropositionalSublist
 import Data.List.Relation.Binary.Sublist.Setoid as SetoidSublist
 import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeteroProperties
 import Data.List.Membership.Setoid as SetoidMembership
 
-open Setoid S using (_≈_; trans) renaming (Carrier to A; refl to ≈-refl)
+open Setoid S using (_≈_; trans; reflexive) renaming (Carrier to A; refl to ≈-refl)
 open SetoidEquality S using (_≋_; ≋-refl)
 open SetoidSublist S hiding (map)
 open SetoidMembership S using (_∈_)
@@ -65,6 +67,13 @@ module _ where
 
   ∷ʳ-injective : ∀ {pxs qxs : xs ⊆ ys} → y ∷ʳ pxs ≡ y ∷ʳ qxs → pxs ≡ qxs
   ∷ʳ-injective refl = refl
+
+------------------------------------------------------------------------
+-- Relationship between Propositional._⊆_ and _⊆_
+------------------------------------------------------------------------
+
+⊆ₚ⇒⊆ : ∀ {as bs} → as PropositionalSublist.⊆ bs → as ⊆ bs
+⊆ₚ⇒⊆ = SetoidSublist.map (setoid _) reflexive
 
 ------------------------------------------------------------------------
 -- Categorical properties


### PR DESCRIPTION
This implements the lemma requested by @mechvel on [zulip](https://agda.zulipchat.com/#narrow/channel/264623-stdlib/topic/.60.60_.E2.8A.86.E2.82.80_.20.E2.87.92.20_.E2.8A.86.E2.82.97_.60.60.20for.20sublist.20by.20propositional.20vs.20by.20Setoid)

[DELETED]

UPDATED:
* lemma in `Propositional.Properties`
* reduces to a triviality involving `Setoid.map`
* Fairbairn threshold?