### PR TITLE
[ refactor ] `Data.Nat.GCD`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Deprecated names
   ≟-≢     ↦  ≡?-≢
   ```
 
+* In `Data.Integer.GCD`:
+  ```agda
+  gcd[0,0]≡0 ↦ gcd[i,i]≡∣i∣
+  ```
+
 * In `Data.Nat.GCD`:
   ```agda
   gcd[0,0]≡0 ↦ gcd[n,n]≡n
@@ -94,6 +99,11 @@ New modules
 
 Additions to existing modules
 -----------------------------
+
+* In `Data.Integer.GCD`:
+  ```agda
+  gcd[i,i]≡∣i∣ : ∀ i → gcd i i ≡ + ∣i∣
+  ```
 
 * In `Data.Nat.GCD`:
   ```agda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ Deprecated names
   ≟-≢     ↦  ≡?-≢
   ```
 
+* In `Data.Nat.GCD`:
+  ```agda
+  gcd[0,0]≡0 ↦ gcd[n,n]≡n
+  ```
+
 * In `Data.Nat.Properties`:
   ```agda
   _≟_       ↦   _≡?_
@@ -89,6 +94,11 @@ New modules
 
 Additions to existing modules
 -----------------------------
+
+* In `Data.Nat.GCD`:
+  ```agda
+  gcd[n,n]≡n : ∀ n → gcd n n ≡ n
+  ```
 
 * In `Data.Rational.Properties`:
   ```agda

--- a/src/Data/Integer/GCD.agda
+++ b/src/Data/Integer/GCD.agda
@@ -38,8 +38,8 @@ gcd[i,j]∣j i j = ℕ.gcd[m,n]∣n ∣ i ∣ ∣ j ∣
 gcd-greatest : ∀ {i j c} → c ∣ i → c ∣ j → c ∣ gcd i j
 gcd-greatest c∣i c∣j = ℕ.gcd-greatest c∣i c∣j
 
-gcd[0,0]≡0 : gcd 0ℤ 0ℤ ≡ 0ℤ
-gcd[0,0]≡0 = cong (+_) ℕ.gcd[0,0]≡0
+gcd[i,i]≡∣i∣ : ∀ i → gcd i i ≡ + ∣ i ∣
+gcd[i,i]≡∣i∣ i = cong (+_) (ℕ.gcd[n,n]≡n ∣ i ∣)
 
 gcd[i,j]≡0⇒i≡0 : ∀ i j → gcd i j ≡ 0ℤ → i ≡ 0ℤ
 gcd[i,j]≡0⇒i≡0 i j eq = ∣i∣≡0⇒i≡0 (ℕ.gcd[m,n]≡0⇒m≡0 (+-injective eq))
@@ -61,3 +61,20 @@ gcd-zeroʳ i = cong (+_) (ℕ.gcd-zeroʳ ∣ i ∣)
 
 gcd-zero : Zero 1ℤ gcd
 gcd-zero = gcd-zeroˡ , gcd-zeroʳ
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 3.0
+
+gcd[0,0]≡0 : gcd 0ℤ 0ℤ ≡ 0ℤ
+gcd[0,0]≡0 = gcd[i,i]≡∣i∣ 0ℤ
+{-# WARNING_ON_USAGE gcd[0,0]≡0
+"Warning: gcd[0,0]≡0 was deprecated in v3.0.
+Please use gcd[i,i]≡∣i∣ instead."
+#-}
+

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -23,7 +23,7 @@ open import Induction using (build)
 open import Induction.Lexicographic using (_⊗_; [_⊗_])
 open import Relation.Binary.Definitions using (tri<; tri>; tri≈; Symmetric)
 open import Relation.Binary.PropositionalEquality.Core as ≡
-  using (_≡_; _≢_; subst; cong; cong₂)
+  using (_≡_; _≢_; subst; cong)
 open import Relation.Binary.PropositionalEquality.Properties
   using (module ≡-Reasoning)
 open import Relation.Nullary.Decidable.Core using (Dec)

--- a/src/Data/Nat/GCD.agda
+++ b/src/Data/Nat/GCD.agda
@@ -94,8 +94,8 @@ gcd-greatest {m} {n} c∣m c∣n with <-cmp m n
 -- Note that all other properties of `gcd` should be inferable from the
 -- 3 core properties above.
 
-gcd[0,0]≡0 : gcd 0 0 ≡ 0
-gcd[0,0]≡0 = ∣-antisym (gcd 0 0 ∣0) (gcd-greatest (0 ∣0) (0 ∣0))
+gcd[n,n]≡n : ∀ n → gcd n n ≡ n
+gcd[n,n]≡n n = ∣-antisym (gcd[m,n]∣m n n) (gcd-greatest ∣-refl ∣-refl)
 
 gcd[m,n]≢0 : ∀ m n → m ≢ 0 ⊎ n ≢ 0 → gcd m n ≢ 0
 gcd[m,n]≢0 m n (inj₁ m≢0) eq = m≢0 (0∣⇒≡0 (subst (_∣ m) eq (gcd[m,n]∣m m n)))
@@ -187,9 +187,9 @@ gcd[cm,cn]/c≡gcd[m,n] c m n = gcd-universality forwards backwards
       *-cancelˡ-∣ c (∣-trans cd∣gcd[cm,n] (gcd[m,n]∣n (c * m) _))
 
 c*gcd[m,n]≡gcd[cm,cn] : ∀ c m n → c * gcd m n ≡ gcd (c * m) (c * n)
-c*gcd[m,n]≡gcd[cm,cn] zero      m n = ≡.sym gcd[0,0]≡0
+c*gcd[m,n]≡gcd[cm,cn] zero      m n = ≡.sym (gcd[n,n]≡n 0)
 c*gcd[m,n]≡gcd[cm,cn] c@(suc _) m n = begin
-  c * gcd m n                   ≡⟨ cong (c *_) (≡.sym (gcd[cm,cn]/c≡gcd[m,n] c m n)) ⟩
+  c * gcd m n                   ≡⟨ cong (c *_) (gcd[cm,cn]/c≡gcd[m,n] c m n) ⟨
   c * (gcd (c * m) (c * n) / c) ≡⟨ m*[n/m]≡n (gcd-greatest (m∣m*n m) (m∣m*n n)) ⟩
   gcd (c * m) (c * n)           ∎
   where open ≡-Reasoning
@@ -204,16 +204,6 @@ n/gcd[m,n]≢0 m n = m<n⇒n≢0 (m≥n⇒m/n>0 {n} {gcd m n} (gcd[m,n]≤n m n)
 m/gcd[m,n]≢0 : ∀ m n .{{_ : NonZero m}} .{{gcd≢0 : NonZero (gcd m n)}} →
                m / gcd m n ≢ 0
 m/gcd[m,n]≢0 m n rewrite gcd-comm m n = n/gcd[m,n]≢0 n m
-
-gcd[n,n]≡n : ∀ n → gcd n n ≡ n
-gcd[n,n]≡n n = begin
-  gcd n n             ≡⟨ cong₂ gcd n*1≡n n*1≡n ⟨
-  gcd (n * 1) (n * 1) ≡⟨ c*gcd[m,n]≡gcd[cm,cn] n 1 1 ⟨
-  n * gcd 1 1         ≡⟨ n*1≡n ⟩
-  n                   ∎
-  where
-  open ≡-Reasoning
-  n*1≡n = *-identityʳ n
 
 ------------------------------------------------------------------------
 -- A formal specification of GCD
@@ -412,3 +402,20 @@ module Bézout where
 
   identity : ∀ {m n d} → GCD m n d → Identity d m n
   identity {m} {n} g with result d g′ b ← lemma m n rewrite GCD.unique g g′ = b
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 3.0
+
+gcd[0,0]≡0 : gcd 0 0 ≡ 0
+gcd[0,0]≡0 = gcd[n,n]≡n 0
+{-# WARNING_ON_USAGE gcd[0,0]≡0
+"Warning: gcd[0,0]≡0 was deprecated in v3.0.
+Please use gcd[n,n]≡n instead."
+#-}
+


### PR DESCRIPTION
This is a coda to @kleinreact 's #2996 to fix up `Data.{Integer|Nat}.GCD` and `CHANGELOG`:
* fixes `CHANGELOG` to restore the addition of `gcd[n,n]≡n` (apologies for this snafu)
* refactors that proof to use the 'abstract' characterisation, and deprecates `gcd[0,0]≡0` in favour of the new lemma
* adds `Data.Integer.GCD.gcd[i,i]≡∣i∣` in like fashion

Low-hanging fruit, suggest merging on one approval!