### PR TITLE
Make irrelevant-recompute unsafe

### DIFF
--- a/src/Relation/Nullary/Recomputable.agda
+++ b/src/Relation/Nullary/Recomputable.agda
@@ -29,6 +29,9 @@ open import Relation.Nullary.Recomputable.Core public
 ------------------------------------------------------------------------
 -- Constructions
 
+⊥-recompute : Recomputable ⊥
+⊥-recompute ()
+
 _×-recompute_ : Recomputable A → Recomputable B → Recomputable (A × B)
 (rA ×-recompute rB) p = rA (p .proj₁) , rB (p .proj₂)
 
@@ -41,4 +44,7 @@ _→-recompute_ : (A : Set a) → Recomputable B → Recomputable (A → B)
 ∀-recompute : (B : A → Set b) → (∀ {x} → Recomputable (B x)) → Recomputable (∀ {x} → B x)
 ∀-recompute B rB f = rB f
 
+-- Corollary: negations are Recomputable
 
+¬-recompute : Recomputable (¬ A)
+¬-recompute {A = A} = A →-recompute ⊥-recompute

--- a/src/Relation/Nullary/Recomputable/Unsafe.agda
+++ b/src/Relation/Nullary/Recomputable/Unsafe.agda
@@ -34,12 +34,3 @@ open import Relation.Nullary.Recomputable public
 irrelevant-recompute : Recomputable (Irrelevant A)
 irrelevant (irrelevant-recompute a) = irrelevant a
 
--- Corollary: so too is ⊥
-
-⊥-recompute : Recomputable ⊥
-⊥-recompute = irrelevant-recompute
-
--- Corollary: negations are Recomputable
-
-¬-recompute : Recomputable (¬ A)
-¬-recompute {A = A} = A →-recompute ⊥-recompute

--- a/src/Relation/Nullary/Recomputable/Unsafe.agda
+++ b/src/Relation/Nullary/Recomputable/Unsafe.agda
@@ -4,9 +4,9 @@
 -- Recomputable types and their algebra as Harrop formulas
 ------------------------------------------------------------------------
 
-{-# OPTIONS --cubical-compatible --safe #-}
+{-# OPTIONS --cubical-compatible --irrelevant-projections #-}
 
-module Relation.Nullary.Recomputable where
+module Relation.Nullary.Recomputable.Unsafe where
 
 open import Data.Empty using (⊥)
 open import Data.Irrelevant using (Irrelevant; irrelevant; [_])
@@ -23,22 +23,23 @@ private
 ------------------------------------------------------------------------
 -- Re-export
 
-open import Relation.Nullary.Recomputable.Core public
+open import Relation.Nullary.Recomputable public
 
 
 ------------------------------------------------------------------------
 -- Constructions
 
-_×-recompute_ : Recomputable A → Recomputable B → Recomputable (A × B)
-(rA ×-recompute rB) p = rA (p .proj₁) , rB (p .proj₂)
+-- Irrelevant types are Recomputable
 
-_→-recompute_ : (A : Set a) → Recomputable B → Recomputable (A → B)
-(A →-recompute rB) f a = rB (f a)
+irrelevant-recompute : Recomputable (Irrelevant A)
+irrelevant (irrelevant-recompute a) = irrelevant a
 
-Π-recompute : (B : A → Set b) → (∀ x → Recomputable (B x)) → Recomputable (∀ x → B x)
-Π-recompute B rB f a = rB a (f a)
+-- Corollary: so too is ⊥
 
-∀-recompute : (B : A → Set b) → (∀ {x} → Recomputable (B x)) → Recomputable (∀ {x} → B x)
-∀-recompute B rB f = rB f
+⊥-recompute : Recomputable ⊥
+⊥-recompute = irrelevant-recompute
 
+-- Corollary: negations are Recomputable
 
+¬-recompute : Recomputable (¬ A)
+¬-recompute {A = A} = A →-recompute ⊥-recompute


### PR DESCRIPTION
This is the less invasive alternative to https://github.com/agda/agda-stdlib/pull/2998, which instead just makes the definitions that are no longer supported unsafe by putting them in a separate `Unsafe` module that has the `--irrelevant-projections` flag.

Currently this is based on the `experimental` branch, which seems to lag a bit behind on `master`. I tried to bring it up to date but got a bunch of merge conflicts that I didn't know how to solve immediately. If someone else could bring the experimental branch up to date, I'd be glad to rebase this PR on it.

TODO:
- [ ] Merge master into this branch
- [ ] Add changelog entry