### PR TITLE
[ refactor ] Rename+deprecate `Algebra.Definitions.Star*Expansive` and `Algebra.Definitions.Star*Destructive`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,12 +79,12 @@ Deprecated names
 
 * In `Algebra.Definitions`:
   ```agda
-  StarLeftExpansive     ↦  Relation.Binary.Definitions.StarLeftExpansive
-  StarRightExpansive    ↦  Relation.Binary.Definitions.StarRightExpansive
-  StarExpansive         ↦  Relation.Binary.Definitions.StarExpansive
-  StarLeftDestructive   ↦  Relation.Binary.Definitions.StarLeftDestructive
-  StarRightDestructive  ↦  Relation.Binary.Definitions.StarRightDestructive
-  StarDestructive       ↦  Relation.Binary.Definitions.StarDestructive
+  StarLeftExpansive     ↦  Relation.Binary.Definitions.KleeneAlgebra.StarLeftExpansive
+  StarRightExpansive    ↦  Relation.Binary.Definitions.KleeneAlgebra.StarRightExpansive
+  StarExpansive         ↦  Relation.Binary.Definitions.KleeneAlgebra.StarExpansive
+  StarLeftDestructive   ↦  Relation.Binary.Definitions.KleeneAlgebra.StarLeftDestructive
+  StarRightDestructive  ↦  Relation.Binary.Definitions.KleeneAlgebra.StarRightDestructive
+  StarDestructive       ↦  Relation.Binary.Definitions.KleeneAlgebra.StarDestructive
   ```
 
 * In `Algebra.Morphism.Structures`:
@@ -229,14 +229,12 @@ Additions to existing modules
 
 * In `Relation.Binary.Definitions`:
   ```agda
-  StarLeftExpansive     : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
-                          Set _
-  StarRightExpansive    : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
-                          Set _
-  StarExpansive         : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
-                          Set _
-  StarLeftDestructive   : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
-  StarRightDestructive  : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
-  StarDestructive       : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+  module KleeneAlgebra (_≤_ : Rel A ℓ₁) where
+    StarLeftExpansive     : ∀ (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+    StarRightExpansive    : ∀ (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+    StarExpansive         : ∀ (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+    StarLeftDestructive   : ∀ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+    StarRightDestructive  : ∀ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+    StarDestructive       : ∀ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@ Deprecated modules
 Deprecated names
 ----------------
 
+* In `Algebra.Definitions`:
+  ```agda
+  StarLeftExpansive     ↦  Relation.Binary.Definitions.StarLeftExpansive
+  StarRightExpansive    ↦  Relation.Binary.Definitions.StarRightExpansive
+  StarExpansive         ↦  Relation.Binary.Definitions.StarExpansive
+  StarLeftDestructive   ↦  Relation.Binary.Definitions.StarLeftDestructive
+  StarRightDestructive  ↦  Relation.Binary.Definitions.StarRightDestructive
+  StarDestructive       ↦  Relation.Binary.Definitions.StarDestructive
+  ```
+
 * In `Algebra.Morphism.Structures`:
   ```agda
   homo  ↦  ∙-homo
@@ -216,3 +226,17 @@ Additions to existing modules
   lookup-head : (xs : Vec A (suc n)) → lookup xs zero ≡ head xs
   lookup-tail : (xs : Vec A (suc n)) → lookup xs (suc i) ≡ lookup (tail xs) i
   ```
+
+* In `Relation.Binary.Definitions`:
+  ```agda
+  StarLeftExpansive     : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
+                          Set _
+  StarRightExpansive    : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
+                          Set _
+  StarExpansive         : ∀ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) →
+                          Set _
+  StarLeftDestructive   : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+  StarRightDestructive  : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+  StarDestructive       : ∀ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
+  ```
+

--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -25,7 +25,8 @@ module Algebra.Definitions
 open import Algebra.Core using (Op₁; Op₂)
 open import Data.Product.Base using (_×_; ∃-syntax)
 open import Data.Sum.Base using (_⊎_)
-open import Relation.Binary.Definitions using (Monotonic₁; Monotonic₂)
+open import Relation.Binary.Definitions as Definitions
+  using (Monotonic₁; Monotonic₂)
 open import Relation.Nullary.Negation.Core using (¬_)
 
 
@@ -186,24 +187,6 @@ LeftDivides ∙ \\ = (LeftDividesˡ ∙ \\) × (LeftDividesʳ ∙ \\)
 RightDivides : Op₂ A → Op₂ A → Set _
 RightDivides ∙ // = (RightDividesˡ ∙ //) × (RightDividesʳ ∙ //)
 
-StarRightExpansive : A → Op₂ A → Op₂ A → Op₁ A → Set _
-StarRightExpansive e _+_ _∙_ _* = ∀ x → (e + (x ∙ (x *))) ≈ (x *)
-
-StarLeftExpansive : A → Op₂ A → Op₂ A → Op₁ A → Set _
-StarLeftExpansive e _+_ _∙_ _* = ∀ x →  (e + ((x *) ∙ x)) ≈ (x *)
-
-StarExpansive : A → Op₂ A → Op₂ A → Op₁ A → Set _
-StarExpansive e _+_ _∙_ _* = (StarLeftExpansive e _+_ _∙_ _*) × (StarRightExpansive e _+_ _∙_ _*)
-
-StarLeftDestructive : Op₂ A → Op₂ A → Op₁ A → Set _
-StarLeftDestructive _+_ _∙_ _* = ∀ a b x → (b + (a ∙ x)) ≈ x → ((a *) ∙ b) ≈ x
-
-StarRightDestructive : Op₂ A → Op₂ A → Op₁ A → Set _
-StarRightDestructive _+_ _∙_ _* = ∀ a b x → (b + (x ∙ a)) ≈ x → (b ∙ (a *)) ≈ x
-
-StarDestructive : Op₂ A → Op₂ A → Op₁ A → Set _
-StarDestructive _+_ _∙_ _* = (StarLeftDestructive _+_ _∙_ _*) × (StarRightDestructive _+_ _∙_ _*)
-
 LeftAlternative : Op₂ A → Set _
 LeftAlternative _∙_ = ∀ x y  →  ((x ∙ x) ∙ y) ≈ (x ∙ (x ∙ y))
 
@@ -239,3 +222,45 @@ MiddleBol _∙_ _\\_ _//_ = ∀ x y z → (x ∙ ((y ∙ z) \\ x)) ≈ ((x // z)
 
 Identical : Op₂ A → Set _
 Identical _∙_ = ∀ x y z → ((z ∙ x) ∙ (y ∙ z)) ≈ (z ∙ ((x ∙ y) ∙ z))
+
+
+------------------------------------------------------------------------
+-- DEPRECATED NAMES
+------------------------------------------------------------------------
+-- Please use the new names as continuing support for the old names is
+-- not guaranteed.
+
+-- Version 3.0
+
+module _ (e : A) (_+_ _*_ : Op₂ A) (_⋆ : Op₁ A) where
+  StarLeftExpansive = Definitions.StarLeftExpansive _≈_ e _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarLeftExpansive
+  "Warning: StarLeftExpansive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarLeftExpansive instead."
+  #-}
+  StarRightExpansive = Definitions.StarRightExpansive _≈_ e _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarRightExpansive
+  "Warning: StarRightExpansive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarRightExpansive instead."
+  #-}
+  StarExpansive = Definitions.StarExpansive _≈_ e _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarExpansive
+  "Warning: StarExpansive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarExpansive instead."
+  #-}
+module _ (_+_ _*_ : Op₂ A) (_⋆ : Op₁ A) where
+  StarLeftDestructive = Definitions.StarLeftDestructive _≈_ _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarLeftDestructive
+  "Warning: StarLeftDestructive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarLeftDestructive instead."
+  #-}
+  StarRightDestructive = Definitions.StarRightDestructive _≈_ _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarRightDestructive
+  "Warning: StarRightDestructive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarRightDestructive instead."
+  #-}
+  StarDestructive = Definitions.StarDestructive _≈_ _+_ _*_ _⋆
+  {-# WARNING_ON_USAGE StarDestructive
+  "Warning: StarDestructive was deprecated in v3.0.
+  Please use Relation.Binary.Definitions.StarDestructive instead."
+  #-}

--- a/src/Algebra/Definitions.agda
+++ b/src/Algebra/Definitions.agda
@@ -25,8 +25,8 @@ module Algebra.Definitions
 open import Algebra.Core using (Op₁; Op₂)
 open import Data.Product.Base using (_×_; ∃-syntax)
 open import Data.Sum.Base using (_⊎_)
-open import Relation.Binary.Definitions as Definitions
-  using (Monotonic₁; Monotonic₂)
+open import Relation.Binary.Definitions
+  using (Monotonic₁; Monotonic₂; module KleeneAlgebra)
 open import Relation.Nullary.Negation.Core using (¬_)
 
 
@@ -232,35 +232,28 @@ Identical _∙_ = ∀ x y z → ((z ∙ x) ∙ (y ∙ z)) ≈ (z ∙ ((x ∙ y) 
 
 -- Version 3.0
 
-module _ (e : A) (_+_ _*_ : Op₂ A) (_⋆ : Op₁ A) where
-  StarLeftExpansive = Definitions.StarLeftExpansive _≈_ e _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarLeftExpansive
-  "Warning: StarLeftExpansive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarLeftExpansive instead."
-  #-}
-  StarRightExpansive = Definitions.StarRightExpansive _≈_ e _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarRightExpansive
-  "Warning: StarRightExpansive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarRightExpansive instead."
-  #-}
-  StarExpansive = Definitions.StarExpansive _≈_ e _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarExpansive
-  "Warning: StarExpansive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarExpansive instead."
-  #-}
-module _ (_+_ _*_ : Op₂ A) (_⋆ : Op₁ A) where
-  StarLeftDestructive = Definitions.StarLeftDestructive _≈_ _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarLeftDestructive
-  "Warning: StarLeftDestructive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarLeftDestructive instead."
-  #-}
-  StarRightDestructive = Definitions.StarRightDestructive _≈_ _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarRightDestructive
-  "Warning: StarRightDestructive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarRightDestructive instead."
-  #-}
-  StarDestructive = Definitions.StarDestructive _≈_ _+_ _*_ _⋆
-  {-# WARNING_ON_USAGE StarDestructive
-  "Warning: StarDestructive was deprecated in v3.0.
-  Please use Relation.Binary.Definitions.StarDestructive instead."
-  #-}
+open KleeneAlgebra _≈_ public
+{-# WARNING_ON_USAGE StarLeftExpansive
+"Warning: StarLeftExpansive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarLeftExpansive instead."
+#-}
+{-# WARNING_ON_USAGE StarRightExpansive
+"Warning: StarRightExpansive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarRightExpansive instead."
+#-}
+{-# WARNING_ON_USAGE StarExpansive
+"Warning: StarExpansive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarExpansive instead."
+#-}
+{-# WARNING_ON_USAGE StarLeftDestructive
+"Warning: StarLeftDestructive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarLeftDestructive instead."
+#-}
+{-# WARNING_ON_USAGE StarRightDestructive
+"Warning: StarRightDestructive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarRightDestructive instead."
+#-}
+{-# WARNING_ON_USAGE StarDestructive
+"Warning: StarDestructive was deprecated in v3.0.
+Please use Relation.Binary.Definitions.KleeneAlgebra.StarDestructive instead."
+#-}

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -27,7 +27,7 @@ import Algebra.Consequences.Setoid as Consequences
 open import Data.Product.Base using (_,_; proj₁; proj₂)
 open import Level using (_⊔_)
 open import Relation.Binary.Definitions
-  using (StarLeftExpansive; StarRightExpansive; StarExpansive
+  using (module KleeneAlgebra; StarLeftExpansive; StarRightExpansive; StarExpansive
         ; StarLeftDestructive; StarRightDestructive; StarDestructive)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
@@ -671,21 +671,25 @@ record IsIdempotentSemiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
 record IsKleeneAlgebra (+ * : Op₂ A) (⋆ : Op₁ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field
     isIdempotentSemiring  : IsIdempotentSemiring + * 0# 1#
-    starExpansive         : StarExpansive _≈_ 1# + * ⋆
-    starDestructive       : StarDestructive _≈_ + * ⋆
+
+  open KleeneAlgebra _≈_
+
+  field
+    starExpansive         : StarExpansive 1# + * ⋆
+    starDestructive       : StarDestructive + * ⋆
 
   open IsIdempotentSemiring isIdempotentSemiring public
 
-  starExpansiveˡ : StarLeftExpansive _≈_ 1# + * ⋆
+  starExpansiveˡ : StarLeftExpansive 1# + * ⋆
   starExpansiveˡ = proj₁ starExpansive
 
-  starExpansiveʳ : StarRightExpansive _≈_ 1# + * ⋆
+  starExpansiveʳ : StarRightExpansive 1# + * ⋆
   starExpansiveʳ = proj₂ starExpansive
 
-  starDestructiveˡ : StarLeftDestructive _≈_ + * ⋆
+  starDestructiveˡ : StarLeftDestructive + * ⋆
   starDestructiveˡ = proj₁ starDestructive
 
-  starDestructiveʳ : StarRightDestructive _≈_ + * ⋆
+  starDestructiveʳ : StarRightDestructive + * ⋆
   starDestructiveʳ = proj₂ starDestructive
 
 

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -27,8 +27,7 @@ import Algebra.Consequences.Setoid as Consequences
 open import Data.Product.Base using (_,_; proj₁; proj₂)
 open import Level using (_⊔_)
 open import Relation.Binary.Definitions
-  using (module KleeneAlgebra; StarLeftExpansive; StarRightExpansive; StarExpansive
-        ; StarLeftDestructive; StarRightDestructive; StarDestructive)
+  using (module KleeneAlgebra)
 open import Relation.Binary.Bundles using (Setoid)
 open import Relation.Binary.Structures using (IsEquivalence)
 

--- a/src/Algebra/Structures.agda
+++ b/src/Algebra/Structures.agda
@@ -10,8 +10,6 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Relation.Binary.Core using (Rel)
-open import Relation.Binary.Bundles using (Setoid)
-open import Relation.Binary.Structures using (IsEquivalence)
 
 module Algebra.Structures
   {a ℓ} {A : Set a}  -- The underlying set
@@ -23,9 +21,17 @@ module Algebra.Structures
 
 open import Algebra.Core using (Op₁; Op₂)
 open import Algebra.Definitions _≈_
+  hiding (StarLeftExpansive; StarRightExpansive; StarExpansive
+         ; StarLeftDestructive; StarRightDestructive; StarDestructive)
 import Algebra.Consequences.Setoid as Consequences
 open import Data.Product.Base using (_,_; proj₁; proj₂)
 open import Level using (_⊔_)
+open import Relation.Binary.Definitions
+  using (StarLeftExpansive; StarRightExpansive; StarExpansive
+        ; StarLeftDestructive; StarRightDestructive; StarDestructive)
+open import Relation.Binary.Bundles using (Setoid)
+open import Relation.Binary.Structures using (IsEquivalence)
+
 import Relation.Binary.Reasoning.Setoid as ≈-Reasoning
 
 ------------------------------------------------------------------------
@@ -665,22 +671,23 @@ record IsIdempotentSemiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
 record IsKleeneAlgebra (+ * : Op₂ A) (⋆ : Op₁ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field
     isIdempotentSemiring  : IsIdempotentSemiring + * 0# 1#
-    starExpansive         : StarExpansive 1# + * ⋆
-    starDestructive       : StarDestructive + * ⋆
+    starExpansive         : StarExpansive _≈_ 1# + * ⋆
+    starDestructive       : StarDestructive _≈_ + * ⋆
 
   open IsIdempotentSemiring isIdempotentSemiring public
 
-  starExpansiveˡ : StarLeftExpansive 1# + * ⋆
+  starExpansiveˡ : StarLeftExpansive _≈_ 1# + * ⋆
   starExpansiveˡ = proj₁ starExpansive
 
-  starExpansiveʳ : StarRightExpansive 1# + * ⋆
+  starExpansiveʳ : StarRightExpansive _≈_ 1# + * ⋆
   starExpansiveʳ = proj₂ starExpansive
 
-  starDestructiveˡ : StarLeftDestructive + * ⋆
+  starDestructiveˡ : StarLeftDestructive _≈_ + * ⋆
   starDestructiveˡ = proj₁ starDestructive
 
-  starDestructiveʳ : StarRightDestructive + * ⋆
+  starDestructiveʳ : StarRightDestructive _≈_ + * ⋆
   starDestructiveʳ = proj₂ starDestructive
+
 
 record IsQuasiring (+ * : Op₂ A) (0# 1# : A) : Set (a ⊔ ℓ) where
   field

--- a/src/Relation/Binary/Definitions.agda
+++ b/src/Relation/Binary/Definitions.agda
@@ -180,27 +180,29 @@ Adjoint _≤_ _⊑_ f g = ∀ {x y} → (f x ⊑ y → x ≤ g y) × (x ≤ g y 
 
 -- Definitions for the Kleene Algebra ordering
 
-module _ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
+module KleeneAlgebra (_≤_ : Rel A ℓ₁) where
 
-  StarRightExpansive :  Set _
-  StarRightExpansive = ∀ x → (e + (x * (x ⋆))) ≤ (x ⋆)
+  module _ (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
 
-  StarLeftExpansive : Set _
-  StarLeftExpansive = ∀ x →  (e + ((x ⋆) * x)) ≤ (x ⋆)
+    StarRightExpansive :  Set _
+    StarRightExpansive = ∀ x → (e + (x * (x ⋆))) ≤ (x ⋆)
 
-  StarExpansive : Set _
-  StarExpansive = StarLeftExpansive × StarRightExpansive
+    StarLeftExpansive : Set _
+    StarLeftExpansive = ∀ x →  (e + ((x ⋆) * x)) ≤ (x ⋆)
 
-module _ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
+    StarExpansive : Set _
+    StarExpansive = StarLeftExpansive × StarRightExpansive
 
-  StarLeftDestructive : Set _
-  StarLeftDestructive = ∀ a b x → (b + (a * x)) ≤ x → ((a ⋆) * b) ≤ x
+  module _ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
 
-  StarRightDestructive : Set _
-  StarRightDestructive = ∀ a b x → (b + (x * a)) ≤ x → (b * (a ⋆)) ≤ x
+    StarLeftDestructive : Set _
+    StarLeftDestructive = ∀ a b x → (b + (a * x)) ≤ x → ((a ⋆) * b) ≤ x
 
-  StarDestructive : Set _
-  StarDestructive = StarLeftDestructive × StarRightDestructive
+    StarRightDestructive : Set _
+    StarRightDestructive = ∀ a b x → (b + (x * a)) ≤ x → (b * (a ⋆)) ≤ x
+
+    StarDestructive : Set _
+    StarDestructive = StarLeftDestructive × StarRightDestructive
 
 -- Unary relations respecting a binary relation.
 

--- a/src/Relation/Binary/Definitions.agda
+++ b/src/Relation/Binary/Definitions.agda
@@ -14,6 +14,7 @@ open import Agda.Builtin.Equality using (_≡_)
 open import Data.Product.Base using (_×_; ∃-syntax)
 open import Data.Sum.Base using (_⊎_)
 open import Function.Base using (_on_; flip)
+open import Function.Core using (Fun₁; Fun₂)
 open import Level using (Level; _⊔_; suc)
 open import Relation.Binary.Core
 open import Relation.Nullary as Nullary using (¬_; Dec)
@@ -176,6 +177,30 @@ Antitonic₂ _≤_ _⊑_ = Monotonic₂ (flip _≤_) (flip _⊑_)
 
 Adjoint : Rel A ℓ₁ → Rel B ℓ₂ → (A → B) → (B → A) → Set _
 Adjoint _≤_ _⊑_ f g = ∀ {x y} → (f x ⊑ y → x ≤ g y) × (x ≤ g y → f x ⊑ y)
+
+-- Definitions for the Kleene Algebra ordering
+
+module _ (_≤_ : Rel A ℓ₁) (e : A) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
+
+  StarRightExpansive :  Set _
+  StarRightExpansive = ∀ x → (e + (x * (x ⋆))) ≤ (x ⋆)
+
+  StarLeftExpansive : Set _
+  StarLeftExpansive = ∀ x →  (e + ((x ⋆) * x)) ≤ (x ⋆)
+
+  StarExpansive : Set _
+  StarExpansive = StarLeftExpansive × StarRightExpansive
+
+module _ (_≤_ : Rel A ℓ₁) (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) where
+
+  StarLeftDestructive : Set _
+  StarLeftDestructive = ∀ a b x → (b + (a * x)) ≤ x → ((a ⋆) * b) ≤ x
+
+  StarRightDestructive : Set _
+  StarRightDestructive = ∀ a b x → (b + (x * a)) ≤ x → (b * (a ⋆)) ≤ x
+
+  StarDestructive : Set _
+  StarDestructive = StarLeftDestructive × StarRightDestructive
 
 -- Unary relations respecting a binary relation.
 


### PR DESCRIPTION
This is a backwards compatible first step towards fixing #3003 : (so not actually fixing a `bug` as such, more infrastructure on the way to doing so)
* moves the various definitions from `Algebra.Definitions` to `Relation.Binary.Definitions`, with an additional `_≤_ : Rel A ℓ₁` parameter
* deprecates the old versions in `Algebra.Definitions`
* refactors `Algebra.Structures.KleeneAlgebra` to plumb in the existing equality as the new relational parameter.

This is an interim step, intended as low-hanging-fruit to review and merge, before considering larger-scale non-backwards-compatible restructuring to support the Kozen *inequational* axiomatisation of `IsKleeneAlgebra` in terms of the `_≤_` definable in any `IsCommutativeBand`.