### PR TITLE
[ bug ] fix knock-on from #2084

### DIFF
--- a/doc/README/Data/Fin/Relation/Unary/Top.agda
+++ b/doc/README/Data/Fin/Relation/Unary/Top.agda
@@ -94,7 +94,7 @@ open WF using (Acc; acc)
   induct : ∀ {i} → Acc _>_ i → P i
   induct {i} (acc rec) with view i
   ... | ‵fromℕ = Pₙ
-  ... | ‵inject₁ j = Pᵢ₊₁⇒Pᵢ j (induct (rec _ inject₁[j]+1≤[j+1]))
+  ... | ‵inject₁ j = Pᵢ₊₁⇒Pᵢ j (induct (rec inject₁[j]+1≤[j+1]))
     where
     inject₁[j]+1≤[j+1] : suc (toℕ (inject₁ j)) ≤ toℕ (suc j)
     inject₁[j]+1≤[j+1] = ≤-reflexive (toℕ-inject₁ (suc j))


### PR DESCRIPTION
Bug introduced by a `breaking` type change that was not caught in (unchecked) `README` module...

... maybe we need to add the `README.*` files to those checked by `make test`? Or to make sure that `doc/README.agda` is suitable kept up-to date?