### PR TITLE
[ refactor ] Move `Data.List.Relation.Unary.All.Properties.all⊆concat` to `Data.List.Relation.Binary.Sublist.Setoid.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,13 +327,12 @@ Additions to existing modules
 * In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
   ```agda
   ⊆⇒⊆ₛ : (S : Setoid a ℓ) → as ⊆ bs → as (SetoidSublist.⊆ S) bs
-  xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
-  all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
   ```
 
 * In `Data.List.Relation.Binary.Sublist.Setoid.Properties`:
   ```agda
-  concat⁺ : Sublist _⊆_ ass bss → concat ass ⊆ concat bss
+  concat⁺    : Sublist _⊆_ ass bss → concat ass ⊆ concat bss
+  all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,7 +327,13 @@ Additions to existing modules
 * In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
   ```agda
   ⊆⇒⊆ₛ : (S : Setoid a ℓ) → as ⊆ bs → as (SetoidSublist.⊆ S) bs
+  xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
   all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
+  ```
+
+* In `Data.List.Relation.Binary.Sublist.Setoid.Properties`:
+  ```agda
+  concat⁺ : Sublist _⊆_ ass bss → concat ass ⊆ concat bss
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,11 +327,11 @@ Additions to existing modules
 * In `Data.List.Relation.Binary.Sublist.Propositional.Properties`:
   ```agda
   ⊆⇒⊆ₛ : (S : Setoid a ℓ) → as ⊆ bs → as (SetoidSublist.⊆ S) bs
+  all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
   ```
 
 * In `Data.List.Relation.Unary.All.Properties`:
   ```agda
-  all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
   all⇒dropWhile≡[] : (P? : Decidable P) → All P xs → dropWhile P? xs ≡ []
   all⇒takeWhile≗id : (P? : Decidable P) → All P xs → takeWhile P? xs ≡ xs
   ```

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -75,9 +75,7 @@ xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
   = prf
 
 all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
-all⊆concat [] = []
-all⊆concat (xs ∷ xss) =
-  ++⁺ʳ (concat xss) ⊆-refl ∷ All.map (++⁺ˡ xs) (all⊆concat xss)
+all⊆concat _ = All.tabulate xs∈xss⇒xs⊆concat[xss]
 
 ------------------------------------------------------------------------
 -- Category laws for _⊆_

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -10,11 +10,12 @@ module Data.List.Relation.Binary.Sublist.Propositional.Properties where
 
 open import Data.List.Base using (List; []; _∷_;  map; concat)
 open import Data.List.Membership.Propositional using (_∈_)
+import Data.List.Properties as List
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
-open import Data.List.Relation.Binary.Sublist.Propositional
+open import Data.List.Relation.Binary.Sublist.Propositional as Propositional
   hiding (map)
 import Data.List.Relation.Binary.Sublist.Setoid
   as SetoidSublist
@@ -37,6 +38,7 @@ private
     A B : Set a
     x y : A
     ws xs ys zs : List A
+    xss : List A
 
 ------------------------------------------------------------------------
 -- Re-exporting setoid properties
@@ -65,6 +67,12 @@ map⁺ f = SetoidProperties.map⁺ (setoid _) (setoid _) (cong f)
 
 ------------------------------------------------------------------------
 -- concat
+
+xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
+xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
+  with prf ← concat⁺ (Propositional.map ⊆-reflexive (from∈ xs∈xss))
+  rewrite List.++-identityʳ xs
+  = prf
 
 all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
 all⊆concat [] = []

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -8,10 +8,10 @@
 
 module Data.List.Relation.Binary.Sublist.Propositional.Properties where
 
-open import Data.List.Base using (List; []; _∷_;  map; concat)
+open import Data.List.Base using (List; []; _∷_;  map)
 open import Data.List.Membership.Propositional using (_∈_)
 import Data.List.Properties as List
-open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
+open import Data.List.Relation.Unary.All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
@@ -64,18 +64,6 @@ module _ (S : Setoid a ℓ) where
 
 map⁺ : (f : A → B) → xs ⊆ ys → map f xs ⊆ map f ys
 map⁺ f = SetoidProperties.map⁺ (setoid _) (setoid _) (cong f)
-
-------------------------------------------------------------------------
--- concat
-
-xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
-xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
-  with prf ← concat⁺ (Propositional.map ⊆-reflexive (from∈ xs∈xss))
-  rewrite List.++-identityʳ xs
-  = prf
-
-all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
-all⊆concat _ = All.tabulate xs∈xss⇒xs⊆concat[xss]
 
 ------------------------------------------------------------------------
 -- Category laws for _⊆_

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -37,7 +37,6 @@ private
     A B : Set a
     x y : A
     ws xs ys zs : List A
-    xss : List A
 
 ------------------------------------------------------------------------
 -- Re-exporting setoid properties

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -10,12 +10,11 @@ module Data.List.Relation.Binary.Sublist.Propositional.Properties where
 
 open import Data.List.Base using (List; []; _∷_;  map)
 open import Data.List.Membership.Propositional using (_∈_)
-import Data.List.Properties as List
 open import Data.List.Relation.Unary.All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
-open import Data.List.Relation.Binary.Sublist.Propositional as Propositional
+open import Data.List.Relation.Binary.Sublist.Propositional
   hiding (map)
 import Data.List.Relation.Binary.Sublist.Setoid
   as SetoidSublist

--- a/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional/Properties.agda
@@ -8,9 +8,9 @@
 
 module Data.List.Relation.Binary.Sublist.Propositional.Properties where
 
-open import Data.List.Base using (List; []; _∷_;  map)
+open import Data.List.Base using (List; []; _∷_;  map; concat)
 open import Data.List.Membership.Propositional using (_∈_)
-open import Data.List.Relation.Unary.All using (All; []; _∷_)
+open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (Any; here; there)
 open import Data.List.Relation.Unary.Any.Properties
   using (here-injective; there-injective)
@@ -62,6 +62,14 @@ module _ (S : Setoid a ℓ) where
 
 map⁺ : (f : A → B) → xs ⊆ ys → map f xs ⊆ map f ys
 map⁺ f = SetoidProperties.map⁺ (setoid _) (setoid _) (cong f)
+
+------------------------------------------------------------------------
+-- concat
+
+all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
+all⊆concat [] = []
+all⊆concat (xs ∷ xss) =
+  ++⁺ʳ (concat xss) ⊆-refl ∷ All.map (++⁺ˡ xs) (all⊆concat xss)
 
 ------------------------------------------------------------------------
 -- Category laws for _⊆_

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -24,7 +24,8 @@ open import Function.Base
 open import Function.Bundles using (_⇔_; _⤖_)
 open import Level
 open import Relation.Binary.Definitions using () renaming (Decidable to Decidable₂)
-open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_; refl; cong; cong₂)
+open import Relation.Binary.PropositionalEquality.Core as ≡
+  using (_≡_; refl; sym; cong; cong₂)
 open import Relation.Binary.Structures using (IsDecTotalOrder)
 open import Relation.Unary using (Pred; Decidable; Universal; Irrelevant)
 open import Relation.Nullary.Negation using (¬_)
@@ -39,7 +40,7 @@ import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
 import Data.List.Membership.Setoid as SetoidMembership
 
 open Setoid S using (_≈_; trans) renaming (Carrier to A; refl to ≈-refl)
-open SetoidEquality S using (_≋_; ≋-refl; ≋-setoid)
+open SetoidEquality S using (_≋_; ≋-refl; ≋-reflexive; ≋-setoid)
 open SetoidSublist S hiding (map)
 
 
@@ -196,9 +197,12 @@ module _ where
 
   xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
   xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
+{-
     with prf ← concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss))
     rewrite ++-identityʳ xs
-    = prf
+-}
+    = ⊆-trans (⊆-reflexive (≋-reflexive {!sym (++-identityʳ xs)!}))
+              (concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss)))
 
   all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
   all⊆concat _ = tabulateₛ ≋-setoid xs∈xss⇒xs⊆concat[xss]

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -185,7 +185,6 @@ module _ where
             concat ass ⊆ concat bss
   concat⁺ = HeteroProperties.concat⁺
 
-
 ------------------------------------------------------------------------
 -- take
 

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -197,11 +197,7 @@ module _ where
 
   xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
   xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
-{-
-    with prf ← concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss))
-    rewrite ++-identityʳ xs
--}
-    = ⊆-trans (⊆-reflexive (≋-reflexive {!sym (++-identityʳ xs)!}))
+    = ⊆-trans (⊆-reflexive (≋-reflexive (sym (++-identityʳ xs))))
               (concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss)))
 
   all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -13,6 +13,7 @@ module Data.List.Relation.Binary.Sublist.Setoid.Properties
   {c ℓ} (S : Setoid c ℓ) where
 
 open import Data.List.Base hiding (_∷ʳ_)
+open import Data.List.Properties using (++-identityʳ)
 open import Data.List.Relation.Unary.Any using (Any)
 import Data.Maybe.Relation.Unary.All as Maybe
 open import Data.Nat.Base using (ℕ; _≤_; _≥_)
@@ -37,16 +38,16 @@ import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
 import Data.List.Membership.Setoid as SetoidMembership
 
 open Setoid S using (_≈_; trans) renaming (Carrier to A; refl to ≈-refl)
-open SetoidEquality S using (_≋_; ≋-refl)
+open SetoidEquality S using (_≋_; ≋-refl; ≋-setoid)
 open SetoidSublist S hiding (map)
-open SetoidMembership S using (_∈_)
+--
 
 private
   variable
     p q r s t : Level
     a b x y : A
     as bs cs ds xs ys : List A
-    ass bss xss yss : List (List A)
+    xss yss : List (List A)
     P : Pred A p
     Q : Pred A q
     m n : ℕ
@@ -181,9 +182,22 @@ module _ where
 ------------------------------------------------------------------------
 -- concat
 
-  concat⁺ : Hetero.Sublist _⊆_ ass bss →
-            concat ass ⊆ concat bss
+module _ where
+
+  concat⁺ : Hetero.Sublist _⊆_ xss yss →
+            concat xss ⊆ concat yss
   concat⁺ = HeteroProperties.concat⁺
+
+  open SetoidMembership ≋-setoid using (_∈_)
+  open SetoidSublist ≋-setoid
+    using ()
+    renaming (map to map-≋; from∈ to from∈-≋)
+
+  xs∈xss⇒xs⊆concat[xss] : xs ∈ xss → xs ⊆ concat xss
+  xs∈xss⇒xs⊆concat[xss] {xs = xs} xs∈xss
+    with prf ← concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss))
+    rewrite ++-identityʳ xs
+    = prf
 
 ------------------------------------------------------------------------
 -- take
@@ -315,6 +329,8 @@ module _ where
 -- (to/from)∈ is a bijection
 
 module _ where
+
+  open SetoidMembership S using (_∈_)
 
   to∈-injective : ∀ {p q : [ x ] ⊆ xs} → to∈ p ≡ to∈ q → p ≡ q
   to∈-injective = HeteroProperties.toAny-injective

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -15,6 +15,7 @@ module Data.List.Relation.Binary.Sublist.Setoid.Properties
 open import Data.List.Base hiding (_∷ʳ_)
 open import Data.List.Properties using (++-identityʳ)
 open import Data.List.Relation.Unary.Any using (Any)
+open import Data.List.Relation.Unary.All using (All; tabulateₛ)
 import Data.Maybe.Relation.Unary.All as Maybe
 open import Data.Nat.Base using (ℕ; _≤_; _≥_)
 import Data.Nat.Properties as ℕ
@@ -40,7 +41,7 @@ import Data.List.Membership.Setoid as SetoidMembership
 open Setoid S using (_≈_; trans) renaming (Carrier to A; refl to ≈-refl)
 open SetoidEquality S using (_≋_; ≋-refl; ≋-setoid)
 open SetoidSublist S hiding (map)
---
+
 
 private
   variable
@@ -198,6 +199,9 @@ module _ where
     with prf ← concat⁺ (map-≋ ⊆-reflexive (from∈-≋ xs∈xss))
     rewrite ++-identityʳ xs
     = prf
+
+  all⊆concat : (xss : List (List A)) → All (_⊆ concat xss) xss
+  all⊆concat _ = tabulateₛ ≋-setoid xs∈xss⇒xs⊆concat[xss]
 
 ------------------------------------------------------------------------
 -- take

--- a/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid/Properties.agda
@@ -30,6 +30,8 @@ open import Relation.Nullary.Decidable using (¬?; yes; no)
 
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
 import Data.List.Relation.Binary.Sublist.Setoid as SetoidSublist
+import Data.List.Relation.Binary.Sublist.Heterogeneous
+  as Hetero
 import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeteroProperties
 import Data.List.Membership.Setoid as SetoidMembership
@@ -44,6 +46,7 @@ private
     p q r s t : Level
     a b x y : A
     as bs cs ds xs ys : List A
+    ass bss xss yss : List (List A)
     P : Pred A p
     Q : Pred A q
     m n : ℕ
@@ -174,6 +177,14 @@ module _ where
 
   ++⁻ : length as ≡ length bs → as ++ cs ⊆ bs ++ ds → cs ⊆ ds
   ++⁻ = HeteroProperties.++⁻
+
+------------------------------------------------------------------------
+-- concat
+
+  concat⁺ : Hetero.Sublist _⊆_ ass bss →
+            concat ass ⊆ concat bss
+  concat⁺ = HeteroProperties.concat⁺
+
 
 ------------------------------------------------------------------------
 -- take

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -46,7 +46,7 @@ open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
   using (Dec; does; yes; no; _because_; ¬?; decidable-stable; dec-true)
 open import Relation.Unary
-  using (Decidable; Pred; Universal; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
+  using (Decidable; Pred; ∁; _⟨×⟩_) renaming (_⊆_ to _⋐_)
 open import Relation.Unary.Properties using (∁?)
 
 private

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -384,12 +384,7 @@ concat⁺ (pxs ∷ pxss) = ++⁺ pxs (concat⁺ pxss)
 concat⁻ : ∀ {xss} → All P (concat xss) → All (All P) xss
 concat⁻ {xss = []}       []  = []
 concat⁻ {xss = xs ∷ xss} pxs = ++⁻ˡ xs pxs ∷ concat⁻ (++⁻ʳ xs pxs)
-{-
-all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
-all⊆concat [] = []
-all⊆concat (xs ∷ xss) =
-  Sublist.++⁺ʳ (concat xss) Sublist.⊆-refl ∷ All.map (Sublist.++⁺ˡ xs) (all⊆concat xss)
--}
+
 ------------------------------------------------------------------------
 -- snoc
 

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -20,9 +20,6 @@ import Data.List.Membership.Setoid as SetoidMembership
 import Data.List.Properties as List
 import Data.List.Relation.Binary.Equality.Setoid as ≋
 open import Data.List.Relation.Binary.Pointwise.Base using (Pointwise; []; _∷_)
-import Data.List.Relation.Binary.Sublist.Propositional as Sublist
-import Data.List.Relation.Binary.Sublist.Propositional.Properties
-  as Sublist
 import Data.List.Relation.Binary.Subset.Propositional as Subset
 open import Data.List.Relation.Unary.All as All using
   ( All; []; _∷_; lookup; updateAt
@@ -49,7 +46,7 @@ open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
   using (Dec; does; yes; no; _because_; ¬?; decidable-stable; dec-true)
 open import Relation.Unary
-  using (Decidable; Pred; Universal; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
+  using (Decidable; Pred; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
 open import Relation.Unary.Properties using (∁?)
 
 private
@@ -387,12 +384,12 @@ concat⁺ (pxs ∷ pxss) = ++⁺ pxs (concat⁺ pxss)
 concat⁻ : ∀ {xss} → All P (concat xss) → All (All P) xss
 concat⁻ {xss = []}       []  = []
 concat⁻ {xss = xs ∷ xss} pxs = ++⁻ˡ xs pxs ∷ concat⁻ (++⁻ʳ xs pxs)
-
+{-
 all⊆concat : (xss : List (List A)) → All (Sublist._⊆ concat xss) xss
 all⊆concat [] = []
 all⊆concat (xs ∷ xss) =
   Sublist.++⁺ʳ (concat xss) Sublist.⊆-refl ∷ All.map (Sublist.++⁺ˡ xs) (all⊆concat xss)
-
+-}
 ------------------------------------------------------------------------
 -- snoc
 

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -45,7 +45,6 @@ open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
   using (Dec; does; yes; no; _because_; ¬?; decidable-stable; dec-true)
-
 open import Relation.Unary
   using (Decidable; Pred; Universal; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
 open import Relation.Unary.Properties using (∁?)

--- a/src/Data/List/Relation/Unary/All/Properties.agda
+++ b/src/Data/List/Relation/Unary/All/Properties.agda
@@ -45,8 +45,9 @@ open import Relation.Nullary.Reflects using (invert)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Decidable
   using (Dec; does; yes; no; _because_; ¬?; decidable-stable; dec-true)
+
 open import Relation.Unary
-  using (Decidable; Pred; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
+  using (Decidable; Pred; Universal; ∁; _∩_; _⟨×⟩_) renaming (_⊆_ to _⋐_)
 open import Relation.Unary.Properties using (∁?)
 
 private


### PR DESCRIPTION
Fixes #2517 following discussion there. 
Re-exports to `Data.List.Relation.Binary.Sublist.Propositional.Properties` automatically, so this strictly generalises #2513 as a solution to #2509 .