### PR TITLE
Fix bug in Relation.Binary.Morphism.Bundles usage

### DIFF
--- a/src/Relation/Binary/OrderMorphism.agda
+++ b/src/Relation/Binary/OrderMorphism.agda
@@ -11,7 +11,7 @@ module Relation.Binary.OrderMorphism where
 
 {-# WARNING_ON_IMPORT
 "Relation.Binary.OrderMorphism was deprecated in v1.5.
-Use Relation.Binary.Reasoning.Morphism instead."
+Use Relation.Binary.Morphism.Bundles instead."
 #-}
 
 open import Relation.Binary.Core using (_=[_]⇒_)


### PR DESCRIPTION
Update the deprecation warning to correctly reference Relation.Binary.Morphism.Bundles instead of Relation.Binary.Reasoning.Morphism.