### PR TITLE
[ add ] eta law for ¬¬ monad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,8 @@ Additions to existing modules
   ≟-≢   : (m≢n : m ≢ n) → (m ≟ n) ≡ no m≢n
   ∸-suc : m ≤ n → suc n ∸ m ≡ suc (n ∸ m)
   ```
+
+* In `Relation.Nullary.Negation.Core`
+  ```agda
+  ¬¬-η : A → ¬ ¬ A
+  ```

--- a/src/Relation/Nullary/Decidable/Core.agda
+++ b/src/Relation/Nullary/Decidable/Core.agda
@@ -28,7 +28,7 @@ open import Relation.Nullary.Recomputable.Core as Recomputable
 open import Relation.Nullary.Reflects as Reflects
   hiding (recompute; recompute-constant)
 open import Relation.Nullary.Negation.Core
-  using (¬_; Stable; negated-stable; contradiction; DoubleNegation)
+  using (¬_; ¬¬-η; Stable; negated-stable; contradiction; DoubleNegation)
 
 
 private
@@ -215,7 +215,7 @@ decidable-stable (true  because  [a]) ¬¬a = invert [a]
 decidable-stable (false because [¬a]) ¬¬a = contradiction (invert [¬a]) ¬¬a
 
 ¬-drop-Dec : Dec (¬ ¬ A) → Dec (¬ A)
-¬-drop-Dec ¬¬a? = map′ negated-stable contradiction (¬? ¬¬a?)
+¬-drop-Dec ¬¬a? = map′ negated-stable ¬¬-η (¬? ¬¬a?)
 
 -- A double-negation-translated variant of excluded middle (or: every
 -- nullary relation is decidable in the double-negation monad).

--- a/src/Relation/Nullary/Negation.agda
+++ b/src/Relation/Nullary/Negation.agda
@@ -56,7 +56,7 @@ open import Relation.Nullary.Negation.Core public
 ¬¬-Monad : RawMonad {a} DoubleNegation
 ¬¬-Monad = mkRawMonad
   DoubleNegation
-  contradiction
+  ¬¬-η
   (λ x f → negated-stable (¬¬-map f x))
 
 ¬¬-push : DoubleNegation Π[ P ] → Π[ DoubleNegation ∘ P ]

--- a/src/Relation/Nullary/Negation/Core.agda
+++ b/src/Relation/Nullary/Negation/Core.agda
@@ -33,6 +33,11 @@ infix 3 ¬_
 DoubleNegation : Set a → Set a
 DoubleNegation A = ¬ ¬ A
 
+-- Eta law for double-negation
+
+¬¬-η : A → ¬ ¬ A
+¬¬-η a ¬a = ¬a a
+
 -- Stability under double-negation.
 Stable : Set a → Set a
 Stable A = ¬ ¬ A → A


### PR DESCRIPTION
This is provable without detour via `contradiction`... so can replace that in a couple of places where it is more 'semantically' correct.