### PR TITLE
[ fix ] make `Data.Nat.Primality.prime⇒nonZero` more strict in its explicit. argument

### DIFF
--- a/src/Data/Nat/Primality.agda
+++ b/src/Data/Nat/Primality.agda
@@ -211,7 +211,7 @@ prime[2] : Prime 2
 prime[2] = prime 2-rough
 
 prime⇒nonZero : Prime p → NonZero p
-prime⇒nonZero _ = nonTrivial⇒nonZero _
+prime⇒nonZero record{} = nonTrivial⇒nonZero _
 
 prime⇒nonTrivial : Prime p → NonTrivial p
 prime⇒nonTrivial _ = recompute-nonTrivial


### PR DESCRIPTION
Fixes #2931 . No `CHANGELOG` unless anyone thinks we need one... the [upstream issue](https://github.com/agda/agda/pull/8367) is the cause.