### PR TITLE
[ add ] `Relation.Nullary.Decidable.dec-yes-recompute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,11 @@ Deprecated names
   left-inverse ↦ rightInverse
   ```
 
+* In `Relation.Nullary.Decidable`:
+  ```agda
+  dec-yes  ↦ dec-yes-recompute
+  ```
+
 New modules
 -----------
 
@@ -310,6 +315,11 @@ Additions to existing modules
   <₋-accessible-⊥₋ : Acc _<₋_ ⊥₋
   <₋-accessible[_] : Acc _<_ x → Acc _<₋_ [ x ]
   <₋-wellFounded   : WellFounded _<_ → WellFounded _<₋_
+  ```
+
+* In `Relation.Nullary.Decidable`:
+  ```agda
+  dec-yes-recompute : (a? : Dec A) → .(a : A) → a? ≡ yes (recompute a? a)
   ```
 
 * In `Relation.Nullary.Decidable.Core`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,8 +152,9 @@ Deprecated names
 
 * In `Relation.Nullary.Decidable`:
   ```agda
-  dec-yes  ↦ dec-yes-recompute
+  dec-yes  ↦ dec-yes-recompute : (a? : Dec A) → .(a : A) → a? ≡ yes (recompute a? a)
   ```
+  with a more precise type.
 
 New modules
 -----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,12 +150,6 @@ Deprecated names
   left-inverse ↦ rightInverse
   ```
 
-* In `Relation.Nullary.Decidable`:
-  ```agda
-  dec-yes  ↦ dec-yes-recompute : (a? : Dec A) → .(a : A) → a? ≡ yes (recompute a? a)
-  ```
-  with a more precise type.
-
 New modules
 -----------
 
@@ -361,12 +355,6 @@ Additions to existing modules
 * In `Relation.Nullary.Negation.Core`:
   ```agda
   contra-diagonal : (A → ¬ A) → ¬ A
-  ```
-
-* In `Relation.Nullary.Recomputable`:
-  ```agda
-  recompute-irrelevant-id : (recompute : Recomputable A) → Irrelevant A →
-                            (a : A) → recompute a ≡ a
   ```
 
 * In `Relation.Nullary.Reflects`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,7 +352,7 @@ Additions to existing modules
   ```agda
   ⊤-dec : Dec {a} ⊤
   ⊥-dec : Dec {a} ⊥
-  recompute-irr≗id : (a? : Decidable A) → Nullary.Irrelevant A →
+  recompute-irr≗id : (a? : Decidable A) → Irrelevant A →
                      (a : A) → recompute a? a ≡ a
   ```
 
@@ -363,14 +363,15 @@ Additions to existing modules
 
 * In `Relation.Nullary.Recomputable`:
   ```agda
-  recompute-irr≗id : (promote : Recomputable A) → Nullary.Irrelevant A →
-                     (a : A) → promote a ≡ a
+  recompute-irrelevant-id : (recompute : Recomputable A) → Nullary.Irrelevant A →
+                            (a : A) → recompute a ≡ a
   ```
 
 * In `Relation.Nullary.Reflects`:
   ```agda
   ⊤-reflects : Reflects (⊤ {a}) true
   ⊥-reflects : Reflects (⊥ {a}) false
+  ```
 
 * In `Data.List.Relation.Unary.AllPairs.Properties`:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,8 @@ New modules
 
 * `Relation.Binary.Properties.PartialSetoid` to systematise properties of a PER
 
+* `Relation.Nullary.Recomputable.Core`
+
 Additions to existing modules
 -----------------------------
 
@@ -363,7 +365,7 @@ Additions to existing modules
 
 * In `Relation.Nullary.Recomputable`:
   ```agda
-  recompute-irrelevant-id : (recompute : Recomputable A) → Nullary.Irrelevant A →
+  recompute-irrelevant-id : (recompute : Recomputable A) → Irrelevant A →
                             (a : A) → recompute a ≡ a
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -352,8 +352,8 @@ Additions to existing modules
   ```agda
   ⊤-dec : Dec {a} ⊤
   ⊥-dec : Dec {a} ⊥
-  recompute-irr≗id : (a? : Decidable A) → Irrelevant A →
-                     (a : A) → recompute a? a ≡ a
+  recompute-irrelevant-id : (a? : Decidable A) → Irrelevant A →
+                            (a : A) → recompute a? a ≡ a
   ```
 
 * In `Relation.Nullary.Negation.Core`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,12 @@ Additions to existing modules
   contra-diagonal : (A → ¬ A) → ¬ A
   ```
 
+* In `Relation.Nullary.Recomputable`:
+  ```agda
+  recompute-irr≗id : (promote : Recomputable A) → Nullary.Irrelevant A →
+                     (a : A) → promote a ≡ a
+  ```
+
 * In `Relation.Nullary.Reflects`:
   ```agda
   ⊤-reflects : Reflects (⊤ {a}) true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -316,6 +316,8 @@ Additions to existing modules
   ```agda
   ⊤-dec : Dec {a} ⊤
   ⊥-dec : Dec {a} ⊥
+  recompute-irr≗id : (a? : Decidable A) → Nullary.Irrelevant A →
+                     (a : A) → recompute a? a ≡ a
   ```
 
 * In `Relation.Nullary.Negation.Core`:

--- a/src/Data/Fin/Permutation.agda
+++ b/src/Data/Fin/Permutation.agda
@@ -26,7 +26,7 @@ open import Function.Base using (_∘_)
 open import Level using (0ℓ)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Nullary using (does; ¬_; yes; no)
-open import Relation.Nullary.Decidable using (dec-yes; dec-no)
+open import Relation.Nullary.Decidable using (dec-yes-recompute; dec-no)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl; sym; trans; subst; cong; cong₂)
@@ -197,7 +197,7 @@ insert {m} {n} i j π = permutation to from inverseˡ′ inverseʳ′
 
   inverseʳ′ : StrictlyInverseʳ _≡_ to from
   inverseʳ′ k with i ≟ k
-  ... | yes i≡k rewrite proj₂ (dec-yes (j ≟ j) refl) = i≡k
+  ... | yes i≡k rewrite dec-yes-recompute (j ≟ j) refl = i≡k -- rewrite {!dec-yes-recompute (j ≟ j) refl!} = i≡k
   ... | no  i≢k
     with j≢punchInⱼπʳpunchOuti≢k ← punchInᵢ≢i j (π ⟨$⟩ʳ punchOut i≢k) ∘ sym
     rewrite dec-no (j ≟ punchIn j (π ⟨$⟩ʳ punchOut i≢k)) j≢punchInⱼπʳpunchOuti≢k
@@ -210,7 +210,7 @@ insert {m} {n} i j π = permutation to from inverseˡ′ inverseʳ′
 
   inverseˡ′ : StrictlyInverseˡ _≡_ to from
   inverseˡ′ k with j ≟ k
-  ... | yes j≡k rewrite proj₂ (dec-yes (i ≟ i) refl) = j≡k
+  ... | yes j≡k rewrite dec-yes-recompute (i ≟ i) refl = j≡k
   ... | no  j≢k
     with i≢punchInᵢπˡpunchOutj≢k ← punchInᵢ≢i i (π ⟨$⟩ˡ punchOut j≢k) ∘ sym
     rewrite dec-no (i ≟ punchIn i (π ⟨$⟩ˡ punchOut j≢k)) i≢punchInᵢπˡpunchOutj≢k

--- a/src/Data/Fin/Permutation.agda
+++ b/src/Data/Fin/Permutation.agda
@@ -197,7 +197,7 @@ insert {m} {n} i j π = permutation to from inverseˡ′ inverseʳ′
 
   inverseʳ′ : StrictlyInverseʳ _≡_ to from
   inverseʳ′ k with i ≟ k
-  ... | yes i≡k rewrite dec-yes-recompute (j ≟ j) refl = i≡k -- rewrite {!dec-yes-recompute (j ≟ j) refl!} = i≡k
+  ... | yes i≡k rewrite dec-yes-recompute (j ≟ j) refl = i≡k
   ... | no  i≢k
     with j≢punchInⱼπʳpunchOuti≢k ← punchInᵢ≢i j (π ⟨$⟩ʳ punchOut i≢k) ∘ sym
     rewrite dec-no (j ≟ punchIn j (π ⟨$⟩ʳ punchOut i≢k)) j≢punchInⱼπʳpunchOuti≢k

--- a/src/Data/Fin/Permutation.agda
+++ b/src/Data/Fin/Permutation.agda
@@ -26,7 +26,7 @@ open import Function.Base using (_∘_)
 open import Level using (0ℓ)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Nullary using (does; ¬_; yes; no)
-open import Relation.Nullary.Decidable using (dec-yes-recompute; dec-no)
+open import Relation.Nullary.Decidable using (dec-yes; dec-no)
 open import Relation.Nullary.Negation using (contradiction)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; _≢_; refl; sym; trans; subst; cong; cong₂)
@@ -197,7 +197,7 @@ insert {m} {n} i j π = permutation to from inverseˡ′ inverseʳ′
 
   inverseʳ′ : StrictlyInverseʳ _≡_ to from
   inverseʳ′ k with i ≟ k
-  ... | yes i≡k rewrite dec-yes-recompute (j ≟ j) refl = i≡k
+  ... | yes i≡k rewrite proj₂ (dec-yes (j ≟ j) refl) = i≡k
   ... | no  i≢k
     with j≢punchInⱼπʳpunchOuti≢k ← punchInᵢ≢i j (π ⟨$⟩ʳ punchOut i≢k) ∘ sym
     rewrite dec-no (j ≟ punchIn j (π ⟨$⟩ʳ punchOut i≢k)) j≢punchInⱼπʳpunchOuti≢k
@@ -210,7 +210,7 @@ insert {m} {n} i j π = permutation to from inverseˡ′ inverseʳ′
 
   inverseˡ′ : StrictlyInverseˡ _≡_ to from
   inverseˡ′ k with j ≟ k
-  ... | yes j≡k rewrite dec-yes-recompute (i ≟ i) refl = j≡k
+  ... | yes j≡k rewrite proj₂ (dec-yes (i ≟ i) refl) = j≡k
   ... | no  j≢k
     with i≢punchInᵢπˡpunchOutj≢k ← punchInᵢ≢i i (π ⟨$⟩ˡ punchOut j≢k) ∘ sym
     rewrite dec-no (i ≟ punchIn i (π ⟨$⟩ˡ punchOut j≢k)) i≢punchInᵢπˡpunchOutj≢k

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -18,7 +18,7 @@ open import Relation.Binary.Definitions using (Decidable)
 open import Relation.Nullary.Irrelevant using (Irrelevant)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Reflects using (invert)
-open import Relation.Binary.PropositionalEquality.Core
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; sym; trans)
 
 private

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -18,7 +18,7 @@ open import Relation.Binary.Definitions using (Decidable)
 open import Relation.Nullary.Irrelevant using (Irrelevant)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
 open import Relation.Nullary.Reflects using (invert)
-open import Relation.Binary.PropositionalEquality.Core
+open import Relation.Binary.PropositionalEquality.Core as ≡
   using (_≡_; refl; sym; trans; cong′)
 
 private
@@ -76,7 +76,8 @@ dec-no : (a? : Dec A) (¬a : ¬ A) → a? ≡ no ¬a
 dec-no a? ¬a with no _ ← a? | refl ← dec-false a? ¬a = refl
 
 dec-yes-irr : (a? : Dec A) → Irrelevant A → (a : A) → a? ≡ yes a
-dec-yes-irr a? irr a rewrite dec-yes-recompute a? a | recompute-irr≗id a? irr a = refl
+dec-yes-irr a? irr a =
+  trans (dec-yes-recompute a? a) (≡.cong yes (recompute-irr≗id a? irr a))
 
 ⌊⌋-map′ : ∀ t f (a? : Dec A) → ⌊ map′ {B = B} t f a? ⌋ ≡ ⌊ a? ⌋
 ⌊⌋-map′ t f a? = trans (isYes≗does (map′ t f a?)) (sym (isYes≗does a?))
@@ -103,4 +104,3 @@ dec-yes a? a = _ , dec-yes-recompute a? a
 "Warning: dec-yes was deprecated in v2.3.
 Please use dec-yes-recompute instead, with a sharper type."
 #-}
-

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -85,7 +85,7 @@ dec-no a? ¬a with no _ ← a? | refl ← dec-false a? ¬a = refl
 
 dec-yes-irr : (a? : Dec A) → Irrelevant A → (a : A) → a? ≡ yes a
 dec-yes-irr a? irr a =
-  trans (dec-yes-recompute a? a) (≡.cong yes (recompute-irr≗id a? irr a))
+  trans (dec-yes-recompute a? a) (≡.cong yes (recompute-irrelevant-id a? irr a))
 
 ⌊⌋-map′ : ∀ t f (a? : Dec A) → ⌊ map′ {B = B} t f a? ⌋ ≡ ⌊ a? ⌋
 ⌊⌋-map′ t f a? = trans (isYes≗does (map′ t f a?)) (sym (isYes≗does a?))

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -80,12 +80,15 @@ dec-false (true  because [a]) ¬a = contradiction (invert [a]) ¬a
 dec-yes-recompute : (a? : Dec A) → .(a : A) → a? ≡ yes (recompute a? a)
 dec-yes-recompute a? a with yes _ ← a? | refl ← dec-true a? (recompute a? a) = refl
 
-dec-no : (a? : Dec A) (¬a : ¬ A) → a? ≡ no ¬a
-dec-no a? ¬a with no _ ← a? | refl ← dec-false a? ¬a = refl
-
 dec-yes-irr : (a? : Dec A) → Irrelevant A → (a : A) → a? ≡ yes a
 dec-yes-irr a? irr a =
   trans (dec-yes-recompute a? a) (≡.cong yes (recompute-irrelevant-id a? irr a))
+
+dec-yes : (a? : Dec A) → A → ∃ λ a → a? ≡ yes a
+dec-yes a? a = _ , dec-yes-recompute a? a
+
+dec-no : (a? : Dec A) (¬a : ¬ A) → a? ≡ no ¬a
+dec-no a? ¬a with no _ ← a? | refl ← dec-false a? ¬a = refl
 
 ⌊⌋-map′ : ∀ t f (a? : Dec A) → ⌊ map′ {B = B} t f a? ⌋ ≡ ⌊ a? ⌋
 ⌊⌋-map′ t f a? = trans (isYes≗does (map′ t f a?)) (sym (isYes≗does a?))
@@ -96,19 +99,3 @@ does-≡ a? (no ¬a) = dec-false a? ¬a
 
 does-⇔ : A ⇔ B → (a? : Dec A) → (b? : Dec B) → does a? ≡ does b?
 does-⇔ A⇔B a? = does-≡ (map A⇔B a?)
-
-
-------------------------------------------------------------------------
--- DEPRECATED NAMES
-------------------------------------------------------------------------
--- Please use the new names as continuing support for the old names is
--- not guaranteed.
-
--- Version 2.3
-
-dec-yes : (a? : Dec A) → A → ∃ λ a → a? ≡ yes a
-dec-yes a? a = _ , dec-yes-recompute a? a
-{-# WARNING_ON_USAGE dec-yes
-"Warning: dec-yes was deprecated in v2.3.
-Please use dec-yes-recompute instead, with a sharper type."
-#-}

--- a/src/Relation/Nullary/Decidable.agda
+++ b/src/Relation/Nullary/Decidable.agda
@@ -69,14 +69,14 @@ dec-false : (a? : Dec A) → ¬ A → does a? ≡ false
 dec-false (false because  _ ) ¬a = refl
 dec-false (true  because [a]) ¬a = contradiction (invert [a]) ¬a
 
-dec-yes : (a? : Dec A) → A → ∃ λ a → a? ≡ yes a
-dec-yes a? a with yes a′ ← a? | refl ← dec-true a? a = a′ , refl
+dec-yes-recompute : (a? : Dec A) → .(a : A) → a? ≡ yes (recompute a? a)
+dec-yes-recompute a? a with yes _ ← a? | refl ← dec-true a? (recompute a? a) = refl
 
 dec-no : (a? : Dec A) (¬a : ¬ A) → a? ≡ no ¬a
 dec-no a? ¬a with no _ ← a? | refl ← dec-false a? ¬a = refl
 
 dec-yes-irr : (a? : Dec A) → Irrelevant A → (a : A) → a? ≡ yes a
-dec-yes-irr a? irr a with a′ , eq ← dec-yes a? a rewrite irr a a′ = eq
+dec-yes-irr a? irr a rewrite dec-yes-recompute a? a | recompute-irr≗id a? irr a = refl
 
 ⌊⌋-map′ : ∀ t f (a? : Dec A) → ⌊ map′ {B = B} t f a? ⌋ ≡ ⌊ a? ⌋
 ⌊⌋-map′ t f a? = trans (isYes≗does (map′ t f a?)) (sym (isYes≗does a?))
@@ -87,3 +87,20 @@ does-≡ a? (no ¬a) = dec-false a? ¬a
 
 does-⇔ : A ⇔ B → (a? : Dec A) → (b? : Dec B) → does a? ≡ does b?
 does-⇔ A⇔B a? = does-≡ (map A⇔B a?)
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 2.3
+
+dec-yes : (a? : Dec A) → A → ∃ λ a → a? ≡ yes a
+dec-yes a? a = _ , dec-yes-recompute a? a
+{-# WARNING_ON_USAGE dec-yes
+"Warning: dec-yes was deprecated in v2.3.
+Please use dec-yes-recompute instead, with a sharper type."
+#-}
+

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -23,7 +23,7 @@ open import Data.Product.Base using (_×_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base using (_∘_; const; _$_; flip)
 open import Relation.Nullary.Irrelevant using (Irrelevant)
-open import Relation.Nullary.Recomputable as Recomputable
+open import Relation.Nullary.Recomputable.Core as Recomputable
   using (Recomputable)
 open import Relation.Nullary.Reflects as Reflects
   hiding (recompute; recompute-constant)
@@ -85,8 +85,8 @@ recompute = Reflects.recompute ∘ proof
 recompute-constant : (a? : Dec A) (p q : A) → recompute a? p ≡ recompute a? q
 recompute-constant = Recomputable.recompute-constant ∘ recompute
 
-recompute-irr≗id : (a? : Dec A) → Irrelevant A → (a : A) → recompute a? a ≡ a
-recompute-irr≗id = Recomputable.recompute-irrelevant-id ∘ recompute
+recompute-irrelevant-id : (a? : Dec A) → Irrelevant A → (a : A) → recompute a? a ≡ a
+recompute-irrelevant-id = Recomputable.recompute-irrelevant-id ∘ recompute
 
 ------------------------------------------------------------------------
 -- Interaction with negation, sum, product etc.

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -24,7 +24,7 @@ open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base using (_∘_; const; _$_; flip)
 open import Relation.Nullary.Irrelevant using (Irrelevant)
 open import Relation.Nullary.Recomputable as Recomputable
-  hiding (recompute-constant; recompute-irr≗id)
+  using (Recomputable)
 open import Relation.Nullary.Reflects as Reflects
   hiding (recompute; recompute-constant)
 open import Relation.Nullary.Negation.Core
@@ -86,7 +86,7 @@ recompute-constant : (a? : Dec A) (p q : A) → recompute a? p ≡ recompute a? 
 recompute-constant = Recomputable.recompute-constant ∘ recompute
 
 recompute-irr≗id : (a? : Dec A) → Irrelevant A → (a : A) → recompute a? a ≡ a
-recompute-irr≗id = Recomputable.recompute-irr≗id ∘ recompute
+recompute-irr≗id = Recomputable.recompute-irrelevant-id ∘ recompute
 
 ------------------------------------------------------------------------
 -- Interaction with negation, sum, product etc.

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -22,8 +22,9 @@ open import Data.Empty.Polymorphic using (⊥)
 open import Data.Product.Base using (_×_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Function.Base using (_∘_; const; _$_; flip)
+open import Relation.Nullary.Irrelevant using (Irrelevant)
 open import Relation.Nullary.Recomputable as Recomputable
-  hiding (recompute-constant)
+  hiding (recompute-constant; recompute-irr≗id)
 open import Relation.Nullary.Reflects as Reflects
   hiding (recompute; recompute-constant)
 open import Relation.Nullary.Negation.Core
@@ -83,6 +84,9 @@ recompute = Reflects.recompute ∘ proof
 
 recompute-constant : (a? : Dec A) (p q : A) → recompute a? p ≡ recompute a? q
 recompute-constant = Recomputable.recompute-constant ∘ recompute
+
+recompute-irr≗id : (a? : Dec A) → Irrelevant A → (a : A) → recompute a? a ≡ a
+recompute-irr≗id = Recomputable.recompute-irr≗id ∘ recompute
 
 ------------------------------------------------------------------------
 -- Interaction with negation, sum, product etc.

--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -44,8 +44,8 @@ module _ (recompute : Recomputable A) where
   recompute-constant : (p q : A) → recompute p ≡ recompute q
   recompute-constant _ _ = refl
 
-  recompute-irr≗id : Nullary.Irrelevant A → (a : A) → recompute a ≡ a
-  recompute-irr≗id irr a = irr (recompute a) a
+  recompute-irrelevant-id : Nullary.Irrelevant A → (a : A) → recompute a ≡ a
+  recompute-irrelevant-id irr a = irr (recompute a) a
 
 
 ------------------------------------------------------------------------

--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -14,6 +14,7 @@ open import Data.Irrelevant using (Irrelevant; irrelevant; [_])
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂)
 open import Level using (Level)
 open import Relation.Nullary.Negation.Core using (¬_)
+import Relation.Nullary.Irrelevant as Nullary
 
 private
   variable
@@ -34,10 +35,18 @@ Recomputable : (A : Set a) → Set a
 Recomputable A = .A → A
 
 ------------------------------------------------------------------------
--- Fundamental property: 'promotion' is a constant function
+-- Fundamental properties:
+-- 'promotion' is a constant function.
+-- it is moreover the identity, if `A` is propositionally irrelevant.
 
-recompute-constant : (r : Recomputable A) (p q : A) → r p ≡ r q
-recompute-constant r p q = refl
+module _ (promote : Recomputable A) where
+
+  recompute-constant : (p q : A) → promote p ≡ promote q
+  recompute-constant _ _ = refl
+
+  recompute-irr≗id : Nullary.Irrelevant A → (a : A) → promote a ≡ a
+  recompute-irr≗id irr a = irr (promote a) a
+
 
 ------------------------------------------------------------------------
 -- Constructions

--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -8,13 +8,11 @@
 
 module Relation.Nullary.Recomputable where
 
-open import Agda.Builtin.Equality using (_≡_; refl)
 open import Data.Empty using (⊥)
 open import Data.Irrelevant using (Irrelevant; irrelevant; [_])
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂)
 open import Level using (Level)
 open import Relation.Nullary.Negation.Core using (¬_)
-import Relation.Nullary.Irrelevant as Nullary
 
 private
   variable
@@ -23,29 +21,9 @@ private
     B : Set b
 
 ------------------------------------------------------------------------
--- Definition
---
--- The idea of being 'recomputable' is that, given an *irrelevant* proof
--- of a proposition `A` (signalled by being a value of type `.A`, all of
--- whose inhabitants are identified up to definitional equality, and hence
--- do *not* admit pattern-matching), one may 'promote' such a value to a
--- 'genuine' value of `A`, available for subsequent eg. pattern-matching.
+-- Re-export
 
-Recomputable : (A : Set a) → Set a
-Recomputable A = .A → A
-
-------------------------------------------------------------------------
--- Fundamental properties:
--- 'promotion' is a constant function.
--- it is moreover the identity, if `A` is propositionally irrelevant.
-
-module _ (recompute : Recomputable A) where
-
-  recompute-constant : (p q : A) → recompute p ≡ recompute q
-  recompute-constant _ _ = refl
-
-  recompute-irrelevant-id : Nullary.Irrelevant A → (a : A) → recompute a ≡ a
-  recompute-irrelevant-id irr a = irr (recompute a) a
+open import Relation.Nullary.Recomputable.Core public
 
 
 ------------------------------------------------------------------------

--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -39,13 +39,13 @@ Recomputable A = .A → A
 -- 'promotion' is a constant function.
 -- it is moreover the identity, if `A` is propositionally irrelevant.
 
-module _ (promote : Recomputable A) where
+module _ (recompute : Recomputable A) where
 
-  recompute-constant : (p q : A) → promote p ≡ promote q
+  recompute-constant : (p q : A) → recompute p ≡ recompute q
   recompute-constant _ _ = refl
 
-  recompute-irr≗id : Nullary.Irrelevant A → (a : A) → promote a ≡ a
-  recompute-irr≗id irr a = irr (promote a) a
+  recompute-irr≗id : Nullary.Irrelevant A → (a : A) → recompute a ≡ a
+  recompute-irr≗id irr a = irr (recompute a) a
 
 
 ------------------------------------------------------------------------

--- a/src/Relation/Nullary/Recomputable/Core.agda
+++ b/src/Relation/Nullary/Recomputable/Core.agda
@@ -1,0 +1,45 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Recomputable types and their algebra as Harrop formulas
+------------------------------------------------------------------------
+
+{-# OPTIONS --cubical-compatible --safe #-}
+
+module Relation.Nullary.Recomputable.Core where
+
+open import Agda.Builtin.Equality using (_≡_; refl)
+open import Level using (Level)
+open import Relation.Nullary.Irrelevant using (Irrelevant)
+
+private
+  variable
+    a : Level
+    A : Set a
+
+
+------------------------------------------------------------------------
+-- Definition
+--
+-- The idea of being 'recomputable' is that, given an *irrelevant* proof
+-- of a proposition `A` (signalled by being a value of type `.A`, all of
+-- whose inhabitants are identified up to definitional equality, and hence
+-- do *not* admit pattern-matching), one may 'promote' such a value to a
+-- 'genuine' value of `A`, available for subsequent eg. pattern-matching.
+
+Recomputable : (A : Set a) → Set a
+Recomputable A = .A → A
+
+------------------------------------------------------------------------
+-- Fundamental properties:
+-- given `Recomputable A`, `recompute` is a constant function;
+-- moreover, the identity, if `A` is propositionally irrelevant.
+
+module _ (recompute : Recomputable A) where
+
+  recompute-constant : (p q : A) → recompute p ≡ recompute q
+  recompute-constant _ _ = refl
+
+  recompute-irrelevant-id : Irrelevant A → (a : A) → recompute a ≡ a
+  recompute-irrelevant-id irr a = irr (recompute a) a
+


### PR DESCRIPTION
This PR sharpens the type of `Relation.Nullary.Decidable.dec-yes` by supplying an explicit existential witness:
* `dec-yes-recompute` weakens the hypothesis to allow *irrelevant* argument `.(a : A)`
* by witnessing the existential with `recompute a? a`
* `dec-yes` then follows immediately.

It introduces two new lemmas:
* `Relation.Nullary.Recomputable.recompute-irrelevant-id`: for propositionally irrelevant `A`, `recompute` is the identity
* `Relation.Nullary.Decidable.Core.recompute-irrelevant-id`, encapsulating the above

UPDATED:
* refactors `Relation.Nullary.Recomputable` to lift definitions and basic properties out into `Relation.Nullary.Recomputable.Core`.