### PR TITLE
[ refactor ] `Algebra.Properties.Magma.Divisibility`

### DIFF
--- a/src/Algebra/Properties/CommutativeMagma/Divisibility.agda
+++ b/src/Algebra/Properties/CommutativeMagma/Divisibility.agda
@@ -28,7 +28,7 @@ x∣xy : ∀ x y → x ∣ x ∙ y
 x∣xy x y = y , comm y x
 
 xy≈z⇒x∣z : ∀ x y {z} → x ∙ y ≈ z → x ∣ z
-xy≈z⇒x∣z x y xy≈z = {!∣-respʳ-≈ xy≈z (x∣xy x y)!}
+xy≈z⇒x∣z x y xy≈z = ∣-respʳ-≈ xy≈z (x∣xy x y)
 
 x|xy∧y|xy : ∀ x y → (x ∣ x ∙ y) × (y ∣ x ∙ y)
 x|xy∧y|xy x y = x∣xy x y , x∣yx y x

--- a/src/Algebra/Properties/CommutativeMagma/Divisibility.agda
+++ b/src/Algebra/Properties/CommutativeMagma/Divisibility.agda
@@ -28,7 +28,7 @@ x∣xy : ∀ x y → x ∣ x ∙ y
 x∣xy x y = y , comm y x
 
 xy≈z⇒x∣z : ∀ x y {z} → x ∙ y ≈ z → x ∣ z
-xy≈z⇒x∣z x y xy≈z = ∣-respʳ xy≈z (x∣xy x y)
+xy≈z⇒x∣z x y xy≈z = {!∣-respʳ-≈ xy≈z (x∣xy x y)!}
 
 x|xy∧y|xy : ∀ x y → (x ∣ x ∙ y) × (y ∣ x ∙ y)
 x|xy∧y|xy x y = x∣xy x y , x∣yx y x

--- a/src/Algebra/Properties/Magma/Divisibility.agda
+++ b/src/Algebra/Properties/Magma/Divisibility.agda
@@ -39,7 +39,7 @@ x∣yx : ∀ x y → x ∣ y ∙ x
 x∣yx x y = y , refl
 
 xy≈z⇒y∣z : ∀ x y {z} → x ∙ y ≈ z → y ∣ z
-xy≈z⇒y∣z x y xy≈z = ∣-respʳ-≈ xy≈z (x∣yx y x)
+xy≈z⇒y∣z x y xy≈z = x , xy≈z
 
 ------------------------------------------------------------------------
 -- Properties of non-divisibility


### PR DESCRIPTION
Fixes:
* the inciting incident from #2629 
* an uncaught use of a deprecated name