### PR TITLE
[ refactor ] `Data.Fin.Properties` following #2746

### DIFF
--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -46,7 +46,8 @@ open import Relation.Binary.PropositionalEquality.Properties as ≡
   using (module ≡-Reasoning)
 open import Relation.Nullary.Decidable as Dec
   using (Dec; _because_; yes; no; _×-dec_; _⊎-dec_; map′)
-open import Relation.Nullary.Negation.Core using (¬_; contradiction)
+open import Relation.Nullary.Negation.Core
+  using (¬_; contradiction; contradiction′)
 open import Relation.Nullary.Reflects using (Reflects; invert)
 open import Relation.Unary as U
   using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
@@ -1069,7 +1070,7 @@ injective⇒existsPivot : ∀ {f : Fin n → Fin m} → Injective _≡_ _≡_ f 
 injective⇒existsPivot {f = f} f-injective i
   with any? (λ j → j ≤? i ×-dec i ≤? f j)
 ... | yes result = result
-... | no ¬result = flip contradiction notInjective-Fin[1+n]→Fin[n] f∘inject!-injective
+... | no ¬result = contradiction′ notInjective-Fin[1+n]→Fin[n] f∘inject!-injective
   where
   fj<i : (j : Fin′ (suc i)) → f (inject! j) < i
   fj<i j with f (inject! j) <? i

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -1043,12 +1043,18 @@ pigeonhole (s<s m<n@(s≤s _)) f with any? (λ k → f zero ≟ f (suc k))
 <⇒notInjective {f = f} n<m inj =
   let i , j , i<j , fᵢ≡fⱼ = pigeonhole n<m f in <-irrefl (inj fᵢ≡fⱼ) i<j
 
+-- specialised to m = suc n
+
+private
+  notInjective-Fin[1+n]→Fin[n] : ∀ {f : Fin (suc n) → Fin n} → ¬ (Injective _≡_ _≡_ f)
+  notInjective-Fin[1+n]→Fin[n] {n = n} = <⇒notInjective (ℕ.n<1+n n)
+
 injective⇒≤ : ∀ {f : Fin m → Fin n} → Injective _≡_ _≡_ f → m ℕ.≤ n
 injective⇒≤ = ℕ.≮⇒≥ ∘ flip <⇒notInjective
 
 ℕ→Fin-notInjective : ∀ (f : ℕ → Fin n) → ¬ (Injective _≡_ _≡_ f)
-ℕ→Fin-notInjective f inj =
-  <⇒notInjective (ℕ.n<1+n _) (Comp.injective _≡_ _≡_ _≡_ toℕ-injective inj)
+ℕ→Fin-notInjective f =
+  notInjective-Fin[1+n]→Fin[n] ∘ Comp.injective _≡_ _≡_ _≡_ toℕ-injective
 
 -- Cantor-Schröder-Bernstein for finite sets
 
@@ -1063,7 +1069,7 @@ injective⇒existsPivot : ∀ {f : Fin n → Fin m} → Injective _≡_ _≡_ f 
 injective⇒existsPivot {f = f} f-injective i
   with any? (λ j → j ≤? i ×-dec i ≤? f j)
 ... | yes result = result
-... | no ¬result = flip contradiction (<⇒notInjective (ℕ.n<1+n _)) f∘inject!-injective
+... | no ¬result = flip contradiction notInjective-Fin[1+n]→Fin[n] f∘inject!-injective
   where
   fj<i : (j : Fin′ (suc i)) → f (inject! j) < i
   fj<i j with f (inject! j) <? i

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -1047,8 +1047,8 @@ injective⇒≤ : ∀ {f : Fin m → Fin n} → Injective _≡_ _≡_ f → m �
 injective⇒≤ = ℕ.≮⇒≥ ∘ flip <⇒notInjective
 
 ℕ→Fin-notInjective : ∀ (f : ℕ → Fin n) → ¬ (Injective _≡_ _≡_ f)
-ℕ→Fin-notInjective f inj = ℕ.<-irrefl refl
-  (injective⇒≤ (Comp.injective _≡_ _≡_ _≡_ toℕ-injective inj))
+ℕ→Fin-notInjective f inj = 
+  <⇒notInjective (ℕ.n<1+n _) (Comp.injective _≡_ _≡_ _≡_ toℕ-injective inj)
 
 -- Cantor-Schröder-Bernstein for finite sets
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -1063,7 +1063,7 @@ injective⇒existsPivot : ∀ {f : Fin n → Fin m} → Injective _≡_ _≡_ f 
 injective⇒existsPivot {f = f} f-injective i
   with any? (λ j → j ≤? i ×-dec i ≤? f j)
 ... | yes result = result
-... | no ¬result = contradiction (injective⇒≤ f∘inject!-injective) ℕ.1+n≰n
+... | no ¬result = flip contradiction (<⇒notInjective (ℕ.n<1+n _)) f∘inject!-injective
   where
   fj<i : (j : Fin′ (suc i)) → f (inject! j) < i
   fj<i j with f (inject! j) <? i

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -1047,7 +1047,7 @@ injective⇒≤ : ∀ {f : Fin m → Fin n} → Injective _≡_ _≡_ f → m �
 injective⇒≤ = ℕ.≮⇒≥ ∘ flip <⇒notInjective
 
 ℕ→Fin-notInjective : ∀ (f : ℕ → Fin n) → ¬ (Injective _≡_ _≡_ f)
-ℕ→Fin-notInjective f inj = 
+ℕ→Fin-notInjective f inj =
   <⇒notInjective (ℕ.n<1+n _) (Comp.injective _≡_ _≡_ _≡_ toℕ-injective inj)
 
 -- Cantor-Schröder-Bernstein for finite sets

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -1035,20 +1035,16 @@ pigeonhole : m ℕ.< n → (f : Fin n → Fin m) → ∃₂ λ i j → i < j × 
 pigeonhole z<s               f = contradiction (f zero) λ()
 pigeonhole (s<s m<n@(s≤s _)) f with any? (λ k → f zero ≟ f (suc k))
 ... | yes (j , f₀≡fⱼ) = zero , suc j , z<s , f₀≡fⱼ
-... | no  f₀≢fₖ
-  with i , j , i<j , fᵢ≡fⱼ ← pigeonhole m<n (λ j → punchOut (f₀≢fₖ ∘ (j ,_ )))
-  = suc i , suc j , s<s i<j , punchOut-injective (f₀≢fₖ ∘ (i ,_)) _ fᵢ≡fⱼ
-
-injective⇒≤ : ∀ {f : Fin m → Fin n} → Injective _≡_ _≡_ f → m ℕ.≤ n
-injective⇒≤ {zero}  {_}     {f} _   = z≤n
-injective⇒≤ {suc _} {zero}  {f} _   = contradiction (f zero) ¬Fin0
-injective⇒≤ {suc _} {suc _} {f} inj = s≤s (injective⇒≤ (λ eq →
-  suc-injective (inj (punchOut-injective
-    (contraInjective inj 0≢1+n)
-    (contraInjective inj 0≢1+n) eq))))
+... | no  f₀≢fₖ =
+  let i , j , i<j , fᵢ≡fⱼ = pigeonhole m<n (λ j → punchOut (f₀≢fₖ ∘ (j ,_ )))
+  in suc i , suc j , s<s i<j , punchOut-injective (f₀≢fₖ ∘ (i ,_)) _ fᵢ≡fⱼ
 
 <⇒notInjective : ∀ {f : Fin m → Fin n} → n ℕ.< m → ¬ (Injective _≡_ _≡_ f)
-<⇒notInjective n<m inj = ℕ.≤⇒≯ (injective⇒≤ inj) n<m
+<⇒notInjective {f = f} n<m inj =
+  let i , j , i<j , fᵢ≡fⱼ = pigeonhole n<m f in <-irrefl (inj fᵢ≡fⱼ) i<j
+
+injective⇒≤ : ∀ {f : Fin m → Fin n} → Injective _≡_ _≡_ f → m ℕ.≤ n
+injective⇒≤ = ℕ.≮⇒≥ ∘ flip <⇒notInjective
 
 ℕ→Fin-notInjective : ∀ (f : ℕ → Fin n) → ¬ (Injective _≡_ _≡_ f)
 ℕ→Fin-notInjective f inj = ℕ.<-irrefl refl


### PR DESCRIPTION
UPDATED: 
* no `CHANGELOG` required! Only existing proofs have been refactored. 
* issue below resolved moderately successfully via @andreasabel 's trick with `flip contradiction` cf. #2784 

NB. I tried to simplify the proof of `injective⇒existsPivot` to use `<⇒notInjective` instead, but it causes a weird explicit/implicit type inference error when trying to obtain a contradiction from `f∘inject!-injective` and `<⇒notInjective`...:
```agda
injective⇒existsPivot {f = f} f-injective i
  with any? (λ j → j ≤? i ×-dec i ≤? f j)
... | yes result = result
... | no ¬result = contradiction f∘inject!-injective (<⇒notInjective {f = f∘inject! } (ℕ.n<1+n (toℕ i)))
  where
  ...
```
yields
```agda
/home/james/RESEARCH/Agda-stdlib-dev-v2.3/src/Data/Fin/Properties.agda:1077.55-104: error: [UnequalHiding]
f∘inject! _x_4739 ≡ f∘inject! _y_4740 → _x_4739 ≡ _y_4740 !=
{x y : Fin (toℕ (suc i))} → f∘inject! x ≡ f∘inject! y → x ≡ y
because one is an implicit function type and the other is an
explicit function type
when checking that the expression
<⇒notInjective {f = f∘inject!} (ℕ.n<1+n (toℕ i)) has type
¬ (f∘inject! _x_4739 ≡ f∘inject! _y_4740 → _x_4739 ≡ _y_4740)
```
(this kind of thing *really* aggravates me: we have two sub-proofs of `a : A` and `¬a : ¬ A` here, with `A = Injective _≡_ _≡_ f∘inject!`, but (re-)typechecking `contradiction a ¬a` causes a type error... :-( See https://github.com/agda/agda/issues/8026