### PR TITLE
Added function to show Rational at a decimal precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -315,7 +315,7 @@ Additions to existing modules
 
 * In `Data.Rational.Show`:
   ```agda
-  atPrecision : (n : ℕ) → ℚ → Vec ℤ (suc n)
+  atPrecision : (n : ℕ) → ℚ → ℤ × Vec ℕ n
   showAtPrecision : ℕ → ℚ → String
   ```
 
@@ -328,7 +328,6 @@ Additions to existing modules
 
 * In `Data.Rational.Unnormalised.Show`:
   ```agda
-  atPrecision : (n : ℕ) → ℚᵘ → Vec ℤ (suc n)
   showAtPrecision : ℕ → ℚᵘ → String
   ```
 

--- a/src/Data/Rational/Show.agda
+++ b/src/Data/Rational/Show.agda
@@ -8,27 +8,33 @@
 
 module Data.Rational.Show where
 
+open import Data.Integer.Base using (ℤ; +_; ∣_∣)
 import Data.Integer.Show as ℤ using (show)
+open import Data.Nat.Base using (ℕ; zero; suc)
+open import Data.Nat.Show using (toDigitChar)
+open import Data.Product.Base using (_×_; _,_)
 open import Data.Rational.Base
   using (ℚ; ↥_; ↧_; _/_; _*_; truncate; fracPart)
-open import Data.String.Base using (String; _++_; concat)
-open import Data.Nat using (ℕ; suc)
-open import Data.Integer using (ℤ; +_)
-open import Data.Vec using (Vec; []; _∷_; map; toList)
+open import Data.String.Base using (String; _++_)
+open import Data.String using (fromVec)
+open import Data.Vec.Base using (Vec; []; _∷_; map)
 
 show : ℚ → String
 show p = ℤ.show (↥ p) ++ "/" ++ ℤ.show (↧ p)
 
 -- The integer part of q,
 -- followed by the first n digits of its decimal representation
-atPrecision : (n : ℕ) → ℚ → Vec ℤ (suc n)
-atPrecision ℕ.zero q = (truncate q) ∷ []
+atPrecision : (n : ℕ) → ℚ → ℤ × Vec ℕ n
+atPrecision n q = (truncate q , decimalPart n ((+ 10 / 1) * (fracPart q)))
+  where
+  decimalPart : (n : ℕ) → ℚ → Vec ℕ n
+  decimalPart zero q = []
 -- fracPart q is a (non-negative) proper fraction,
 -- and 0 ≤ num < den implies 0 ≤ 10 num/den < 10,
 -- so everything but position 0 is a proper digit
-atPrecision (ℕ.suc n) q
-  = (truncate q) ∷ (atPrecision n ((+ 10 / 1) * (fracPart q)))
+  decimalPart (suc n) q
+    = ∣ truncate q ∣ ∷ decimalPart n ((+ 10 / 1) * (fracPart q))
 
 showAtPrecision : ℕ → ℚ → String
 showAtPrecision n q with atPrecision n q
-... | int ∷ dec = ℤ.show int ++ "." ++ concat (toList (map ℤ.show dec))
+... | (int , dec) = ℤ.show int ++ "." ++ (fromVec (map toDigitChar dec))

--- a/src/Data/Rational/Unnormalised/Show.agda
+++ b/src/Data/Rational/Unnormalised/Show.agda
@@ -9,26 +9,15 @@
 module Data.Rational.Unnormalised.Show where
 
 import Data.Integer.Show as ℤ using (show)
+open import Data.Nat.Base using (ℕ)
+open import Data.Rational.Base using (fromℚᵘ)
+import Data.Rational.Show as ℚ using (showAtPrecision)
 open import Data.Rational.Unnormalised.Base
-  using (ℚᵘ; ↥_; ↧_; _/_; _*_; truncate; fracPart)
-open import Data.String.Base using (String; _++_; concat)
-open import Data.Nat using (ℕ; suc)
-open import Data.Integer using (ℤ; +_)
-open import Data.Vec using (Vec; []; _∷_; map; toList)
+  using (ℚᵘ; ↥_; ↧_)
+open import Data.String.Base using (String; _++_)
 
 show : ℚᵘ → String
 show p = ℤ.show (↥ p) ++ "/" ++ ℤ.show (↧ p)
 
--- The integer part of q,
--- followed by the first n digits of its decimal representation
-atPrecision : (n : ℕ) → ℚᵘ → Vec ℤ (suc n)
-atPrecision ℕ.zero q = (truncate q) ∷ []
--- fracPart q is a (non-negative) proper fraction,
--- and 0 ≤ num < den implies 0 ≤ 10 num/den < 10,
--- so everything but position 0 is a proper digit
-atPrecision (ℕ.suc n) q
-  = (truncate q) ∷ (atPrecision n ((+ 10 / 1) * (fracPart q)))
-
 showAtPrecision : ℕ → ℚᵘ → String
-showAtPrecision n q with atPrecision n q
-... | int ∷ dec = ℤ.show int ++ "." ++ concat (toList (map ℤ.show dec))
+showAtPrecision n q = ℚ.showAtPrecision n (fromℚᵘ q)


### PR DESCRIPTION
#1481 I added functions to show the decimal representation of a `Data.Rational` (or `Data.Rational.Unnormalised`) with `n` decimal digits.