### PR TITLE
[ refactor ] Define and use `Relation.Binary.Definitions.Refl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,3 +149,8 @@ Additions to existing modules
   ```agda
   filter-↭ : ∀ (P? : Pred.Decidable P) → xs ↭ ys → filter P? xs ↭ filter P? ys
   ```
+
+* In `Relation.Binary.Definitions`:
+  ```agda
+  Refl : Rel A ℓ → Rel A ℓ → Set _
+  ```

--- a/src/Algebra/Construct/LiftedChoice.agda
+++ b/src/Algebra/Construct/LiftedChoice.agda
@@ -15,7 +15,8 @@ open import Data.Sum.Base as Sum using (_⊎_; inj₁; inj₂; [_,_]; [_,_]′)
 open import Data.Product.Base using (_×_; _,_)
 open import Function.Base using (const; _$_)
 open import Level using (Level; _⊔_)
-open import Relation.Binary.Core using (Rel; _⇒_; _Preserves_⟶_)
+open import Relation.Binary.Core using (Rel; _Preserves_⟶_)
+open import Relation.Binary.Definitions using (Refl)
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 open import Relation.Binary.Structures using (IsEquivalence)
@@ -63,7 +64,7 @@ module _ {_≈_ : Rel B ℓ} {_∙_ : Op₂ B}
     ... | inj₂ fx∙fy≈fy = fx∙fy≈fy
 
   module _ (f : A → B) {_≈′_ : Rel A ℓ}
-           (≈-reflexive : _≡_ ⇒ _≈′_) where
+           (≈-reflexive : Refl _≡_ _≈′_) where
 
     private
       _◦_ = Lift _≈_ _∙_ M.sel f

--- a/src/Algebra/Properties/Magma/Divisibility.agda
+++ b/src/Algebra/Properties/Magma/Divisibility.agda
@@ -39,7 +39,7 @@ x∣yx : ∀ x y → x ∣ y ∙ x
 x∣yx x y = y , refl
 
 xy≈z⇒y∣z : ∀ x y {z} → x ∙ y ≈ z → y ∣ z
-xy≈z⇒y∣z x y xy≈z = ∣-respʳ-≈ xy≈z (x∣yx y x)
+xy≈z⇒y∣z x y xy≈z = {!∣-respʳ-≈ xy≈z (x∣yx y x)!}
 
 ------------------------------------------------------------------------
 -- Properties of non-divisibility

--- a/src/Codata/Musical/Colist.agda
+++ b/src/Codata/Musical/Colist.agda
@@ -29,7 +29,7 @@ open import Function.Bundles
 open import Level using (_⊔_)
 open import Relation.Binary.Core using (Rel; _⇒_)
 open import Relation.Binary.Bundles using (Poset; Setoid; Preorder)
-open import Relation.Binary.Definitions using (Transitive; Antisymmetric)
+open import Relation.Binary.Definitions using (Refl; Transitive; Antisymmetric)
 import Relation.Binary.Construct.FromRel as Ind
 import Relation.Binary.Reasoning.Preorder as ≲-Reasoning
 import Relation.Binary.Reasoning.PartialOrder as ≤-Reasoning
@@ -148,7 +148,7 @@ Any-∈ {P = P} = mk↔ₛ′
     }
   }
   where
-  reflexive : _≈_ ⇒ _⊑_
+  reflexive : Refl _≈_ _⊑_
   reflexive []        = []
   reflexive (x ∷ xs≈) = x ∷ ♯ reflexive (♭ xs≈)
 

--- a/src/Codata/Musical/Covec.agda
+++ b/src/Codata/Musical/Covec.agda
@@ -20,7 +20,7 @@ open import Level using (Level)
 open import Relation.Binary.Core using (_⇒_; _=[_]⇒_)
 open import Relation.Binary.Bundles using (Setoid; Poset)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; Antisymmetric)
+  using (Refl; Reflexive; Symmetric; Transitive; Antisymmetric)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 
 private
@@ -153,7 +153,7 @@ poset A n = record
     }
   }
   where
-  reflexive : ∀ {n} → _≈_ {n = n} ⇒ _⊑_
+  reflexive : ∀ {n} → Refl (_≈_ {n = n}) _⊑_
   reflexive []        = []
   reflexive (x ∷ xs≈) = x ∷ ♯ reflexive (♭ xs≈)
 

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -7,6 +7,7 @@
 {-# OPTIONS --cubical-compatible --safe #-}
 
 module Data.Bool.Properties where
+
 open import Algebra.Bundles
 open import Algebra.Lattice.Bundles using
   (BooleanAlgebra; DistributiveLattice; Lattice; Semilattice)
@@ -22,10 +23,9 @@ open import Induction.WellFounded using (Acc; WellFounded; acc)
 open import Level using (0ℓ; Level)
 open import Relation.Binary.Bundles using (DecSetoid; DecTotalOrder; Poset;
   Preorder; Setoid; StrictPartialOrder; StrictTotalOrder; TotalOrder)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Definitions using (Antisymmetric; Asymmetric;
   Decidable; DecidableEquality; Irreflexive; Irrelevant; Maximum; Minimum;
-  Reflexive; Total; Trans; Transitive; Trichotomous; _Respects₂_;
+  Refl; Reflexive; Total; Trans; Transitive; Trichotomous; _Respects₂_;
   tri<; tri>; tri≈)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_;
   cong; cong₂; refl; subst; sym; trans)
@@ -71,7 +71,7 @@ false ≟ true  = no λ()
 
 -- Relational properties
 
-≤-reflexive : _≡_ ⇒ _≤_
+≤-reflexive : Refl _≡_ _≤_
 ≤-reflexive refl = b≤b
 
 ≤-refl : Reflexive _≤_

--- a/src/Data/Char/Properties.agda
+++ b/src/Data/Char/Properties.agda
@@ -17,13 +17,13 @@ open import Data.Product.Base using (_,_)
 open import Function.Base
 open import Relation.Nullary using (¬_; yes; no)
 open import Relation.Nullary.Decidable using (map′; isYes)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles
   using (Setoid; DecSetoid; StrictPartialOrder; StrictTotalOrder; Preorder; Poset; DecPoset)
+open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Structures
   using (IsDecEquivalence; IsStrictPartialOrder; IsStrictTotalOrder; IsPreorder; IsPartialOrder; IsDecPartialOrder; IsEquivalence)
 open import Relation.Binary.Definitions
-  using (Decidable; DecidableEquality; Trichotomous; Irreflexive; Transitive; Asymmetric; Antisymmetric; Symmetric; Substitutive; Reflexive; tri<; tri≈; tri>)
+  using (Decidable; DecidableEquality; Trichotomous; Irreflexive; Transitive; Asymmetric; Antisymmetric; Symmetric; Substitutive; Refl; Reflexive; tri<; tri≈; tri>)
 import Relation.Binary.Construct.On as On
 import Relation.Binary.Construct.Subst.Equality as Subst
 import Relation.Binary.Construct.Closure.Reflexive as Refl
@@ -42,13 +42,13 @@ open import Agda.Builtin.Char.Properties
 ------------------------------------------------------------------------
 -- Properties of _≈_
 
-≈⇒≡ : _≈_ ⇒ _≡_
+≈⇒≡ : Refl _≈_ _≡_
 ≈⇒≡ = toℕ-injective _ _
 
 ≉⇒≢ : _≉_ ⇒ _≢_
 ≉⇒≢ p refl = p refl
 
-≈-reflexive : _≡_ ⇒ _≈_
+≈-reflexive : Refl _≡_ _≈_
 ≈-reflexive = cong toℕ
 
 ------------------------------------------------------------------------
@@ -144,7 +144,7 @@ infix 4 _≤?_
 _≤?_ : Decidable _≤_
 _≤?_ = Refl.decidable <-cmp
 
-≤-reflexive : _≡_ ⇒ _≤_
+≤-reflexive : Refl _≡_ _≤_
 ≤-reflexive = Refl.reflexive
 
 ≤-trans : Transitive _≤_

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -284,7 +284,7 @@ cast-trans {m = suc _} {n = suc _} {o = suc _} eq₁ eq₂ (suc k) =
 ------------------------------------------------------------------------
 -- Relational properties
 
-≤-reflexive : _≡_ ⇒ (_≤_ {n})
+≤-reflexive : Refl _≡_ (_≤_ {n})
 ≤-reflexive refl = ℕ.≤-refl
 
 ≤-refl : Reflexive (_≤_ {n})

--- a/src/Data/Float/Properties.agda
+++ b/src/Data/Float/Properties.agda
@@ -17,12 +17,11 @@ import Data.Word64.Base as Word64
 import Data.Word64.Properties as Word64
 open import Function.Base using (_∘_)
 open import Relation.Nullary.Decidable as RN using (map′)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles using (Setoid; DecSetoid)
 open import Relation.Binary.Structures
   using (IsEquivalence; IsDecEquivalence)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; Substitutive; Decidable; DecidableEquality)
+  using (Refl; Reflexive; Symmetric; Transitive; Substitutive; Decidable; DecidableEquality)
 import Relation.Binary.Construct.On as On
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; cong; sym; trans; subst)
@@ -39,10 +38,10 @@ open import Agda.Builtin.Float.Properties
 ------------------------------------------------------------------------
 -- Properties of _≈_
 
-≈⇒≡ : _≈_ ⇒ _≡_
+≈⇒≡ : Refl _≈_ _≡_
 ≈⇒≡ eq = toWord64-injective _ _ (Maybe.map-injective Word64.≈⇒≡ eq)
 
-≈-reflexive : _≡_ ⇒ _≈_
+≈-reflexive : Refl _≡_ _≈_
 ≈-reflexive eq = cong (Maybe.map Word64.toℕ ∘ toWord64) eq
 
 ≈-refl : Reflexive _≈_

--- a/src/Data/Integer/Divisibility/Signed.agda
+++ b/src/Data/Integer/Divisibility/Signed.agda
@@ -19,11 +19,11 @@ import Data.Nat.Coprimality as ℕ
 import Data.Nat.Properties as ℕ
 import Data.Sign.Base as Sign
 import Data.Sign.Properties as Sign
-open import Relation.Binary.Core using (_⇒_; _Preserves_⟶_)
+open import Relation.Binary.Core using (_Preserves_⟶_)
 open import Relation.Binary.Bundles using (Preorder)
 open import Relation.Binary.Structures using (IsPreorder)
 open import Relation.Binary.Definitions
-  using (Reflexive; Transitive; Decidable)
+  using (Refl; Reflexive; Transitive; Decidable)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; trans; sym; cong; refl)
 open import Relation.Binary.PropositionalEquality.Properties
@@ -92,7 +92,7 @@ open _∣_ using (quotient) public
 ∣-refl : Reflexive _∣_
 ∣-refl = ∣ᵤ⇒∣ ℕ.∣-refl
 
-∣-reflexive : _≡_ ⇒ _∣_
+∣-reflexive : Refl _≡_ _∣_
 ∣-reflexive refl = ∣-refl
 
 ∣-trans : Transitive _∣_

--- a/src/Data/Integer/Properties.agda
+++ b/src/Data/Integer/Properties.agda
@@ -34,7 +34,7 @@ open import Relation.Binary.Consequences using (wlog)
 open import Relation.Binary.Structures
   using (IsPreorder; IsTotalPreorder; IsPartialOrder; IsTotalOrder; IsDecTotalOrder; IsStrictPartialOrder; IsStrictTotalOrder)
 open import Relation.Binary.Definitions
-  using (DecidableEquality; Reflexive; Transitive; Antisymmetric; Total; Decidable; Irrelevant; Irreflexive; Asymmetric; LeftTrans; RightTrans; Trichotomous; tri≈; tri<; tri>)
+  using (DecidableEquality; Refl; Reflexive; Transitive; Antisymmetric; Total; Decidable; Irrelevant; Irreflexive; Asymmetric; LeftTrans; RightTrans; Trichotomous; tri≈; tri<; tri>)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; cong; cong₂; sym; _≢_; subst; subst₂; resp₂; trans)
 open import Relation.Binary.PropositionalEquality.Properties
@@ -96,7 +96,7 @@ drop‿-≤- (-≤- n≤m) = n≤m
 ------------------------------------------------------------------------
 -- Relational properties
 
-≤-reflexive : _≡_ ⇒ _≤_
+≤-reflexive : Refl _≡_ _≤_
 ≤-reflexive { -[1+ n ]} refl = -≤- ℕ.≤-refl
 ≤-reflexive {+ n}       refl = +≤+ ℕ.≤-refl
 

--- a/src/Data/List/Relation/Binary/Equality/Propositional.agda
+++ b/src/Data/List/Relation/Binary/Equality/Propositional.agda
@@ -10,12 +10,11 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Core using (_⇒_)
-
 module Data.List.Relation.Binary.Equality.Propositional {a} {A : Set a} where
 
-open import Data.List.Base
+open import Data.List.Base using (_∷_)
 import Data.List.Relation.Binary.Equality.Setoid as SetoidEquality
+open import Relation.Binary.Definitions using (Refl)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; cong)
 import Relation.Binary.PropositionalEquality.Properties as ≡
 
@@ -27,9 +26,9 @@ open SetoidEquality (≡.setoid A) public
 ------------------------------------------------------------------------
 -- ≋ is propositional
 
-≋⇒≡ : _≋_ ⇒ _≡_
+≋⇒≡ : Refl _≋_ _≡_
 ≋⇒≡ []             = refl
 ≋⇒≡ (refl ∷ xs≈ys) = cong (_ ∷_) (≋⇒≡ xs≈ys)
 
-≡⇒≋ : _≡_ ⇒ _≋_
+≡⇒≋ : Refl _≡_ _≋_
 ≡⇒≋ refl = ≋-refl

--- a/src/Data/List/Relation/Binary/Lex/NonStrict.agda
+++ b/src/Data/List/Relation/Binary/Lex/NonStrict.agda
@@ -19,13 +19,13 @@ open import Data.List.Relation.Binary.Pointwise.Base using (Pointwise; [])
 import Data.List.Relation.Binary.Lex.Strict as Strict
 open import Level
 open import Relation.Nullary
-open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Bundles
   using (Poset; StrictPartialOrder; DecTotalOrder; StrictTotalOrder; Preorder)
 open import Relation.Binary.Structures
   using (IsEquivalence; IsPartialOrder; IsStrictPartialOrder; IsTotalOrder; IsStrictTotalOrder; IsPreorder; IsDecTotalOrder)
 open import Relation.Binary.Definitions
-  using (Irreflexive; _Respects₂_; Antisymmetric; Asymmetric; Symmetric; Transitive; Decidable; Total; Trichotomous)
+  using (Irreflexive; _Respects₂_; Antisymmetric; Asymmetric; Refl; Symmetric; Transitive; Decidable; Total; Trichotomous)
 import Relation.Binary.Construct.NonStrictToStrict as Conv
 
 import Data.List.Relation.Binary.Lex as Core
@@ -120,7 +120,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
   Lex-≤ : (_≈_ : Rel A ℓ₁) (_≼_ : Rel A ℓ₂) → Rel (List A) (a ⊔ ℓ₁ ⊔ ℓ₂)
   Lex-≤ _≈_ _≼_ = Core.Lex ⊤ _≈_ (Conv._<_ _≈_ _≼_)
 
-  ≤-reflexive : ∀ _≈_ _≼_ → Pointwise _≈_ ⇒ Lex-≤ _≈_ _≼_
+  ≤-reflexive : ∀ _≈_ _≼_ → Refl (Pointwise _≈_) (Lex-≤ _≈_ _≼_)
   ≤-reflexive _≈_ _≼_ = Strict.≤-reflexive _≈_ (Conv._<_ _≈_ _≼_)
 
   -- Properties

--- a/src/Data/List/Relation/Binary/Lex/Strict.agda
+++ b/src/Data/List/Relation/Binary/Lex/Strict.agda
@@ -19,13 +19,13 @@ open import Data.Sum.Base using (inj₁; inj₂)
 open import Data.List.Base using (List; []; _∷_)
 open import Level using (_⊔_)
 open import Relation.Nullary using (yes; no; ¬_)
-open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Bundles
   using (StrictPartialOrder; StrictTotalOrder; Preorder; Poset; DecPoset; DecTotalOrder)
 open import Relation.Binary.Structures
   using (IsEquivalence; IsStrictPartialOrder; IsStrictTotalOrder; IsPreorder; IsPartialOrder; IsDecPartialOrder; IsTotalOrder; IsDecTotalOrder)
 open import Relation.Binary.Definitions
-  using (Irreflexive; Symmetric; _Respects₂_; Total; Asymmetric; Antisymmetric; Transitive; Trichotomous; Decidable; tri≈; tri<; tri>)
+  using (Refl; Irreflexive; Symmetric; _Respects₂_; Total; Asymmetric; Antisymmetric; Transitive; Trichotomous; Decidable; tri≈; tri<; tri>)
 open import Relation.Binary.Consequences
 open import Data.List.Relation.Binary.Pointwise as Pointwise
    using (Pointwise; []; _∷_; head; tail)
@@ -145,7 +145,7 @@ module _ {a ℓ₁ ℓ₂} {A : Set a} where
   -- Properties
 
   ≤-reflexive : (_≈_ : Rel A ℓ₁) (_≺_ : Rel A ℓ₂) →
-                Pointwise _≈_ ⇒ Lex-≤ _≈_ _≺_
+                Refl (Pointwise _≈_) (Lex-≤ _≈_ _≺_)
   ≤-reflexive _≈_ _≺_ []            = base tt
   ≤-reflexive _≈_ _≺_ (x≈y ∷ xs≈ys) =
     next x≈y (≤-reflexive _≈_ _≺_ xs≈ys)

--- a/src/Data/List/Relation/Binary/Permutation/Propositional.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional.agda
@@ -11,10 +11,10 @@ module Data.List.Relation.Binary.Permutation.Propositional
 
 open import Data.List.Base using (List; []; _∷_)
 open import Data.List.Relation.Binary.Equality.Propositional using (_≋_; ≋⇒≡)
-open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
-open import Relation.Binary.Definitions using (Reflexive; Transitive)
+open import Relation.Binary.Definitions using (Refl; Reflexive; Transitive)
 open import Relation.Binary.PropositionalEquality as ≡ using (_≡_; refl)
 import Relation.Binary.Reasoning.Setoid as EqReasoning
 open import Relation.Binary.Reasoning.Syntax
@@ -57,10 +57,10 @@ data _↭_ : Rel (List A) a where
 ------------------------------------------------------------------------
 -- _↭_ is an equivalence
 
-↭-reflexive : _≡_ ⇒ _↭_
+↭-reflexive : Refl _≡_ _↭_
 ↭-reflexive refl = ↭-refl
 
-↭-reflexive-≋ : _≋_ ⇒ _↭_
+↭-reflexive-≋ : Refl _≋_ _↭_
 ↭-reflexive-≋ xs≋ys = ↭-reflexive (≋⇒≡ xs≋ys)
 
 ↭-sym : xs ↭ ys → ys ↭ xs
@@ -102,7 +102,7 @@ private
 ↭⇒↭ₛ (trans p q)  = ↭ₛ.↭-trans′ (↭⇒↭ₛ p) (↭⇒↭ₛ q)
 
 
-↭ₛ⇒↭ : _↭ₛ_ ⇒ _↭_
+↭ₛ⇒↭ : xs ↭ₛ ys → xs ↭ ys
 ↭ₛ⇒↭ (↭ₛ.refl xs≋ys)       = ↭-reflexive-≋ xs≋ys
 ↭ₛ⇒↭ (↭ₛ.prep refl p)      = ↭-prep _ (↭ₛ⇒↭ p)
 ↭ₛ⇒↭ (↭ₛ.swap refl refl p) = ↭-swap _ _ (↭ₛ⇒↭ p)

--- a/src/Data/List/Relation/Binary/Permutation/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Setoid.agda
@@ -16,9 +16,9 @@ import Data.List.Relation.Binary.Permutation.Homogeneous as Homogeneous
 import Data.List.Relation.Binary.Equality.Setoid as ≋
 open import Function.Base using (_∘′_)
 open import Level using (_⊔_)
-open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; LeftTrans; RightTrans)
+  using (Refl; Reflexive; Symmetric; Transitive; LeftTrans; RightTrans)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl)
 import Relation.Binary.Reasoning.Setoid as ≈-Reasoning
 open import Relation.Binary.Reasoning.Syntax
@@ -45,7 +45,7 @@ steps = Homogeneous.steps {R = _≈_}
 
 -- Constructor alias
 
-↭-reflexive-≋ : _≋_ ⇒ _↭_
+↭-reflexive-≋ : Refl _≋_ _↭_
 ↭-reflexive-≋ = refl
 
 ↭-trans : Transitive _↭_
@@ -63,7 +63,7 @@ steps = Homogeneous.steps {R = _≈_}
 ------------------------------------------------------------------------
 -- _↭_ is an equivalence
 
-↭-reflexive : _≡_ ⇒ _↭_
+↭-reflexive : Refl _≡_ _↭_
 ↭-reflexive refl = ↭-reflexive-≋ ≋-refl
 
 ↭-refl : Reflexive _↭_

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -35,7 +35,7 @@ open import Relation.Unary as U using (Pred)
 open import Relation.Binary.Core using (Rel; REL; _⇒_)
 open import Relation.Binary.Bundles using (Preorder; Poset; DecPoset)
 open import Relation.Binary.Definitions
-  using (Reflexive; Trans; Antisym; Decidable; Irrelevant; Irreflexive)
+  using (Refl; Reflexive; Trans; Antisym; Decidable; Irrelevant; Irreflexive)
 open import Relation.Binary.Structures
   using (IsPreorder; IsPartialOrder; IsDecPartialOrder)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
@@ -374,11 +374,11 @@ module Reflexivity
     {R : Rel A r}
     (R-refl : Reflexive R) where
 
-  reflexive : _≡_ ⇒ Sublist R
-  reflexive ≡.refl = fromPointwise (Pw.refl R-refl)
+  reflexive : Refl _≡_ (Sublist R)
+  reflexive = ≡.refl⇒reflexive {_≈_ = Sublist R} (fromPointwise (Pw.refl R-refl))
 
   refl : Reflexive (Sublist R)
-  refl = reflexive ≡.refl
+  refl = ≡.reflexive⇒refl reflexive
 
 open Reflexivity public
 

--- a/src/Data/List/Relation/Binary/Sublist/Propositional.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Propositional.agda
@@ -14,10 +14,9 @@ open import Data.List.Base using (List)
 open import Data.List.Relation.Binary.Equality.Propositional using (≋⇒≡)
 import Data.List.Relation.Binary.Sublist.Setoid as SetoidSublist
 open import Data.List.Relation.Unary.Any using (Any)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles using (Preorder; Poset)
 open import Relation.Binary.Structures using (IsPreorder; IsPartialOrder)
-open import Relation.Binary.Definitions using (Antisymmetric)
+open import Relation.Binary.Definitions using (Refl; Antisymmetric)
 open import Relation.Binary.PropositionalEquality.Core
   using (subst; _≡_; refl)
 open import Relation.Binary.PropositionalEquality.Properties
@@ -45,7 +44,7 @@ module _ {p} {P : Pred A p} where
 ------------------------------------------------------------------------
 -- Relational properties
 
-⊆-reflexive : _≡_ ⇒ _⊆_
+⊆-reflexive : Refl _≡_ _⊆_
 ⊆-reflexive refl = ⊆-refl
 
 ⊆-antisym : Antisymmetric _≡_ _⊆_

--- a/src/Data/List/Relation/Binary/Sublist/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Setoid.agda
@@ -26,7 +26,7 @@ import Data.List.Relation.Binary.Sublist.Heterogeneous.Properties
   as HeterogeneousProperties
 open import Data.Product.Base using (∃; ∃₂; _×_; _,_; proj₂)
 
-open import Relation.Binary.Core using (_⇒_)
+open import Relation.Binary.Definitions using (Refl)
 open import Relation.Binary.Bundles using (Preorder; Poset)
 open import Relation.Binary.Structures using (IsPreorder; IsPartialOrder)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
@@ -86,7 +86,7 @@ open DisjointUnion public
 ------------------------------------------------------------------------
 -- Relational properties holding for Setoid case
 
-⊆-reflexive : _≋_ ⇒ _⊆_
+⊆-reflexive : Refl _≋_ _⊆_
 ⊆-reflexive = HeterogeneousProperties.fromPointwise
 
 open HeterogeneousProperties.Reflexivity {R = _≈_} refl public using ()

--- a/src/Data/Maybe/Relation/Binary/Connected.agda
+++ b/src/Data/Maybe/Relation/Binary/Connected.agda
@@ -10,9 +10,10 @@ module Data.Maybe.Relation.Binary.Connected where
 
 open import Level
 open import Data.Maybe.Base using (Maybe; just; nothing)
+open import Function.Base using (_∘_)
 open import Function.Bundles using (_⇔_; mk⇔)
-open import Relation.Binary.Core using (REL; _⇒_)
-open import Relation.Binary.Definitions using (Reflexive; Sym; Decidable)
+open import Relation.Binary.Core using (REL)
+open import Relation.Binary.Definitions using (Refl; Reflexive; Sym; Decidable)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 open import Relation.Nullary
 import Relation.Nullary.Decidable as Dec
@@ -51,8 +52,8 @@ refl : Reflexive R → Reflexive (Connected R)
 refl R-refl {just _}  = just R-refl
 refl R-refl {nothing} = nothing
 
-reflexive : _≡_ ⇒ R → _≡_ ⇒ Connected R
-reflexive reflexive ≡.refl = refl (reflexive ≡.refl)
+reflexive : Refl _≡_ R → Refl _≡_ (Connected R)
+reflexive = ≡.refl⇒reflexive ∘ refl ∘ ≡.reflexive⇒refl
 
 sym : Sym R S → Sym (Connected R) (Connected S)
 sym R-sym (just p)     = just (R-sym p)

--- a/src/Data/Maybe/Relation/Binary/Pointwise.agda
+++ b/src/Data/Maybe/Relation/Binary/Pointwise.agda
@@ -12,10 +12,11 @@ open import Level
 open import Data.Product.Base using (∃; _×_; -,_; _,_)
 open import Data.Maybe.Base using (Maybe; just; nothing)
 open import Data.Maybe.Relation.Unary.Any using (Any; just)
+open import Function.Base using (_∘_)
 open import Function.Bundles using (_⇔_; mk⇔)
 open import Relation.Binary.Core using (REL; Rel; _⇒_)
 open import Relation.Binary.Bundles using (Setoid; DecSetoid)
-open import Relation.Binary.Definitions using (Reflexive; Sym; Trans; Decidable)
+open import Relation.Binary.Definitions using (Refl; Reflexive; Sym; Trans; Decidable)
 open import Relation.Binary.Structures using (IsEquivalence; IsDecEquivalence)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 open import Relation.Nullary
@@ -57,8 +58,8 @@ module _ {a r} {A : Set a} {R : Rel A r} where
   refl R-refl {just _}  = just R-refl
   refl R-refl {nothing} = nothing
 
-  reflexive : _≡_ ⇒ R → _≡_ ⇒ Pointwise R
-  reflexive reflexive ≡.refl = refl (reflexive ≡.refl)
+  reflexive : Refl _≡_ R → Refl _≡_ (Pointwise R)
+  reflexive = ≡.refl⇒reflexive ∘ refl ∘ ≡.reflexive⇒refl
 
 module _ {a b r₁ r₂} {A : Set a} {B : Set b}
          {R : REL A B r₁} {S : REL B A r₂} where

--- a/src/Data/Nat/Binary/Properties.agda
+++ b/src/Data/Nat/Binary/Properties.agda
@@ -525,8 +525,8 @@ toℕ-isMonomorphism-≤ = record
 ≤-refl : Reflexive _≤_
 ≤-refl =  inj₂ refl
 
-≤-reflexive : _≡_ ⇒ _≤_
-≤-reflexive {x} {_} refl =  ≤-refl {x}
+≤-reflexive : Refl _≡_ _≤_
+≤-reflexive {x} {_} refl = ≤-refl {x}
 
 ≤-trans : Transitive _≤_
 ≤-trans = StrictToNonStrict.trans isEquivalence (resp₂ _<_) <-trans

--- a/src/Data/Nat/Divisibility.agda
+++ b/src/Data/Nat/Divisibility.agda
@@ -17,12 +17,11 @@ open import Function.Bundles using (_⇔_; mk⇔)
 open import Level using (0ℓ)
 open import Relation.Nullary.Decidable as Dec using (yes; no)
 open import Relation.Nullary.Negation.Core using (contradiction)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles using (Preorder; Poset)
 open import Relation.Binary.Structures
   using (IsPreorder; IsPartialOrder)
 open import Relation.Binary.Definitions
-  using (Reflexive; Transitive; Antisymmetric; Decidable)
+  using (Refl; Reflexive; Transitive; Antisymmetric; Decidable)
 import Relation.Binary.Reasoning.Preorder as ≲-Reasoning
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl; sym; cong; subst)
@@ -102,7 +101,7 @@ m%n≡0⇔n∣m m n = mk⇔ (m%n≡0⇒n∣m m n) (n∣m⇒m%n≡0 m n)
 
 -- these could/should inherit from Algebra.Properties.Monoid.Divisibility
 
-∣-reflexive : _≡_ ⇒ _∣_
+∣-reflexive : Refl _≡_ _∣_
 ∣-reflexive {n} refl = divides 1 (sym (*-identityˡ n))
 
 ∣-refl : Reflexive _∣_

--- a/src/Data/Nat/Properties.agda
+++ b/src/Data/Nat/Properties.agda
@@ -170,7 +170,7 @@ m ≟ n = map′ (≡ᵇ⇒≡ m n) (≡⇒≡ᵇ m n) (T? (m ≡ᵇ n))
 ------------------------------------------------------------------------
 -- Relational properties of _≤_
 
-≤-reflexive : _≡_ ⇒ _≤_
+≤-reflexive : Refl _≡_ _≤_
 ≤-reflexive {zero}  refl = z≤n
 ≤-reflexive {suc m} refl = s≤s (≤-reflexive refl)
 

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -37,7 +37,7 @@ Pointwise R S (a , c) (b , d) = (R a b) × (S c d)
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
 
-×-reflexive : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
+×-reflexive : Refl ≈₁ R → Refl ≈₂ S → Refl (Pointwise ≈₁ ≈₂) (Pointwise R S)
 ×-reflexive refl₁ refl₂ = Product.map refl₁ refl₂
 
 ×-refl : Reflexive R → Reflexive S → Reflexive (Pointwise R S)
@@ -190,10 +190,10 @@ _×ₛ_ = ×-setoid
 -- The propositional equality setoid over products can be
 -- decomposed using ×-Rel
 
-≡×≡⇒≡ : Pointwise _≡_ _≡_ ⇒ _≡_ {A = A × B}
+≡×≡⇒≡ : Refl (Pointwise _≡_ _≡_) (_≡_ {A = A × B})
 ≡×≡⇒≡ (≡.refl , ≡.refl) = ≡.refl
 
-≡⇒≡×≡ : _≡_ {A = A × B} ⇒ Pointwise _≡_ _≡_
+≡⇒≡×≡ : Refl (_≡_ {A = A × B}) (Pointwise _≡_ _≡_)
 ≡⇒≡×≡ ≡.refl = (≡.refl , ≡.refl)
 
 Pointwise-≡↔≡ : Inverse (≡.setoid A ×ₛ ≡.setoid B) (≡.setoid (A × B))

--- a/src/Data/Rational/Properties.agda
+++ b/src/Data/Rational/Properties.agda
@@ -499,7 +499,7 @@ toℚᵘ-isOrderMonomorphism-≤ = record
 private
   module ≤-Monomorphism = OrderMonomorphisms toℚᵘ-isOrderMonomorphism-≤
 
-≤-reflexive : _≡_ ⇒ _≤_
+≤-reflexive : Refl _≡_ _≤_
 ≤-reflexive refl = *≤* ℤ.≤-refl
 
 ≤-refl : Reflexive _≤_

--- a/src/Data/Rational/Unnormalised/Properties.agda
+++ b/src/Data/Rational/Unnormalised/Properties.agda
@@ -37,7 +37,7 @@ open import Relation.Binary.Bundles
 open import Relation.Binary.Structures
   using (IsEquivalence; IsDecEquivalence; IsApartnessRelation; IsTotalPreorder; IsPreorder; IsPartialOrder; IsTotalOrder; IsDecTotalOrder; IsStrictPartialOrder; IsStrictTotalOrder; IsDenseLinearOrder)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; Cotransitive; Tight; Decidable; Antisymmetric; Asymmetric; Dense; Total; Trans; Trichotomous; Irreflexive; Irrelevant; _Respectsˡ_; _Respectsʳ_; _Respects₂_; tri≈; tri<; tri>)
+  using (Refl; Reflexive; Symmetric; Transitive; Cotransitive; Tight; Decidable; Antisymmetric; Asymmetric; Dense; Total; Trans; Trichotomous; Irreflexive; Irrelevant; _Respectsˡ_; _Respectsʳ_; _Respects₂_; tri≈; tri<; tri>)
 import Relation.Binary.Consequences as BC
 open import Relation.Binary.PropositionalEquality
 import Relation.Binary.Properties.Poset as PosetProperties
@@ -81,7 +81,7 @@ drop-*≡* (*≡* eq) = eq
 ≃-refl : Reflexive _≃_
 ≃-refl = *≡* refl
 
-≃-reflexive : _≡_ ⇒ _≃_
+≃-reflexive : Refl _≡_ _≃_
 ≃-reflexive refl = *≡* refl
 
 ≃-sym : Symmetric _≃_

--- a/src/Data/String/Properties.agda
+++ b/src/Data/String/Properties.agda
@@ -17,13 +17,12 @@ open import Data.String.Base
 open import Function.Base
 open import Relation.Nullary.Decidable using (yes; no)
 open import Relation.Nullary.Decidable using (map′; isYes)
-open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles
   using (Setoid; DecSetoid; StrictPartialOrder; StrictTotalOrder; DecTotalOrder; DecPoset)
 open import Relation.Binary.Structures
   using (IsEquivalence; IsDecEquivalence; IsStrictPartialOrder; IsStrictTotalOrder; IsDecPartialOrder; IsDecTotalOrder)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; Substitutive; Decidable; DecidableEquality)
+  using (Refl; Reflexive; Symmetric; Transitive; Substitutive; Decidable; DecidableEquality)
 open import Relation.Binary.PropositionalEquality.Core
 import Relation.Binary.Construct.On as On
 import Relation.Binary.PropositionalEquality.Properties as PropEq
@@ -37,11 +36,11 @@ open import Agda.Builtin.String.Properties public
 ------------------------------------------------------------------------
 -- Properties of _≈_
 
-≈⇒≡ : _≈_ ⇒ _≡_
+≈⇒≡ : Refl _≈_ _≡_
 ≈⇒≡ = toList-injective _ _
     ∘ Pointwise.Pointwise-≡⇒≡
 
-≈-reflexive : _≡_ ⇒ _≈_
+≈-reflexive : Refl _≡_ _≈_
 ≈-reflexive = Pointwise.≡⇒Pointwise-≡
             ∘ cong toList
 

--- a/src/Data/Sum/Relation/Binary/Pointwise.agda
+++ b/src/Data/Sum/Relation/Binary/Pointwise.agda
@@ -200,11 +200,11 @@ _⊎ₛ_ = ⊎-setoid
 -- The propositional equality setoid over products can be
 -- decomposed using Pointwise
 
-Pointwise-≡⇒≡ : (Pointwise _≡_ _≡_) ⇒ _≡_ {A = A ⊎ B}
+Pointwise-≡⇒≡ : Refl (Pointwise _≡_ _≡_) (_≡_ {A = A ⊎ B})
 Pointwise-≡⇒≡ (inj₁ x) = ≡.cong inj₁ x
 Pointwise-≡⇒≡ (inj₂ x) = ≡.cong inj₂ x
 
-≡⇒Pointwise-≡ : _≡_ {A = A ⊎ B} ⇒ (Pointwise _≡_ _≡_)
+≡⇒Pointwise-≡ : Refl (_≡_ {A = A ⊎ B}) (Pointwise _≡_ _≡_)
 ≡⇒Pointwise-≡ ≡.refl = ⊎-refl ≡.refl ≡.refl
 
 Pointwise-≡↔≡ : (A : Set a) (B : Set b) →

--- a/src/Data/Vec/Functional/Relation/Binary/Equality/Setoid.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Equality/Setoid.agda
@@ -16,7 +16,7 @@ open import Relation.Binary.Core using (_⇒_)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive)
+  using (Refl; Reflexive; Symmetric; Transitive)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 
 module Data.Vec.Functional.Relation.Binary.Equality.Setoid
@@ -40,7 +40,7 @@ _≋_ = Pointwise _≈_
 ≋-refl : ∀ {n} → Reflexive (_≋_ {n = n})
 ≋-refl {n} = PW.refl {R = _≈_} refl
 
-≋-reflexive : ∀ {n} → _≡_ ⇒ (_≋_ {n = n})
+≋-reflexive : ∀ {n} → Refl _≡_ (_≋_ {n = n})
 ≋-reflexive ≡.refl = ≋-refl
 
 ≋-sym : ∀ {n} → Symmetric (_≋_ {n = n})

--- a/src/Data/Vec/Relation/Binary/Equality/Cast.agda
+++ b/src/Data/Vec/Relation/Binary/Equality/Cast.agda
@@ -17,8 +17,8 @@ open import Function.Base using (_∘_)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Nat.Properties using (suc-injective)
 open import Data.Vec.Base
-open import Relation.Binary.Core using (REL; _⇒_)
-open import Relation.Binary.Definitions using (Sym; Trans)
+open import Relation.Binary.Core using (REL)
+open import Relation.Binary.Definitions using (Refl; Sym; Trans)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; trans; sym; cong)
 open import Relation.Binary.PropositionalEquality.Properties
@@ -51,7 +51,7 @@ xs ≈[ eq ] ys = cast eq xs ≡ ys
 ------------------------------------------------------------------------
 -- _≈[_]_ is ‘reflexive’, ‘symmetric’ and ‘transitive’
 
-≈-reflexive : ∀ {n} → _≡_ ⇒ (λ xs ys → _≈[_]_ {A = A} {n} xs refl ys)
+≈-reflexive : ∀ {n} → Refl _≡_ (λ xs ys → _≈[_]_ {A = A} {n} xs refl ys)
 ≈-reflexive {x = x} eq = trans (cast-is-id refl x) eq
 
 ≈-sym : .{m≡n : m ≡ n} → Sym {A = Vec A m} _≈[ m≡n ]_ _≈[ sym m≡n ]_

--- a/src/Data/Word64/Properties.agda
+++ b/src/Data/Word64/Properties.agda
@@ -14,7 +14,7 @@ open import Data.Word64.Base using (_≈_; toℕ; Word64; _<_)
 import Data.Nat.Properties as ℕ
 open import Relation.Nullary.Decidable.Core using (map′; ⌊_⌋)
 open import Relation.Binary
-  using ( _⇒_; Reflexive; Symmetric; Transitive; Substitutive
+  using ( _⇒_; Refl; Reflexive; Symmetric; Transitive; Substitutive
         ; Decidable; DecidableEquality; IsEquivalence; IsDecEquivalence
         ; Setoid; DecSetoid; StrictTotalOrder)
 import Relation.Binary.Construct.On as On
@@ -33,10 +33,10 @@ open import Agda.Builtin.Word.Properties
 ------------------------------------------------------------------------
 -- Properties of _≈_
 
-≈⇒≡ : _≈_ ⇒ _≡_
+≈⇒≡ : Refl _≈_ _≡_
 ≈⇒≡ = toℕ-injective _ _
 
-≈-reflexive : _≡_ ⇒ _≈_
+≈-reflexive : Refl _≡_ _≈_
 ≈-reflexive = cong toℕ
 
 ≈-refl : Reflexive _≈_

--- a/src/Relation/Binary/Construct/FromPred.agda
+++ b/src/Relation/Binary/Construct/FromPred.agda
@@ -7,10 +7,10 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Core using (Rel; _⇒_)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Bundles using (Setoid; Preorder)
 open import Relation.Binary.Structures using (IsPreorder)
-open import Relation.Binary.Definitions using (_Respects_; Reflexive; Transitive)
+open import Relation.Binary.Definitions using (_Respects_; Refl; Reflexive; Transitive)
 open import Relation.Unary using (Pred)
 
 module Relation.Binary.Construct.FromPred
@@ -18,7 +18,7 @@ module Relation.Binary.Construct.FromPred
   {p} (P : Pred (Setoid.Carrier S) p) -- The predicate
   where
 
-open import Function.Base
+open import Function.Base using (_∘_)
 
 open module Eq = Setoid S using (_≈_) renaming (Carrier to A)
 
@@ -31,7 +31,7 @@ Resp x y = P x → P y
 ------------------------------------------------------------------------
 -- Properties
 
-reflexive : P Respects _≈_ → _≈_ ⇒ Resp
+reflexive : P Respects _≈_ → Refl _≈_ Resp
 reflexive resp = resp
 
 refl : P Respects _≈_ → Reflexive Resp
@@ -44,7 +44,7 @@ isPreorder : P Respects _≈_ → IsPreorder _≈_ Resp
 isPreorder resp = record
   { isEquivalence = Eq.isEquivalence
   ; reflexive     = reflexive resp
-  ; trans         = flip _∘′_
+  ; trans         = trans
   }
 
 preorder : P Respects _≈_ → Preorder _ _ _

--- a/src/Relation/Binary/Construct/FromRel.agda
+++ b/src/Relation/Binary/Construct/FromRel.agda
@@ -7,10 +7,10 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Core using (REL; Rel; _⇒_)
+open import Relation.Binary.Core using (REL; Rel)
 open import Relation.Binary.Bundles using (Setoid; Preorder)
 open import Relation.Binary.Structures using (IsPreorder)
-open import Relation.Binary.Definitions using (_Respects_; Transitive)
+open import Relation.Binary.Definitions using (_Respects_; Refl; Transitive)
 open Setoid using (Carrier)
 
 module Relation.Binary.Construct.FromRel
@@ -32,7 +32,7 @@ Resp x y = ∀ {a} → a R x → a R y
 ------------------------------------------------------------------------
 -- Properties
 
-reflexive : (∀ {a} → (a R_) Respects _≈_) → _≈_ ⇒ Resp
+reflexive : (∀ {a} → (a R_) Respects _≈_) → Refl _≈_ Resp
 reflexive resp x≈y = resp x≈y
 
 trans : Transitive Resp

--- a/src/Relation/Binary/Construct/StrictToNonStrict.agda
+++ b/src/Relation/Binary/Construct/StrictToNonStrict.agda
@@ -14,7 +14,7 @@ open import Relation.Binary.Core using (Rel; _⇒_)
 open import Relation.Binary.Structures
   using (IsEquivalence; IsPreorder; IsStrictPartialOrder; IsPartialOrder; IsStrictTotalOrder; IsTotalOrder; IsDecTotalOrder)
 open import Relation.Binary.Definitions
-  using (Transitive; Symmetric; Irreflexive; Antisymmetric; Trichotomous; Decidable; Trans; Total; _Respects₂_; _Respectsʳ_; _Respectsˡ_; tri<; tri≈; tri>)
+  using (Refl; Transitive; Symmetric; Irreflexive; Antisymmetric; Trichotomous; Decidable; Trans; Total; _Respects₂_; _Respectsʳ_; _Respectsˡ_; tri<; tri≈; tri>)
 
 module Relation.Binary.Construct.StrictToNonStrict
   {a ℓ₁ ℓ₂} {A : Set a}
@@ -44,7 +44,7 @@ x ≤ y = (x < y) ⊎ (x ≈ y)
 <⇒≤ : _<_ ⇒ _≤_
 <⇒≤ = inj₁
 
-reflexive : _≈_ ⇒ _≤_
+reflexive : Refl _≈_ _≤_
 reflexive = inj₂
 
 antisym : IsEquivalence _≈_ → Transitive _<_ → Irreflexive _≈_ _<_ →

--- a/src/Relation/Binary/Construct/Union.agda
+++ b/src/Relation/Binary/Construct/Union.agda
@@ -14,7 +14,7 @@ open import Function.Base using (_∘_)
 open import Level using (Level; _⊔_)
 open import Relation.Binary.Core using (REL; Rel; _⇒_)
 open import Relation.Binary.Definitions
-  using (Reflexive; Total; Minimum; Maximum; Symmetric; Irreflexive; Decidable; _Respects_; _Respectsˡ_; _Respectsʳ_; _Respects₂_)
+  using (Refl; Reflexive; Total; Minimum; Maximum; Symmetric; Irreflexive; Decidable; _Respects_; _Respectsˡ_; _Respectsʳ_; _Respects₂_)
 open import Relation.Nullary.Decidable using (yes; no; _⊎-dec_)
 
 private

--- a/src/Relation/Binary/Definitions.agda
+++ b/src/Relation/Binary/Definitions.agda
@@ -41,6 +41,9 @@ private
 Reflexive : Rel A ℓ → Set _
 Reflexive _∼_ = ∀ {x} → x ∼ x
 
+Refl : Rel A ℓ₁ → Rel A ℓ₂ → Set _
+Refl = _⇒_
+
 -- Generalised symmetry.
 
 Sym : REL A B ℓ₁ → REL B A ℓ₂ → Set _

--- a/src/Relation/Binary/Morphism/OrderMonomorphism.agda
+++ b/src/Relation/Binary/Morphism/OrderMonomorphism.agda
@@ -16,7 +16,7 @@ open import Relation.Binary.Core using (Rel; _⇒_)
 open import Relation.Binary.Structures
   using (IsPreorder; IsPartialOrder; IsTotalOrder; IsDecTotalOrder; IsStrictPartialOrder; IsStrictTotalOrder)
 open import Relation.Binary.Definitions
-  using (Irreflexive; Antisymmetric; Trichotomous; tri<; tri≈; tri>; _Respectsˡ_; _Respectsʳ_; _Respects₂_)
+  using (Refl; Irreflexive; Antisymmetric; Trichotomous; tri<; tri≈; tri>; _Respectsˡ_; _Respectsʳ_; _Respects₂_)
 open import Relation.Binary.Morphism
 import Relation.Binary.Morphism.RelMonomorphism as RawRelation
 
@@ -40,8 +40,8 @@ open RawRelation isRelMonomorphism public
 ------------------------------------------------------------------------
 -- Properties
 
-reflexive : _≈₂_ ⇒ _≲₂_ → _≈₁_ ⇒ _≲₁_
-reflexive refl x≈y = cancel (refl (cong x≈y))
+reflexive : Refl _≈₂_ _≲₂_ → Refl _≈₁_ _≲₁_
+reflexive refl = cancel ∘ refl ∘ cong
 
 irrefl : Irreflexive _≈₂_ _≲₂_ → Irreflexive _≈₁_ _≲₁_
 irrefl irrefl x≈y x∼y = irrefl (cong x≈y) (mono x∼y)

--- a/src/Relation/Binary/PropositionalEquality/Core.agda
+++ b/src/Relation/Binary/PropositionalEquality/Core.agda
@@ -96,6 +96,17 @@ resp₂ : ∀ (∼ : Rel A ℓ) → ∼ Respects₂ _≡_
 resp₂ _∼_ = respʳ _∼_ , respˡ _∼_
 
 ------------------------------------------------------------------------
+-- Proofs for Reflexive relations
+
+module _ {_≈_ : Rel A ℓ} where
+
+  refl⇒reflexive : Reflexive _≈_ → Refl _≡_ _≈_
+  refl⇒reflexive r refl = r
+
+  reflexive⇒refl : Refl _≡_ _≈_ → Reflexive _≈_
+  reflexive⇒refl r = r refl
+
+------------------------------------------------------------------------
 -- Properties of _≢_
 
 ≢-sym : Symmetric {A = A} _≢_

--- a/src/Relation/Binary/Structures.agda
+++ b/src/Relation/Binary/Structures.agda
@@ -50,8 +50,8 @@ record IsEquivalence : Set (a ⊔ ℓ) where
     sym   : Symmetric _≈_
     trans : Transitive _≈_
 
-  reflexive : _≡_ ⇒ _≈_
-  reflexive ≡.refl = refl
+  reflexive : Refl _≡_ _≈_
+  reflexive = ≡.refl⇒reflexive {_≈_ = _≈_} refl
 
   isPartialEquivalence : IsPartialEquivalence
   isPartialEquivalence = record
@@ -77,7 +77,7 @@ record IsPreorder (_≲_ : Rel A ℓ₂) : Set (a ⊔ ℓ ⊔ ℓ₂) where
   field
     isEquivalence : IsEquivalence
     -- Reflexivity is expressed in terms of the underlying equality:
-    reflexive     : _≈_ ⇒ _≲_
+    reflexive     : Refl _≈_ _≲_
     trans         : Transitive _≲_
 
   module Eq = IsEquivalence isEquivalence


### PR DESCRIPTION
Fixes #2628

Probably sheer folly without also making the swap of `Refl` and `Reflexive`, but this could be the enabling groundwork for that.

DRAFT for comment/discussion; will only fix merge conflicts if it's worth pursuing at all.