### PR TITLE
[ add ] `concat [ xs ] ≡  xs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ Deprecated names
   normalise-correct  ↦  Algebra.Solver.Monoid.Normal.correct
   ```
 
-* In `Data.Vec.Properties`:
+* In `Data.List.Properties`:
   ```agda
   concat-[_]   ↦  concat-map-[_]
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,7 @@ Additions to existing modules
   ```agda
   product≢0    : All NonZero ns → NonZero (product ns)
   ∈⇒≤product   : All NonZero ns → n ∈ ns → n ≤ product ns
+  concat-[_]   : concat ∘ [_] ≗ id
   concatMap-++ : concatMap f (xs ++ ys) ≡ concatMap f xs ++ concatMap f ys
   filter-≐     : P ≐ Q → filter P? ≗ filter Q?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ Deprecated names
   normalise-correct  ↦  Algebra.Solver.Monoid.Normal.correct
   ```
 
+* In `Data.Vec.Properties`:
+  ```agda
+  concat-[_]   ↦  concat-map-[_]
+  ```
+
 * In `Data.List.Relation.Binary.Permutation.Setoid.Properties`:
   ```agda
   split  ↦  ↭-split

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Deprecated names
 
 * In `Data.List.Properties`:
   ```agda
-  concat-[_]   ↦  concat-map-[_]
+  concat-[-]   ↦  concat-map-[_]
   ```
 
 * In `Data.List.Relation.Binary.Permutation.Setoid.Properties`:

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -681,6 +681,9 @@ concat-[-] : concat {A = A} ∘ map [_] ≗ id
 concat-[-] [] = refl
 concat-[-] (x ∷ xs) = cong (x ∷_) (concat-[-] xs)
 
+concat-[_] : concat {A = A} ∘ [_] ≗ id
+concat-[ xs ] = ++-identityʳ xs
+
 ------------------------------------------------------------------------
 -- concatMap
 

--- a/src/Data/List/Properties.agda
+++ b/src/Data/List/Properties.agda
@@ -677,9 +677,9 @@ concat-concat (xss ∷ xsss) = begin
   concat xss ++ concat (concat xsss) ≡⟨ concat-++ xss (concat xsss) ⟩
   concat (concat (xss ∷ xsss))       ∎
 
-concat-[-] : concat {A = A} ∘ map [_] ≗ id
-concat-[-] [] = refl
-concat-[-] (x ∷ xs) = cong (x ∷_) (concat-[-] xs)
+concat-map-[_] : concat {A = A} ∘ map [_] ≗ id
+concat-map-[ [] ]     = refl
+concat-map-[ x ∷ xs ] = cong (x ∷_) (concat-map-[ xs ])
 
 concat-[_] : concat {A = A} ∘ [_] ≗ id
 concat-[ xs ] = ++-identityʳ xs
@@ -691,7 +691,7 @@ concatMap-cong : ∀ {f g : A → List B} → f ≗ g → concatMap f ≗ concat
 concatMap-cong eq xs = cong concat (map-cong eq xs)
 
 concatMap-pure : concatMap {A = A} [_] ≗ id
-concatMap-pure = concat-[-]
+concatMap-pure = concat-map-[_]
 
 concatMap-map : (g : B → List C) → (f : A → B) → (xs : List A) →
                 concatMap g (map f xs) ≡ concatMap (g ∘′ f) xs
@@ -1656,4 +1656,12 @@ scanl-defn f e (x ∷ xs) = cong (e ∷_) (begin
 {-# WARNING_ON_USAGE scanl-defn
 "Warning: scanl-defn was deprecated in v2.1.
 Please use Data.List.Scans.Properties.scanl-defn instead."
+#-}
+
+-- Version 2.2
+
+concat-[-] = concat-map-[_]
+{-# WARNING_ON_USAGE concat-[-]
+"Warning: concat-[-] was deprecated in v2.2.
+Please use concat-map-[_] instead."
 #-}

--- a/src/Data/List/Sort/MergeSort.agda
+++ b/src/Data/List/Sort/MergeSort.agda
@@ -17,7 +17,7 @@ module Data.List.Sort.MergeSort
 open import Data.Bool.Base using (true; false)
 open import Data.List.Base
   using (List; []; _∷_; merge; length; map; [_]; concat; _++_)
-open import Data.List.Properties using (length-partition; ++-assoc; concat-[-])
+open import Data.List.Properties using (length-partition; ++-assoc; concat-map-[_])
 open import Data.List.Relation.Unary.Linked using ([]; [-])
 import Data.List.Relation.Unary.Sorted.TotalOrder.Properties as Sorted
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
@@ -86,7 +86,7 @@ mergeAll-↭ (xs ∷ ys ∷ xss) (acc rec) = begin
 sort-↭ : ∀ xs → sort xs ↭ xs
 sort-↭ xs = begin
   mergeAll (map [_] xs) _ ↭⟨ mergeAll-↭ (map [_] xs) _ ⟩
-  concat (map [_] xs)     ≡⟨ concat-[-] xs ⟩
+  concat (map [_] xs)     ≡⟨ concat-map-[ xs ] ⟩
   xs                      ∎
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
I'm persuaded by the [discussion on Zulip](https://agda.zulipchat.com/#narrow/channel/264623-stdlib/topic/.60concat-single.60.20.3F) (and my own thoughtlessness in responding there) that this is a simple worthwhile addition, with its potential downstream use in #2524 (and elsewhere). Thanks to @ncfavier for clarifying the triangle laws for the `List` monad!

Possible issue(s):
* naming (as ever); alternatives `concat∘[_]≗id`? (or some prefix version?)
* use of mixfix notation; but here it seems to chime well with `[_]` as an operator?
* rename existing `concat-[-]` to eg. `concat∘map[_]≗id`? (or some more informative prefix version?)