### PR TITLE
Replace irrelevance with Prop

### DIFF
--- a/doc/standard-library-doc.agda-lib
+++ b/doc/standard-library-doc.agda-lib
@@ -2,3 +2,4 @@ name: standard-library-doc
 include: . ../src
 flags:
   --warning=noUnsupportedIndexedMatch
+  --prop

--- a/src/Data/Empty.agda
+++ b/src/Data/Empty.agda
@@ -18,23 +18,31 @@ open import Data.Irrelevant using (Irrelevant)
 -- universe polymorphic variant.
 
 private
-  data Empty : Set where
+  data Empty : Prop where
 
 -- ⊥ is defined via Data.Irrelevant (a record with a single irrelevant
 -- field) so that Agda can judgementally declare that all proofs of ⊥
 -- are equal to each other. In particular this means that all functions
 -- returning a proof of ⊥ are equal.
 
-⊥ : Set
-⊥ = Irrelevant Empty
+record ⊥ : Set where
+  constructor [_]
+  field
+    empty : Empty
+open ⊥ public
 
 {-# DISPLAY Irrelevant Empty = ⊥ #-}
 
 ------------------------------------------------------------------------
 -- Functions
 
+private
+  empty-elim : ∀ {w} {Whatever : Set w} → .Empty → Whatever
+  empty-elim ()
+
 ⊥-elim : ∀ {w} {Whatever : Set w} → ⊥ → Whatever
-⊥-elim ()
+⊥-elim x = empty-elim (empty x)
 
 ⊥-elim-irr : ∀ {w} {Whatever : Set w} → .⊥ → Whatever
-⊥-elim-irr ()
+⊥-elim-irr x = empty-elim (empty x)
+

--- a/src/Data/Squash.agda
+++ b/src/Data/Squash.agda
@@ -11,10 +11,9 @@
 
 {-# OPTIONS --cubical-compatible --safe #-}
 
-module Data.Irrelevant where
+module Data.Squash where
 
 open import Level using (Level)
-open import Data.Squash as Squash using (Squash; squash)
 
 private
   variable
@@ -26,31 +25,20 @@ private
 ------------------------------------------------------------------------
 -- Type
 
-record Irrelevant (A : Set a) : Set a where
-  constructor [_]
-  field
-    irrelevant : Squash A
-open Irrelevant public
+data Squash (A : Set a) : Prop a where
+  squash : A → Squash A
 
 ------------------------------------------------------------------------
 -- Algebraic structure: Functor, Appplicative and Monad-like
 
-map : (A → B) → Irrelevant A → Irrelevant B
-map f [ a ] = [ Squash.map f a ]
-
-pure : A → Irrelevant A
-pure x = [ squash x ]
+map : (A → B) → Squash A → Squash B
+map f (squash x) = squash (f x)
 
 infixl 4 _<*>_
-_<*>_ : Irrelevant (A → B) → Irrelevant A → Irrelevant B
-[ f ] <*> [ a ] = [ f Squash.<*> a ]
+_<*>_ : Squash (A → B) → Squash A → Squash B
+squash f <*> squash x = squash (f x)
 
 infixl 1 _>>=_
-_>>=_ : Irrelevant A → (A → Irrelevant B) → Irrelevant B
-[ a ] >>= f = [ a Squash.>>= (λ x → irrelevant (f x)) ]
+_>>=_ : Squash A → (A → Squash B) → Squash B
+squash x >>= f = f x
 
-------------------------------------------------------------------------
--- Other functions
-
-zipWith : (A → B → C) → Irrelevant A → Irrelevant B → Irrelevant C
-zipWith f a b = ⦇ f a b ⦈

--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -9,7 +9,7 @@
 module Relation.Nullary.Recomputable where
 
 open import Data.Empty using (⊥)
-open import Data.Irrelevant using (Irrelevant; irrelevant; [_])
+open import Data.Irrelevant using (Irrelevant; [_])
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂)
 open import Level using (Level)
 open import Relation.Nullary.Negation.Core using (¬_)
@@ -29,15 +29,10 @@ open import Relation.Nullary.Recomputable.Core public
 ------------------------------------------------------------------------
 -- Constructions
 
--- Irrelevant types are Recomputable
-
-irrelevant-recompute : Recomputable (Irrelevant A)
-irrelevant (irrelevant-recompute [ a ]) = a
-
--- Corollary: so too is ⊥
+-- ⊥ is Recomputable
 
 ⊥-recompute : Recomputable ⊥
-⊥-recompute = irrelevant-recompute
+⊥-recompute ()
 
 _×-recompute_ : Recomputable A → Recomputable B → Recomputable (A × B)
 (rA ×-recompute rB) p = rA (p .proj₁) , rB (p .proj₂)

--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -2,3 +2,4 @@ name: standard-library-2.4
 include: src
 flags:
   --warning=noUnsupportedIndexedMatch
+  --prop


### PR DESCRIPTION
As discussed in https://github.com/agda/agda/issues/8557, I made an attempt at replacing the use of irrelevance for the definition of the empty type with `Prop`. It seems to work rather nicely, with the main disadvantage being that `--prop` needs to be enabled in basically every file (I haven't yet checked which ones exactly, just enabled it globally for now). On the other hand, this would allow the standard library to adopt the `--no-irrelevance` flag once https://github.com/agda/agda/pull/8575 is merged.

I'm curious to hear what the standard library developers think of this potential change, in particular @MatthewDaggitt @jamesmckinna @fredrikNordvallForsberg 