### PR TITLE
Data.List.Base.all: fix warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Bug-fixes
 
 * Fix a typo in `Function.Construct.Constant`.
 
-* Fix a warning for `Data.List.Base.all` referencing the wrong replacement `Data.Nat.ListAction.all`, corrected to `Data.Bool.ListAction.all`.
+* Fix the warning for `Data.List.Base.all` referencing the wrong replacement `Data.Nat.ListAction.all`, corrected to `Data.Bool.ListAction.all`.
 
 Non-backwards compatible changes
 --------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Bug-fixes
 
 * Fix a typo in `Function.Construct.Constant`.
 
+* Fix a warning for `Data.List.Base.all` referencing the wrong replacement `Data.Nat.ListAction.all`, corrected to `Data.Bool.ListAction.All`.
+
 Non-backwards compatible changes
 --------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Bug-fixes
 
 * Fix a typo in `Function.Construct.Constant`.
 
-* Fix a warning for `Data.List.Base.all` referencing the wrong replacement `Data.Nat.ListAction.all`, corrected to `Data.Bool.ListAction.All`.
+* Fix a warning for `Data.List.Base.all` referencing the wrong replacement `Data.Nat.ListAction.all`, corrected to `Data.Bool.ListAction.all`.
 
 Non-backwards compatible changes
 --------------------------------

--- a/src/Data/List/Base.agda
+++ b/src/Data/List/Base.agda
@@ -576,7 +576,7 @@ Please use Data.Bool.ListAction.and instead."
 #-}
 {-# WARNING_ON_USAGE all
 "Warning: all was deprecated in v2.3.
-Please use Data.Nat.ListAction.all instead."
+Please use Data.Bool.ListAction.all instead."
 #-}
 
 or : List Bool → Bool


### PR DESCRIPTION
Fix warning for Data.List.Base.all which refered to Nat instead of Bool, issue #2991