### PR TITLE
Rename overloaded sym in apartness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,15 @@ Highlights
 Bug-fixes
 ---------
 
+* In `Algebra.Apartness.Structures`, renamed `sym` from `IsApartnessRelation`
+  to `#-sym` in order to avoid overloaded projection.
+  `irrefl` and `cotrans` are similarly renamed.
+
 Non-backwards compatible changes
 --------------------------------
 
 Minor improvements
 ------------------
-
-* In `Algebra.Apartness.Structures`, renamed `sym` from `IsApartnessRelation`
-  to `#-sym` in order to avoid overloaded projection.
-
 
 Deprecated modules
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Non-backwards compatible changes
 Minor improvements
 ------------------
 
+* In `Algebra.Apartness.Structures`, renamed `sym` from `IsApartnessRelation`
+  to `#-sym` in order to avoid overloaded projection.
+
+
 Deprecated modules
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Bug-fixes
 
 * In `Algebra.Apartness.Structures`, renamed `sym` from `IsApartnessRelation`
   to `#-sym` in order to avoid overloaded projection.
-  `irrefl` and `cotrans` are similarly renamed.
+  `irrefl` and `cotrans` are similarly renamed for the sake of consistency.
 
 Non-backwards compatible changes
 --------------------------------

--- a/src/Algebra/Apartness/Properties/HeytingCommutativeRing.agda
+++ b/src/Algebra/Apartness/Properties/HeytingCommutativeRing.agda
@@ -64,30 +64,6 @@ x#0y#0→xy#0 {x} {y} x#0 y#0 = helper (#⇒invertible x#0) (#⇒invertible y#0)
       y⁻¹ * (y - 0#)               ≈⟨ y⁻¹*y≈1 ⟩
       1# ∎
 
-#-sym : Symmetric _#_
-#-sym {x} {y} x#y = invertibleˡ⇒# (- x-y⁻¹ , x-y⁻¹*y-x≈1)
-  where
-  open ≈-Reasoning setoid
-  InvX-Y : Invertible _≈_ 1# _*_ (x - y)
-  InvX-Y = #⇒invertible x#y
-
-  x-y⁻¹ = InvX-Y .proj₁
-
-  y-x≈-[x-y] : y - x ≈ - (x - y)
-  y-x≈-[x-y] = begin
-    y - x     ≈⟨ +-congʳ (-‿involutive y) ⟨
-    - - y - x ≈⟨ -‿anti-homo-+ x (- y) ⟨
-    - (x - y) ∎
-
-  x-y⁻¹*y-x≈1 : (- x-y⁻¹) * (y - x) ≈ 1#
-  x-y⁻¹*y-x≈1 = begin
-    (- x-y⁻¹) * (y - x)   ≈⟨ -‿distribˡ-* x-y⁻¹ (y - x) ⟨
-    - (x-y⁻¹ * (y - x))    ≈⟨ -‿cong (*-congˡ y-x≈-[x-y]) ⟩
-    - (x-y⁻¹ * - (x - y)) ≈⟨ -‿cong (-‿distribʳ-* x-y⁻¹ (x - y)) ⟨
-    - - (x-y⁻¹ * (x - y))  ≈⟨ -‿involutive (x-y⁻¹ * ((x - y))) ⟩
-    x-y⁻¹ * (x - y)        ≈⟨ InvX-Y .proj₂ .proj₁ ⟩
-    1# ∎
-
 #-congʳ : x ≈ y → x # z → y # z
 #-congʳ {x} {y} {z} x≈y x#z = helper (#⇒invertible x#z)
   where

--- a/src/Algebra/Apartness/Structures.agda
+++ b/src/Algebra/Apartness/Structures.agda
@@ -34,7 +34,11 @@ record IsHeytingCommutativeRing : Set (c ⊔ ℓ₁ ⊔ ℓ₂) where
 
   open IsCommutativeRing isCommutativeRing public
   open IsApartnessRelation isApartnessRelation public
-    renaming (sym to #-sym)
+    renaming 
+      ( irrefl  to #-irrefl
+      ; sym     to #-sym
+      ; cotrans to #-cotrans 
+      )
 
   field
     #⇒invertible : ∀ {x y} → x # y → Invertible 1# _*_ (x - y)

--- a/src/Algebra/Apartness/Structures.agda
+++ b/src/Algebra/Apartness/Structures.agda
@@ -33,7 +33,8 @@ record IsHeytingCommutativeRing : Set (c ⊔ ℓ₁ ⊔ ℓ₂) where
     isApartnessRelation : IsApartnessRelation _≈_ _#_
 
   open IsCommutativeRing isCommutativeRing public
-  open IsApartnessRelation isApartnessRelation public
+  open IsApartnessRelation isApartnessRelation public 
+    renaming (sym to #-sym)
 
   field
     #⇒invertible : ∀ {x y} → x # y → Invertible 1# _*_ (x - y)

--- a/src/Algebra/Apartness/Structures.agda
+++ b/src/Algebra/Apartness/Structures.agda
@@ -34,10 +34,10 @@ record IsHeytingCommutativeRing : Set (c ⊔ ℓ₁ ⊔ ℓ₂) where
 
   open IsCommutativeRing isCommutativeRing public
   open IsApartnessRelation isApartnessRelation public
-    renaming 
+    renaming
       ( irrefl  to #-irrefl
       ; sym     to #-sym
-      ; cotrans to #-cotrans 
+      ; cotrans to #-cotrans
       )
 
   field

--- a/src/Algebra/Apartness/Structures.agda
+++ b/src/Algebra/Apartness/Structures.agda
@@ -33,7 +33,7 @@ record IsHeytingCommutativeRing : Set (c ⊔ ℓ₁ ⊔ ℓ₂) where
     isApartnessRelation : IsApartnessRelation _≈_ _#_
 
   open IsCommutativeRing isCommutativeRing public
-  open IsApartnessRelation isApartnessRelation public 
+  open IsApartnessRelation isApartnessRelation public
     renaming (sym to #-sym)
 
   field


### PR DESCRIPTION
Currently in `IsHeytingCommutativeRing`, `sym` is overloaded as it is exported both from `IsCommutativeRing` and `IsApartnessRelation`. This PR renames the apartness sym to `#-sym`.

NOTE: `#-sym` is also removed from `Algebra.Apartness.Properties.HeytingCommutativeRing` as it is now redundant.