### PR TITLE
Add definitions for function-like relations

### DIFF
--- a/src/Relation/Binary/Definitions.agda
+++ b/src/Relation/Binary/Definitions.agda
@@ -262,3 +262,23 @@ record NonEmpty {A : Set a} {B : Set b}
     {x}   : A
     {y}   : B
     proof : T x y
+
+-- LeftUnique - the relation is injective,
+-- i.e. every element of the codomain has at most one preimage.
+LeftUnique : Rel A ℓ₁ → Rel B ℓ₂ → REL A B ℓ → Set _
+LeftUnique _≈₁_ _≈₂_ _↦_ = ∀ {x y u v} → x ↦ u → y ↦ v → u ≈₂ v → x ≈₁ y
+
+-- RightUnique - the relation is a (partial) function,
+-- i.e. every element of the domain has at most one image.
+RightUnique : Rel A ℓ₁ → Rel B ℓ₂ → REL A B ℓ → Set _
+RightUnique _≈₁_ _≈₂_ _↦_ = ∀ {x y u v} → x ↦ u → y ↦ v → x ≈₁ y → u ≈₂ v
+
+-- LeftTotal - the relation is total (as in a total function),
+-- i.e. every element of the domain has at least one image.
+LeftTotal : Rel A ℓ₁ → REL A B ℓ → Set _
+LeftTotal _≈_ _↦_ = ∀ x → ∃[ u ] x ↦ u
+
+-- RightTotal - the relation is surjective,
+-- i.e. every element of the codomain has at least one preimage.
+RightTotal : Rel B ℓ₂ → REL A B ℓ → Set _
+RightTotal _≈_ _↦_ = ∀ u → ∃[ x ] x ↦ u


### PR DESCRIPTION
From https://agda.zulipchat.com/#narrow/channel/264623-stdlib/topic/Functional.20relation.3F/with/600727343

I've dithered and ruminated on the names for a while my initial choices were `Injective`, `Functional`, `Total`, and `Surjective`, but:

* `Total` is already defined in this module to be a total _order_
* `Injective` and `Surjective` conflict with definitions in `Function.Definitions`, both of which are imported unqualified in several places
* Tom de Jong on Zulip points out that `Functional` may imply a _total_ function

I took these names from https://en.wikipedia.org/wiki/Binary_relation#Definition but I'm still open to further suggestions