### PR TITLE
Add tool to scan for references of deleted or renamed READMEs

### DIFF
--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -15,7 +15,7 @@ echo "Searching for deleted READMEs..."
 git diff --diff-filter DR --name-status master \
     | awk '{print $2}' \
     | grep '^doc/README/' \
-    | while read file; do
+    | while read -r file; do
     echo "$file was deleted, scanning for references"
    
     # remove 'doc/' and '.agda, replace / with .
@@ -35,7 +35,7 @@ git diff --diff-filter DR --name-status master \
     #         "-- see README.A for some notes. :-)"
     #      or "-- see README.A"
     # but not "-- see README.A.Some.Sub.Module"
-    grep -r -E ".*$module([^\.].*)?$" | while read ref; do
+    grep -r -E ".*$module([^\.].*)?$" | while read -r ref; do
         echo "ERROR: file referenced: $ref" >&2
         exit 1
     done

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# This script searches through any READMEs which have been removed from 
+# the current branch (via a diff with master) and scans for references
+# for them in existing READMEs
+#
+# If a reference to a now deleted README is found, an error is raised
+
+echo "Searching for deleted READMEs"
+
+git diff --diff-filter D --name-only master | grep '^doc/README/' | while read file; do
+    echo "$p was deleted, scanning for references"
+done
+

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -9,6 +9,6 @@
 echo "Searching for deleted READMEs"
 
 git diff --diff-filter D --name-only master | grep '^doc/README/' | while read file; do
-    echo "$p was deleted, scanning for references"
+    echo "$file was deleted, scanning for references"
 done
 

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 
-# This script searches through any READMEs which have been removed from 
-# the current branch (via a diff with master) and scans for references
+# This script searches through any READMEs which have
+# been removed (or renamed) from the current branch 
+# (via a diff with master) and scans for references
 # for them in existing READMEs
 #
-# If a reference to a now deleted README is found, an error is raised
+# If a reference to a now deleted/renamed README is 
+# found, an error is raised (exit code 1)
 #
 # Silas Hayes-Williams, 2026
 
 echo "Searching for deleted READMEs..."
 
-git diff --diff-filter DR --name-status master | awk '{print $2}' | grep '^doc/README/' | while read file; do
+git diff --diff-filter DR --name-status master \
+    | awk '{print $2}' \
+    | grep '^doc/README/' \
+    | while read file; do
     echo "$file was deleted, scanning for references"
    
     # remove 'doc/' and '.agda, replace / with .
@@ -19,14 +24,17 @@ git diff --diff-filter DR --name-status master | awk '{print $2}' | grep '^doc/R
     module=${module//\//.} 
     
     # search for *any* reference to the README
-    # be it an import, in a comment, or wherever else
-    # ([^\.]*)?$ says the module must be followed by *not* a . and any other text, or followed
-    # by nothing
+    # be it an import, in a comment, or wherever 
+    # else. 
     #
-    # E.g. if README.Axiom was deleted, then it would match
-    #         "-- see README.Axiom for some notes. :-)"
-    #      or "-- see README.Axiom"
-    # but not "-- see README.Axiom.Some.Sub.Mod"
+    # ([^\.]*)?$ says the module must be followed 
+    # by *anything but* a '.' + any other text, or 
+    # followed by nothing at all
+    #
+    # E.g. if README.A was deleted, then it would match
+    #         "-- see README.A for some notes. :-)"
+    #      or "-- see README.A"
+    # but not "-- see README.A.Some.Sub.Module"
     grep -r -E ".*$module([^\.].*)?$" | while read ref; do
         echo "ERROR: file referenced: $ref" >&2
         exit 1

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -3,7 +3,7 @@
 # This script searches through any READMEs which have
 # been removed (or renamed) from the current branch 
 # (via a diff with master) and scans for references
-# for them in existing READMEs
+# for them in all files within the curretn working directory
 #
 # If a reference to a now deleted/renamed README is 
 # found, an error is raised (exit code 1)

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -39,6 +39,10 @@ git diff --diff-filter DR --name-status master \
         echo "ERROR: file referenced: $ref" >&2
         exit 1
     done
+
+    if [[ $? == 1 ]]; then
+        exit 1
+    fi
 done
 
 exit

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -10,9 +10,17 @@ set -eu
 #
 # Silas Hayes-Williams, 2026
 
+if [[ "$1" =~ ^(-h|--help)$ ]]; then
+    printf "usage: defunct-readme [-h | --help] <branch>\n\n"
+    printf "Scan for all README files deleted or renamed on the
+current branch (compared to <branch>) and check for references in
+remaining files. An error is thrown if any reference is found.\n"
+    exit
+fi
+
 echo "Searching for deleted READMEs..."
 
-git diff --diff-filter DR --name-status master \
+git diff --diff-filter DR --name-status $1 \
     | awk '{print $2}' \
     | grep '^doc/README/' \
     | while read -r file; do
@@ -44,5 +52,3 @@ git diff --diff-filter DR --name-status master \
         exit 1
     fi
 done
-
-exit

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -6,9 +6,22 @@
 #
 # If a reference to a now deleted README is found, an error is raised
 
-echo "Searching for deleted READMEs"
+echo "Searching for deleted READMEs..."
 
 git diff --diff-filter D --name-only master | grep '^doc/README/' | while read file; do
     echo "$file was deleted, scanning for references"
+   
+    # remove 'doc/' and '.agda, replace / with .
+    module=${file#"doc/"}
+    module=${module%".agda"}
+    module=${module//\//.} 
+    
+    # search for *any* reference to the README
+    # be it an import, in a comment, or wherever else
+    grep -r ".*$module.*" | while read ref; do
+        echo "ERROR: file referenced: $ref" >&2
+        exit 1
+    done
 done
 
+exit

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -eu
 # This script searches through any READMEs which have
 # been removed (or renamed) from the current branch 
 # (via a diff with master) and scans for references

--- a/.github/tooling/defunct-readme.sh
+++ b/.github/tooling/defunct-readme.sh
@@ -5,10 +5,12 @@
 # for them in existing READMEs
 #
 # If a reference to a now deleted README is found, an error is raised
+#
+# Silas Hayes-Williams, 2026
 
 echo "Searching for deleted READMEs..."
 
-git diff --diff-filter D --name-only master | grep '^doc/README/' | while read file; do
+git diff --diff-filter DR --name-status master | awk '{print $2}' | grep '^doc/README/' | while read file; do
     echo "$file was deleted, scanning for references"
    
     # remove 'doc/' and '.agda, replace / with .
@@ -18,7 +20,14 @@ git diff --diff-filter D --name-only master | grep '^doc/README/' | while read f
     
     # search for *any* reference to the README
     # be it an import, in a comment, or wherever else
-    grep -r ".*$module.*" | while read ref; do
+    # ([^\.]*)?$ says the module must be followed by *not* a . and any other text, or followed
+    # by nothing
+    #
+    # E.g. if README.Axiom was deleted, then it would match
+    #         "-- see README.Axiom for some notes. :-)"
+    #      or "-- see README.Axiom"
+    # but not "-- see README.Axiom.Some.Sub.Mod"
+    grep -r -E ".*$module([^\.].*)?$" | while read ref; do
         echo "ERROR: file referenced: $ref" >&2
         exit 1
     done


### PR DESCRIPTION
- Added `.github/tooling/defunct-readme.sh`, which compares the current branch against `master` to see if any READMEs have been deleted, and if so scans for references to that README in other files. If any are found, the script exits with an error
- CI hasn't been modified to use it yet
- Currently the script exits on the first error, but it shouldn't be hard to update it to list all errors before exiting
- Partially addresses #3037 