### PR TITLE
Optimize hexadecimal display functions for Word64 and Word8 to resolve performance issue #2722

### DIFF
--- a/src/Data/Nat/Show.agda
+++ b/src/Data/Nat/Show.agda
@@ -8,7 +8,7 @@
 
 module Data.Nat.Show where
 
-open import Data.Bool.Base using (_∧_)
+open import Data.Bool.Base using (_∧_; if_then_else_)
 open import Data.Char.Base as Char using (Char)
 open import Data.Digit using (showDigit; toDigits; toNatDigits)
 open import Data.List.Base as List using (List; []; _∷_)
@@ -83,3 +83,24 @@ showInBase : (base : ℕ)
              ℕ → String
 showInBase base {base≥2} {base≤16} = fromList
                                    ∘ charsInBase base {base≥2} {base≤16}
+
+-- Fast version of `charsInBase` and `showInBase` for bases 2 to 16.
+
+charsInBaseFast : (base : ℕ)
+                  {base≥1 : True (1 ≤? base)}
+                  {base≤16 : True (base ≤? 16)} →
+                  ℕ → List Char
+charsInBaseFast base {base≥1} {base≤16} n = List.map toHexChar (toNatDigits base {base≤16 = base≥1} n)
+  where
+  toHexChar : ℕ → Char
+  toHexChar digit = if digit <ᵇ 10
+    then Char.fromℕ (digit + Char.toℕ '0')
+    else Char.fromℕ (digit ∸ 10 + Char.toℕ 'a')
+
+showInBaseFast : (base : ℕ)
+                 {base≥1 : True (1 ≤? base)}
+                 {base≤16 : True (base ≤? 16)} →
+                 ℕ → String  
+showInBaseFast base {base≥1} {base≤16} = fromList
+                              ∘ List.reverse
+                              ∘ charsInBaseFast base {base≥1} {base≤16}

--- a/src/Data/Nat/Show.agda
+++ b/src/Data/Nat/Show.agda
@@ -64,43 +64,14 @@ toDecimalChars = List.map toDigitChar ∘′ toNatDigits 10
 show : ℕ → String
 show = fromList ∘′ toDecimalChars
 
--- Arbitrary base betwen 2 & 16.
--- Warning: when compiled the time complexity of `showInBase b n` is
--- O(n) instead of the expected O(log(n)).
 
-charsInBase : (base : ℕ)
-              {base≥2 : True (2 ≤? base)}
-              {base≤16 : True (base ≤? 16)} →
-              ℕ → List Char
-charsInBase base {base≥2} {base≤16} = List.map (showDigit {base≤16 = base≤16})
-                                    ∘ List.reverse
-                                    ∘ proj₁
-                                    ∘ toDigits base {base≥2 = base≥2}
-
-showInBase : (base : ℕ)
-             {base≥2 : True (2 ≤? base)}
-             {base≤16 : True (base ≤? 16)} →
-             ℕ → String
-showInBase base {base≥2} {base≤16} = fromList
-                                   ∘ charsInBase base {base≥2} {base≤16}
-
--- Fast version of `charsInBase` and `showInBase` for bases 2 to 16.
-
-charsInBaseFast : (base : ℕ)
-                  {base≥1 : True (1 ≤? base)}
-                  {base≤16 : True (base ≤? 16)} →
-                  ℕ → List Char
-charsInBaseFast base {base≥1} {base≤16} n = List.map toHexChar (toNatDigits base {base≤16 = base≥1} n)
+charsInBase : (base : ℕ) {base≥1 : True (1 ≤? base)} {base≤16 : True (base ≤? 16)} → ℕ → List Char
+charsInBase base {base≥1} {base≤16} n = List.map toHexChar (toNatDigits base {base≤16 = base≥1} n)
   where
   toHexChar : ℕ → Char
   toHexChar digit = if digit <ᵇ 10
     then Char.fromℕ (digit + Char.toℕ '0')
     else Char.fromℕ (digit ∸ 10 + Char.toℕ 'a')
 
-showInBaseFast : (base : ℕ)
-                 {base≥1 : True (1 ≤? base)}
-                 {base≤16 : True (base ≤? 16)} →
-                 ℕ → String  
-showInBaseFast base {base≥1} {base≤16} = fromList
-                              ∘ List.reverse
-                              ∘ charsInBaseFast base {base≥1} {base≤16}
+showInBase : (base : ℕ) {base≥1 : True (1 ≤? base)} {base≤16 : True (base ≤? 16)} → ℕ → String
+showInBase base {base≥1} {base≤16} = fromList ∘ List.reverse ∘ charsInBase base {base≥1} {base≤16}

--- a/src/Data/Word64/Show.agda
+++ b/src/Data/Word64/Show.agda
@@ -21,7 +21,7 @@ open import Data.Word64.Unsafe using (toBits)
 open import Data.Bool
 open import Data.Nat
 open import Data.List using ( List )
-open import Data.String 
+open import Data.String
 open import Data.Word64
 
 open import Data.Digit using ( toNatDigits )
@@ -45,9 +45,8 @@ toHexadecimalChars : ℕ → List Char
 toHexadecimalChars = Data.List.map toHexDigitChar ∘′ toNatDigits 16
 
 showHexa : Word64 -> String
-showHexa w 
-  = "0x" ++_
+showHexa w = "0x" ++_
   $ padLeft '0' 16
-  $ Data.String.fromList  
+  $ Data.String.fromList
   $ toHexadecimalChars (Data.Word64.toℕ w)
 

--- a/src/Data/Word64/Show.agda
+++ b/src/Data/Word64/Show.agda
@@ -13,11 +13,20 @@ open import Agda.Builtin.String using (String)
 open import Data.Bool.Show using (showBit)
 open import Data.Fin.Base as Fin using (Fin)
 import Data.Nat.Show as ℕ using (showInBase)
-open import Data.String using (_++_; fromVec; padLeft)
+open import Data.String using (_++_; fromVec; padLeft; String)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Data.Word64.Base using (Word64; toℕ)
 open import Data.Word64.Unsafe using (toBits)
-open import Function.Base using (_$_)
+
+open import Data.Bool
+open import Data.Nat
+open import Data.List using ( List )
+open import Data.String 
+open import Data.Word64
+
+open import Data.Digit using ( toNatDigits )
+open import Data.Char as Char
+open import Function.Base using ( _$_ ; _∘′_ )
 
 showBits : Word64 → String
 showBits w
@@ -27,8 +36,18 @@ showBits w
   $ Vec.map showBit
   $ toBits w
 
-showHexa : Word64 → String
-showHexa w
+toHexDigitChar : ℕ → Char
+toHexDigitChar n = if n <ᵇ 10
+  then Char.fromℕ (n + Char.toℕ '0')
+  else Char.fromℕ (n ∸ 10 + Char.toℕ 'a')
+
+toHexadecimalChars : ℕ → List Char
+toHexadecimalChars = Data.List.map toHexDigitChar ∘′ toNatDigits 16
+
+showHexa : Word64 -> String
+showHexa w 
   = "0x" ++_
-  $ padLeft '0' 8
-  $ ℕ.showInBase 16 (toℕ w)
+  $ padLeft '0' 16
+  $ Data.String.fromList  
+  $ toHexadecimalChars (Data.Word64.toℕ w)
+

--- a/src/Data/Word8/Show.agda
+++ b/src/Data/Word8/Show.agda
@@ -18,9 +18,9 @@ open import Data.Word8.Base using (Word8; toℕ; toBits)
 open import Function.Base using (_$_; _∘′_)
 open import Data.Digit using (toNatDigits)
 open import Data.List using (List; map)
-open import Data.Char as Char
+open import Data.Char as Char using (Char; toℕ; fromℕ)
 open import Data.Bool.Base using (if_then_else_)
-open import Data.Nat
+open import Data.Nat using (ℕ; _<ᵇ_; _≤ᵇ_; _∸_; _*_; _+_)
 
 
 showBits : Word8 → String

--- a/src/Data/Word8/Show.agda
+++ b/src/Data/Word8/Show.agda
@@ -9,14 +9,19 @@
 module Data.Word8.Show where
 
 open import Agda.Builtin.String using (String)
-
 open import Data.Bool.Show using (showBit)
 open import Data.Fin.Base as Fin using (Fin)
 import Data.Nat.Show as ℕ using (showInBase)
-open import Data.String using (_++_; fromVec; padLeft)
+open import Data.String using (_++_; fromVec; padLeft; fromList)
 open import Data.Vec.Base as Vec using (Vec; []; _∷_)
 open import Data.Word8.Base using (Word8; toℕ; toBits)
-open import Function.Base using (_$_)
+open import Function.Base using (_$_; _∘′_)
+open import Data.Digit using (toNatDigits)
+open import Data.List using (List; map)
+open import Data.Char as Char
+open import Data.Bool.Base using (if_then_else_)
+open import Data.Nat
+
 
 showBits : Word8 → String
 showBits w
@@ -26,8 +31,16 @@ showBits w
   $ Vec.map showBit
   $ toBits w
 
+toHexDigitChar : ℕ → Char
+toHexDigitChar n = if n <ᵇ 10
+  then Char.fromℕ (n + Char.toℕ '0')
+  else Char.fromℕ (n ∸ 10 + Char.toℕ 'a')
+
+toHexadecimalChars : ℕ → List Char
+toHexadecimalChars = map toHexDigitChar ∘′ toNatDigits 16
+
 showHexa : Word8 → String
-showHexa w
-  = "0x" ++_
-  $ padLeft '0' 2
-  $ ℕ.showInBase 16 (toℕ w)
+showHexa w = "0x" ++_ 
+  $ padLeft '0' 2 
+  $ fromList 
+  $ toHexadecimalChars (Data.Word8.Base.toℕ w)

--- a/src/Data/Word8/Show.agda
+++ b/src/Data/Word8/Show.agda
@@ -40,7 +40,7 @@ toHexadecimalChars : ℕ → List Char
 toHexadecimalChars = map toHexDigitChar ∘′ toNatDigits 16
 
 showHexa : Word8 → String
-showHexa w = "0x" ++_ 
-  $ padLeft '0' 2 
-  $ fromList 
+showHexa w = "0x" ++_
+  $ padLeft '0' 2
+  $ fromList
   $ toHexadecimalChars (Data.Word8.Base.toℕ w)


### PR DESCRIPTION
Replace slow proof-carrying hexadecimal display implementations with fast proof-free alternatives for Word64 and Word8. The original showHexa functions used `Data.Nat.Show.showInBase` which relies on `Data.Digit.toDigits`, causing expensive normalization due to proof terms (∃[ ds ] (Represents base ds n)). 


- Resolves: [Issue #2722](https://github.com/agda/agda-stdlib/issues/2722)