### PR TITLE
Added properties about DiffList in Data.DifferenceList.Properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,10 @@ New modules
 * `Data.Bool.ListAction.Properties` for properties of conjunction and
   disjunction of lists.
 
+* `Data.DifferenceList` has been refactored to reexport the contents of two new modules:
+  - `Data.DifferenceList.Base`
+  - `Data.DifferenceList.Properties`
+
 * A new type of lists that grow on the right.
   This is typically useful to model contexts of typing rules
   or type accumulators that need to be reversed in the base case.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,11 @@ Deprecated names
   homo  ↦  ∙-homo
   ```
 
+* In `Data.DifferenceList.Base`:
+  ```agda
+  lift ↦ _++_
+  ```
+
 * In `Data.Fin.Properties`:
   ```agda
   _≟_      ↦  _≡?_

--- a/src/Data/DifferenceList.agda
+++ b/src/Data/DifferenceList.agda
@@ -1,7 +1,10 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- A DiffList is a List with fast append
+-- A DiffList is a List with fast append.
+-- Based on Hughes' 'A NOVEL REPRESENTATION OF LISTS AND ITS APPLICATION
+-- TO THE FUNCTION "REVERSE"'
+-- DiffList is the Cayley representation for the List.++ monoid.
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}

--- a/src/Data/DifferenceList.agda
+++ b/src/Data/DifferenceList.agda
@@ -1,84 +1,12 @@
 ------------------------------------------------------------------------
 -- The Agda standard library
 --
--- Lists with fast append
+-- A DiffList is a List with fast append
 ------------------------------------------------------------------------
 
 {-# OPTIONS --without-K --safe #-}
 
 module Data.DifferenceList where
 
-open import Level using (Level)
-open import Data.List.Base as List using (List)
-open import Function.Base using (_⟨_⟩_)
-open import Data.Nat.Base using (ℕ)
-
-private
-  variable
-    a b : Level
-    A : Set a
-    B : Set b
-
-------------------------------------------------------------------------
--- Type definition and list function lifting
-
-DiffList : Set a → Set a
-DiffList A = List A → List A
-
-lift : (List A → List A) → (DiffList A → DiffList A)
-lift f xs = λ k → f (xs k)
-
-------------------------------------------------------------------------
--- Building difference lists
-
-infixr 5 _∷_ _++_
-
-[] : DiffList A
-[] = λ k → k
-
-_∷_ : A → DiffList A → DiffList A
-_∷_ x = lift (x List.∷_)
-
-[_] : A → DiffList A
-[ x ] = x ∷ []
-
-_++_ : DiffList A → DiffList A → DiffList A
-xs ++ ys = λ k → xs (ys k)
-
-infixl 6 _∷ʳ_
-_∷ʳ_ : DiffList A → A → DiffList A
-xs ∷ʳ x = λ k → xs (x List.∷ k)
-
-------------------------------------------------------------------------
--- Conversion back and forth with List
-
-toList : DiffList A → List A
-toList xs = xs List.[]
-
--- fromList xs is linear in the length of xs.
-
-fromList : List A → DiffList A
-fromList xs = λ k → xs ⟨ List._++_ ⟩ k
-
-------------------------------------------------------------------------
--- Transforming difference lists
-
--- It is OK to use List._++_ here, since map is linear in the length of
--- the list anyway.
-
-map : (A → B) → DiffList A → DiffList B
-map f xs = λ k → List.map f (toList xs) ⟨ List._++_ ⟩ k
-
--- concat is linear in the length of the outer list.
-
-concat : DiffList (DiffList A) → DiffList A
-concat xs = concat′ (toList xs)
-  where
-  concat′ : List (DiffList A) → DiffList A
-  concat′ = List.foldr _++_ []
-
-take : ℕ → DiffList A → DiffList A
-take n = lift (List.take n)
-
-drop : ℕ → DiffList A → DiffList A
-drop n = lift (List.drop n)
+open import Data.DifferenceList.Base public
+open import Data.DifferenceList.Properties public

--- a/src/Data/DifferenceList/Base.agda
+++ b/src/Data/DifferenceList/Base.agda
@@ -59,7 +59,7 @@ toList xs = xs List.[]
 -- fromList xs is linear in the length of xs.
 
 fromList : List A → DiffList A
-fromList xs = λ k → xs ⟨ List._++_ ⟩ k
+fromList xs = λ k → xs List.++ k
 
 ------------------------------------------------------------------------
 -- Transforming difference lists

--- a/src/Data/DifferenceList/Base.agda
+++ b/src/Data/DifferenceList/Base.agda
@@ -10,7 +10,6 @@ module Data.DifferenceList.Base where
 
 open import Level using (Level)
 open import Data.List.Base as List using (List)
-open import Function.Base using (_⟨_⟩_)
 open import Data.Nat.Base using (ℕ)
 
 private
@@ -59,7 +58,7 @@ toList xs = xs List.[]
 -- fromList xs is linear in the length of xs.
 
 fromList : List A → DiffList A
-fromList xs = λ k → xs List.++ k
+fromList = List._++_
 
 ------------------------------------------------------------------------
 -- Transforming difference lists
@@ -68,7 +67,7 @@ fromList xs = λ k → xs List.++ k
 -- the list anyway.
 
 map : (A → B) → DiffList A → DiffList B
-map f xs = λ k → List.map f (toList xs) ⟨ List._++_ ⟩ k
+map f xs = List.map f (toList xs) List.++_
 
 -- concat is linear in the length of the outer list.
 

--- a/src/Data/DifferenceList/Base.agda
+++ b/src/Data/DifferenceList/Base.agda
@@ -21,7 +21,7 @@ private
 
 
 ------------------------------------------------------------------------
--- Type definition and list function lifting
+-- Type definition
 
 DiffList : Set a → Set a
 DiffList A = List A → List A

--- a/src/Data/DifferenceList/Base.agda
+++ b/src/Data/DifferenceList/Base.agda
@@ -1,0 +1,85 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- DiffList: basic types and operations
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.DifferenceList.Base where
+
+open import Level using (Level)
+open import Data.List.Base as List using (List)
+open import Function.Base using (_⟨_⟩_)
+open import Data.Nat.Base using (ℕ)
+
+private
+  variable
+    a b : Level
+    A : Set a
+    B : Set b
+
+
+------------------------------------------------------------------------
+-- Type definition and list function lifting
+
+DiffList : Set a → Set a
+DiffList A = List A → List A
+
+lift : (List A → List A) → (DiffList A → DiffList A)
+lift f xs = λ k → f (xs k)
+
+------------------------------------------------------------------------
+-- Building difference lists
+
+infixr 5 _∷_ _++_
+
+[] : DiffList A
+[] = λ k → k
+
+_∷_ : A → DiffList A → DiffList A
+_∷_ x = lift (x List.∷_)
+
+[_] : A → DiffList A
+[ x ] = x ∷ []
+
+_++_ : DiffList A → DiffList A → DiffList A
+xs ++ ys = λ k → xs (ys k)
+
+infixl 6 _∷ʳ_
+_∷ʳ_ : DiffList A → A → DiffList A
+xs ∷ʳ x = λ k → xs (x List.∷ k)
+
+------------------------------------------------------------------------
+-- Conversion back and forth with List
+
+toList : DiffList A → List A
+toList xs = xs List.[]
+
+-- fromList xs is linear in the length of xs.
+
+fromList : List A → DiffList A
+fromList xs = λ k → xs ⟨ List._++_ ⟩ k
+
+------------------------------------------------------------------------
+-- Transforming difference lists
+
+-- It is OK to use List._++_ here, since map is linear in the length of
+-- the list anyway.
+
+map : (A → B) → DiffList A → DiffList B
+map f xs = λ k → List.map f (toList xs) ⟨ List._++_ ⟩ k
+
+-- concat is linear in the length of the outer list.
+
+concat : DiffList (DiffList A) → DiffList A
+concat xs = concat′ (toList xs)
+  where
+  concat′ : List (DiffList A) → DiffList A
+  concat′ = List.foldr _++_ []
+
+take : ℕ → DiffList A → DiffList A
+take n = lift (List.take n)
+
+drop : ℕ → DiffList A → DiffList A
+drop n = lift (List.drop n)

--- a/src/Data/DifferenceList/Base.agda
+++ b/src/Data/DifferenceList/Base.agda
@@ -68,7 +68,7 @@ fromList xs = λ k → xs List.++ k
 -- the list anyway.
 
 map : (A → B) → DiffList A → DiffList B
-map f xs = λ k → List.map f (toList xs) ⟨ List._++_ ⟩ k
+map = fromList ∘′ List.map f ∘′ toList
 
 -- concat is linear in the length of the outer list.
 

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -15,7 +15,7 @@ open import Data.List.Properties using (++-assoc; ++-identityʳ)
 open import Function using (id)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; cong; sym; _≗_; module ≡-Reasoning)
+  using (_≡_; refl; cong; _≗_; module ≡-Reasoning)
 
 open ≡-Reasoning
 
@@ -46,7 +46,7 @@ toList∘fromList = ++-identityʳ
 
 toList⁺ : xs ∼ ys → xs ≡ toList ys
 toList⁺ {xs = xs} {ys} xs∼ys = begin
-  xs                  ≡⟨ sym (++-identityʳ xs) ⟩
+  xs                  ≡⟨ (++-identityʳ xs) ⟨
   xs List.++ List.[]  ≡⟨ xs∼ys List.[] ⟩
   ys List.[]          ≡⟨⟩
   toList ys           ∎
@@ -77,12 +77,7 @@ toList⁺ {xs = xs} {ys} xs∼ys = begin
 ++-∷⁺ x xs₁∼ys₁ xs₂∼ys₂ = ++⁺ xs₁∼ys₁ (∷⁺ x xs₂∼ys₂)
 
 ∷ʳ⁺ : (x : A) → xs ∼ ys → xs List.∷ʳ x ∼ ys ∷ʳ x
-∷ʳ⁺ {xs = xs} {ys} x xs∼ys k = begin
-  xs List.∷ʳ x List.++ k             ≡⟨⟩
-  (xs List.++ List.[ x ]) List.++ k  ≡⟨ ++-assoc xs List.[ x ] k ⟩
-  xs List.++ (x List.∷ k)            ≡⟨ xs∼ys (x List.∷ k) ⟩
-  ys (x List.∷ k)                    ≡⟨⟩
-  (ys ∷ʳ x) k                        ∎
+∷ʳ⁺ {xs = xs} {ys} x xs∼ys k = ++⁺ xs∼ys [ x ]⁺ k
 
 map⁺ : (f : A → B) → xs ∼ ys → List.map f xs ∼ map f ys
 map⁺ f xs∼ys k =

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -46,7 +46,7 @@ toList∘fromList = ++-identityʳ
 
 toList⁺ : xs ∼ ys → xs ≡ toList ys
 toList⁺ {xs = xs} {ys} xs∼ys = begin
-  xs                  ≡⟨ (++-identityʳ xs) ⟨
+  xs                  ≡⟨ ++-identityʳ xs ⟨
   xs List.++ List.[]  ≡⟨ xs∼ys List.[] ⟩
   ys List.[]          ≡⟨⟩
   toList ys           ∎

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -51,9 +51,6 @@ toList⁺ {xs = xs} {ys} xs∼ys = begin
   ys List.[]          ≡⟨⟩
   toList ys           ∎
 
-fromList⁺ : xs ∼ ys → (k : List A) → fromList xs k ≡ ys k
-fromList⁺ = id
-
 ------------------------------------------------------------------------
 -- Properties of operations that preserve _∼_
 

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -1,0 +1,104 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of operations on DiffList
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+module Data.DifferenceList.Properties where
+
+open import Data.DifferenceList.Base
+  using (DiffList; fromList; toList; lift; []; _∷_; [_]; _++_; _∷ʳ_; map)
+open import Data.List as List using (List)
+open import Data.List.Properties using (++-assoc; ++-identityʳ)
+open import Function using (id)
+open import Level using (Level)
+open import Relation.Binary.PropositionalEquality
+  using (_≡_; refl; cong; sym; module ≡-Reasoning)
+
+open ≡-Reasoning
+
+private
+  variable
+    a b : Level
+    A : Set a
+    B : Set b
+    xs xs₁ xs₂ : List A
+    ys ys₁ ys₂ : DiffList A
+
+
+------------------------------------------------------------------------
+-- Relation between Lists and equivalent DiffLists
+
+infix 4 _∼_
+_∼_ : {A : Set a} → List A → DiffList A → Set a
+_∼_ {A = A} xs ys = (k : List A) → fromList xs k ≡ ys k
+
+------------------------------------------------------------------------
+-- Properties of fromList and toList
+
+∼-fromList : xs ∼ fromList xs
+∼-fromList _ = refl
+
+toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
+toList∘fromList = ++-identityʳ
+
+toList⁺ : xs ∼ ys → xs ≡ toList ys
+toList⁺ {xs = xs} {ys} xs∼ys = begin
+  xs                  ≡⟨ sym (++-identityʳ xs) ⟩
+  xs List.++ List.[]  ≡⟨ xs∼ys List.[] ⟩
+  ys List.[]          ≡⟨⟩
+  toList ys           ∎
+
+fromList⁺ : xs ∼ ys → (k : List A) → fromList xs k ≡ ys k
+fromList⁺ = id
+
+------------------------------------------------------------------------
+-- Properties of operations that preserve _∼_
+
+-- `lift` preserves `∼` when `f` is a prepend
+lift⁺ : (f : List A → List A) →
+        (∀ xs′ → f xs′ ≡ f List.[] List.++ xs′) →
+        xs ∼ ys → f xs ∼ lift f ys
+lift⁺ {xs = xs} {ys = ys} f prepend xs∼ys k = begin
+  f xs List.++ k                    ≡⟨ cong (List._++ k) (prepend xs) ⟩
+  (f List.[] List.++ xs) List.++ k  ≡⟨ ++-assoc (f List.[]) xs k ⟩
+  f List.[] List.++ (xs List.++ k)  ≡⟨ sym (prepend (xs List.++ k)) ⟩
+  f (xs List.++ k)                  ≡⟨ cong f (xs∼ys k) ⟩
+  f (ys k)                          ≡⟨⟩
+  lift f ys k                       ∎
+
+[]⁺ : List.[] {A = A} ∼ []
+[]⁺ _ = refl
+
+∷⁺ : (x : A) → xs ∼ ys → x List.∷ xs ∼ x ∷ ys
+∷⁺ x = lift⁺ (x List.∷_) (λ _ → refl)
+
+[_]⁺ : (x : A) → List.[ x ] ∼ [ x ]
+[_]⁺ _ _ = refl
+
+++⁺ : xs₁ ∼ ys₁ → xs₂ ∼ ys₂ → xs₁ List.++ xs₂ ∼ ys₁ ++ ys₂
+++⁺ {xs₁ = xs₁} {ys₁ = ys₁} {xs₂ = xs₂} {ys₂ = ys₂}
+    xs₁∼ys₁ xs₂∼ys₂ k = begin
+  (xs₁ List.++ xs₂) List.++ k  ≡⟨ ++-assoc xs₁ xs₂ k ⟩
+  xs₁ List.++ (xs₂ List.++ k)  ≡⟨ cong (xs₁ List.++_) (xs₂∼ys₂ k) ⟩
+  xs₁ List.++ ys₂ k            ≡⟨ xs₁∼ys₁ (ys₂ k) ⟩
+  ys₁ (ys₂ k)                  ≡⟨⟩
+  (ys₁ ++ ys₂) k               ∎
+
+++-∷⁺ : (x : A) → xs₁ ∼ ys₁ → xs₂ ∼ ys₂ →
+        xs₁ List.++ x List.∷ xs₂ ∼ ys₁ ++ x ∷ ys₂
+++-∷⁺ x xs₁∼ys₁ xs₂∼ys₂ = ++⁺ xs₁∼ys₁ (∷⁺ x xs₂∼ys₂)
+
+∷ʳ⁺ : (x : A) → xs ∼ ys → xs List.∷ʳ x ∼ ys ∷ʳ x
+∷ʳ⁺ {xs = xs} {ys} x xs∼ys k = begin
+  xs List.∷ʳ x List.++ k             ≡⟨⟩
+  (xs List.++ List.[ x ]) List.++ k  ≡⟨ ++-assoc xs List.[ x ] k ⟩
+  xs List.++ (x List.∷ k)            ≡⟨ xs∼ys (x List.∷ k) ⟩
+  ys (x List.∷ k)                    ≡⟨⟩
+  (ys ∷ʳ x) k                        ∎
+
+map⁺ : (f : A → B) → xs ∼ ys → List.map f xs ∼ map f ys
+map⁺ f xs∼ys k =
+  cong (λ xs → fromList (List.map f xs) k) (toList⁺ xs∼ys)


### PR DESCRIPTION
This adds `Data.DifferenceList.Properties` and moves `Data.DifferenceList` to `Data.DifferenceList.Base`. `DiffList` is like `List` but has efficient `++`.

The new file is centered the new relation `xs ~ ys` between `xs : List A` and its equivalent `ys : DiffList A`. `~` is kind of like a simulation relation between `List` and `DiffList`. Each property shows preservation of a `List` op and its equivalent `DiffList` op. For example `map⁺` relates `List.map` and `DifferenceList.map`:
```
map⁺ : (f : A → B) → xs ∼ ys → List.map f xs ∼ map f ys
```

It was easier for me to define and use properties on the relation `xs ~ ys` than properties on a transport function between `List` and `DiffList` (i.e. `toList` or `fromList`). The transport approach seemed complicated because there are many `DiffList`s that aren't equivalent to `List`s.

This change is motivated by the characterization of `Data.Tree.AVL.Indexed.toList`, which was implemented using `DiffList` for efficiency. A followup PR for the AVL's `toList` will use this PR's `[]⁺` and `++-∷⁺` (pre-PR code is [here](https://github.com/mikedelorimier/agda-stdlib/blob/avl-to-list/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda)). `Properties` also adds similar properties that seemed natural but are not currently used: `∼-fromList` `toList∘fromList` `toList⁺` `fromList⁺` `[_]⁺` `∷ʳ⁺` `map⁺`. So let me know if you'd like to review this one as a self-contained change or wait for followup PRs and review them all at once.
