### PR TITLE
[ add ] `Setoid` from `PartialSetoid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,11 @@ Additions to existing modules
                     updateAt (padRight m≤n x xs) (inject≤ i m≤n) f ≡ padRight m≤n x (updateAt xs i f)
   ```
 
+* In `Relation.Binary.Definitions`
+  ```agda
+  Defined : Rel A ℓ → A → Set ℓ
+  ```
+
 * In `Relation.Nullary.Negation.Core`
   ```agda
   ¬¬-η : A → ¬ ¬ A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ New modules
 
 * `Data.List.Relation.Binary.Permutation.Declarative{.Properties}` for the least congruence on `List` making `_++_` commutative, and its equivalence with the `Setoid` definition.
 
+* `Relation.Binary.Construct.SetoidFromPartialSetoid`.
+
 Additions to existing modules
 -----------------------------
 
@@ -97,17 +99,6 @@ Additions to existing modules
 
   padRight-updateAt : (m≤n : m ≤ n) (x : A) (xs : Vec A m) (f : A → A) (i : Fin m) →
                     updateAt (padRight m≤n x xs) (inject≤ i m≤n) f ≡ padRight m≤n x (updateAt xs i f)
-  ```
-
-* In `Relation.Binary.Properties.PartialSetoid`
-  ```agda
-  Carrierₛ          : Set _
-  _≈ₛ_              : Rel Carrierₛ _
-  reflₛ             : Reflexive _≈ₛ_
-  isEquivalenceₛ    : IsEquivalence _≈ₛ_
-  setoidₛ           : Setoid _ _
-  isRelHomomorphism : IsRelHomomorphism _≈ₛ_ _≈_ proj₁
-  isRelMonomorphism : IsRelMonomorphism _≈ₛ_ _≈_ proj₁
   ```
 
 * In `Relation.Nullary.Negation.Core`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,17 @@ Additions to existing modules
                     updateAt (padRight m≤n x xs) (inject≤ i m≤n) f ≡ padRight m≤n x (updateAt xs i f)
   ```
 
+* In `Relation.Binary.Properties.PartialSetoid`
+  ```agda
+  Carrierₛ          : Set _
+  _≈ₛ_              : Rel Carrierₛ _
+  reflₛ             : Reflexive _≈ₛ_
+  isEquivalenceₛ    : IsEquivalence _≈ₛ_
+  setoidₛ           : Setoid _ _
+  isRelHomomorphism : IsRelHomomorphism _≈ₛ_ _≈_ proj₁
+  isRelMonomorphism : IsRelMonomorphism _≈ₛ_ _≈_ proj₁
+  ```
+
 * In `Relation.Nullary.Negation.Core`
   ```agda
   ¬¬-η : A → ¬ ¬ A

--- a/src/Relation/Binary/Construct/Kernel.agda
+++ b/src/Relation/Binary/Construct/Kernel.agda
@@ -1,0 +1,65 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Equaliser of a kernel pair in Setoid
+------------------------------------------------------------------------
+
+open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
+
+module Relation.Binary.Construct.Kernel
+  {a i ℓ} {I : Set i}
+  (S : PartialSetoid a ℓ) (let module S = PartialSetoid S)
+  (f g : I → S.Carrier)
+  where
+
+open import Function.Base using (id; _∘_; _on_)
+open import Level using (Level; _⊔_)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.Definitions using (Defined)
+open import Relation.Binary.Structures using (IsEquivalence)
+open import Relation.Binary.Morphism.Structures
+  using (IsRelHomomorphism; IsRelMonomorphism)
+
+import Relation.Binary.Properties.PartialSetoid S as Properties
+
+
+------------------------------------------------------------------------
+-- Definitions
+
+record Carrier : Set (a ⊔ i ⊔ ℓ) where
+
+  field
+    h    : I
+    refl : (f h) S.≈ (g h)
+
+  ι : S.Carrier
+  ι = f h
+
+
+open Carrier public using (ι)
+
+_≈_ : Rel Carrier _
+_≈_ = S._≈_ on ι
+
+-- Structure
+
+isEquivalence : IsEquivalence _≈_
+isEquivalence = record
+  { refl = λ {x = x} → Properties.partial-reflˡ (Carrier.refl x)
+  ; sym = S.sym
+  ; trans = S.trans
+  }
+
+-- Bundle
+
+setoid : Setoid _ _
+setoid = record { isEquivalence = isEquivalence }
+
+-- Monomorphism
+
+isRelHomomorphism : IsRelHomomorphism _≈_ S._≈_ ι
+isRelHomomorphism = record { cong = id }
+
+isRelMonomorphism : IsRelMonomorphism _≈_ S._≈_ ι
+isRelMonomorphism = record { isHomomorphism = isRelHomomorphism ; injective = id }
+

--- a/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
+++ b/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
@@ -12,7 +12,6 @@ module Relation.Binary.Construct.SetoidFromPartialSetoid
 open import Data.Product.Base using (_,_; Σ; proj₁; proj₂)
 open import Function.Base using (id; _on_)
 open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Definitions using (Reflexive)
 open import Relation.Binary.Structures
   using (IsPartialEquivalence; IsEquivalence)
 open import Relation.Binary.Morphism.Structures
@@ -33,16 +32,11 @@ Carrier = Σ S.Carrier λ x → x S.≈ x
 _≈_ : Rel Carrier _
 _≈_ = S._≈_ on proj₁
 
--- Properties
-
-refl : Reflexive _≈_
-refl {x = x} = proj₂ x
-
 -- Structure
 
 isEquivalence : IsEquivalence _≈_
 isEquivalence = record
-  { refl = λ {x} → refl {x = x}
+  { refl = λ {x = x} → proj₂ x
   ; sym = S.sym
   ; trans = S.trans
   }

--- a/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
+++ b/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
@@ -9,8 +9,8 @@ open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
 module Relation.Binary.Construct.SetoidFromPartialSetoid
   {a ℓ} (S : PartialSetoid a ℓ) where
 
-open import Data.Product.Base using (_,_; Σ; proj₁)
-open import Function.Base using (id)
+open import Data.Product.Base using (_,_; Σ; proj₁; proj₂)
+open import Function.Base using (id; _on_)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Definitions using (Reflexive)
 open import Relation.Binary.Structures
@@ -31,12 +31,12 @@ Carrier : Set _
 Carrier = Σ S.Carrier λ x → x S.≈ x
 
 _≈_ : Rel Carrier _
-x≈x@(x , _) ≈ y≈y@(y , _) = x S.≈ y
+_≈_ = S._≈_ on proj₁
 
 -- Properties
 
 refl : Reflexive _≈_
-refl {x = _ , x≈x} = x≈x
+refl {x = x} = proj₂ x
 
 -- Structure
 

--- a/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
+++ b/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
@@ -9,34 +9,37 @@ open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
 module Relation.Binary.Construct.SetoidFromPartialSetoid
   {a ℓ} (S : PartialSetoid a ℓ) where
 
-open import Data.Product.Base using (_,_; Σ; proj₁; proj₂)
 open import Function.Base using (id; _on_)
+open import Level using (_⊔_)
 open import Relation.Binary.Core using (Rel)
 open import Relation.Binary.Structures
-  using (IsPartialEquivalence; IsEquivalence)
+  using (IsEquivalence)
 open import Relation.Binary.Morphism.Structures
   using (IsRelHomomorphism; IsRelMonomorphism)
 
 private
   module S = PartialSetoid S
 
-  variable
-    x y z : S.Carrier
 
 ------------------------------------------------------------------------
 -- Definitions
 
-Carrier : Set _
-Carrier = Σ S.Carrier λ x → x S.≈ x
+record Carrier : Set (a ⊔ ℓ) where
+
+  field
+    ι    : S.Carrier
+    refl : ι S.≈ ι
+
+open Carrier public using (ι)
 
 _≈_ : Rel Carrier _
-_≈_ = S._≈_ on proj₁
+_≈_ = S._≈_ on ι
 
 -- Structure
 
 isEquivalence : IsEquivalence _≈_
 isEquivalence = record
-  { refl = λ {x = x} → proj₂ x
+  { refl = λ {x = x} → Carrier.refl x
   ; sym = S.sym
   ; trans = S.trans
   }
@@ -48,8 +51,8 @@ setoid = record { isEquivalence = isEquivalence }
 
 -- Monomorphism
 
-isRelHomomorphism : IsRelHomomorphism _≈_ S._≈_ proj₁
+isRelHomomorphism : IsRelHomomorphism _≈_ S._≈_ ι
 isRelHomomorphism = record { cong = id }
 
-isRelMonomorphism : IsRelMonomorphism _≈_ S._≈_ proj₁
+isRelMonomorphism : IsRelMonomorphism _≈_ S._≈_ ι
 isRelMonomorphism = record { isHomomorphism = isRelHomomorphism ; injective = id }

--- a/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
+++ b/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
@@ -12,8 +12,8 @@ module Relation.Binary.Construct.SetoidFromPartialSetoid
 open import Function.Base using (id; _on_)
 open import Level using (_⊔_)
 open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Structures
-  using (IsEquivalence)
+open import Relation.Binary.Definitions using (Defined)
+open import Relation.Binary.Structures using (IsEquivalence)
 open import Relation.Binary.Morphism.Structures
   using (IsRelHomomorphism; IsRelMonomorphism)
 
@@ -28,7 +28,7 @@ record Carrier : Set (a ⊔ ℓ) where
 
   field
     ι    : S.Carrier
-    refl : ι S.≈ ι
+    refl : Defined S._≈_ ι
 
 open Carrier public using (ι)
 

--- a/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
+++ b/src/Relation/Binary/Construct/SetoidFromPartialSetoid.agda
@@ -1,0 +1,61 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Conversion of a PartialSetoid into a Setoid
+------------------------------------------------------------------------
+
+open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
+
+module Relation.Binary.Construct.SetoidFromPartialSetoid
+  {a ℓ} (S : PartialSetoid a ℓ) where
+
+open import Data.Product.Base using (_,_; Σ; proj₁)
+open import Function.Base using (id)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.Definitions using (Reflexive)
+open import Relation.Binary.Structures
+  using (IsPartialEquivalence; IsEquivalence)
+open import Relation.Binary.Morphism.Structures
+  using (IsRelHomomorphism; IsRelMonomorphism)
+
+private
+  module S = PartialSetoid S
+
+  variable
+    x y z : S.Carrier
+
+------------------------------------------------------------------------
+-- Definitions
+
+Carrier : Set _
+Carrier = Σ S.Carrier λ x → x S.≈ x
+
+_≈_ : Rel Carrier _
+x≈x@(x , _) ≈ y≈y@(y , _) = x S.≈ y
+
+-- Properties
+
+refl : Reflexive _≈_
+refl {x = _ , x≈x} = x≈x
+
+-- Structure
+
+isEquivalence : IsEquivalence _≈_
+isEquivalence = record
+  { refl = λ {x} → refl {x = x}
+  ; sym = S.sym
+  ; trans = S.trans
+  }
+
+-- Bundle
+
+setoid : Setoid _ _
+setoid = record { isEquivalence = isEquivalence }
+
+-- Monomorphism
+
+isRelHomomorphism : IsRelHomomorphism _≈_ S._≈_ proj₁
+isRelHomomorphism = record { cong = id }
+
+isRelMonomorphism : IsRelMonomorphism _≈_ S._≈_ proj₁
+isRelMonomorphism = record { isHomomorphism = isRelHomomorphism ; injective = id }

--- a/src/Relation/Binary/Construct/SubSetoid.agda
+++ b/src/Relation/Binary/Construct/SubSetoid.agda
@@ -1,0 +1,20 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Conversion of a PartialSetoid into a Setoid
+------------------------------------------------------------------------
+
+open import Relation.Binary.Bundles using (PartialSetoid)
+
+module Relation.Binary.Construct.SubSetoid
+  {a ℓ} (S : PartialSetoid a ℓ)
+  where
+
+open import Function.Base using (id)
+import Relation.Binary.Construct.Kernel as Kernel
+
+
+------------------------------------------------------------------------
+-- Definitions
+
+open module SubSetoid = Kernel S id id public

--- a/src/Relation/Binary/Definitions.agda
+++ b/src/Relation/Binary/Definitions.agda
@@ -37,8 +37,11 @@ private
 -- e.g. in the definition of `IsEquivalence` later in this file. This
 -- convention is a legacy from the early days of the library.
 
+Defined : Rel A ℓ → A → Set ℓ
+Defined _∼_ x = x ∼ x
+
 Reflexive : Rel A ℓ → Set _
-Reflexive _∼_ = ∀ {x} → x ∼ x
+Reflexive _∼_ = ∀ {x} → Defined _∼_ x
 
 -- Generalised symmetry.
 

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -6,20 +6,28 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Bundles using (PartialSetoid)
+open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
 
 module Relation.Binary.Properties.PartialSetoid
   {a ℓ} (S : PartialSetoid a ℓ) where
 
-open import Data.Product.Base using (_,_; _×_)
-open import Relation.Binary.Definitions using (LeftTrans; RightTrans)
+open import Data.Product.Base using (_,_; _×_; Σ; proj₁)
+open import Function.Base using (id)
+open import Relation.Binary.Core using (Rel)
+open import Relation.Binary.Definitions
+  using (Reflexive; Symmetric; Transitive; LeftTrans; RightTrans)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
-
-open PartialSetoid S
+import Relation.Binary.Structures as Structures
+  using (IsPartialEquivalence; IsEquivalence)
+open import Relation.Binary.Morphism.Structures
+  using (IsRelHomomorphism; IsRelMonomorphism)
 
 private
+  open module PER = PartialSetoid S
+
   variable
     x y z : Carrier
+
 
 ------------------------------------------------------------------------
 -- Proofs for partial equivalence relations
@@ -44,4 +52,38 @@ partial-reflexiveˡ p ≡.refl = partial-reflˡ p
 
 partial-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
 partial-reflexiveʳ p ≡.refl = partial-reflʳ p
+
+------------------------------------------------------------------------
+-- Setoids from partial setoids
+
+-- Definitions
+
+Carrierₛ : Set _
+Carrierₛ = Σ Carrier λ x → x ≈ x
+
+_≈ₛ_ : Rel Carrierₛ _
+x≈x@(x , _) ≈ₛ y≈y@(y , _) = x ≈ y
+
+-- Properties
+
+reflₛ : Reflexive _≈ₛ_
+reflₛ {x = _ , x≈x} = x≈x
+
+-- Structure
+
+isEquivalenceₛ : Structures.IsEquivalence _≈ₛ_
+isEquivalenceₛ = record { refl = λ {x} → reflₛ {x = x} ; sym = sym ; trans = trans }
+
+-- Bundle
+
+setoidₛ : Setoid _ _
+setoidₛ = record { isEquivalence = isEquivalenceₛ }
+
+-- Monomorphism
+
+isRelHomomorphism : IsRelHomomorphism _≈ₛ_ _≈_ proj₁
+isRelHomomorphism = record { cong = id }
+
+isRelMonomorphism : IsRelMonomorphism _≈ₛ_ _≈_ proj₁
+isRelMonomorphism = record { isHomomorphism = isRelHomomorphism ; injective = id }
 

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -21,7 +21,6 @@ private
   variable
     x y z : Carrier
 
-
 ------------------------------------------------------------------------
 -- Proofs for partial equivalence relations
 
@@ -45,3 +44,4 @@ partial-reflexiveˡ p ≡.refl = partial-reflˡ p
 
 partial-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
 partial-reflexiveʳ p ≡.refl = partial-reflʳ p
+

--- a/src/Relation/Binary/Properties/PartialSetoid.agda
+++ b/src/Relation/Binary/Properties/PartialSetoid.agda
@@ -6,25 +6,18 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-open import Relation.Binary.Bundles using (PartialSetoid; Setoid)
+open import Relation.Binary.Bundles using (PartialSetoid)
 
 module Relation.Binary.Properties.PartialSetoid
   {a ℓ} (S : PartialSetoid a ℓ) where
 
-open import Data.Product.Base using (_,_; _×_; Σ; proj₁)
-open import Function.Base using (id)
-open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Definitions
-  using (Reflexive; Symmetric; Transitive; LeftTrans; RightTrans)
+open import Data.Product.Base using (_,_; _×_)
+open import Relation.Binary.Definitions using (LeftTrans; RightTrans)
 open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
-import Relation.Binary.Structures as Structures
-  using (IsPartialEquivalence; IsEquivalence)
-open import Relation.Binary.Morphism.Structures
-  using (IsRelHomomorphism; IsRelMonomorphism)
+
+open PartialSetoid S
 
 private
-  open module PER = PartialSetoid S
-
   variable
     x y z : Carrier
 
@@ -52,38 +45,3 @@ partial-reflexiveˡ p ≡.refl = partial-reflˡ p
 
 partial-reflexiveʳ : x ≈ y → y ≡ z → y ≈ z
 partial-reflexiveʳ p ≡.refl = partial-reflʳ p
-
-------------------------------------------------------------------------
--- Setoids from partial setoids
-
--- Definitions
-
-Carrierₛ : Set _
-Carrierₛ = Σ Carrier λ x → x ≈ x
-
-_≈ₛ_ : Rel Carrierₛ _
-x≈x@(x , _) ≈ₛ y≈y@(y , _) = x ≈ y
-
--- Properties
-
-reflₛ : Reflexive _≈ₛ_
-reflₛ {x = _ , x≈x} = x≈x
-
--- Structure
-
-isEquivalenceₛ : Structures.IsEquivalence _≈ₛ_
-isEquivalenceₛ = record { refl = λ {x} → reflₛ {x = x} ; sym = sym ; trans = trans }
-
--- Bundle
-
-setoidₛ : Setoid _ _
-setoidₛ = record { isEquivalence = isEquivalenceₛ }
-
--- Monomorphism
-
-isRelHomomorphism : IsRelHomomorphism _≈ₛ_ _≈_ proj₁
-isRelHomomorphism = record { cong = id }
-
-isRelMonomorphism : IsRelMonomorphism _≈ₛ_ _≈_ proj₁
-isRelMonomorphism = record { isHomomorphism = isRelHomomorphism ; injective = id }
-


### PR DESCRIPTION
This tackles one version of how to develop 'subsetoid's via PERs. Cf. #2814 

Not necessarily the 'right' way to go, but still functionality which may be useful in the future

UPDATED: to live under `Relation.Binary.Construct`