### PR TITLE
Fix breaking introduction of variable in `Semiring.Primality`

### DIFF
--- a/src/Algebra/Properties/Semiring/Primality.agda
+++ b/src/Algebra/Properties/Semiring/Primality.agda
@@ -22,8 +22,7 @@ open import Algebra.Properties.Semiring.Divisibility R
 
 private
   variable
-    x p : A
-
+    x : A
 
 ------------------------------------------------------------------------
 -- Re-export primality definitions
@@ -43,6 +42,6 @@ Coprime-sym coprime = flip coprime
 ------------------------------------------------------------------------
 -- Properties of Irreducible
 
-Irreducible⇒≉0 : 0# ≉ 1# → Irreducible p → p ≉ 0#
+Irreducible⇒≉0 : 0# ≉ 1# → ∀ {p} → Irreducible p → p ≉ 0#
 Irreducible⇒≉0 0≉1 (mkIrred _ chooseInvertible) p≈0 =
   0∤1 0≉1 (reduce (chooseInvertible (trans p≈0 (sym (zeroˡ 0#)))))


### PR DESCRIPTION
Fixes accidental breaking change in https://github.com/agda/agda-stdlib/issues/2772. 