### PR TITLE
Some extra support for homogeneous n-ary products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@ Deprecated names
   left-inverse ↦ rightInverse
   ```
 
+* In `Data.Product.Nary.NonDependent`:
+  ```agda
+  Allₙ ↦ Pointwiseₙ
+  ```
+
 New modules
 -----------
 
@@ -296,6 +301,12 @@ Additions to existing modules
     LeftInverse (I ×ₛ A) (J ×ₛ B)
   ```
 
+* In `Data.Product.Nary.NonDependent`:
+  ```agda
+  HomoProduct′ n f = Product n (stabulate n (const _) f)
+  HomoProduct  n A = HomoProduct′ n (const A)
+  ```
+
 * In `Data.Vec.Relation.Binary.Pointwise.Inductive`:
   ```agda
   zipWith-assoc : Associative _∼_ f → Associative (Pointwise _∼_) (zipWith {n = n} f)
@@ -303,6 +314,13 @@ Additions to existing modules
   zipWith-identityʳ: RightIdentity _∼_ e f → RightIdentity (Pointwise _∼_) (replicate n e) (zipWith f)
   zipWith-comm : Commutative _∼_ f → Commutative (Pointwise _∼_) (zipWith {n = n} f)
   zipWith-cong : Congruent₂ _∼_ f → Pointwise _∼_ ws xs → Pointwise _∼_ ys zs → Pointwise _∼_ (zipWith f ws ys) (zipWith f xs zs)
+  ```
+
+* In `Function.Nary.NonDependent.Base`:
+  ```agda
+  lconst l n = ⨆ l (lreplicate l n)
+  stabulate : ∀ n → (f : Fin n → Level) → (g : (i : Fin n) → Set (f i)) → Sets n (ltabulate n f)
+  sreplicate : ∀ n → Set a → Sets n (lreplicate n a)
   ```
 
 * In `Relation.Binary.Construct.Add.Infimum.Strict`:

--- a/src/Data/Product/Nary/NonDependent.agda
+++ b/src/Data/Product/Nary/NonDependent.agda
@@ -256,7 +256,7 @@ updateₙ′ n k = updateₙ n k
 -- Please use the new names as continuing support for the old names is
 -- not guaranteed.
 
--- Version 1.7
+-- Version 2.3
 
 Allₙ = Pointwiseₙ
 {-# WARNING_ON_USAGE Allₙ

--- a/src/Data/Product/Nary/NonDependent.agda
+++ b/src/Data/Product/Nary/NonDependent.agda
@@ -46,19 +46,32 @@ Product 0       _        = ⊤
 Product 1       (a , _)  = a
 Product (suc n) (a , as) = a × Product n as
 
--- Pointwise lifting of a relation on products
+-- An n-ary product where every element of the product lives at the same universe level.
 
-Allₙ : (∀ {a} {A : Set a} → Rel A a) →
-        ∀ n {ls} {as : Sets n ls} (l r : Product n as) → Sets n ls
-Allₙ R 0               l       r       = _
-Allₙ R 1               a       b       = R a b , _
-Allₙ R (suc n@(suc _)) (a , l) (b , r) = R a b , Allₙ R n l r
+HomoProduct′ : ∀ n {a} → (Fin n → Set a) → Set (lconst n a)
+HomoProduct′ n f = Product n (stabulate n (const _) f)
+
+-- An n-ary product where every element of the product lives in the same type.
+
+HomoProduct : ∀ n {a} → Set a → Set (lconst n a)
+HomoProduct n A = HomoProduct′ n (const A)
+
+-- Pointwise lifting of a relation over n-ary products
+
+Pointwiseₙ : (∀ {a} {A : Set a} → Rel A a) →
+             ∀ n {ls} {as : Sets n ls} (l r : Product n as) → Sets n ls
+Pointwiseₙ R 0               l       r       = _
+Pointwiseₙ R 1               a       b       = R a b , _
+Pointwiseₙ R (suc n@(suc _)) (a , l) (b , r) = R a b , Pointwiseₙ R n l r
+
+-- Pointwise lifting of propositional equality over n-ary products
 
 Equalₙ : ∀ n {ls} {as : Sets n ls} (l r : Product n as) → Sets n ls
-Equalₙ = Allₙ _≡_
+Equalₙ = Pointwiseₙ _≡_
 
 ------------------------------------------------------------------------
 -- Generic Programs
+------------------------------------------------------------------------
 
 -- Once we have these type definitions, we can write generic programs
 -- over them. They will typically be split into two or three definitions:
@@ -66,7 +79,6 @@ Equalₙ = Allₙ _≡_
 -- 1. action on the vector of n levels (if any)
 -- 2. action on the corresponding vector of n Sets
 -- 3. actual program, typed thank to the function defined in step 2.
-------------------------------------------------------------------------
 
 -- see Relation.Binary.PropositionalEquality for congₙ and substₙ, two
 -- equality-related generic programs.
@@ -168,7 +180,6 @@ projₙ : ∀ n {ls} {as : Sets n ls} k → Product n as → Projₙ as k
 projₙ 1               zero    v        = v
 projₙ (suc n@(suc _)) zero    (v , _)  = v
 projₙ (suc n@(suc _)) (suc k) (_ , vs) = projₙ n k vs
-projₙ 1 (suc ()) v
 
 ------------------------------------------------------------------------
 -- zip
@@ -188,12 +199,10 @@ zipWith (suc n@(suc _)) f (v , vs) (w , ws) =
 Levelₙ⁻ : ∀ {n} → Levels n → Fin n → Levels (pred n)
 Levelₙ⁻               (_ , ls) zero    = ls
 Levelₙ⁻ {suc (suc _)} (l , ls) (suc k) = l , Levelₙ⁻ ls k
-Levelₙ⁻ {1} _ (suc ())
 
 Removeₙ : ∀ {n ls} → Sets n ls → ∀ k → Sets (pred n) (Levelₙ⁻ ls k)
 Removeₙ               (_ , as) zero    = as
 Removeₙ {suc (suc _)} (a , as) (suc k) = a , Removeₙ as k
-Removeₙ {1} _ (suc ())
 
 removeₙ : ∀ n {ls} {as : Sets n ls} k →
           Product n as → Product (pred n) (Removeₙ as k)
@@ -201,7 +210,6 @@ removeₙ (suc zero)          zero    _        = _
 removeₙ (suc (suc _))       zero    (_ , vs) = vs
 removeₙ (suc (suc zero))    (suc k) (v , _)  = v
 removeₙ (suc (suc (suc _))) (suc k) (v , vs) = v , removeₙ _ k vs
-removeₙ (suc zero) (suc ()) _
 
 ------------------------------------------------------------------------
 -- insertion of a k-th component
@@ -209,12 +217,10 @@ removeₙ (suc zero) (suc ()) _
 Levelₙ⁺ : ∀ {n} → Levels n → Fin (suc n) → Level → Levels (suc n)
 Levelₙ⁺         ls       zero    l⁺ = l⁺ , ls
 Levelₙ⁺ {suc _} (l , ls) (suc k) l⁺ = l , Levelₙ⁺ ls k l⁺
-Levelₙ⁺ {0} _ (suc ())
 
 Insertₙ : ∀ {n ls l⁺} → Sets n ls → ∀ k (a⁺ : Set l⁺) → Sets (suc n) (Levelₙ⁺ ls k l⁺)
 Insertₙ         as       zero    a⁺ = a⁺ , as
 Insertₙ {suc _} (a , as) (suc k) a⁺ = a , Insertₙ as k a⁺
-Insertₙ {zero} _ (suc ()) _
 
 insertₙ : ∀ n {ls l⁺} {as : Sets n ls} {a⁺ : Set l⁺} k (v⁺ : a⁺) →
           Product n as → Product (suc n) (Insertₙ as k a⁺)
@@ -222,7 +228,6 @@ insertₙ 0               zero    v⁺ vs       = v⁺
 insertₙ (suc n)         zero    v⁺ vs       = v⁺ , vs
 insertₙ 1               (suc k) v⁺ vs       = vs , insertₙ 0 k v⁺ _
 insertₙ (suc n@(suc _)) (suc k) v⁺ (v , vs) = v , insertₙ n k v⁺ vs
-insertₙ 0 (suc ()) _ _
 
 ------------------------------------------------------------------------
 -- update of a k-th component
@@ -240,8 +245,20 @@ updateₙ : ∀ n {ls lᵘ} {as : Sets n ls} k {aᵘ : _ → Set lᵘ} (f : ∀ 
 updateₙ 1               zero    f v        = f v
 updateₙ (suc (suc _))   zero    f (v , vs) = f v , vs
 updateₙ (suc n@(suc _)) (suc k) f (v , vs) = v , updateₙ n k f vs
-updateₙ 1 (suc ()) _ _
 
 updateₙ′ : ∀ n {ls lᵘ} {as : Sets n ls} k {aᵘ : Set lᵘ} (f : Projₙ as k → aᵘ) →
            Product n as → Product n (Updateₙ as k aᵘ)
 updateₙ′ n k = updateₙ n k
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 1.7
+
+Allₙ = Pointwiseₙ
+{-# WARNING_ON_USAGE Allₙ
+"Warning: Allₙ was deprecated in v2.3. Please use Pointwiseₙ instead."
+#-}

--- a/src/Function/Nary/NonDependent.agda
+++ b/src/Function/Nary/NonDependent.agda
@@ -22,7 +22,7 @@ open import Data.Product.Nary.NonDependent
   using (Product; uncurryₙ; Equalₙ; curryₙ; fromEqualₙ; toEqualₙ)
 open import Function.Base using (_∘′_; _$′_; const; flip)
 open import Relation.Unary using (IUniversal)
-open import Relation.Binary.PropositionalEquality.Core using (_≡_; cong)
+open import Relation.Binary.PropositionalEquality.Core using (_≡_; refl; subst; cong)
 
 private
   variable
@@ -34,19 +34,6 @@ private
 -- Re-exporting the basic operations
 
 open import Function.Nary.NonDependent.Base public
-
-------------------------------------------------------------------------
--- Additional operations on Levels
-
-ltabulate : ∀ n → (Fin n → Level) → Levels n
-ltabulate zero    f = _
-ltabulate (suc n) f = f zero , ltabulate n (f ∘′ suc)
-
-lreplicate : ∀ n → Level → Levels n
-lreplicate n ℓ = ltabulate n (const ℓ)
-
-0ℓs : ∀[ Levels ]
-0ℓs = lreplicate _ 0ℓ
 
 ------------------------------------------------------------------------
 -- Congruence


### PR DESCRIPTION
Lately my students and I have been writing a lot of code with N-ary products where all elements either belong to types with the same universe level or belong to the same types. This adds some extra infrastructure to make this all a little bit nicer.

If `⨆` (which acts as a fold) took a level for the `n = zero` case instead of defaulting to `Level.zero` then we could prove that `HomoProduct n A : Set a` instead of `HomoProduct n A : Set (lconst n a)`. However, a) that is a breaking change and b) there's no nice way that I can see to make that cast so that the other n-ary functions over n-ary products can see through the cast. Therefore leaving as is in order to make incremental progress 