### PR TITLE
[ fix ] Add correct fixities for `constructor` uses of `_,_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Highlights
 Bug-fixes
 ---------
 
+* Neither of the `record` constructors `_,_` in `Algebra.Definitions.RawMagma`
+  nor `Relation.Binary.Construct.Interior.Symmetric`, introduced to mimic that
+  of `Data.Product.Base`, were introduced with the appropriate fixity, namely
+  `infixr 4 _,_`.
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/src/Algebra/Definitions/RawMagma.agda
+++ b/src/Algebra/Definitions/RawMagma.agda
@@ -25,6 +25,7 @@ open RawMagma M renaming (Carrier to A)
 ------------------------------------------------------------------------
 -- Divisibility
 
+infixr 4 _,_
 infix 5 _∣ˡ_ _∤ˡ_ _∣ʳ_ _∤ʳ_ _∣_ _∤_ _∥_ _∦_
 
 -- Divisibility from the left.

--- a/src/Relation/Binary/Construct/Interior/Symmetric.agda
+++ b/src/Relation/Binary/Construct/Interior/Symmetric.agda
@@ -24,6 +24,8 @@ private
 ------------------------------------------------------------------------
 -- Definition
 
+infixr 4 _,_
+
 record SymInterior (R : Rel A ℓ) (x y : A) : Set ℓ where
   constructor _,_
   field


### PR DESCRIPTION
Fixes the fixity bugs discussed in #2582 .
Hopefully there aren't any others!?