### PR TITLE
[ add ] product structure on `RawSetoid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,9 +163,9 @@ New modules
 
 * `Data.List.Relation.Binary.Suffix.Propositional.Properties` showing the equivalence to right divisibility induced by the list monoid.
 
-* `Data.Sign.Show` to show a sign
+* `Data.Sign.Show` to show a sign.
 
-* `Relation.Binary.Morphism.Construct.Product` to plumb in the (categorical) product structure on `RawSetoid`
+* `Relation.Binary.Morphism.Construct.Product` to plumb in the (categorical) product structure on `RawSetoid`.
 
 Additions to existing modules
 -----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@ New modules
 
 * `Data.Sign.Show` to show a sign
 
+* `Relation.Binary.Morphism.Construct.Product` to plumb in the (categorical) product structure on `RawSetoid`
+
 Additions to existing modules
 -----------------------------
 

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -2,7 +2,7 @@
 -- The Agda standard library
 --
 -- The projection morphisms for relational structures arising from the
--- product construction
+-- non-dependent product construction
 ------------------------------------------------------------------------
 
 {-# OPTIONS --safe --cubical-compatible #-}

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -66,9 +66,12 @@ module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
 ------------------------------------------------------------------------
 -- package up for export
 
-module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} {P : RawSetoid c ℓ} where
+module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} where
 
   proj₁ = Proj₁.isRelHomomorphism M N
   proj₂ = Proj₂.isRelHomomorphism M N
+
+module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} {P : RawSetoid c ℓ} where
+
   <_,_> = Pair.isRelHomomorphism M N P
 

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -13,7 +13,6 @@ import Data.Product.Base as Product using (<_,_>; proj₁; proj₂)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent as Pointwise
   using (Pointwise)
 open import Level using (Level)
---open import Relation.Binary.Construct using ()
 open import Relation.Binary.Bundles.Raw using (RawSetoid)
 open import Relation.Binary.Morphism.Structures using (IsRelHomomorphism)
 
@@ -23,7 +22,7 @@ private
 
 
 ------------------------------------------------------------------------
--- product construction on RawSetoid belongs in Relation.Binary.Construct.Product?
+-- definitions
 
 module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
 

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -14,48 +14,44 @@ open import Data.Product.Relation.Binary.Pointwise.NonDependent as Pointwise
   using (Pointwise)
 open import Level using (Level)
 open import Relation.Binary.Bundles.Raw using (RawSetoid)
+open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Morphism.Structures using (IsRelHomomorphism)
 
 private
   variable
     a b c ℓ₁ ℓ₂ ℓ : Level
+    A : Set a
+    B : Set b
+    C : Set c
 
 
 ------------------------------------------------------------------------
 -- definitions
 
-module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
+module _ (_≈₁_ : Rel A ℓ₁) (_≈₂_ : Rel B ℓ₂) where
 
   private
 
-    module M = RawSetoid M
-    module N = RawSetoid N
-
-    P : RawSetoid _ _
-    P = record { _≈_ = Pointwise M._≈_ N._≈_ }
-
-    module P = RawSetoid P
+    _≈_ = Pointwise _≈₁_ _≈₂_
 
   module Proj₁ where
 
-    isRelHomomorphism : IsRelHomomorphism P._≈_ M._≈_ Product.proj₁
+    isRelHomomorphism : IsRelHomomorphism _≈_ _≈₁_ Product.proj₁
     isRelHomomorphism = record { cong = Product.proj₁ }
 
 
   module Proj₂ where
 
-    isRelHomomorphism : IsRelHomomorphism P._≈_ N._≈_ Product.proj₂
+    isRelHomomorphism : IsRelHomomorphism _≈_ _≈₂_ Product.proj₂
     isRelHomomorphism = record { cong = Product.proj₂ }
 
 
-  module Pair (X : RawSetoid c ℓ)  where
-
-    private module X = RawSetoid X
+  module Pair (_≈′_ : Rel C ℓ)  where
 
     isRelHomomorphism : ∀ {h k} →
-                        IsRelHomomorphism X._≈_ M._≈_ h →
-                        IsRelHomomorphism X._≈_ N._≈_ k →
-                        IsRelHomomorphism X._≈_ P._≈_ Product.< h , k >
+                        IsRelHomomorphism _≈′_ _≈₁_ h →
+                        IsRelHomomorphism _≈′_ _≈₂_ k →
+                        IsRelHomomorphism _≈′_ _≈_ Product.< h , k >
     isRelHomomorphism H K = record { cong = Product.< H.cong , K.cong > }
       where
       module H = IsRelHomomorphism H
@@ -67,10 +63,19 @@ module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
 
 module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} where
 
-  proj₁ = Proj₁.isRelHomomorphism M N
-  proj₂ = Proj₂.isRelHomomorphism M N
+  private
 
-module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} {P : RawSetoid c ℓ} where
+    module M = RawSetoid M
+    module N = RawSetoid N
 
-  <_,_> = Pair.isRelHomomorphism M N P
+  proj₁ = Proj₁.isRelHomomorphism M._≈_ N._≈_
+  proj₂ = Proj₂.isRelHomomorphism M._≈_ N._≈_
+
+  module _ {P : RawSetoid c ℓ} where
+
+    private
+
+      module P = RawSetoid P
+
+    <_,_> = Pair.isRelHomomorphism M._≈_ N._≈_ P._≈_
 

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -1,0 +1,74 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- The projection morphisms for relational structures arising from the
+-- product construction
+------------------------------------------------------------------------
+
+{-# OPTIONS --safe --cubical-compatible #-}
+
+module Relation.Binary.Morphism.Construct.Product where
+
+import Data.Product.Base as Product using (<_,_>; proj₁; proj₂)
+open import Data.Product.Relation.Binary.Pointwise.NonDependent as Pointwise
+  using (Pointwise)
+open import Level using (Level)
+--open import Relation.Binary.Construct using ()
+open import Relation.Binary.Bundles.Raw using (RawSetoid)
+open import Relation.Binary.Morphism.Structures using (IsRelHomomorphism)
+
+private
+  variable
+    a b c ℓ₁ ℓ₂ ℓ : Level
+
+
+------------------------------------------------------------------------
+-- product construction on RawSetoid belongs in Relation.Binary.Construct.Product?
+
+module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
+
+  private
+
+    module M = RawSetoid M
+    module N = RawSetoid N
+
+    P : RawSetoid _ _
+    P = record { _≈_ = Pointwise M._≈_ N._≈_ }
+
+    module P = RawSetoid P
+
+  module Proj₁ where
+
+    isRelHomomorphism : IsRelHomomorphism P._≈_ M._≈_ Product.proj₁
+    isRelHomomorphism = record { cong = λ z → z .Product.proj₁ }
+
+
+  module Proj₂ where
+
+    isRelHomomorphism : IsRelHomomorphism P._≈_ N._≈_ Product.proj₂
+    isRelHomomorphism = record { cong = λ z → z .Product.proj₂ }
+
+
+  module Pair (X : RawSetoid c ℓ)  where
+
+    private module X = RawSetoid X
+
+    isRelHomomorphism : ∀ {h k} →
+                        IsRelHomomorphism X._≈_ M._≈_ h →
+                        IsRelHomomorphism X._≈_ N._≈_ k →
+                        IsRelHomomorphism X._≈_ P._≈_ Product.< h , k >
+    isRelHomomorphism H K = record { cong = Product.< H.cong , K.cong > }
+      where
+      module H = IsRelHomomorphism H
+      module K = IsRelHomomorphism K
+
+
+------------------------------------------------------------------------
+-- package up for export
+
+module _ {M : RawSetoid a ℓ₁} {N : RawSetoid b ℓ₂} {P : RawSetoid c ℓ} where
+
+  proj₁ = Proj₁.isRelHomomorphism M N
+  proj₂ = Proj₂.isRelHomomorphism M N
+  <_,_> = Pair.isRelHomomorphism M N P
+

--- a/src/Relation/Binary/Morphism/Construct/Product.agda
+++ b/src/Relation/Binary/Morphism/Construct/Product.agda
@@ -40,13 +40,13 @@ module _ (M : RawSetoid a ℓ₁) (N : RawSetoid b ℓ₂) where
   module Proj₁ where
 
     isRelHomomorphism : IsRelHomomorphism P._≈_ M._≈_ Product.proj₁
-    isRelHomomorphism = record { cong = λ z → z .Product.proj₁ }
+    isRelHomomorphism = record { cong = Product.proj₁ }
 
 
   module Proj₂ where
 
     isRelHomomorphism : IsRelHomomorphism P._≈_ N._≈_ Product.proj₂
-    isRelHomomorphism = record { cong = λ z → z .Product.proj₂ }
+    isRelHomomorphism = record { cong = Product.proj₂ }
 
 
   module Pair (X : RawSetoid c ℓ)  where


### PR DESCRIPTION
Lifts out the relevant constructions on `RawSetoid` from #2715 which is now marked blocking on this PR.

NB.
* constructions defined in named modules with explicit parametrisation, each as the relevant `IsRelHomomorphism`
* *then* defined for export in terms of the 'usual' expected names, with *implicit* parametrisation
* should the underlying `Pointwise` product of `RawSetoid`s be lifted out (trivially) to `Relation.Binary.Construct.Product`? (see discussion with/comments from @JacquesCarette below...)