### PR TITLE
Fix universe level typo in `Function.Construct.Constant`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Bug-fixes
 
 * Fix a typo in `Algebra.Morphism.Construct.DirectProduct`.
 
+* Fix a typo in `Function.Construct.Constant`.
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/src/Function/Construct/Constant.agda
+++ b/src/Function/Construct/Constant.agda
@@ -53,7 +53,7 @@ module _
 ------------------------------------------------------------------------
 -- Setoid bundles
 
-module _ (S : Setoid a ℓ₂) (T : Setoid b ℓ₂) where
+module _ (S : Setoid a ℓ₁) (T : Setoid b ℓ₂) where
 
   open Setoid
 


### PR DESCRIPTION
Fix typo preventing `Function.Construct.Constant.function` from being as general as possible