### PR TITLE
[ refactor ] make `n≢i : n ≢ toℕ i` argument to `lower₁` irrelevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Non-backwards compatible changes
 Minor improvements
 ------------------
 
+* The type of `Relation.Nullary.Negation.Core.contradiction-irr` has been further
+  weakened so that the negated hypothesis `¬ A` is marked as irrelevant. This is
+  safe to do, in view of `Relation.Nullary.Recomputable.Properties.¬-recompute`.
+
+* As a consequence, the type of `Data.Fin.Base.lower₁` has been correspondingly
+  weakened so that the negated hypothesis `n≢i : n ≢ toℕ i` is marked irrelevant.
+
 Deprecated modules
 ------------------
 

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -19,8 +19,7 @@ open import Level using (0ℓ)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
 open import Relation.Binary.Indexed.Heterogeneous.Core using (IRel)
-open import Relation.Nullary.Negation.Core using (¬_; contradiction)
-open import Relation.Nullary.Recomputable using (¬-recompute)
+open import Relation.Nullary.Negation.Core using (¬_; contradiction-irr)
 
 private
   variable
@@ -117,11 +116,8 @@ inject≤ {n = suc _} (suc i) m≤n = suc (inject≤ i (ℕ.s≤s⁻¹ m≤n))
 
 -- lower₁ "i" _ = "i".
 
-lower₁-¬0≢0 : ∀ {ℓ} {A : Set ℓ} → .(0 ≢ 0) → A
-lower₁-¬0≢0 0≢0 = contradiction refl (¬-recompute 0≢0)
-
 lower₁ : ∀ (i : Fin (suc n)) → .(n ≢ toℕ i) → Fin n
-lower₁ {zero}  zero    ne = lower₁-¬0≢0 ne
+lower₁ {zero}  zero    ne = contradiction-irr refl ne
 lower₁ {suc n} zero    _  = zero
 lower₁ {suc n} (suc i) ne = suc (lower₁ i (ne ∘ cong suc))
 
@@ -257,7 +253,7 @@ opposite {suc n} (suc i) = inject₁ (opposite i)
 -- McBride's "First-order unification by structural recursion".
 
 punchOut : ∀ {i j : Fin (suc n)} → i ≢ j → Fin n
-punchOut {_}     {zero}   {zero}  i≢j = contradiction refl i≢j
+punchOut {_}     {zero}   {zero}  i≢j = contradiction-irr refl i≢j
 punchOut {_}     {zero}   {suc j} _   = j
 punchOut {suc _} {suc i}  {zero}  _   = zero
 punchOut {suc _} {suc i}  {suc j} i≢j = suc (punchOut (i≢j ∘ cong suc))

--- a/src/Data/Fin/Base.agda
+++ b/src/Data/Fin/Base.agda
@@ -20,6 +20,7 @@ open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.PropositionalEquality.Core using (_≡_; _≢_; refl; cong)
 open import Relation.Binary.Indexed.Heterogeneous.Core using (IRel)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
+open import Relation.Nullary.Recomputable using (¬-recompute)
 
 private
   variable
@@ -116,8 +117,11 @@ inject≤ {n = suc _} (suc i) m≤n = suc (inject≤ i (ℕ.s≤s⁻¹ m≤n))
 
 -- lower₁ "i" _ = "i".
 
-lower₁ : ∀ (i : Fin (suc n)) → n ≢ toℕ i → Fin n
-lower₁ {zero}  zero    ne = contradiction refl ne
+lower₁-¬0≢0 : ∀ {ℓ} {A : Set ℓ} → .(0 ≢ 0) → A
+lower₁-¬0≢0 0≢0 = contradiction refl (¬-recompute 0≢0)
+
+lower₁ : ∀ (i : Fin (suc n)) → .(n ≢ toℕ i) → Fin n
+lower₁ {zero}  zero    ne = lower₁-¬0≢0 ne
 lower₁ {suc n} zero    _  = zero
 lower₁ {suc n} (suc i) ne = suc (lower₁ i (ne ∘ cong suc))
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -47,8 +47,7 @@ open import Relation.Binary.PropositionalEquality.Properties as ≡
 open import Relation.Nullary.Decidable as Dec
   using (Dec; _because_; yes; no; _×-dec_; _⊎-dec_; map′)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
-open import Relation.Nullary.Recomputable using (¬-recompute)
-open import Relation.Nullary.Reflects using (Reflects; invert)
+open import Relation.Nullary.Reflects using (invert)
 open import Relation.Unary as U
   using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
 open import Relation.Unary.Properties using (U?)

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -568,7 +568,7 @@ lower₁≗lower {n = suc _ } zero    _   = refl
 lower₁≗lower {n = suc _ } (suc i) ne  = cong suc (lower₁≗lower i (ne ∘ cong suc))
 
 lower≗lower₁ : ∀ (i : Fin (suc n)) .(i<n : toℕ i ℕ.< n) →
-               lower i i<n ≡ lower₁ i {!ℕ.<⇒≢ i<n ∘ sym!}
+               lower i i<n ≡ lower₁ i (ℕ.<⇒≢ i<n ∘ sym)
 lower≗lower₁ {n = suc _ } zero    _   = refl
 lower≗lower₁ {n = suc _ } (suc i) lt  = cong suc (lower≗lower₁ i (ℕ.s<s⁻¹ lt))
 

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -47,6 +47,7 @@ open import Relation.Binary.PropositionalEquality.Properties as ≡
 open import Relation.Nullary.Decidable as Dec
   using (Dec; _because_; yes; no; _×-dec_; _⊎-dec_; map′)
 open import Relation.Nullary.Negation.Core using (¬_; contradiction)
+open import Relation.Nullary.Recomputable using (¬-recompute)
 open import Relation.Nullary.Reflects using (Reflects; invert)
 open import Relation.Unary as U
   using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
@@ -506,30 +507,30 @@ inject!-< {suc n} {suc i} (suc k) = s≤s (inject!-< k)
 -- lower₁
 ------------------------------------------------------------------------
 
-toℕ-lower₁ : ∀ i (p : n ≢ toℕ i) → toℕ (lower₁ i p) ≡ toℕ i
-toℕ-lower₁ {ℕ.zero}  zero    p = contradiction refl p
-toℕ-lower₁ {ℕ.suc m} zero    p = refl
-toℕ-lower₁ {ℕ.suc m} (suc i) p = cong ℕ.suc (toℕ-lower₁ i (p ∘ cong ℕ.suc))
+toℕ-lower₁ : ∀ i .(p : n ≢ toℕ i) → toℕ (lower₁ i p) ≡ toℕ i
+toℕ-lower₁ {ℕ.zero}  zero    0≢0 = lower₁-¬0≢0 0≢0
+toℕ-lower₁ {ℕ.suc m} zero    _   = refl
+toℕ-lower₁ {ℕ.suc m} (suc i) ne  = cong ℕ.suc (toℕ-lower₁ i (ne ∘ cong ℕ.suc))
 
-lower₁-injective : ∀ {n≢i : n ≢ toℕ i} {n≢j : n ≢ toℕ j} →
+lower₁-injective : ∀ .{n≢i : n ≢ toℕ i} .{n≢j : n ≢ toℕ j} →
                    lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
-lower₁-injective {zero}  {zero}  {_}     {n≢i} {_}   _    = contradiction refl n≢i
-lower₁-injective {zero}  {_}     {zero}  {_}   {n≢j} _    = contradiction refl n≢j
-lower₁-injective {suc n} {zero}  {zero}  {_}   {_}   refl = refl
-lower₁-injective {suc n} {suc i} {suc j} {n≢i} {n≢j} eq   =
+lower₁-injective {zero}  {zero}  {_}     {0≢0} {_}   _  = lower₁-¬0≢0 0≢0
+lower₁-injective {zero}  {_}     {zero}  {_}   {0≢0} _  = lower₁-¬0≢0 0≢0
+lower₁-injective {suc n} {zero}  {zero}  {_}   {_}   _  = refl
+lower₁-injective {suc n} {suc i} {suc j} {_}   {_}   eq =
   cong suc (lower₁-injective (suc-injective eq))
 
 ------------------------------------------------------------------------
 -- inject₁ and lower₁
 
-inject₁-lower₁ : ∀ (i : Fin (suc n)) (n≢i : n ≢ toℕ i) →
+inject₁-lower₁ : ∀ (i : Fin (suc n)) .(n≢i : n ≢ toℕ i) →
                  inject₁ (lower₁ i n≢i) ≡ i
-inject₁-lower₁ {zero}  zero     0≢0     = contradiction refl 0≢0
+inject₁-lower₁ {zero}  zero     0≢0     = lower₁-¬0≢0 0≢0
 inject₁-lower₁ {suc n} zero     _       = refl
 inject₁-lower₁ {suc n} (suc i)  n+1≢i+1 =
   cong suc (inject₁-lower₁ i  (n+1≢i+1 ∘ cong suc))
 
-lower₁-inject₁′ : ∀ (i : Fin n) (n≢i : n ≢ toℕ (inject₁ i)) →
+lower₁-inject₁′ : ∀ (i : Fin n) .(n≢i : n ≢ toℕ (inject₁ i)) →
                   lower₁ (inject₁ i) n≢i ≡ i
 lower₁-inject₁′ zero    _       = refl
 lower₁-inject₁′ (suc i) n+1≢i+1 =
@@ -539,15 +540,15 @@ lower₁-inject₁ : ∀ (i : Fin n) →
                  lower₁ (inject₁ i) (toℕ-inject₁-≢ i) ≡ i
 lower₁-inject₁ i = lower₁-inject₁′ i (toℕ-inject₁-≢ i)
 
-lower₁-irrelevant : ∀ (i : Fin (suc n)) (n≢i₁ n≢i₂ : n ≢ toℕ i) →
+lower₁-irrelevant : ∀ (i : Fin (suc n)) .(n≢i₁ n≢i₂ : n ≢ toℕ i) →
                     lower₁ i n≢i₁ ≡ lower₁ i n≢i₂
-lower₁-irrelevant {zero}  zero     0≢0 _ = contradiction refl 0≢0
+lower₁-irrelevant {zero}  zero     0≢0 _ = lower₁-¬0≢0 0≢0
 lower₁-irrelevant {suc n} zero     _   _ = refl
 lower₁-irrelevant {suc n} (suc i)  _   _ =
   cong suc (lower₁-irrelevant i _ _)
 
 inject₁≡⇒lower₁≡ : ∀ {i : Fin n} {j : Fin (ℕ.suc n)} →
-                  (n≢j : n ≢ toℕ j) → inject₁ i ≡ j → lower₁ j n≢j ≡ i
+                  .(n≢j : n ≢ toℕ j) → inject₁ i ≡ j → lower₁ j n≢j ≡ i
 inject₁≡⇒lower₁≡ n≢j i≡j = inject₁-injective (trans (inject₁-lower₁ _ n≢j) (sym i≡j))
 
 ------------------------------------------------------------------------
@@ -560,6 +561,12 @@ lower-injective : ∀ (i j : Fin m)
 lower-injective {n = suc n} zero    zero    eq = refl
 lower-injective {n = suc n} (suc i) (suc j) eq =
   cong suc (lower-injective i j (suc-injective eq))
+
+lower₁≗lower : ∀ (i : Fin (suc n)) .(n≢i : n ≢ toℕ i) →
+               lower₁ i n≢i ≡ lower i (ℕ.≤∧≢⇒< (toℕ≤pred[n]′ i) (n≢i ∘ sym))
+lower₁≗lower {n = zero}   zero    0≢0 = lower₁-¬0≢0 0≢0
+lower₁≗lower {n = suc _ } zero    _   = refl
+lower₁≗lower {n = suc _ } (suc i) ne  = cong suc (lower₁≗lower i (ne ∘ cong suc))
 
 ------------------------------------------------------------------------
 -- inject≤

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -562,17 +562,6 @@ lower-injective {n = suc n} zero    zero    eq = refl
 lower-injective {n = suc n} (suc i) (suc j) eq =
   cong suc (lower-injective i j (suc-injective eq))
 
-lower₁≗lower : ∀ (i : Fin (suc n)) .(n≢i : n ≢ toℕ i) →
-               lower₁ i n≢i ≡ lower i (ℕ.≤∧≢⇒< (toℕ≤pred[n]′ i) (n≢i ∘ sym))
-lower₁≗lower {n = zero}   zero    0≢0 = contradiction-irr refl 0≢0
-lower₁≗lower {n = suc _ } zero    _   = refl
-lower₁≗lower {n = suc _ } (suc i) ne  = cong suc (lower₁≗lower i (ne ∘ cong suc))
-
-lower≗lower₁ : ∀ (i : Fin (suc n)) .(i<n : toℕ i ℕ.< n) →
-               lower i i<n ≡ lower₁ i (ℕ.<⇒≢ i<n ∘ sym)
-lower≗lower₁ {n = suc _ } zero    _   = refl
-lower≗lower₁ {n = suc _ } (suc i) lt  = cong suc (lower≗lower₁ i (ℕ.s<s⁻¹ lt))
-
 ------------------------------------------------------------------------
 -- inject≤
 ------------------------------------------------------------------------

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -567,6 +567,11 @@ lower₁≗lower {n = zero}   zero    0≢0 = lower₁-¬0≢0 0≢0
 lower₁≗lower {n = suc _ } zero    _   = refl
 lower₁≗lower {n = suc _ } (suc i) ne  = cong suc (lower₁≗lower i (ne ∘ cong suc))
 
+lower≗lower₁ : ∀ (i : Fin (suc n)) .(i<n : toℕ i ℕ.< n) →
+               lower i i<n ≡ lower₁ i {!ℕ.<⇒≢ i<n ∘ sym!}
+lower≗lower₁ {n = suc _ } zero    _   = refl
+lower≗lower₁ {n = suc _ } (suc i) lt  = cong suc (lower≗lower₁ i (ℕ.s<s⁻¹ lt))
+
 ------------------------------------------------------------------------
 -- inject≤
 ------------------------------------------------------------------------

--- a/src/Data/Fin/Properties.agda
+++ b/src/Data/Fin/Properties.agda
@@ -46,7 +46,8 @@ open import Relation.Binary.PropositionalEquality.Properties as ≡
   using (module ≡-Reasoning)
 open import Relation.Nullary.Decidable as Dec
   using (Dec; _because_; yes; no; _×-dec_; _⊎-dec_; map′)
-open import Relation.Nullary.Negation.Core using (¬_; contradiction)
+open import Relation.Nullary.Negation.Core
+  using (¬_; contradiction; contradiction-irr)
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Unary as U
   using (U; Pred; Decidable; _⊆_; Satisfiable; Universal)
@@ -506,15 +507,15 @@ inject!-< {suc n} {suc i} (suc k) = s≤s (inject!-< k)
 -- lower₁
 ------------------------------------------------------------------------
 
-toℕ-lower₁ : ∀ i .(p : n ≢ toℕ i) → toℕ (lower₁ i p) ≡ toℕ i
-toℕ-lower₁ {ℕ.zero}  zero    0≢0 = lower₁-¬0≢0 0≢0
+toℕ-lower₁ : ∀ i .(n≢i : n ≢ toℕ i) → toℕ (lower₁ i n≢i) ≡ toℕ i
+toℕ-lower₁ {ℕ.zero}  zero    0≢0 = contradiction-irr refl 0≢0
 toℕ-lower₁ {ℕ.suc m} zero    _   = refl
 toℕ-lower₁ {ℕ.suc m} (suc i) ne  = cong ℕ.suc (toℕ-lower₁ i (ne ∘ cong ℕ.suc))
 
 lower₁-injective : ∀ .{n≢i : n ≢ toℕ i} .{n≢j : n ≢ toℕ j} →
                    lower₁ i n≢i ≡ lower₁ j n≢j → i ≡ j
-lower₁-injective {zero}  {zero}  {_}     {0≢0} {_}   _  = lower₁-¬0≢0 0≢0
-lower₁-injective {zero}  {_}     {zero}  {_}   {0≢0} _  = lower₁-¬0≢0 0≢0
+lower₁-injective {zero}  {zero}  {_}     {0≢0} {_}   _  = contradiction-irr refl 0≢0
+lower₁-injective {zero}  {_}     {zero}  {_}   {0≢0} _  = contradiction-irr refl 0≢0
 lower₁-injective {suc n} {zero}  {zero}  {_}   {_}   _  = refl
 lower₁-injective {suc n} {suc i} {suc j} {_}   {_}   eq =
   cong suc (lower₁-injective (suc-injective eq))
@@ -524,7 +525,7 @@ lower₁-injective {suc n} {suc i} {suc j} {_}   {_}   eq =
 
 inject₁-lower₁ : ∀ (i : Fin (suc n)) .(n≢i : n ≢ toℕ i) →
                  inject₁ (lower₁ i n≢i) ≡ i
-inject₁-lower₁ {zero}  zero     0≢0     = lower₁-¬0≢0 0≢0
+inject₁-lower₁ {zero}  zero     0≢0     = contradiction-irr refl 0≢0
 inject₁-lower₁ {suc n} zero     _       = refl
 inject₁-lower₁ {suc n} (suc i)  n+1≢i+1 =
   cong suc (inject₁-lower₁ i  (n+1≢i+1 ∘ cong suc))
@@ -541,7 +542,7 @@ lower₁-inject₁ i = lower₁-inject₁′ i (toℕ-inject₁-≢ i)
 
 lower₁-irrelevant : ∀ (i : Fin (suc n)) .(n≢i₁ n≢i₂ : n ≢ toℕ i) →
                     lower₁ i n≢i₁ ≡ lower₁ i n≢i₂
-lower₁-irrelevant {zero}  zero     0≢0 _ = lower₁-¬0≢0 0≢0
+lower₁-irrelevant {zero}  zero     0≢0 _ = contradiction-irr refl 0≢0
 lower₁-irrelevant {suc n} zero     _   _ = refl
 lower₁-irrelevant {suc n} (suc i)  _   _ =
   cong suc (lower₁-irrelevant i _ _)
@@ -563,7 +564,7 @@ lower-injective {n = suc n} (suc i) (suc j) eq =
 
 lower₁≗lower : ∀ (i : Fin (suc n)) .(n≢i : n ≢ toℕ i) →
                lower₁ i n≢i ≡ lower i (ℕ.≤∧≢⇒< (toℕ≤pred[n]′ i) (n≢i ∘ sym))
-lower₁≗lower {n = zero}   zero    0≢0 = lower₁-¬0≢0 0≢0
+lower₁≗lower {n = zero}   zero    0≢0 = contradiction-irr refl 0≢0
 lower₁≗lower {n = suc _ } zero    _   = refl
 lower₁≗lower {n = suc _ } (suc i) ne  = cong suc (lower₁≗lower i (ne ∘ cong suc))
 

--- a/src/Relation/Nullary/Negation/Core.agda
+++ b/src/Relation/Nullary/Negation/Core.agda
@@ -47,11 +47,11 @@ _¬-⊎_ = [_,_]
 ------------------------------------------------------------------------
 -- Uses of negation
 
-contradiction-irr : .A → ¬ A → Whatever
+contradiction-irr : .A → .(¬ A) → Whatever
 contradiction-irr a ¬a = ⊥-elim-irr (¬a a)
 
 contradiction : A → ¬ A → Whatever
-contradiction a = contradiction-irr a
+contradiction a ¬a = contradiction-irr a ¬a
 
 contradiction₂ : A ⊎ B → ¬ A → ¬ B → Whatever
 contradiction₂ (inj₁ a) ¬a ¬b = contradiction a ¬a


### PR DESCRIPTION
PR #2748 made me rethink whether `Data.Fin.Base.lower₁` is fit-for-purpose (as an inverse to `inject₁`), or could instead be deprecated in favour of the new `Data.Fin.Base.lower`...

This PR doesn't entirely solve that issue, but does prove the two definitions extensionally equal on their domains, as a consequence, perhaps more importantly, of weakening the type of `lower₁` so that its precondition is made irrelevant.

Two (possibly more downstream) knock-on consequences:
* ~~lemma `lower₁-¬0≢0 : ∀ {ℓ} {A : Set ℓ} → .(0 ≢ 0) → A` encapsulates a repeated pattern of (`¬-recompute`) reasoning, which ideally would be made `private`, but is needed in *both* `Base` and `Properties`... so, reluctantly, has been added;~~ avoided in favour of #2785 on which this PR is now `blocked`.
* many of the proofs about `lower₁` could/should be simplified by delegation to those for  `lower`...?
* #2790 `Data.Fin.Base.punchOut` and its properties could similarly be weakened by making its `i≢j : i ≢ j` argument irrelevant! What else might be susceptible to this kind of refactoring?

NB. As observed/observable in `README.Data.Fin.Relation.Unary.Top`, we can actually avoid having *any* uses of `lower₁` in the library, so `deprecation` seems possible/desirable #2786 

UPDATED: no longer `blocked` on #2785 .
