### PR TITLE
Factor antisymmetry proof for sublist

### DIFF
--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -400,18 +400,19 @@ module Antisymmetry
 
   open ℕ.≤-Reasoning
 
+  private
+    antisym-lemma : ∀ xs ys₁ y → Sublist R xs ys₁ → ¬ Sublist S (y ∷ ys₁) xs
+    antisym-lemma xs ys₁ y rs ss = ℕ.<-irrefl ≡.refl (begin
+      length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
+      length xs        ≤⟨ length-mono-≤ rs ⟩
+      length ys₁       ∎)
+
   antisym : Antisym (Sublist R) (Sublist S) (Pointwise E)
   -- impossible cases
   antisym (_∷ʳ_ {xs} {ys₁} y rs) ss =
-    contradiction (begin
-    length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
-    length xs        ≤⟨ length-mono-≤ rs ⟩
-    length ys₁       ∎) $ ℕ.<-irrefl ≡.refl
+    case (antisym-lemma xs ys₁ y rs ss) of λ()
   antisym (_∷_ {x} {xs} {y} {ys₁} r rs)  (_∷ʳ_ {ys₂} {zs} z ss) =
-    contradiction (begin
-    length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
-    length xs        ≤⟨ length-mono-≤ rs ⟩
-    length ys₁       ∎) $ ℕ.<-irrefl ≡.refl
+    case (antisym-lemma xs ys₁ y rs ss) of λ()
   -- diagonal cases
   antisym []        []        = []
   antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -401,18 +401,17 @@ module Antisymmetry
   open ℕ.≤-Reasoning
 
   private
-    antisym-lemma : ∀ xs ys₁ y → Sublist R xs ys₁ → ¬ Sublist S (y ∷ ys₁) xs
-    antisym-lemma xs ys₁ y rs ss = ℕ.<-irrefl ≡.refl (begin
-      length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
-      length xs        ≤⟨ length-mono-≤ rs ⟩
-      length ys₁       ∎)
+    antisym-lemma : Sublist R xs ys → ¬ Sublist S (y ∷ ys) xs
+    antisym-lemma {xs} {ys} {y} rs ss = ℕ.<-irrefl ≡.refl $ begin
+      length (y ∷ ys) ≤⟨ length-mono-≤ ss ⟩
+      length xs       ≤⟨ length-mono-≤ rs ⟩
+      length ys       ∎
 
   antisym : Antisym (Sublist R) (Sublist S) (Pointwise E)
   -- impossible cases
-  antisym (_∷ʳ_ {xs} {ys₁} y rs) ss =
-    contradiction′ (antisym-lemma xs ys₁ y rs) ss
+  antisym (_ ∷ʳ rs) ss = contradiction′ (antisym-lemma rs) ss
   antisym (_∷_ {x} {xs} {y} {ys₁} r rs)  (_∷ʳ_ {ys₂} {zs} z ss) =
-    contradiction′ (antisym-lemma xs ys₁ y rs) ss
+    contradiction′ (antisym-lemma rs) ss
   -- diagonal cases
   antisym []        []        = []
   antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -29,7 +29,7 @@ open import Function.Base
 open import Function.Bundles using (_⤖_; _⇔_ ; mk⤖; mk⇔)
 open import Function.Consequences.Propositional using (strictlySurjective⇒surjective)
 open import Relation.Nullary.Decidable as Dec using (Dec; does; _because_; yes; no; ¬?)
-open import Relation.Nullary.Negation using (¬_; contradiction)
+open import Relation.Nullary.Negation using (¬_; contradiction; contradiction′)
 open import Relation.Nullary.Reflects using (invert)
 open import Relation.Unary as U using (Pred)
 open import Relation.Binary.Core using (Rel; REL; _⇒_)
@@ -410,9 +410,9 @@ module Antisymmetry
   antisym : Antisym (Sublist R) (Sublist S) (Pointwise E)
   -- impossible cases
   antisym (_∷ʳ_ {xs} {ys₁} y rs) ss =
-    case (antisym-lemma xs ys₁ y rs ss) of λ()
+    contradiction′ (antisym-lemma xs ys₁ y rs) ss
   antisym (_∷_ {x} {xs} {y} {ys₁} r rs)  (_∷ʳ_ {ys₂} {zs} z ss) =
-    case (antisym-lemma xs ys₁ y rs ss) of λ()
+    contradiction′ (antisym-lemma xs ys₁ y rs) ss
   -- diagonal cases
   antisym []        []        = []
   antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss

--- a/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
+++ b/src/Data/List/Relation/Binary/Sublist/Heterogeneous/Properties.agda
@@ -401,25 +401,20 @@ module Antisymmetry
   open ℕ.≤-Reasoning
 
   antisym : Antisym (Sublist R) (Sublist S) (Pointwise E)
-  antisym []        []        = []
-  antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss
   -- impossible cases
-  antisym (_∷ʳ_ {xs} {ys₁} y rs) (_∷ʳ_ {ys₂} {zs} z ss) =
+  antisym (_∷ʳ_ {xs} {ys₁} y rs) ss =
     contradiction (begin
     length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
-    length zs        ≤⟨ ℕ.n≤1+n (length zs) ⟩
-    length (z ∷ zs)  ≤⟨ length-mono-≤ rs ⟩
+    length xs        ≤⟨ length-mono-≤ rs ⟩
     length ys₁       ∎) $ ℕ.<-irrefl ≡.refl
-  antisym (_∷ʳ_ {xs} {ys₁} y rs) (_∷_ {y} {ys₂} {z} {zs} s ss)  =
-    contradiction (begin
-    length (z ∷ zs) ≤⟨ length-mono-≤ rs ⟩
-    length ys₁      ≤⟨ length-mono-≤ ss ⟩
-    length zs       ∎) $ ℕ.<-irrefl ≡.refl
   antisym (_∷_ {x} {xs} {y} {ys₁} r rs)  (_∷ʳ_ {ys₂} {zs} z ss) =
     contradiction (begin
     length (y ∷ ys₁) ≤⟨ length-mono-≤ ss ⟩
     length xs        ≤⟨ length-mono-≤ rs ⟩
     length ys₁       ∎) $ ℕ.<-irrefl ≡.refl
+  -- diagonal cases
+  antisym []        []        = []
+  antisym (r ∷ rs)  (s ∷ ss)  = rs⇒e r s ∷ antisym rs ss
 
 open Antisymmetry public
 


### PR DESCRIPTION
Commits:

- Simplify Sublist/Heterogeneous/antisym: collapse two cases:
   Removes an unnecessary case split.
  
- Simplify Sublist/Heterogeneous/antisym: factor out contradiction:
   Pulls the duplicated proof into a lemma.
  
These can be squashed, but I worked in two steps since I am unsure about the style policy.