### PR TITLE
Deprecate `Data.List.Relation.Unary.All.Properties.takeWhile⁻`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,7 @@ Additions to existing modules
 * In `Data.List.Relation.Unary.All.Properties`:
   ```agda
   all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
+  dropWhile++⁻ : (P? : Decidable P) → dropWhile P? (xs ++ ys) ≡ ys → All P xs
   takeWhileP⇒Q⇒R⁺ : (∀ {x} → P x → Q x → R x) → (Q? : Decidable Q) →
                     All P xs → All R (takeWhile Q? xs)
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,9 +337,6 @@ Additions to existing modules
 * In `Data.List.Relation.Unary.All.Properties`:
   ```agda
   all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
-  dropWhile++⁻ : (P? : Decidable P) → dropWhile P? (xs ++ ys) ≡ ys → All P xs
-  takeWhileP⇒Q⇒R⁺ : (∀ {x} → P x → Q x → R x) → (Q? : Decidable Q) →
-                    All P xs → All R (takeWhile Q? xs)
   ```
 
 * In `Data.List.Relation.Unary.Any.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,6 @@ Non-backwards compatible changes
 Minor improvements
 ------------------
 
-* In `Data.List.Relation.Unary.All.Properties` the type of `takeWhile⁻` has been generalised, and its proof now delegates to that of `all-takeWhile`:
-  ```agda
-  takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ ys → All P ys
-  ```
-
 Deprecated modules
 ------------------
 
@@ -84,6 +79,11 @@ Deprecated names
   split  ↦  ↭-split
   ```
   with a more informative type (see below).
+  ```
+
+* In `Data.List.Relation.Unary.All.Properties`:
+  ```agda
+  takeWhile⁻  ↦  all-takeWhile
   ```
 
 * In `Data.Vec.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Non-backwards compatible changes
 Minor improvements
 ------------------
 
+* In `Data.List.Relation.Unary.All.Properties` the type of `takeWhile⁻` has been generalised, and its proof now delegates to that of `all-takeWhile`:
+  ```agda
+  takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ ys → All P ys
+  ```
+
 Deprecated modules
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,8 @@ Additions to existing modules
 * In `Data.List.Relation.Unary.All.Properties`:
   ```agda
   all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
+  takeWhileP⇒Q⇒R⁺ : (∀ {x} → P x → Q x → R x) → (Q? : Decidable Q) →
+                    All P xs → All R (takeWhile Q? xs)
   ```
 
 * In `Data.List.Relation.Unary.Any.Properties`:

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -49,7 +49,7 @@ open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
   using (Dec; does; yes; no; _because_; ¬?; decidable-stable)
 open import Relation.Unary
-  using (Decidable; Pred; Universal; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
+  using (Decidable; Pred; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
 open import Relation.Unary.Properties using (∁?)
 
 private
@@ -466,17 +466,20 @@ take⁺ zero    pxs        = []
 take⁺ (suc n) []         = []
 take⁺ (suc n) (px ∷ pxs) = px ∷ take⁺ n pxs
 
+takeWhileP⇒Q⇒R⁺ : (∀ {x} → P x → Q x → R x) → (Q? : Decidable Q) →
+                  All P xs → All R (takeWhile Q? xs)
+takeWhileP⇒Q⇒R⁺ {P = P} {Q = Q} {R = R} P⇒Q⇒R Q? = go where
+  go : All P xs → All R (takeWhile Q? xs)
+  go [] = []
+  go {xs = x ∷ xs} (px ∷ pxs) with Q? x
+  ... | yes qx = P⇒Q⇒R px qx ∷ go pxs
+  ... | no _ = []
+
 takeWhile⁺ : (Q? : Decidable Q) → All P xs → All P (takeWhile Q? xs)
-takeWhile⁺               Q? []         = []
-takeWhile⁺ {xs = x ∷ xs} Q? (px ∷ pxs) with does (Q? x)
-... | true  = px ∷ takeWhile⁺ Q? pxs
-... | false = []
+takeWhile⁺ = takeWhileP⇒Q⇒R⁺ λ p _ → p
 
 all-takeWhile : (P? : Decidable P) → ∀ xs → All P (takeWhile P? xs)
-all-takeWhile P? []       = []
-all-takeWhile P? (x ∷ xs) with P? x
-... | yes px = px ∷ all-takeWhile P? xs
-... | no  _ = []
+all-takeWhile P? = takeWhileP⇒Q⇒R⁺ (λ _ q → q) P? ∘ All.universal-U
 
 ------------------------------------------------------------------------
 -- applyUpTo

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -472,17 +472,14 @@ takeWhile⁺ {xs = x ∷ xs} Q? (px ∷ pxs) with does (Q? x)
 ... | true  = px ∷ takeWhile⁺ Q? pxs
 ... | false = []
 
-takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ xs → All P xs
-takeWhile⁻ {xs = []}     P? eq = []
-takeWhile⁻ {xs = x ∷ xs} P? eq with P? x
-... | yes px = px ∷ takeWhile⁻ P? (List.∷-injectiveʳ eq)
-... | no ¬px = case eq of λ ()
-
 all-takeWhile : (P? : Decidable P) → ∀ xs → All P (takeWhile P? xs)
 all-takeWhile P? []       = []
 all-takeWhile P? (x ∷ xs) with P? x
 ... | yes px = px ∷ all-takeWhile P? xs
-... | no ¬px = []
+... | no  _ = []
+
+takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ ys → All P ys
+takeWhile⁻ {xs = xs} P? refl = all-takeWhile P? xs
 
 ------------------------------------------------------------------------
 -- applyUpTo

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -43,7 +43,7 @@ open import Relation.Binary.Core using (REL)
 open import Relation.Binary.Bundles using (Setoid)
 import Relation.Binary.Definitions as B
 open import Relation.Binary.PropositionalEquality.Core
-  using (_≡_; refl; cong; cong₂; _≗_)
+  using (_≡_; refl; sym; cong; cong₂; _≗_)
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
@@ -478,9 +478,6 @@ all-takeWhile P? (x ∷ xs) with P? x
 ... | yes px = px ∷ all-takeWhile P? xs
 ... | no  _ = []
 
-takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ ys → All P ys
-takeWhile⁻ {xs = xs} P? refl = all-takeWhile P? xs
-
 ------------------------------------------------------------------------
 -- applyUpTo
 
@@ -752,3 +749,13 @@ map-compose = map-∘
 "Warning: map-compose was deprecated in v2.1.
 Please use map-∘ instead."
 #-}
+
+-- Version 2.2
+
+takeWhile⁻ : (P? : Decidable P) → takeWhile P? xs ≡ xs → All P xs
+takeWhile⁻ {xs = xs} P? eq rewrite sym eq = all-takeWhile P? xs
+{-# WARNING_ON_USAGE takeWhile⁻
+"Warning: takeWhile⁻ was deprecated in v2.2.
+Please use all-takeWhile instead."
+#-}
+


### PR DESCRIPTION
This is a coda to #2520 / #2521 : the type of `takeWhile⁻` is insufficiently general, and generalising it makes the proof trivially delegate to that of `all-takeWhile`; another instance of 'non-linear bindings considered harmful' ...

NB. UPDATED: following @MatthewDaggitt 's suggestions below, can now ignore first three items here
* not sure how to record this in `CHANGELOG`: under `Minor improvements`? 
* possible deprecation of `takeWhile⁻` now possible? or else of `all-takeWhile`? 
* not `breaking`, but not clear whether the generalisation may lead to `unsolved metas` errors downstream?
* any other similar refactorings possible?
