### PR TITLE
Add stack configuration for GHC 9.12.4

### DIFF
--- a/stack-9.12.4.yaml
+++ b/stack-9.12.4.yaml
@@ -1,0 +1,6 @@
+resolver: nightly-2026-04-18
+compiler: ghc-9.12.4
+compiler-check: match-exact
+packages:
+- .
+

--- a/stack-9.12.4.yaml
+++ b/stack-9.12.4.yaml
@@ -3,4 +3,3 @@ compiler: ghc-9.12.4
 compiler-check: match-exact
 packages:
 - .
-


### PR DESCRIPTION
Add stack-9.12.4.yaml for GHC 9.12.4 just like https://github.com/agda/agda/blob/5a2b5c5955b1d9aea48c9f2209f8fa3454d5d6ee/stack-9.12.4.yaml so GenerateEverything.hs can be built using GHC 9.12.4.

Because agda-stdlib mainly uses Cabal, this addition wouldn't break anything.