### PR TITLE
[ bug ] local module parametrisation in `Data.SnocList.Base`

### DIFF
--- a/src/Data/SnocList/Base.agda
+++ b/src/Data/SnocList/Base.agda
@@ -275,14 +275,14 @@ iterate f e zero    = []
 iterate f e (suc n) = iterate f (f e) n <: e
 
 inits : List< A → List< (List< A)
-inits {A = A} sx = tail sx <: []
+inits {A = A} = λ sx → tail sx <: []
   module Inits where
     tail : List< A → List< (List< A)
     tail []        = []
     tail (sx <: x) = map (_<: x) (tail sx) <: ([] <: x)
 
 tails : List< A → List< (List< A)
-tails {A = A} sx = tail sx <: sx
+tails {A = A} = λ sx → tail sx <: sx
   module Tails where
     tail : List< A → List< (List< A)
     tail []        = []


### PR DESCRIPTION
Shifting lambda-bound arguments from RHS to being pattern-bound on the LHS of
https://github.com/agda/agda-stdlib/blob/47beb938489d1d9dd27c93c828a4e5e161acf758/src/Data/SnocList/Base.agda#L277-L289
actually changes the parameterisation of the local module declarations in those definitions to include the additional `sx` argument as a parameter.

This change arises from my erroneous review comment https://github.com/agda/agda-stdlib/pull/2982#discussion_r3104880712 and the resulting commit https://github.com/agda/agda-stdlib/pull/2982/commits/8bf6192b7bba419ee02c492d238302ce41eca169

This PR undoes this mistake. Hopefully no real damage done!

No `CHANGELOG` as we caught this in time.