### PR TITLE
[ add ] missing `Monoid`s to `Data.Bool.Properties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ New modules
 Additions to existing modules
 -----------------------------
 
+* In `Data.Bool.Properties`:
+  ```agda
+  ∨-monoid : Monoid 0ℓ 0ℓ
+  ∧-monoid : Monoid 0ℓ 0ℓ
+  ```
+
 * In `Data.Integer.GCD`:
   ```agda
   gcd[i,i]≡∣i∣ : ∀ i → gcd i i ≡ + ∣i∣

--- a/src/Data/Bool/Properties.agda
+++ b/src/Data/Bool/Properties.agda
@@ -8,7 +8,7 @@
 
 module Data.Bool.Properties where
 open import Algebra.Bundles
-  using (Magma; Semigroup; Band; CommutativeMonoid
+  using (Magma; Semigroup; Band; Monoid; CommutativeMonoid
         ; IdempotentCommutativeMonoid; CommutativeSemiring; CommutativeRing)
 open import Algebra.Lattice.Bundles
   using (Lattice; DistributiveLattice; BooleanAlgebra; Semilattice)
@@ -348,6 +348,11 @@ true  <? _     = no  (λ())
   ; identity = ∨-identity
   }
 
+∨-monoid : Monoid 0ℓ 0ℓ
+∨-monoid = record
+  { isMonoid = ∨-isMonoid
+  }
+
 ∨-isCommutativeMonoid : IsCommutativeMonoid _∨_ false
 ∨-isCommutativeMonoid = record
   { isMonoid = ∨-isMonoid
@@ -518,6 +523,11 @@ true  <? _     = no  (λ())
 ∧-isMonoid = record
   { isSemigroup = ∧-isSemigroup
   ; identity = ∧-identity
+  }
+
+∧-monoid : Monoid 0ℓ 0ℓ
+∧-monoid = record
+  { isMonoid = ∧-isMonoid
   }
 
 ∧-isCommutativeMonoid : IsCommutativeMonoid _∧_ true


### PR DESCRIPTION
Tackles the first item of #3016 notwithstanding the considerations of #2391 which suggest an alternative, and perhaps more scalable, approach.