### PR TITLE
Refactor `Data.Vec.Properties` : Add toList-injective and new lemmas 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,17 @@ Additions to existing modules
     LeftInverse (I ×ₛ A) (J ×ₛ B)
   ```
 
+* In `Data.Vec.Properties`:
+  ```agda
+  toList-injective : ∀ {m n} → .(m=n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) →
+                     toList xs ≡ toList ys → xs ≈[ m=n ] ys
+  fromList-reverse : (xs : List A) → (fromList (L.reverse xs)) ≈[ L.length-reverse xs ] reverse (fromList xs)
+  ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
+                  cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
+  ʳ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
+                   cast eq ((xs ʳ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ++ zs)
+  ```
+
 * In `Data.Vec.Relation.Binary.Pointwise.Inductive`:
   ```agda
   zipWith-assoc : Associative _∼_ f → Associative (Pointwise _∼_) (zipWith {n = n} f)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Deprecated names
   ∈⇒∣product   ↦  Data.Nat.ListAction.Properties.∈⇒∣product
   product≢0    ↦  Data.Nat.ListAction.Properties.product≢0
   ∈⇒≤product   ↦  Data.Nat.ListAction.Properties.∈⇒≤product
+  ∷-ʳ++-eqFree ↦  Data.List.Properties.ʳ++-ʳ++-eqFree
   ```
 
 * In `Data.List.Relation.Binary.Permutation.Propositional.Properties`:
@@ -296,13 +297,14 @@ Additions to existing modules
 
 * In `Data.Vec.Properties`:
   ```agda
-  toList-injective : ∀ {m n} → .(m=n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) →
-                     toList xs ≡ toList ys → xs ≈[ m=n ] ys
-  fromList-reverse : (xs : List A) → (fromList (L.reverse xs)) ≈[ L.length-reverse xs ] reverse (fromList xs)
-  ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
-                  cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
-  ʳ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
-                   cast eq ((xs ʳ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ++ zs)
+  toList-injective : ∀ {m n} → .(m=n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) → toList xs ≡ toList ys → xs ≈[ m=n ] ys
+
+  toList-∷ʳ : ∀ x (xs : Vec A n) → toList (xs ∷ʳ x) ≡ toList xs List.++ List.[ x ]
+
+  fromList-reverse : (xs : List A) → (fromList (List.reverse xs)) ≈[ List.length-reverse xs ] reverse (fromList xs)
+
+  fromList∘toList : ∀  (xs : Vec A n) → fromList (toList xs) ≈[ length-toList xs ] xs
+
   ```
 
 * In `Data.Vec.Relation.Binary.Pointwise.Inductive`:

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -1361,20 +1361,30 @@ fromList-reverse xs =
     toList (reverse (fromList xs))      ∎
     where open ≡-Reasoning
 
+
 ------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.3
+
+∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
+               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
+∷-ʳ++-eqFree a xs {ys} = ʳ++-ʳ++-eqFree (a ∷ []) {ys = xs} {zs = ys}
+{-# WARNING_ON_USAGE ∷-ʳ++-eqFree
+"Warning: ∷-ʳ++-eqFree was deprecated in v2.3.
+Please use ʳ++-ʳ++-eqFree instead, which does not take eq."
+#-}
+
+-- Version 2.2
+
 -- TRANSITION TO EQ-FREE LEMMA
-------------------------------------------------------------------------
+--
 -- Please use the new proofs, which do not require an `eq` parameter.
 -- In v3, `name` will be changed to be the same lemma as `name-eqFree`,
 -- and `name-eqFree` will be deprecated.
-
-++-assoc : ∀ .(eq : (m + n) + o ≡ m + (n + o)) (xs : Vec A m) (ys : Vec A n) (zs : Vec A o) →
-           cast eq ((xs ++ ys) ++ zs) ≡ xs ++ (ys ++ zs)
-++-assoc _ = ++-assoc-eqFree
-{-# WARNING_ON_USAGE ++-assoc
-"Warning: ++-assoc was deprecated in v2.2.
-Please use ++-assoc-eqFree instead, which does not take eq."
-#-}
 
 ++-identityʳ : ∀ .(eq : n + zero ≡ n) (xs : Vec A n) → cast eq (xs ++ []) ≡ xs
 ++-identityʳ _ = ++-identityʳ-eqFree
@@ -1423,15 +1433,6 @@ Please use reverse-++-eqFree instead, which does not take eq."
 Please use ∷-ʳ++-eqFree instead, which does not take eq."
 #-}
 
-∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
-               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
-∷-ʳ++-eqFree a xs {ys} = ʳ++-ʳ++-eqFree (a ∷ []) {ys = xs} {zs = ys}
-
-{-# WARNING_ON_USAGE ∷-ʳ++-eqFree
-"Warning: ∷-ʳ++-eqFree was deprecated in v2.2.
-Please use ʳ++-ʳ++-eqFree instead, which does not take eq."
-#-}
-
 ++-ʳ++ : ∀ .(eq : m + n + o ≡ n + (m + o)) (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} →
          cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
 ++-ʳ++ _ = ++-ʳ++-eqFree
@@ -1448,11 +1449,13 @@ Please use ++-ʳ++-eqFree instead, which does not take eq."
 Please use ʳ++-ʳ++-eqFree instead, which does not take eq."
 #-}
 
-------------------------------------------------------------------------
--- DEPRECATED NAMES
-------------------------------------------------------------------------
--- Please use the new names as continuing support for the old names is
--- not guaranteed.
+++-assoc : ∀ .(eq : (m + n) + o ≡ m + (n + o)) (xs : Vec A m) (ys : Vec A n) (zs : Vec A o) →
+           cast eq ((xs ++ ys) ++ zs) ≡ xs ++ (ys ++ zs)
+++-assoc _ = ++-assoc-eqFree
+{-# WARNING_ON_USAGE ++-assoc
+"Warning: ++-assoc was deprecated in v2.2.
+Please use ++-assoc-eqFree instead, which does not take eq."
+#-}
 
 -- Version 2.0
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -54,7 +54,7 @@ private
     ws xs ys zs : Vec A n
 
 ------------------------------------------------------------------------
--- Properties to List 
+-- Properties to List
 
 toList-injective
   : ∀ {m n}
@@ -63,7 +63,7 @@ toList-injective
   → toList xs ≡ toList ys
   → xs ≈[ m=n ] ys
 toList-injective m=n [] [] xs=ys = refl
-toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys = 
+toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys =
   cong₂ _∷_ (L.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (L.∷-injectiveʳ xs=ys))
 
 ------------------------------------------------------------------------
@@ -1053,10 +1053,10 @@ toList-reverse (x ∷ xs) = begin
   L.reverse (toList (x ∷ xs))        ∎
   where open ≡-Reasoning
 
-reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n) 
+reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n)
                   → reverse (xs ++ ys) ≈[ +-comm m n ] reverse ys ++ reverse xs
-reverse-++-eqFree {m = m} {n = n} xs ys = 
-  toList-injective (+-comm m n) (reverse (xs ++ ys)) (reverse ys ++ reverse xs) $ 
+reverse-++-eqFree {m = m} {n = n} xs ys =
+  toList-injective (+-comm m n) (reverse (xs ++ ys)) (reverse ys ++ reverse xs) $
   begin
     toList (reverse (xs ++ ys))                      ≡⟨ toList-reverse ((xs ++ ys)) ⟩
     L.reverse (toList (xs ++ ys))                    ≡⟨ cong L.reverse (toList-++ xs ys) ⟩
@@ -1109,7 +1109,7 @@ toList-ʳ++ xs {ys} = begin
 
 ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                 cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
-++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} = toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $ 
+++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} = toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $
   begin
     toList ((xs ++ ys) ʳ++ zs)                      ≡⟨ toList-ʳ++ (xs ++ ys) ⟩
     toList (xs ++ ys) L.ʳ++ toList zs               ≡⟨ cong! (toList-++ xs ys)  ⟩
@@ -1122,7 +1122,7 @@ toList-ʳ++ xs {ys} = begin
 ʳ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                  cast eq ((xs ʳ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ++ zs)
 ʳ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =
-  toList-injective (m+n+o≡n+[m+o] m n o) ((xs ʳ++ ys) ʳ++ zs) (ys ʳ++ (xs ++ zs)) $ 
+  toList-injective (m+n+o≡n+[m+o] m n o) ((xs ʳ++ ys) ʳ++ zs) (ys ʳ++ (xs ++ zs)) $
   begin
     toList ((xs ʳ++ ys) ʳ++ zs)                 ≡⟨ cong! (toList-ʳ++ (xs ʳ++ ys)) ⟩
     toList (xs ʳ++ ys) L.ʳ++ toList zs          ≡⟨ cong! (toList-ʳ++ xs) ⟩
@@ -1354,7 +1354,7 @@ fromList-++ L.[]       {ys} = cast-is-id refl (fromList ys)
 fromList-++ (x L.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
 
 fromList-reverse : (xs : List A) → (fromList (L.reverse xs)) ≈[ L.length-reverse xs ] reverse (fromList xs)
-fromList-reverse xs = toList-injective (L.length-reverse xs) (fromList (L.reverse xs)) (reverse (fromList xs)) $ 
+fromList-reverse xs = toList-injective (L.length-reverse xs) (fromList (L.reverse xs)) (reverse (fromList xs)) $
   begin
     toList (fromList (L.reverse xs)) ≡⟨ toList∘fromList (L.reverse xs) ⟩
     L.reverse xs ≡⟨ cong (λ x → L.reverse x) (toList∘fromList xs) ⟨

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -56,7 +56,7 @@ private
 ------------------------------------------------------------------------
 -- Properties of toList
 
-toList-injective : .(m≡n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) → 
+toList-injective : .(m≡n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) →
                   toList xs ≡ toList ys → xs ≈[ m≡n ] ys
 toList-injective m≡n [] [] xs=ys = refl
 toList-injective m≡n (x ∷ xs) (y ∷ ys) xs=ys =

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -1103,7 +1103,15 @@ toList-ʳ++ xs {ys} = begin
   toList xs List.ʳ++ toList ys                ∎
   where open ≡-Reasoning
 
-
+∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
+               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
+∷-ʳ++-eqFree a xs {ys} = begin
+  (a ∷ xs) ʳ++ ys         ≂⟨ unfold-ʳ++ (a ∷ xs) ys ⟩
+  reverse (a ∷ xs) ++ ys  ≂⟨ cong (_++ ys) (reverse-∷ a xs) ⟩
+  (reverse xs ∷ʳ a) ++ ys ≈⟨ ∷ʳ-++-eqFree a (reverse xs) ⟩
+  reverse xs ++ (a ∷ ys)  ≂⟨ unfold-ʳ++ xs (a ∷ ys) ⟨
+  xs ʳ++ (a ∷ ys)         ∎
+  where open CastReasoning
 ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                 cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
 ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -38,7 +38,6 @@ open import Relation.Unary using (Pred; Decidable)
 open import Relation.Nullary.Decidable.Core
   using (Dec; does; yes; _×-dec_; map′)
 open import Relation.Nullary.Negation.Core using (contradiction)
-open import Tactic.Cong using (cong!)
 import Data.Nat.GeneralisedArithmetic as ℕ
 
 private
@@ -1103,15 +1102,7 @@ toList-ʳ++ xs {ys} = begin
   toList xs List.ʳ++ toList ys                ∎
   where open ≡-Reasoning
 
-∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
-               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
-∷-ʳ++-eqFree a xs {ys} = begin
-  (a ∷ xs) ʳ++ ys         ≂⟨ unfold-ʳ++ (a ∷ xs) ys ⟩
-  reverse (a ∷ xs) ++ ys  ≂⟨ cong (_++ ys) (reverse-∷ a xs) ⟩
-  (reverse xs ∷ʳ a) ++ ys ≈⟨ ∷ʳ-++-eqFree a (reverse xs) ⟩
-  reverse xs ++ (a ∷ ys)  ≂⟨ unfold-ʳ++ xs (a ∷ ys) ⟨
-  xs ʳ++ (a ∷ ys)         ∎
-  where open CastReasoning
+
 ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                 cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
 ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =
@@ -1430,6 +1421,15 @@ Please use reverse-++-eqFree instead, which does not take eq."
 {-# WARNING_ON_USAGE ∷-ʳ++
 "Warning: ∷-ʳ++ was deprecated in v2.2.
 Please use ∷-ʳ++-eqFree instead, which does not take eq."
+#-}
+
+∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
+               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
+∷-ʳ++-eqFree a xs {ys} = ʳ++-ʳ++-eqFree (a ∷ []) {ys = xs} {zs = ys}
+
+{-# WARNING_ON_USAGE ∷-ʳ++-eqFree
+"Warning: ∷-ʳ++-eqFree was deprecated in v2.2.
+Please use ʳ++-ʳ++-eqFree instead, which does not take eq."
 #-}
 
 ++-ʳ++ : ∀ .(eq : m + n + o ≡ n + (m + o)) (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} →

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -12,8 +12,8 @@ open import Algebra.Definitions
 open import Data.Bool.Base using (true; false)
 open import Data.Fin.Base as Fin
   using (Fin; zero; suc; toℕ; fromℕ<; _↑ˡ_; _↑ʳ_)
-open import Data.List.Base as L using (List)
-import Data.List.Properties as L
+open import Data.List.Base as List using (List)
+import Data.List.Properties as List
 open import Data.Nat.Base
   using (ℕ; zero; suc; _+_; _≤_; _<_; s≤s; pred; s<s⁻¹; _≥_; s≤s⁻¹; z≤n)
 open import Data.Nat.Properties
@@ -64,7 +64,7 @@ toList-injective
   → xs ≈[ m=n ] ys
 toList-injective m=n [] [] xs=ys = refl
 toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys =
-  cong₂ _∷_ (L.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (L.∷-injectiveʳ xs=ys))
+  cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (List.∷-injectiveʳ xs=ys))
 
 ------------------------------------------------------------------------
 -- Properties of propositional equality over vectors
@@ -473,9 +473,9 @@ map-concat f (xs ∷ xss) = begin
     ∎ where open ≡-Reasoning
 
 toList-map : ∀ (f : A → B) (xs : Vec A n) →
-             toList (map f xs) ≡ L.map f (toList xs)
+             toList (map f xs) ≡ List.map f (toList xs)
 toList-map f [] = refl
-toList-map f (x ∷ xs) = cong (f x L.∷_) (toList-map f xs)
+toList-map f (x ∷ xs) = cong (f x List.∷_) (toList-map f xs)
 
 ------------------------------------------------------------------------
 -- _++_
@@ -547,9 +547,9 @@ lookup-splitAt (suc m) (x ∷ xs) ys (suc i) = trans
   (sym ([,]-map (Fin.splitAt m i)))
 
 toList-++ : (xs : Vec A n) (ys : Vec A m) →
-            toList (xs ++ ys) ≡ toList xs L.++ toList ys
+            toList (xs ++ ys) ≡ toList xs List.++ toList ys
 toList-++ []       ys = refl
-toList-++ (x ∷ xs) ys = cong (x L.∷_) (toList-++ xs ys)
+toList-++ (x ∷ xs) ys = cong (x List.∷_) (toList-++ xs ys)
 
 ------------------------------------------------------------------------
 -- concat
@@ -1039,18 +1039,18 @@ map-reverse f (x ∷ xs) = begin
   where open ≡-Reasoning
 
 -- append and reverse
-toList-∷ʳ : ∀ x (xs : Vec A n) → toList (xs ∷ʳ x) ≡ toList xs L.++ L.[ x ]
+toList-∷ʳ : ∀ x (xs : Vec A n) → toList (xs ∷ʳ x) ≡ toList xs List.++ List.[ x ]
 toList-∷ʳ x []       = refl
-toList-∷ʳ x (y ∷ xs) = cong (y L.∷_) (toList-∷ʳ x xs)
+toList-∷ʳ x (y ∷ xs) = cong (y List.∷_) (toList-∷ʳ x xs)
 
-toList-reverse : ∀ (xs : Vec A n) → toList (reverse xs) ≡ L.reverse (toList xs)
+toList-reverse : ∀ (xs : Vec A n) → toList (reverse xs) ≡ List.reverse (toList xs)
 toList-reverse [] = refl
 toList-reverse (x ∷ xs) = begin
   toList (reverse (x ∷ xs))          ≡⟨ cong toList (reverse-∷ x xs) ⟩
   toList (reverse xs ∷ʳ x)           ≡⟨ toList-∷ʳ x (reverse xs) ⟩
-  toList (reverse xs) L.++ L.[ x ]   ≡⟨ cong (L._++ L.[ x ]) (toList-reverse xs) ⟩
-  L.reverse (toList xs) L.++ L.[ x ] ≡⟨ L.unfold-reverse x (toList xs) ⟨
-  L.reverse (toList (x ∷ xs))        ∎
+  toList (reverse xs) List.++ List.[ x ]   ≡⟨ cong (List._++ List.[ x ]) (toList-reverse xs) ⟩
+  List.reverse (toList xs) List.++ List.[ x ] ≡⟨ List.unfold-reverse x (toList xs) ⟨
+  List.reverse (toList (x ∷ xs))        ∎
   where open ≡-Reasoning
 
 reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n)
@@ -1059,10 +1059,10 @@ reverse-++-eqFree {m = m} {n = n} xs ys =
   toList-injective (+-comm m n) (reverse (xs ++ ys)) (reverse ys ++ reverse xs) $
   begin
     toList (reverse (xs ++ ys))                      ≡⟨ toList-reverse ((xs ++ ys)) ⟩
-    L.reverse (toList (xs ++ ys))                    ≡⟨ cong L.reverse (toList-++ xs ys) ⟩
-    L.reverse (toList xs L.++ toList ys)             ≡⟨ L.reverse-++ (toList xs) (toList ys) ⟩
-    L.reverse (toList ys) L.++ L.reverse (toList xs) ≡⟨ cong₂ L._++_ (toList-reverse ys) (toList-reverse xs) ⟨
-    toList (reverse ys) L.++ toList (reverse xs)     ≡⟨ toList-++ (reverse ys) (reverse xs) ⟨
+    List.reverse (toList (xs ++ ys))                    ≡⟨ cong List.reverse (toList-++ xs ys) ⟩
+    List.reverse (toList xs List.++ toList ys)             ≡⟨ List.reverse-++ (toList xs) (toList ys) ⟩
+    List.reverse (toList ys) List.++ List.reverse (toList xs) ≡⟨ cong₂ List._++_ (toList-reverse ys) (toList-reverse xs) ⟨
+    toList (reverse ys) List.++ toList (reverse xs)     ≡⟨ toList-++ (reverse ys) (reverse xs) ⟨
     toList (reverse ys ++ reverse xs)                ∎
   where open ≡-Reasoning
 
@@ -1097,13 +1097,13 @@ map-ʳ++ {ys = ys} f xs = begin
   map f xs ʳ++ map f ys          ∎
   where open ≡-Reasoning
 
-toList-ʳ++ : ∀ (xs : Vec A m) {ys : Vec A n} → toList (xs ʳ++ ys) ≡ (toList xs) L.ʳ++ toList ys
+toList-ʳ++ : ∀ (xs : Vec A m) {ys : Vec A n} → toList (xs ʳ++ ys) ≡ (toList xs) List.ʳ++ toList ys
 toList-ʳ++ xs {ys} = begin
   toList (xs ʳ++ ys)                    ≡⟨ cong toList (unfold-ʳ++ xs ys) ⟩
   toList (reverse xs ++ ys)             ≡⟨ toList-++ ((reverse xs )) ys ⟩
-  toList (reverse xs) L.++ toList ys    ≡⟨ cong! (toList-reverse xs) ⟩
-  L.reverse (toList xs) L.++ toList ys  ≡⟨ L.ʳ++-defn (toList xs) ⟨
-  toList xs L.ʳ++ toList ys ∎
+  toList (reverse xs) List.++ toList ys    ≡⟨ cong! (toList-reverse xs) ⟩
+  List.reverse (toList xs) List.++ toList ys  ≡⟨ List.ʳ++-defn (toList xs) ⟨
+  toList xs List.ʳ++ toList ys ∎
   where open ≡-Reasoning
 
 
@@ -1112,10 +1112,10 @@ toList-ʳ++ xs {ys} = begin
 ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} = toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $
   begin
     toList ((xs ++ ys) ʳ++ zs)                      ≡⟨ toList-ʳ++ (xs ++ ys) ⟩
-    toList (xs ++ ys) L.ʳ++ toList zs               ≡⟨ cong! (toList-++ xs ys)  ⟩
-    ( (toList xs) L.++ toList ys ) L.ʳ++ toList zs  ≡⟨ L.++-ʳ++ (toList xs) ⟩
-    toList ys L.ʳ++ (toList xs L.ʳ++ toList zs)     ≡⟨ cong! (toList-ʳ++ xs) ⟨
-    toList ys L.ʳ++ toList (xs ʳ++ zs)              ≡⟨ toList-ʳ++ ys ⟨
+    toList (xs ++ ys) List.ʳ++ toList zs               ≡⟨ cong! (toList-++ xs ys)  ⟩
+    ( (toList xs) List.++ toList ys ) List.ʳ++ toList zs  ≡⟨ List.++-ʳ++ (toList xs) ⟩
+    toList ys List.ʳ++ (toList xs List.ʳ++ toList zs)     ≡⟨ cong! (toList-ʳ++ xs) ⟨
+    toList ys List.ʳ++ toList (xs ʳ++ zs)              ≡⟨ toList-ʳ++ ys ⟨
     toList (ys ʳ++ (xs ʳ++ zs)) ∎
     where open ≡-Reasoning
 
@@ -1125,10 +1125,10 @@ toList-ʳ++ xs {ys} = begin
   toList-injective (m+n+o≡n+[m+o] m n o) ((xs ʳ++ ys) ʳ++ zs) (ys ʳ++ (xs ++ zs)) $
   begin
     toList ((xs ʳ++ ys) ʳ++ zs)                 ≡⟨ cong! (toList-ʳ++ (xs ʳ++ ys)) ⟩
-    toList (xs ʳ++ ys) L.ʳ++ toList zs          ≡⟨ cong! (toList-ʳ++ xs) ⟩
-    (toList xs L.ʳ++ toList ys) L.ʳ++ toList zs ≡⟨ L.ʳ++-ʳ++ (toList xs) ⟩
-    toList ys L.ʳ++ (toList xs L.++ toList zs)  ≡⟨ cong! (toList-++ xs zs) ⟨
-    toList ys L.ʳ++ (toList (xs ++ zs))         ≡⟨ toList-ʳ++ ys ⟨
+    toList (xs ʳ++ ys) List.ʳ++ toList zs          ≡⟨ cong! (toList-ʳ++ xs) ⟩
+    (toList xs List.ʳ++ toList ys) List.ʳ++ toList zs ≡⟨ List.ʳ++-ʳ++ (toList xs) ⟩
+    toList ys List.ʳ++ (toList xs List.++ toList zs)  ≡⟨ cong! (toList-++ xs zs) ⟨
+    toList ys List.ʳ++ (toList (xs ++ zs))         ≡⟨ toList-ʳ++ ys ⟨
     toList (ys ʳ++ (xs ++ zs)) ∎
   where open ≡-Reasoning
 
@@ -1183,9 +1183,9 @@ zipWith-replicate₂ _⊕_ (x ∷ xs) y =
   cong (x ⊕ y ∷_) (zipWith-replicate₂ _⊕_ xs y)
 
 toList-replicate : ∀ (n : ℕ) (x : A) →
-                   toList (replicate n x) ≡ L.replicate n x
+                   toList (replicate n x) ≡ List.replicate n x
 toList-replicate zero    x = refl
-toList-replicate (suc n) x = cong (_ L.∷_) (toList-replicate n x)
+toList-replicate (suc n) x = cong (_ List.∷_) (toList-replicate n x)
 
 ------------------------------------------------------------------------
 -- iterate
@@ -1206,9 +1206,9 @@ lookup-iterate :  ∀ f (x : A) (i : Fin n) → lookup (iterate f x n) i ≡ ℕ
 lookup-iterate f x zero    = refl
 lookup-iterate f x (suc i) = lookup-iterate f (f x) i
 
-toList-iterate : ∀ f (x : A) n → toList (iterate f x n) ≡ L.iterate f x n
+toList-iterate : ∀ f (x : A) n → toList (iterate f x n) ≡ List.iterate f x n
 toList-iterate f x zero    = refl
-toList-iterate f x (suc n) = cong (_ L.∷_) (toList-iterate f (f x) n)
+toList-iterate f x (suc n) = cong (_ List.∷_) (toList-iterate f (f x) n)
 
 ------------------------------------------------------------------------
 -- tabulate
@@ -1267,7 +1267,7 @@ module _ {P : Pred A p} (P? : Decidable P) where
 ------------------------------------------------------------------------
 -- length
 
-length-toList : (xs : Vec A n) → L.length (toList xs) ≡ length xs
+length-toList : (xs : Vec A n) → List.length (toList xs) ≡ length xs
 length-toList []       = refl
 length-toList (x ∷ xs) = cong suc (length-toList xs)
 
@@ -1286,9 +1286,9 @@ insertAt-punchIn (x ∷ xs) (suc i)  v zero    = refl
 insertAt-punchIn (x ∷ xs) (suc i)  v (suc j) = insertAt-punchIn xs i v j
 
 toList-insertAt : ∀ (xs : Vec A n) (i : Fin (suc n)) (v : A) →
-                  toList (insertAt xs i v) ≡ L.insertAt (toList xs) (Fin.cast (cong suc (sym (length-toList xs))) i) v
+                  toList (insertAt xs i v) ≡ List.insertAt (toList xs) (Fin.cast (cong suc (sym (length-toList xs))) i) v
 toList-insertAt xs       zero    v = refl
-toList-insertAt (x ∷ xs) (suc i) v = cong (_ L.∷_) (toList-insertAt xs i v)
+toList-insertAt (x ∷ xs) (suc i) v = cong (_ List.∷_) (toList-insertAt xs i v)
 
 ------------------------------------------------------------------------
 -- removeAt
@@ -1321,8 +1321,8 @@ insertAt-removeAt (x ∷ xs@(_ ∷ _)) (suc i)  =
 -- Conversion function
 
 toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
-toList∘fromList L.[]       = refl
-toList∘fromList (x L.∷ xs) = cong (x L.∷_) (toList∘fromList xs)
+toList∘fromList List.[]       = refl
+toList∘fromList (x List.∷ xs) = cong (x List.∷_) (toList∘fromList xs)
 
 fromList∘toList : ∀  (xs : Vec A n) → fromList (toList xs) ≈[ length-toList xs ] xs
 fromList∘toList [] = refl
@@ -1331,34 +1331,34 @@ fromList∘toList (x ∷ xs) = cong (x ∷_) (fromList∘toList xs)
 toList-cast : ∀ .(eq : m ≡ n) (xs : Vec A m) → toList (cast eq xs) ≡ toList xs
 toList-cast {n = zero}  eq []       = refl
 toList-cast {n = suc _} eq (x ∷ xs) =
-  cong (x L.∷_) (toList-cast (cong pred eq) xs)
+  cong (x List.∷_) (toList-cast (cong pred eq) xs)
 
 cast-fromList : ∀ {xs ys : List A} (eq : xs ≡ ys) →
-                cast (cong L.length eq) (fromList xs) ≡ fromList ys
-cast-fromList {xs = L.[]}     {ys = L.[]}     eq = refl
-cast-fromList {xs = x L.∷ xs} {ys = y L.∷ ys} eq =
-  let x≡y , xs≡ys = L.∷-injective eq in begin
-  x ∷ cast (cong (pred ∘ L.length) eq) (fromList xs) ≡⟨ cong (_ ∷_) (cast-fromList xs≡ys) ⟩
+                cast (cong List.length eq) (fromList xs) ≡ fromList ys
+cast-fromList {xs = List.[]}     {ys = List.[]}     eq = refl
+cast-fromList {xs = x List.∷ xs} {ys = y List.∷ ys} eq =
+  let x≡y , xs≡ys = List.∷-injective eq in begin
+  x ∷ cast (cong (pred ∘ List.length) eq) (fromList xs) ≡⟨ cong (_ ∷_) (cast-fromList xs≡ys) ⟩
   x ∷ fromList ys                                    ≡⟨ cong (_∷ _) x≡y ⟩
   y ∷ fromList ys                                    ∎
   where open ≡-Reasoning
 
 fromList-map : ∀ (f : A → B) (xs : List A) →
-               cast (L.length-map f xs) (fromList (L.map f xs)) ≡ map f (fromList xs)
-fromList-map f L.[]       = refl
-fromList-map f (x L.∷ xs) = cong (f x ∷_) (fromList-map f xs)
+               cast (List.length-map f xs) (fromList (List.map f xs)) ≡ map f (fromList xs)
+fromList-map f List.[]       = refl
+fromList-map f (x List.∷ xs) = cong (f x ∷_) (fromList-map f xs)
 
 fromList-++ : ∀ (xs : List A) {ys : List A} →
-              cast (L.length-++ xs) (fromList (xs L.++ ys)) ≡ fromList xs ++ fromList ys
-fromList-++ L.[]       {ys} = cast-is-id refl (fromList ys)
-fromList-++ (x L.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
+              cast (List.length-++ xs) (fromList (xs List.++ ys)) ≡ fromList xs ++ fromList ys
+fromList-++ List.[]       {ys} = cast-is-id refl (fromList ys)
+fromList-++ (x List.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
 
-fromList-reverse : (xs : List A) → (fromList (L.reverse xs)) ≈[ L.length-reverse xs ] reverse (fromList xs)
-fromList-reverse xs = toList-injective (L.length-reverse xs) (fromList (L.reverse xs)) (reverse (fromList xs)) $
+fromList-reverse : (xs : List A) → (fromList (List.reverse xs)) ≈[ List.length-reverse xs ] reverse (fromList xs)
+fromList-reverse xs = toList-injective (List.length-reverse xs) (fromList (List.reverse xs)) (reverse (fromList xs)) $
   begin
-    toList (fromList (L.reverse xs)) ≡⟨ toList∘fromList (L.reverse xs) ⟩
-    L.reverse xs ≡⟨ cong (λ x → L.reverse x) (toList∘fromList xs) ⟨
-    L.reverse (toList (fromList xs)) ≡⟨ toList-reverse (fromList xs) ⟨
+    toList (fromList (List.reverse xs)) ≡⟨ toList∘fromList (List.reverse xs) ⟩
+    List.reverse xs ≡⟨ cong (λ x → List.reverse x) (toList∘fromList xs) ⟨
+    List.reverse (toList (fromList xs)) ≡⟨ toList-reverse (fromList xs) ⟨
     toList (reverse (fromList xs)) ∎
     where open ≡-Reasoning
 

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -38,6 +38,7 @@ open import Relation.Unary using (Pred; Decidable)
 open import Relation.Nullary.Decidable.Core
   using (Dec; does; yes; _×-dec_; map′)
 open import Relation.Nullary.Negation.Core using (contradiction)
+open import Tactic.Cong using (cong!)
 import Data.Nat.GeneralisedArithmetic as ℕ
 
 private
@@ -1045,25 +1046,24 @@ toList-∷ʳ x (y ∷ xs) = cong (y L.∷_) (toList-∷ʳ x xs)
 toList-reverse : ∀ (xs : Vec A n) → toList (reverse xs) ≡ L.reverse (toList xs)
 toList-reverse [] = refl
 toList-reverse (x ∷ xs) = begin
-  toList (reverse (x ∷ xs))                ≡⟨ cong toList (reverse-∷ x xs) ⟩
-  toList (reverse xs ∷ʳ x)                 ≡⟨ toList-∷ʳ x (reverse xs) ⟩
+  toList (reverse (x ∷ xs))          ≡⟨ cong toList (reverse-∷ x xs) ⟩
+  toList (reverse xs ∷ʳ x)           ≡⟨ toList-∷ʳ x (reverse xs) ⟩
   toList (reverse xs) L.++ L.[ x ]   ≡⟨ cong (L._++ L.[ x ]) (toList-reverse xs) ⟩
-  L.reverse (toList xs) L.++ L.[ x ] ≡⟨ sym (L.unfold-reverse x (toList xs)) ⟩
-  L.reverse (x L.∷ toList xs)        ≡⟨⟩
-  L.reverse (toList (x ∷ xs))           ∎
+  L.reverse (toList xs) L.++ L.[ x ] ≡⟨ L.unfold-reverse x (toList xs) ⟨
+  L.reverse (toList (x ∷ xs))        ∎
   where open ≡-Reasoning
 
-reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n) → let eq = +-comm m n in
-                    cast eq (reverse (xs ++ ys)) ≡ reverse ys ++ reverse xs
+reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n) 
+                  → reverse (xs ++ ys) ≈[ +-comm m n ] reverse ys ++ reverse xs
 reverse-++-eqFree {m = m} {n = n} xs ys = 
   toList-injective (+-comm m n) (reverse (xs ++ ys)) (reverse ys ++ reverse xs) $ 
   begin
-    toList (reverse (xs ++ ys))                               ≡⟨ toList-reverse ((xs ++ ys)) ⟩
-    L.reverse (toList (xs ++ ys))                          ≡⟨ cong L.reverse (toList-++ xs ys) ⟩
-    L.reverse (toList xs L.++ toList ys)                ≡⟨ L.reverse-++ (toList xs) (toList ys) ⟩
-    L.reverse (toList ys) L.++ L.reverse (toList xs) ≡⟨ cong₂ L._++_ (sym (toList-reverse ys)) (sym (toList-reverse xs)) ⟩
-    toList (reverse ys) L.++ toList (reverse xs)           ≡⟨ sym (toList-++ (reverse ys) (reverse xs)) ⟩
-    toList (reverse ys ++ reverse xs)                         ∎
+    toList (reverse (xs ++ ys))                      ≡⟨ toList-reverse ((xs ++ ys)) ⟩
+    L.reverse (toList (xs ++ ys))                    ≡⟨ cong L.reverse (toList-++ xs ys) ⟩
+    L.reverse (toList xs L.++ toList ys)             ≡⟨ L.reverse-++ (toList xs) (toList ys) ⟩
+    L.reverse (toList ys) L.++ L.reverse (toList xs) ≡⟨ cong₂ L._++_ (toList-reverse ys) (toList-reverse xs) ⟨
+    toList (reverse ys) L.++ toList (reverse xs)     ≡⟨ toList-++ (reverse ys) (reverse xs) ⟨
+    toList (reverse ys ++ reverse xs)                ∎
   where open ≡-Reasoning
 
 cast-reverse : ∀ .(eq : m ≡ n) → cast eq ∘ reverse {A = A} {n = m} ≗ reverse ∘ cast eq
@@ -1090,50 +1090,32 @@ foldr-ʳ++ B f {e} xs = foldl-fusion (foldr B f e) refl (λ _ _ → refl) xs
 map-ʳ++ : ∀ (f : A → B) (xs : Vec A m) →
           map f (xs ʳ++ ys) ≡ map f xs ʳ++ map f ys
 map-ʳ++ {ys = ys} f xs = begin
-  map f (xs ʳ++ ys)              ≡⟨  cong (map f) (unfold-ʳ++ xs ys) ⟩
-  map f (reverse xs ++ ys)       ≡⟨  map-++ f (reverse xs) ys ⟩
-  map f (reverse xs) ++ map f ys ≡⟨  cong (_++ map f ys) (map-reverse f xs) ⟩
+  map f (xs ʳ++ ys)              ≡⟨ cong (map f) (unfold-ʳ++ xs ys) ⟩
+  map f (reverse xs ++ ys)       ≡⟨ map-++ f (reverse xs) ys ⟩
+  map f (reverse xs) ++ map f ys ≡⟨ cong (_++ map f ys) (map-reverse f xs) ⟩
   reverse (map f xs) ++ map f ys ≡⟨ unfold-ʳ++ (map f xs) (map f ys) ⟨
   map f xs ʳ++ map f ys          ∎
   where open ≡-Reasoning
 
-∷-ʳ++-eqFree : ∀ a (xs : Vec A m) {ys : Vec A n} → let eq = sym (+-suc m n) in
-               cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
-∷-ʳ++-eqFree {m = m} {n = n} a xs {ys} = toList-injective (sym (+-suc m n)) ((a ∷ xs) ʳ++ ys) (xs ʳ++ (a ∷ ys)) $ 
-  begin
-    toList ((a ∷ xs) ʳ++ ys)                                         ≡⟨ cong toList (unfold-ʳ++ (a ∷ xs) ys) ⟩
-    toList (reverse (a ∷ xs) ++ ys)                                  ≡⟨ toList-++ (reverse (a ∷ xs)) ys ⟩
-    toList (reverse (a ∷ xs)) L.++ toList ys                      ≡⟨ cong (L._++ toList ys) (toList-reverse (a ∷ xs)) ⟩
-    L.reverse (toList (a ∷ xs)) L.++ toList ys                 ≡⟨ cong (L._++ toList ys) (L.unfold-reverse a (toList xs)) ⟩
-    (L.reverse (toList xs) L.++ L.[ a ]) L.++ toList ys  ≡⟨ L.++-assoc (L.reverse (toList xs)) (L.[ a ]) (toList ys) ⟩
-    L.reverse (toList xs) L.++ (L.[ a ] L.++ toList ys)  ≡⟨ cong (L.reverse (toList xs) L.++_) refl ⟩
-    L.reverse (toList xs) L.++ toList (a ∷ ys)                 ≡⟨ cong (L._++ toList (a ∷ ys)) (sym (toList-reverse xs)) ⟩
-    toList (reverse xs) L.++ toList (a ∷ ys)                      ≡⟨ sym (toList-++ (reverse xs) (a ∷ ys)) ⟩
-    toList (reverse xs ++ (a ∷ ys))                                  ≡⟨ sym (cong toList (unfold-ʳ++ xs (a ∷ ys))) ⟩
-    toList (xs ʳ++ (a ∷ ys)) ∎
+toList-ʳ++ : ∀ (xs : Vec A m) {ys : Vec A n} → toList (xs ʳ++ ys) ≡ (toList xs) L.ʳ++ toList ys
+toList-ʳ++ xs {ys} = begin
+  toList (xs ʳ++ ys)                    ≡⟨ cong toList (unfold-ʳ++ xs ys) ⟩
+  toList (reverse xs ++ ys)             ≡⟨ toList-++ ((reverse xs )) ys ⟩
+  toList (reverse xs) L.++ toList ys    ≡⟨ cong! (toList-reverse xs) ⟩
+  L.reverse (toList xs) L.++ toList ys  ≡⟨ L.ʳ++-defn (toList xs) ⟨
+  toList xs L.ʳ++ toList ys ∎
   where open ≡-Reasoning
 
-open import Tactic.Cong
 
 ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                 cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
 ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} = toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $ 
   begin
-    toList ((xs ++ ys) ʳ++ zs)                               ≡⟨ cong toList (unfold-ʳ++ (xs ++ ys) zs) ⟩
-    toList (reverse (xs ++ ys) ++ zs)                        ≡⟨ toList-++ (reverse (xs ++ ys)) zs ⟩
-    toList (reverse (xs ++ ys)) L.++ toList zs            ≡⟨ cong! (toList-reverse (xs ++ ys)) ⟩
-    L.reverse (toList (xs ++ ys)) L.++ toList zs       ≡⟨ cong! (toList-++ xs ys) ⟩
-    -- L.reverse (toList (xs ++ ys)) L.++ toList zs       ≡⟨ cong (λ l → L.reverse l L.++ toList zs) (toList-++ xs ys) ⟩
-
-    L.reverse (toList xs L.++ toList ys) L.++ toList zs ≡⟨ cong! (L.reverse-++ (toList xs) (toList ys)) ⟩
-    (L.reverse (toList ys) L.++ L.reverse (toList xs)) L.++ toList zs
-      ≡⟨ L.++-assoc (L.reverse (toList ys)) (L.reverse (toList xs)) (toList zs) ⟩
-    L.reverse (toList ys) L.++ (L.reverse (toList xs) L.++ toList zs)  ≡⟨ cong (L.reverse (toList ys) L.++_) (cong (L._++ toList zs) (sym (toList-reverse xs))) ⟩
-    L.reverse (toList ys) L.++ (toList (reverse xs) L.++ toList zs)    ≡⟨ cong (L.reverse (toList ys) L.++_) (sym (toList-++ (reverse xs) zs)) ⟩
-    L.reverse (toList ys) L.++ toList (reverse xs ++ zs) ≡⟨ cong (L.reverse (toList ys) L.++_) (sym (cong toList (unfold-ʳ++ xs zs))) ⟩
-    L.reverse (toList ys) L.++ toList (xs ʳ++ zs)      ≡⟨ cong (L._++ toList (xs ʳ++ zs)) (sym (toList-reverse ys)) ⟩
-    toList (reverse ys) L.++ toList (xs ʳ++ zs)           ≡⟨ sym (toList-++ (reverse ys) (xs ʳ++ zs)) ⟩
-    toList (reverse ys ++ (xs ʳ++ zs))                       ≡⟨ sym (cong toList (unfold-ʳ++ ys (xs ʳ++ zs))) ⟩
+    toList ((xs ++ ys) ʳ++ zs)                      ≡⟨ toList-ʳ++ (xs ++ ys) ⟩
+    toList (xs ++ ys) L.ʳ++ toList zs               ≡⟨ cong! (toList-++ xs ys)  ⟩
+    ( (toList xs) L.++ toList ys ) L.ʳ++ toList zs  ≡⟨ L.++-ʳ++ (toList xs) ⟩
+    toList ys L.ʳ++ (toList xs L.ʳ++ toList zs)     ≡⟨ cong! (toList-ʳ++ xs) ⟨
+    toList ys L.ʳ++ toList (xs ʳ++ zs)              ≡⟨ toList-ʳ++ ys ⟨
     toList (ys ʳ++ (xs ʳ++ zs)) ∎
     where open ≡-Reasoning
 
@@ -1142,33 +1124,13 @@ open import Tactic.Cong
 ʳ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =
   toList-injective (m+n+o≡n+[m+o] m n o) ((xs ʳ++ ys) ʳ++ zs) (ys ʳ++ (xs ++ zs)) $ 
   begin
-    toList ((xs ʳ++ ys) ʳ++ zs)                              ≡⟨ cong toList (unfold-ʳ++ (xs ʳ++ ys) zs) ⟩
-    toList (reverse (xs ʳ++ ys) ++ zs)                       ≡⟨ toList-++ (reverse (xs ʳ++ ys)) zs ⟩
-    toList (reverse (xs ʳ++ ys)) L.++ toList zs           ≡⟨ cong (L._++ toList zs) (trans (toList-reverse (xs ʳ++ ys)) (cong L.reverse (trans (cong toList (unfold-ʳ++ xs ys)) (toList-++ (reverse xs) ys)))) ⟩
-    L.reverse (toList (reverse xs) L.++ toList ys) L.++ toList zs    ≡⟨ cong (L._++ toList zs) (L.reverse-++ (toList (reverse xs)) (toList ys)) ⟩
-    (L.reverse (toList ys) L.++ L.reverse (toList (reverse xs))) L.++ toList zs      ≡⟨ cong (L._++ toList zs) (cong (L.reverse (toList ys) L.++_) 
-                                        (trans (cong L.reverse (toList-reverse xs)) 
-                                               (L.reverse-involutive (toList xs)))) ⟩
-    (L.reverse (toList ys) L.++ toList xs) L.++ toList zs            ≡⟨ L.++-assoc (L.reverse (toList ys)) (toList xs) (toList zs) ⟩
-    L.reverse (toList ys) L.++ (toList xs L.++ toList zs)   
-      ≡⟨ cong (L.reverse (toList ys) L.++_) (sym (toList-++ xs zs)) ⟩
-    L.reverse (toList ys) L.++ toList (xs ++ zs)               
-      ≡⟨ trans (cong (L._++ toList (xs ++ zs)) (sym (toList-reverse ys))) 
-               (sym (toList-++ (reverse ys) (xs ++ zs))) ⟩
-    toList (reverse ys ++ (xs ++ zs))                                
-      ≡⟨ sym (cong toList (unfold-ʳ++ ys (xs ++ zs))) ⟩
+    toList ((xs ʳ++ ys) ʳ++ zs)                 ≡⟨ cong! (toList-ʳ++ (xs ʳ++ ys)) ⟩
+    toList (xs ʳ++ ys) L.ʳ++ toList zs          ≡⟨ cong! (toList-ʳ++ xs) ⟩
+    (toList xs L.ʳ++ toList ys) L.ʳ++ toList zs ≡⟨ L.ʳ++-ʳ++ (toList xs) ⟩
+    toList ys L.ʳ++ (toList xs L.++ toList zs)  ≡⟨ cong! (toList-++ xs zs) ⟨
+    toList ys L.ʳ++ (toList (xs ++ zs))         ≡⟨ toList-ʳ++ ys ⟨
     toList (ys ʳ++ (xs ++ zs)) ∎
   where open ≡-Reasoning
-  
-  -- begin
-  -- (xs ʳ++ ys) ʳ++ zs                         ≂⟨ cong (_ʳ++ zs) (unfold-ʳ++ xs ys) ⟩
-  -- (reverse xs ++ ys) ʳ++ zs                  ≂⟨ unfold-ʳ++ (reverse xs ++ ys) zs ⟩
-  -- reverse (reverse xs ++ ys) ++ zs           ≈⟨ ≈-cong′ (_++ zs) (reverse-++-eqFree (reverse xs) ys) ⟩
-  -- (reverse ys ++ reverse (reverse xs)) ++ zs ≂⟨ cong ((_++ zs) ∘ (reverse ys ++_)) (reverse-involutive xs) ⟩
-  -- (reverse ys ++ xs) ++ zs                   ≈⟨ ++-assoc-eqFree (reverse ys) xs zs ⟩
-  -- reverse ys ++ (xs ++ zs)                   ≂⟨ unfold-ʳ++ ys (xs ++ zs) ⟨
-  -- ys ʳ++ (xs ++ zs)                          ∎
-  -- where open CastReasoning
 
 ------------------------------------------------------------------------
 --sum
@@ -1176,7 +1138,7 @@ open import Tactic.Cong
 sum-++ : ∀ (xs : Vec ℕ m) → sum (xs ++ ys) ≡ sum xs + sum ys
 sum-++ {_}       []       = refl
 sum-++ {ys = ys} (x ∷ xs) = begin
-  x + sum (xs ++ ys)     ≡⟨  cong (x +_) (sum-++ xs) ⟩
+  x + sum (xs ++ ys)     ≡⟨ cong (x +_) (sum-++ xs) ⟩
   x + (sum xs + sum ys)  ≡⟨ +-assoc x (sum xs) (sum ys) ⟨
   sum (x ∷ xs) + sum ys  ∎
   where open ≡-Reasoning
@@ -1362,6 +1324,10 @@ toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
 toList∘fromList L.[]       = refl
 toList∘fromList (x L.∷ xs) = cong (x L.∷_) (toList∘fromList xs)
 
+fromList∘toList : ∀  (xs : Vec A n) → fromList (toList xs) ≈[ length-toList xs ] xs
+fromList∘toList [] = refl
+fromList∘toList (x ∷ xs) = cong (x ∷_) (fromList∘toList xs)
+
 toList-cast : ∀ .(eq : m ≡ n) (xs : Vec A m) → toList (cast eq xs) ≡ toList xs
 toList-cast {n = zero}  eq []       = refl
 toList-cast {n = suc _} eq (x ∷ xs) =
@@ -1373,8 +1339,8 @@ cast-fromList {xs = L.[]}     {ys = L.[]}     eq = refl
 cast-fromList {xs = x L.∷ xs} {ys = y L.∷ ys} eq =
   let x≡y , xs≡ys = L.∷-injective eq in begin
   x ∷ cast (cong (pred ∘ L.length) eq) (fromList xs) ≡⟨ cong (_ ∷_) (cast-fromList xs≡ys) ⟩
-  x ∷ fromList ys                                       ≡⟨ cong (_∷ _) x≡y ⟩
-  y ∷ fromList ys                                       ∎
+  x ∷ fromList ys                                    ≡⟨ cong (_∷ _) x≡y ⟩
+  y ∷ fromList ys                                    ∎
   where open ≡-Reasoning
 
 fromList-map : ∀ (f : A → B) (xs : List A) →
@@ -1387,16 +1353,14 @@ fromList-++ : ∀ (xs : List A) {ys : List A} →
 fromList-++ L.[]       {ys} = cast-is-id refl (fromList ys)
 fromList-++ (x L.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
 
-fromList-reverse : (xs : List A) → cast (L.length-reverse xs) (fromList (L.reverse xs)) ≡ reverse (fromList xs)
-fromList-reverse L.[] = refl
-fromList-reverse (x L.∷ xs) = toList-injective 
-  (L.length-reverse (x L.∷ xs)) 
-  (fromList (L.foldl (λ y x₁ → x₁ L.∷ y) (x L.∷ L.[]) xs))
-  (reverse (fromList (x L.∷ xs))) $ 
-   begin
-     toList (fromList (L.foldl (λ y x₁ → x₁ L.∷ y) (x L.∷ L.[]) xs)) ≡⟨ {!   !} ⟩
-     toList (reverse (fromList (x L.∷ xs))) ∎
-     where open ≡-Reasoning
+fromList-reverse : (xs : List A) → (fromList (L.reverse xs)) ≈[ L.length-reverse xs ] reverse (fromList xs)
+fromList-reverse xs = toList-injective (L.length-reverse xs) (fromList (L.reverse xs)) (reverse (fromList xs)) $ 
+  begin
+    toList (fromList (L.reverse xs)) ≡⟨ toList∘fromList (L.reverse xs) ⟩
+    L.reverse xs ≡⟨ cong (λ x → L.reverse x) (toList∘fromList xs) ⟨
+    L.reverse (toList (fromList xs)) ≡⟨ toList-reverse (fromList xs) ⟨
+    toList (reverse (fromList xs)) ∎
+    where open ≡-Reasoning
 
 ------------------------------------------------------------------------
 -- TRANSITION TO EQ-FREE LEMMA
@@ -1453,7 +1417,8 @@ Please use reverse-++-eqFree instead, which does not take eq."
 
 ∷-ʳ++ : ∀ .(eq : (suc m) + n ≡ m + suc n) a (xs : Vec A m) {ys} →
         cast eq ((a ∷ xs) ʳ++ ys) ≡ xs ʳ++ (a ∷ ys)
-∷-ʳ++ _ = ∷-ʳ++-eqFree
+∷-ʳ++ _ a xs {ys} = ʳ++-ʳ++-eqFree (a ∷ []) {ys = xs} {zs = ys}
+
 {-# WARNING_ON_USAGE ∷-ʳ++
 "Warning: ∷-ʳ++ was deprecated in v2.2.
 Please use ∷-ʳ++-eqFree instead, which does not take eq."

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -53,6 +53,19 @@ private
     ws xs ys zs : Vec A n
 
 ------------------------------------------------------------------------
+-- Properties to List 
+
+toList-injective
+  : ∀ {m n}
+  → .(m=n : m ≡ n)
+  → (xs : Vec A m) (ys : Vec A n)
+  → toList xs ≡ toList ys
+  → xs ≈[ m=n ] ys
+toList-injective m=n [] [] xs=ys = refl
+toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys = 
+  cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (List.∷-injectiveʳ xs=ys))
+
+------------------------------------------------------------------------
 -- Properties of propositional equality over vectors
 
 ∷-injectiveˡ : x ∷ xs ≡ y ∷ ys → x ≡ y

--- a/src/Data/Vec/Properties.agda
+++ b/src/Data/Vec/Properties.agda
@@ -54,17 +54,13 @@ private
     ws xs ys zs : Vec A n
 
 ------------------------------------------------------------------------
--- Properties to List
+-- Properties of toList
 
-toList-injective
-  : ∀ {m n}
-  → .(m=n : m ≡ n)
-  → (xs : Vec A m) (ys : Vec A n)
-  → toList xs ≡ toList ys
-  → xs ≈[ m=n ] ys
-toList-injective m=n [] [] xs=ys = refl
-toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys =
-  cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (List.∷-injectiveʳ xs=ys))
+toList-injective : .(m≡n : m ≡ n) → (xs : Vec A m) (ys : Vec A n) → 
+                  toList xs ≡ toList ys → xs ≈[ m≡n ] ys
+toList-injective m≡n [] [] xs=ys = refl
+toList-injective m≡n (x ∷ xs) (y ∷ ys) xs=ys =
+  cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m≡n) xs ys (List.∷-injectiveʳ xs=ys))
 
 ------------------------------------------------------------------------
 -- Properties of propositional equality over vectors
@@ -1030,9 +1026,9 @@ map-reverse : ∀ (f : A → B) (xs : Vec A n) →
               map f (reverse xs) ≡ reverse (map f xs)
 map-reverse f []       = refl
 map-reverse f (x ∷ xs) = begin
-  map f (reverse (x ∷ xs))  ≡⟨  cong (map f) (reverse-∷ x xs) ⟩
-  map f (reverse xs ∷ʳ x)   ≡⟨  map-∷ʳ f x (reverse xs) ⟩
-  map f (reverse xs) ∷ʳ f x ≡⟨  cong (_∷ʳ f x) (map-reverse f xs ) ⟩
+  map f (reverse (x ∷ xs))  ≡⟨ cong (map f) (reverse-∷ x xs) ⟩
+  map f (reverse xs ∷ʳ x)   ≡⟨ map-∷ʳ f x (reverse xs) ⟩
+  map f (reverse xs) ∷ʳ f x ≡⟨ cong (_∷ʳ f x) (map-reverse f xs ) ⟩
   reverse (map f xs) ∷ʳ f x ≡⟨ reverse-∷ (f x) (map f xs) ⟨
   reverse (f x ∷ map f xs)  ≡⟨⟩
   reverse (map f (x ∷ xs))  ∎
@@ -1046,11 +1042,11 @@ toList-∷ʳ x (y ∷ xs) = cong (y List.∷_) (toList-∷ʳ x xs)
 toList-reverse : ∀ (xs : Vec A n) → toList (reverse xs) ≡ List.reverse (toList xs)
 toList-reverse [] = refl
 toList-reverse (x ∷ xs) = begin
-  toList (reverse (x ∷ xs))          ≡⟨ cong toList (reverse-∷ x xs) ⟩
-  toList (reverse xs ∷ʳ x)           ≡⟨ toList-∷ʳ x (reverse xs) ⟩
-  toList (reverse xs) List.++ List.[ x ]   ≡⟨ cong (List._++ List.[ x ]) (toList-reverse xs) ⟩
+  toList (reverse (x ∷ xs))                   ≡⟨ cong toList (reverse-∷ x xs) ⟩
+  toList (reverse xs ∷ʳ x)                    ≡⟨ toList-∷ʳ x (reverse xs) ⟩
+  toList (reverse xs) List.++ List.[ x ]      ≡⟨ cong (List._++ List.[ x ]) (toList-reverse xs) ⟩
   List.reverse (toList xs) List.++ List.[ x ] ≡⟨ List.unfold-reverse x (toList xs) ⟨
-  List.reverse (toList (x ∷ xs))        ∎
+  List.reverse (toList (x ∷ xs))              ∎
   where open ≡-Reasoning
 
 reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n)
@@ -1058,12 +1054,12 @@ reverse-++-eqFree : ∀ (xs : Vec A m) (ys : Vec A n)
 reverse-++-eqFree {m = m} {n = n} xs ys =
   toList-injective (+-comm m n) (reverse (xs ++ ys)) (reverse ys ++ reverse xs) $
   begin
-    toList (reverse (xs ++ ys))                      ≡⟨ toList-reverse ((xs ++ ys)) ⟩
-    List.reverse (toList (xs ++ ys))                    ≡⟨ cong List.reverse (toList-++ xs ys) ⟩
-    List.reverse (toList xs List.++ toList ys)             ≡⟨ List.reverse-++ (toList xs) (toList ys) ⟩
+    toList (reverse (xs ++ ys))                               ≡⟨ toList-reverse ((xs ++ ys)) ⟩
+    List.reverse (toList (xs ++ ys))                          ≡⟨ cong List.reverse (toList-++ xs ys) ⟩
+    List.reverse (toList xs List.++ toList ys)                ≡⟨ List.reverse-++ (toList xs) (toList ys) ⟩
     List.reverse (toList ys) List.++ List.reverse (toList xs) ≡⟨ cong₂ List._++_ (toList-reverse ys) (toList-reverse xs) ⟨
-    toList (reverse ys) List.++ toList (reverse xs)     ≡⟨ toList-++ (reverse ys) (reverse xs) ⟨
-    toList (reverse ys ++ reverse xs)                ∎
+    toList (reverse ys) List.++ toList (reverse xs)           ≡⟨ toList-++ (reverse ys) (reverse xs) ⟨
+    toList (reverse ys ++ reverse xs)                         ∎
   where open ≡-Reasoning
 
 cast-reverse : ∀ .(eq : m ≡ n) → cast eq ∘ reverse {A = A} {n = m} ≗ reverse ∘ cast eq
@@ -1097,26 +1093,28 @@ map-ʳ++ {ys = ys} f xs = begin
   map f xs ʳ++ map f ys          ∎
   where open ≡-Reasoning
 
-toList-ʳ++ : ∀ (xs : Vec A m) {ys : Vec A n} → toList (xs ʳ++ ys) ≡ (toList xs) List.ʳ++ toList ys
+toList-ʳ++ : ∀ (xs : Vec A m) {ys : Vec A n} →
+            toList (xs ʳ++ ys) ≡ (toList xs) List.ʳ++ toList ys
 toList-ʳ++ xs {ys} = begin
-  toList (xs ʳ++ ys)                    ≡⟨ cong toList (unfold-ʳ++ xs ys) ⟩
-  toList (reverse xs ++ ys)             ≡⟨ toList-++ ((reverse xs )) ys ⟩
-  toList (reverse xs) List.++ toList ys    ≡⟨ cong! (toList-reverse xs) ⟩
+  toList (xs ʳ++ ys)                          ≡⟨ cong toList (unfold-ʳ++ xs ys) ⟩
+  toList (reverse xs ++ ys)                   ≡⟨ toList-++ ((reverse xs )) ys ⟩
+  toList (reverse xs) List.++ toList ys       ≡⟨ cong (List._++ toList ys) (toList-reverse xs) ⟩
   List.reverse (toList xs) List.++ toList ys  ≡⟨ List.ʳ++-defn (toList xs) ⟨
-  toList xs List.ʳ++ toList ys ∎
+  toList xs List.ʳ++ toList ys                ∎
   where open ≡-Reasoning
 
 
 ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
                 cast eq ((xs ++ ys) ʳ++ zs) ≡ ys ʳ++ (xs ʳ++ zs)
-++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} = toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $
+++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =
+  toList-injective (m+n+o≡n+[m+o] m n o) ((xs ++ ys) ʳ++ zs) (ys ʳ++ (xs ʳ++ zs)) $
   begin
-    toList ((xs ++ ys) ʳ++ zs)                      ≡⟨ toList-ʳ++ (xs ++ ys) ⟩
-    toList (xs ++ ys) List.ʳ++ toList zs               ≡⟨ cong! (toList-++ xs ys)  ⟩
-    ( (toList xs) List.++ toList ys ) List.ʳ++ toList zs  ≡⟨ List.++-ʳ++ (toList xs) ⟩
-    toList ys List.ʳ++ (toList xs List.ʳ++ toList zs)     ≡⟨ cong! (toList-ʳ++ xs) ⟨
-    toList ys List.ʳ++ toList (xs ʳ++ zs)              ≡⟨ toList-ʳ++ ys ⟨
-    toList (ys ʳ++ (xs ʳ++ zs)) ∎
+    toList ((xs ++ ys) ʳ++ zs)                          ≡⟨ toList-ʳ++ (xs ++ ys) ⟩
+    toList (xs ++ ys) List.ʳ++ toList zs                ≡⟨ cong (List._ʳ++ toList zs) (toList-++ xs ys)  ⟩
+    ((toList xs) List.++ toList ys ) List.ʳ++ toList zs ≡⟨ List.++-ʳ++ (toList xs) ⟩
+    toList ys List.ʳ++ (toList xs List.ʳ++ toList zs)   ≡⟨ cong (toList ys List.ʳ++_) (toList-ʳ++ xs) ⟨
+    toList ys List.ʳ++ toList (xs ʳ++ zs)               ≡⟨ toList-ʳ++ ys ⟨
+    toList (ys ʳ++ (xs ʳ++ zs))                         ∎
     where open ≡-Reasoning
 
 ʳ++-ʳ++-eqFree : ∀ (xs : Vec A m) {ys : Vec A n} {zs : Vec A o} → let eq = m+n+o≡n+[m+o] m n o in
@@ -1124,12 +1122,12 @@ toList-ʳ++ xs {ys} = begin
 ʳ++-ʳ++-eqFree {m = m} {n} {o} xs {ys} {zs} =
   toList-injective (m+n+o≡n+[m+o] m n o) ((xs ʳ++ ys) ʳ++ zs) (ys ʳ++ (xs ++ zs)) $
   begin
-    toList ((xs ʳ++ ys) ʳ++ zs)                 ≡⟨ cong! (toList-ʳ++ (xs ʳ++ ys)) ⟩
-    toList (xs ʳ++ ys) List.ʳ++ toList zs          ≡⟨ cong! (toList-ʳ++ xs) ⟩
+    toList ((xs ʳ++ ys) ʳ++ zs)                       ≡⟨ toList-ʳ++ (xs ʳ++ ys) ⟩
+    toList (xs ʳ++ ys) List.ʳ++ toList zs             ≡⟨ cong (List._ʳ++ toList zs) (toList-ʳ++ xs) ⟩
     (toList xs List.ʳ++ toList ys) List.ʳ++ toList zs ≡⟨ List.ʳ++-ʳ++ (toList xs) ⟩
-    toList ys List.ʳ++ (toList xs List.++ toList zs)  ≡⟨ cong! (toList-++ xs zs) ⟨
-    toList ys List.ʳ++ (toList (xs ++ zs))         ≡⟨ toList-ʳ++ ys ⟨
-    toList (ys ʳ++ (xs ++ zs)) ∎
+    toList ys List.ʳ++ (toList xs List.++ toList zs)  ≡⟨ cong (toList ys List.ʳ++_) (toList-++ xs zs) ⟨
+    toList ys List.ʳ++ (toList (xs ++ zs))            ≡⟨ toList-ʳ++ ys ⟨
+    toList (ys ʳ++ (xs ++ zs))                        ∎
   where open ≡-Reasoning
 
 ------------------------------------------------------------------------
@@ -1339,8 +1337,8 @@ cast-fromList {xs = List.[]}     {ys = List.[]}     eq = refl
 cast-fromList {xs = x List.∷ xs} {ys = y List.∷ ys} eq =
   let x≡y , xs≡ys = List.∷-injective eq in begin
   x ∷ cast (cong (pred ∘ List.length) eq) (fromList xs) ≡⟨ cong (_ ∷_) (cast-fromList xs≡ys) ⟩
-  x ∷ fromList ys                                    ≡⟨ cong (_∷ _) x≡y ⟩
-  y ∷ fromList ys                                    ∎
+  x ∷ fromList ys                                       ≡⟨ cong (_∷ _) x≡y ⟩
+  y ∷ fromList ys                                       ∎
   where open ≡-Reasoning
 
 fromList-map : ∀ (f : A → B) (xs : List A) →
@@ -1353,13 +1351,15 @@ fromList-++ : ∀ (xs : List A) {ys : List A} →
 fromList-++ List.[]       {ys} = cast-is-id refl (fromList ys)
 fromList-++ (x List.∷ xs) {ys} = cong (x ∷_) (fromList-++ xs)
 
-fromList-reverse : (xs : List A) → (fromList (List.reverse xs)) ≈[ List.length-reverse xs ] reverse (fromList xs)
-fromList-reverse xs = toList-injective (List.length-reverse xs) (fromList (List.reverse xs)) (reverse (fromList xs)) $
+fromList-reverse : (xs : List A) →
+                  (fromList (List.reverse xs)) ≈[ List.length-reverse xs ] reverse (fromList xs)
+fromList-reverse xs =
+  toList-injective (List.length-reverse xs) (fromList (List.reverse xs)) (reverse (fromList xs)) $
   begin
     toList (fromList (List.reverse xs)) ≡⟨ toList∘fromList (List.reverse xs) ⟩
-    List.reverse xs ≡⟨ cong (λ x → List.reverse x) (toList∘fromList xs) ⟨
+    List.reverse xs                     ≡⟨ cong (λ x → List.reverse x) (toList∘fromList xs) ⟨
     List.reverse (toList (fromList xs)) ≡⟨ toList-reverse (fromList xs) ⟨
-    toList (reverse (fromList xs)) ∎
+    toList (reverse (fromList xs))      ∎
     where open ≡-Reasoning
 
 ------------------------------------------------------------------------

--- a/src/Data/Vec/Properties/WithK.agda
+++ b/src/Data/Vec/Properties/WithK.agda
@@ -15,18 +15,6 @@ open import Data.Vec.Base
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; cong)
 open import Relation.Binary.HeterogeneousEquality as ≅ using (_≅_; refl)
 
-module _ {a} {A : Set a} where
-
-  toList-injective
-    : ∀ {m n}
-    → .(m=n : m ≡ n)
-    → (xs : Vec A m) (ys : Vec A n)
-    → toList xs ≡ toList ys
-    → xs ≈[ m=n ] ys
-  toList-injective m=n [] [] xs=ys = refl
-  toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys = 
-    cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (List.∷-injectiveʳ xs=ys))
-
 ------------------------------------------------------------------------
 -- _[_]=_
 

--- a/src/Data/Vec/Properties/WithK.agda
+++ b/src/Data/Vec/Properties/WithK.agda
@@ -15,6 +15,18 @@ open import Data.Vec.Base
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; cong)
 open import Relation.Binary.HeterogeneousEquality as ≅ using (_≅_; refl)
 
+module _ {a} {A : Set a} where
+
+  toList-injective
+    : ∀ {m n}
+    → .(m=n : m ≡ n)
+    → (xs : Vec A m) (ys : Vec A n)
+    → toList xs ≡ toList ys
+    → xs ≈[ m=n ] ys
+  toList-injective m=n [] [] xs=ys = refl
+  toList-injective m=n (x ∷ xs) (y ∷ ys) xs=ys = 
+    cong₂ _∷_ (List.∷-injectiveˡ xs=ys) (toList-injective (cong pred m=n) xs ys (List.∷-injectiveʳ xs=ys))
+
 ------------------------------------------------------------------------
 -- _[_]=_
 


### PR DESCRIPTION
- Replace `Data.List.Base as List` and `Data.List.Properties as List` with shorter `L` aliases throughout the module for better readable proof 

- Add new utility lemma `toList-injective` that proves vector equality from list equality using heterogeneous equality

- Add new equation-free lemmas that leverage `toList-injective` for cleaner proofs:
  - `fromList-reverse`: proves `fromList (L.reverse xs) ≈[ L.length-reverse xs ] reverse (fromList xs)`
  - `++-ʳ++-eqFree`: proves associativity-like property for reverse-append without explicit equation parameter
  - `ʳ++-ʳ++-eqFree`: proves composition property for reverse-append operations

- Update all `List.` references to `L.` in function types and implementations

- Import `Tactic.Cong` module to support the `cong!` tactic used in several proofs

This change improves code readability and adds a fundamental lemma for  reasoning about vector equality via list conversion, which is used in several proofs throughout the module.