### PR TITLE
[ refactor ] weaken type of `Relation.Nullary.Negation.Core.contradiction-irr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Non-backwards compatible changes
 Minor improvements
 ------------------
 
+* The type of `Relation.Nullary.Negation.Core.contradiction-irr` has been further
+  weakened so that the negated hypothesis `¬ A` is marked as irrelevant. This is
+  safe to do, in view of `Relation.Nullary.Recomputable.Properties.¬-recompute`.
+
 Deprecated modules
 ------------------
 

--- a/src/Relation/Nullary/Negation/Core.agda
+++ b/src/Relation/Nullary/Negation/Core.agda
@@ -47,11 +47,11 @@ _¬-⊎_ = [_,_]
 ------------------------------------------------------------------------
 -- Uses of negation
 
-contradiction-irr : .A → ¬ A → Whatever
+contradiction-irr : .A → .(¬ A) → Whatever
 contradiction-irr a ¬a = ⊥-elim-irr (¬a a)
 
 contradiction : A → ¬ A → Whatever
-contradiction a = contradiction-irr a
+contradiction a ¬a = contradiction-irr a ¬a
 
 contradiction₂ : A ⊎ B → ¬ A → ¬ B → Whatever
 contradiction₂ (inj₁ a) ¬a ¬b = contradiction a ¬a


### PR DESCRIPTION
For justification, see `CHANGELOG`: this is really a consequence of #2199 and subsequent refactorings of `Relation.Nullary.Recomputable{.Properties}`. Cf. #2346 which might be worth re-opening?

Very little is affected, except that `contradiction` now needs to be eta-expanded because there is no subtyping between `A → B` and `.A → B`.

For candidate use, see the discussion in #2783 .