### PR TITLE
[ add ] `style-guide` recommendation preferring `contradiction` over `⊥-elim`

### DIFF
--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -719,5 +719,6 @@ systematic for `Nary` relations in PR
 
 ## Prefer use of `Relation.Nullary.Negation.Core.contradiction`
 
-Where possible use `contradiction` between two explicit arguments rather than appealing to the lower-level
-`Data.Empty.⊥-elim`. This provides clearer documentation for readers of the code.
+Where possible use `contradiction` between two explicit arguments rather
+than appealing to the lower-level `Data.Empty.⊥-elim`. This provides
+clearer documentation for readers of the code.


### PR DESCRIPTION
Fix #2653 .
Placeholder text for now; suggestions for improvement welcome (esp. wrt rationale/links to associated issues...)... and received.