### PR TITLE
[ add ] `Relation.Binary._Reflects_⟶_` as a companion to `_Preserves_⟶_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,3 +85,8 @@ Additions to existing modules
   quasiring                       : Quasiring c ℓ → Quasiring (a ⊔ c) (a ⊔ ℓ)
   commutativeRing                 : CommutativeRing c ℓ → CommutativeRing (a ⊔ c) (a ⊔ ℓ)
   ```
+
+* In `Relation.Binary.Core`:
+  ```agda
+  _Reflects_⟶_ : (A → B) → Rel B ℓ₁ → Rel A ℓ₂ → Set _
+  ```

--- a/src/Function/Definitions.agda
+++ b/src/Function/Definitions.agda
@@ -10,9 +10,10 @@
 
 module Function.Definitions where
 
-open import Data.Product.Base using (∃; _×_)
+open import Data.Product.Base using (∃; _×_; proj₁)
+open import Function.Base using (_∘_)
 open import Level using (Level)
-open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.Core using (Rel; _Reflects_⟶_)
 
 private
   variable
@@ -31,7 +32,7 @@ module _
   Congruent f = ∀ {x y} → x ≈₁ y → f x ≈₂ f y
 
   Injective : (A → B) → Set _
-  Injective f = ∀ {x y} → f x ≈₂ f y → x ≈₁ y
+  Injective = _Reflects _≈₂_ ⟶ _≈₁_
 
   Surjective : (A → B) → Set _
   Surjective f = ∀ y → ∃ λ x → ∀ {z} → z ≈₁ x → f z ≈₂ y

--- a/src/Function/Definitions.agda
+++ b/src/Function/Definitions.agda
@@ -10,7 +10,7 @@
 
 module Function.Definitions where
 
-open import Data.Product.Base using (∃; _×_; proj₁)
+open import Data.Product.Base using (∃; _×_)
 open import Function.Base using (_∘_)
 open import Level using (Level)
 open import Relation.Binary.Core using (Rel; _Reflects_⟶_)

--- a/src/Function/Definitions.agda
+++ b/src/Function/Definitions.agda
@@ -11,7 +11,6 @@
 module Function.Definitions where
 
 open import Data.Product.Base using (∃; _×_)
-open import Function.Base using (_∘_)
 open import Level using (Level)
 open import Relation.Binary.Core using (Rel; _Reflects_⟶_)
 

--- a/src/Relation/Binary/Core.agda
+++ b/src/Relation/Binary/Core.agda
@@ -60,6 +60,9 @@ P =[ f ]⇒ Q = P ⇒ (Q on f)
 _Preserves_⟶_ : (A → B) → Rel A ℓ₁ → Rel B ℓ₂ → Set _
 f Preserves P ⟶ Q = P =[ f ]⇒ Q
 
+_Reflects_⟶_ : (A → B) → Rel B ℓ₁ → Rel A ℓ₂ → Set _
+f Reflects Q ⟶ P = (Q on f) ⇒ P
+
 -- A binary variant of _Preserves_⟶_.
 
 _Preserves₂_⟶_⟶_ : (A → B → C) → Rel A ℓ₁ → Rel B ℓ₂ → Rel C ℓ₃ → Set _


### PR DESCRIPTION
A preparatory PR ahead of tackling #1436 in earnest.
NB:
* illustrative refactoring of `Function.Definitions.Injective`
* surprisingly, attempting to do the same for `Function.Definitions.Congruent` in terms of `Preserves` results in many, many, unsolved metas... sigh. See #2565 for details