### PR TITLE
Fixes for agda/agda#8533: eta equality is no longer inferred

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -76,7 +76,7 @@ jobs:
           if [[ '${{ github.ref }}' == 'refs/heads/experimental' \
              || '${{ github.base_ref }}' == 'experimental' ]]; then
             # Pick Agda version for experimental
-            echo "AGDA_COMMIT=tags/v2.8.0" >> "${GITHUB_ENV}";
+            echo "AGDA_COMMIT=f3697415ac835c4e0898fb7eb0a5a46e313c2065" >> "${GITHUB_ENV}";
             echo "AGDA_HTML_DIR=html/experimental" >> "${GITHUB_ENV}"
           else
             # Pick Agda version for master

--- a/src/Data/Record.agda
+++ b/src/Data/Record.agda
@@ -62,6 +62,8 @@ mutual
   -- Record is a record type to ensure that the signature can be
   -- inferred from a value of type Record Sig.
 
+  {-# ETA_EQUALITY #-}  -- Suppress warning UnguardedEtaRecord
+
   record Record {s} (Sig : Signature s) : Set s where
     eta-equality
     inductive

--- a/src/Reflection/AST/Traversal.agda
+++ b/src/Reflection/AST/Traversal.agda
@@ -27,7 +27,7 @@ open RawApplicative AppF
 -- compute the length of the context everytime it's needed.
 record Cxt : Set where
   constructor _,_
-  pattern
+  no-eta-equality; pattern
   field
     len     : ℕ
     context : List (String × Arg Term)


### PR DESCRIPTION
- `Data.Record` needs a `ETA_EQUALITY` pragma to suppress the `UnguardedEtaRecord` warning.
- `Reflection.AST.Traversal` needs an explicit declaration of `no-eta-equality`.
  This was previously inferred.

These changes will be needed in `experimental` once agda/agda#8533 lands.
- agda/agda#8533

Superseds:
- https://github.com/agda/agda-stdlib/pull/2476