### PR TITLE
[ refactor ] cosmetic improvement to `Algebra.Construct.Initial`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,12 @@ Additions to existing modules
     ∙-congʳ : RightCongruent _≈_ _∙_
   ```
 
+* In `Algebra.Construct.Initial`:
+  ```agda
+  assoc : Associative _≈_ _∙_
+  idem  : Idempotent _≈_ _∙_
+  ```
+
 * In `Algebra.Construct.Pointwise`:
   ```agda
   isNearSemiring                  : IsNearSemiring _≈_ _+_ _*_ 0# →

--- a/src/Algebra/Construct/Initial.agda
+++ b/src/Algebra/Construct/Initial.agda
@@ -19,7 +19,7 @@ open import Algebra.Bundles
 open import Algebra.Bundles.Raw
   using (RawMagma)
 open import Algebra.Core using (Op₂)
-open import Algebra.Definitions using (Congruent₂)
+open import Algebra.Definitions using (Congruent₂; Associative; Idempotent)
 open import Algebra.Structures using (IsMagma; IsSemigroup; IsBand)
 open import Data.Empty.Polymorphic using (⊥)
 open import Relation.Binary.Core using (Rel)
@@ -63,6 +63,12 @@ module ℤero where
   ∙-cong : Congruent₂ _≈_ _∙_
   ∙-cong {x = ()}
 
+  assoc : Associative _≈_ _∙_
+  assoc ()
+
+  idem : Idempotent _≈_ _∙_
+  idem ()
+
 open ℤero
 
 ------------------------------------------------------------------------
@@ -75,16 +81,16 @@ rawMagma = record { ℤero }
 -- Structures
 
 isEquivalence : IsEquivalence _≈_
-isEquivalence = record { refl = refl; sym = sym; trans = λ {k = k} → trans {k = k} }
+isEquivalence = record { refl = refl; sym = sym; trans = λ where {i = ()} }
 
 isMagma : IsMagma _≈_ _∙_
-isMagma = record { isEquivalence = isEquivalence ; ∙-cong = λ {y = y} {u = u} {v = v} → ∙-cong {y = y} {v = v} }
+isMagma = record { isEquivalence = isEquivalence ; ∙-cong = λ where {x = ()} }
 
 isSemigroup : IsSemigroup _≈_ _∙_
-isSemigroup = record { isMagma = isMagma ; assoc = λ () }
+isSemigroup = record { isMagma = isMagma ; assoc = assoc }
 
 isBand : IsBand _≈_ _∙_
-isBand = record { isSemigroup = isSemigroup ; idem = λ () }
+isBand = record { isSemigroup = isSemigroup ; idem = idem }
 
 ------------------------------------------------------------------------
 -- Bundles


### PR DESCRIPTION
PR #2546 fixed a v2.8.0 compatibility issue regarding inference of implicit arguments in instantiation of `record` fields.

This PR tidies up those changes:
* to be less noisy
* to add two more definitions which don't incur the problem.

Badged as v2.3, because it 'fixes' an earlier v2.3 issue/pr but could easily be bumped to v2.4.

The original refactoring hoped to define a single module `ℤero` from which all subsequent definitions could be given by record subtyping simply as `... = record { ℤero }`, but that dream has now evaporated. So it might be worth simply abandoning the explicit definition altogether, although the book-keeping overhead outweighs the benefit. Could make this `breaking` for v3.0, though!?