### PR TITLE
[ add ] `Relation.Binary.Properties.PartialSetoid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ New modules
 
 * `Data.Sign.Show` to show a sign
 
+* `Relation.Binary.Properties.PartialSetoid` to systematise properties of a PER
+
 Additions to existing modules
 -----------------------------
 

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -30,18 +30,18 @@ trans-reflˡ ≡.refl p = p
 trans-reflʳ : RightTrans _≈_ _≡_
 trans-reflʳ p ≡.refl = p
 
-p-reflˡ : x ≈ y → x ≈ x
-p-reflˡ p = trans p (sym p)
+partial-reflˡ : x ≈ y → x ≈ x
+partial-reflˡ p = trans p (sym p)
 
-p-reflʳ : x ≈ y → y ≈ y
-p-reflʳ p = trans (sym p) p
+partial-reflʳ : x ≈ y → y ≈ y
+partial-reflʳ p = trans (sym p) p
 
-p-refl : x ≈ y → x ≈ x × y ≈ y
-p-refl p = p-reflˡ p , p-reflʳ p
+partial-refl : x ≈ y → x ≈ x × y ≈ y
+partial-refl p = partial-reflˡ p , partial-reflʳ p
 
-p-reflexiveˡ : x ≈ y → x ≡ z → x ≈ z
-p-reflexiveˡ p ≡.refl = p-reflˡ p
+partial-reflexiveˡ : x ≈ y → x ≡ z → x ≈ z
+partial-reflexiveˡ p ≡.refl = partial-reflˡ p
 
-p-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
-p-reflexiveʳ p ≡.refl = p-reflʳ p
+partial-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
+partial-reflexiveʳ p ≡.refl = partial-reflʳ p
 

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -12,6 +12,7 @@ module Relation.Binary.Properties.PartialSetoid
   {a ℓ} (S : PartialSetoid a ℓ) where
 
 open import Data.Product.Base using (_,_; _×_)
+open import Relation.Binary.Definitions using (LeftTrans; RightTrans)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
 
 open PartialSetoid S
@@ -23,10 +24,10 @@ private
 ------------------------------------------------------------------------
 -- Proofs for partial equivalence relations
 
-trans-reflˡ : x ≡ y → y ≈ z → x ≈ z
+trans-reflˡ : LeftTrans _≡_ _≈_
 trans-reflˡ ≡.refl p = p
 
-trans-reflʳ : x ≈ y → y ≡ z → x ≈ z
+trans-reflʳ : RightTrans _≈_ _≡_
 trans-reflʳ p ≡.refl = p
 
 p-reflˡ : x ≈ y → x ≈ x

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -1,0 +1,46 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Additional properties for setoids
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+open import Relation.Binary.Bundles using (PartialSetoid)
+
+module Relation.Binary.Properties.PartialSetoid
+  {a ℓ} (S : PartialSetoid a ℓ) where
+
+open import Data.Product.Base using (_,_; _×_)
+open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
+
+open PartialSetoid S
+
+private
+  variable
+    x y z : Carrier
+
+------------------------------------------------------------------------
+-- Proofs for partial equivalence relations
+
+trans-reflˡ : x ≡ y → y ≈ z → x ≈ z
+trans-reflˡ ≡.refl p = p
+
+trans-reflʳ : x ≈ y → y ≡ z → x ≈ z
+trans-reflʳ p ≡.refl = p
+
+p-reflˡ : x ≈ y → x ≈ x
+p-reflˡ p = trans p (sym p)
+
+p-reflʳ : x ≈ y → y ≈ y
+p-reflʳ p = trans (sym p) p
+
+p-refl : x ≈ y → x ≈ x × y ≈ y
+p-refl p = p-reflˡ p , p-reflʳ p
+
+p-reflexiveˡ : x ≈ y → x ≡ z → x ≈ z
+p-reflexiveˡ p ≡.refl = p-reflˡ p
+
+p-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
+p-reflexiveʳ p ≡.refl = p-reflʳ p
+


### PR DESCRIPTION
This adds the properties of PERs discussed in #2677 .

Issues:
* naming: `p-` prefix to signify 'partial'
* where to add: 
   - `Properties` (as here)
   - `Consequences` (contra: dependency on `PropositionalEquality`)
   - or as manifest fields of `Relation.Binary.Structures.IsPartialEquivalence` (contra: every `IsEquivalence` gets bloated by the addition)

Downstream:
* potential refactoring of `Relation.Binary.Properties.Setoid` to inherit from this?