### PR TITLE
Add product-locate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ Additions to existing modules
   gcd[n,n]≡n : ∀ n → gcd n n ≡ n
   ```
 
+* In `Data.Nat.ListAction.Properties`:
+  ```agda
+  product-locate : ∀ ns → product ns ≡ 0 → 0 ∈ ns
+  ```
+
 * In `Data.Rational.Properties`:
   ```agda
   ↥[i/1]≡i  : (i : ℤ) → ↥ (i / 1) ≡ i

--- a/src/Data/Nat/ListAction/Properties.agda
+++ b/src/Data/Nat/ListAction/Properties.agda
@@ -28,7 +28,8 @@ open import Data.Nat.Properties
         ; +-0-commutativeMonoid; *-1-commutativeMonoid
         ; *-zeroˡ; *-zeroʳ; *-distribˡ-+; *-distribʳ-+
         ; ^-zeroˡ; ^-distribʳ-*; m*n≡0⇒m≡0∨n≡0)
-open import Data.Sum.Base using (inj₁; inj₂)
+open import Data.Sum.Base using ([_,_]′)
+open import Function.Base using (_∘′_)
 open import Relation.Binary.Core using (_Preserves_⟶_)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; sym; trans; cong)
@@ -83,7 +84,7 @@ product-++ (m ∷ ms) ns = begin
 
 product-locate : ∀ ns → product ns ≡ 0 → 0 ∈ ns
 product-locate (n ∷ ns) =
-  [ here ∘ sym , there ∘ product-locate ns ]′ ∘ m*n≡0⇒m≡0∨n≡0 n
+  [ here ∘′ sym , there ∘′ product-locate ns ]′ ∘′ m*n≡0⇒m≡0∨n≡0 n
 
 
 product≢0 : All NonZero ns → NonZero (product ns)

--- a/src/Data/Nat/ListAction/Properties.agda
+++ b/src/Data/Nat/ListAction/Properties.agda
@@ -82,9 +82,9 @@ product-++ (m ∷ ms) ns = begin
 ∈⇒∣product {ns = m ∷ ns} (there n∈ns) = ∣n⇒∣m*n m (∈⇒∣product n∈ns)
 
 product-locate : ∀ ns → product ns ≡ 0 → 0 ∈ ns
-product-locate (n ∷ ns) p with m*n≡0⇒m≡0∨n≡0 n p
-... | inj₁ n≡0 = here (sym n≡0)
-... | inj₂ Πns≡0 = there (product-locate ns Πns≡0)
+product-locate (n ∷ ns) =
+  [ here ∘ sym , there ∘ product-locate ns ]′ ∘ m*n≡0⇒m≡0∨n≡0 n
+
 
 product≢0 : All NonZero ns → NonZero (product ns)
 product≢0 []           = _

--- a/src/Data/Nat/ListAction/Properties.agda
+++ b/src/Data/Nat/ListAction/Properties.agda
@@ -27,7 +27,8 @@ open import Data.Nat.Properties
   using (+-assoc; *-assoc; *-identityˡ; m*n≢0; m≤m*n; m≤n⇒m≤o*n
         ; +-0-commutativeMonoid; *-1-commutativeMonoid
         ; *-zeroˡ; *-zeroʳ; *-distribˡ-+; *-distribʳ-+
-        ; ^-zeroˡ; ^-distribʳ-*)
+        ; ^-zeroˡ; ^-distribʳ-*; m*n≡0⇒m≡0∨n≡0)
+open import Data.Sum.Base using (inj₁; inj₂)
 open import Relation.Binary.Core using (_Preserves_⟶_)
 open import Relation.Binary.PropositionalEquality.Core
   using (_≡_; refl; sym; trans; cong)
@@ -79,6 +80,11 @@ product-++ (m ∷ ms) ns = begin
 ∈⇒∣product : n ∈ ns → n ∣ product ns
 ∈⇒∣product {ns = n ∷ ns} (here  refl) = m∣m*n (product ns)
 ∈⇒∣product {ns = m ∷ ns} (there n∈ns) = ∣n⇒∣m*n m (∈⇒∣product n∈ns)
+
+product-locate : ∀ ns → product ns ≡ 0 → 0 ∈ ns
+product-locate (n ∷ ns) p with m*n≡0⇒m≡0∨n≡0 n p
+... | inj₁ n≡0 = here (sym n≡0)
+... | inj₂ Πns≡0 = there (product-locate ns Πns≡0)
 
 product≢0 : All NonZero ns → NonZero (product ns)
 product≢0 []           = _


### PR DESCRIPTION
Same idea as the recently added `and-locate` and `or-locate`.

`product≢0` can be defined in terms of this but it ends up kind of ugly translating between `NonZero` and `≢` a lot, so doesn't seem worth it to me