### PR TITLE
[ add ] syntax for `antisym` equality reasoning in `Relation.Binary.Reasoning.PartialOrder` #3047

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,3 +443,9 @@ Additions to existing modules
     StarRightDestructive  : ∀ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
     StarDestructive       : ∀ (_+_ _*_ : Fun₂ A) (_⋆ : Fun₁ A) → Set _
   ```
+
+* In `Relation.Binary.Reasoning.PartialOrder`:
+  ```agda
+  antisym-syntax = antisym
+  syntax antisym-syntax x≤y y≤x = x≤y ⟨⟩ y≤x
+  ```

--- a/src/Algebra/Properties/KleeneAlgebra.agda
+++ b/src/Algebra/Properties/KleeneAlgebra.agda
@@ -246,18 +246,16 @@ x⋆≈1+xx⋆ x = ≤-antisym (⋆-elimˡ (x≤x+y _ _) $ begin
   1# + x * x ⋆           ∎) $ starExpansiveʳ _
 
 x⋆≈1+x⋆x : ∀ x → x ⋆ ≈ 1# + x ⋆ * x
-x⋆≈1+x⋆x x = ≤-antisym (⋆-elimʳ (x≤x+y _ _) $ begin
-  (1# + x ⋆ * x) * x     ≤⟨ *-monoʳ _ $ +-monoˡ _ $ x⋆x≤x⋆ _ ⟩
-  (1# + x ⋆) * x         ≈⟨ *-congʳ (1+x⋆≈x⋆ _) ⟩
-  x ⋆ * x                ≤⟨ y≤x+y _ _ ⟩
-  1# + x ⋆ * x           ∎) $ starExpansiveˡ _
-
-{- FAILS: parser falls over
-  begin-equality
-  x ⋆ ≈⟨ {!!} ⟨⟩ ? ⟩
-  {!!} ≈⟨ {!!} ⟩
+x⋆≈1+x⋆x x =   begin-equality
+  x ⋆ ≈⟨ ⋆-elimʳ (x≤x+y _ _) lemma ⟨⟩ starExpansiveˡ _ ⟩
   1# + x ⋆ * x ∎
--}
+  where
+  lemma : (1# + x ⋆ * x) * x ≤ 1# + x ⋆ * x
+  lemma = begin
+    (1# + x ⋆ * x) * x     ≤⟨ *-monoʳ _ $ +-monoˡ _ $ x⋆x≤x⋆ _ ⟩
+    (1# + x ⋆) * x         ≈⟨ *-congʳ (1+x⋆≈x⋆ _) ⟩
+    x ⋆ * x                ≤⟨ y≤x+y _ _ ⟩
+    1# + x ⋆ * x           ∎
 
 -- special cases for 0# and 1#
 

--- a/src/Algebra/Properties/KleeneAlgebra.agda
+++ b/src/Algebra/Properties/KleeneAlgebra.agda
@@ -236,24 +236,29 @@ x≤x⋆ x = begin
 ⋆-*-elimʳ = starDestructiveʳ _ _ _ ∘ x≤z∧y≤z⇒[x+y]≤z ≤-refl
 
 1+x⋆≈x⋆ : ∀ x → 1# + x ⋆ ≈ x ⋆
-1+x⋆≈x⋆ x = ≤-antisym (x≤z∧y≤z⇒[x+y]≤z 1≤[ _ ]⋆ ≤-refl) (y≤x+y _ _)
+1+x⋆≈x⋆ x = x≤z∧y≤z⇒[x+y]≤z 1≤[ _ ]⋆ ≤-refl ⟨⟩ y≤x+y _ _
 
 x⋆≈1+xx⋆ : ∀ x → x ⋆ ≈ 1# + x * x ⋆
-x⋆≈1+xx⋆ x = ≤-antisym (⋆-elimˡ (x≤x+y _ _) $ begin
-  x * (1# + x * x ⋆)     ≤⟨ *-monoˡ _ $ +-monoˡ _ $ xx⋆≤x⋆ _ ⟩
-  x * (1# + x ⋆)         ≈⟨ *-congˡ (1+x⋆≈x⋆ _) ⟩
-  x * x ⋆                ≤⟨ y≤x+y _ _ ⟩
-  1# + x * x ⋆           ∎) $ starExpansiveʳ _
+x⋆≈1+xx⋆ x = begin-equality
+  x ⋆          ≈⟨ ⋆-elimˡ (x≤x+y _ _) lemma ⟨⟩ starExpansiveʳ _ ⟩
+  1# + x * x ⋆ ∎
+  where
+  lemma : x * (1# + x * x ⋆) ≤ 1# + x * x ⋆
+  lemma = begin
+    x * (1# + x * x ⋆)     ≤⟨ *-monoˡ _ $ +-monoˡ _ $ xx⋆≤x⋆ _ ⟩
+    x * (1# + x ⋆)         ≈⟨ *-congˡ (1+x⋆≈x⋆ _) ⟩
+    x * x ⋆                ≤⟨ y≤x+y _ _ ⟩
+    1# + x * x ⋆           ∎
 
 x⋆≈1+x⋆x : ∀ x → x ⋆ ≈ 1# + x ⋆ * x
-x⋆≈1+x⋆x x =   begin-equality
-  x ⋆ ≈⟨ ⋆-elimʳ (x≤x+y _ _) lemma ⟨⟩ starExpansiveˡ _ ⟩
+x⋆≈1+x⋆x x = begin-equality
+  x ⋆          ≈⟨ ⋆-elimʳ (x≤x+y _ _) lemma ⟨⟩ starExpansiveˡ _ ⟩
   1# + x ⋆ * x ∎
   where
   lemma : (1# + x ⋆ * x) * x ≤ 1# + x ⋆ * x
   lemma = begin
     (1# + x ⋆ * x) * x     ≤⟨ *-monoʳ _ $ +-monoˡ _ $ x⋆x≤x⋆ _ ⟩
-    (1# + x ⋆) * x         ≈⟨ *-congʳ (1+x⋆≈x⋆ _) ⟩
+    (1# + x ⋆) * x         ≈⟨ *-congʳ $ 1+x⋆≈x⋆ _ ⟩
     x ⋆ * x                ≤⟨ y≤x+y _ _ ⟩
     1# + x ⋆ * x           ∎
 
@@ -266,13 +271,13 @@ x⋆≈1+x⋆x x =   begin-equality
   1#      ∎
 
 0⋆≈1 : 0# ⋆ ≈ 1#
-0⋆≈1 = ≤-antisym 0⋆≤1 1≤[ _ ]⋆
+0⋆≈1 = 0⋆≤1 ⟨⟩ 1≤[ _ ]⋆
 
 1⋆≤1 : 1# ⋆ ≤ 1#
 1⋆≤1 = ⋆-elimˡ ≤-refl $ ≤-reflexive $ *-identityˡ _
 
 1⋆≈1 : 1# ⋆ ≈ 1#
-1⋆≈1 = ≤-antisym 1⋆≤1 1≤[ _ ]⋆
+1⋆≈1 = 1⋆≤1 ⟨⟩ 1≤[ _ ]⋆
 
 -- _⋆ is monotonic, and hence congruent for _≈_
 
@@ -294,7 +299,7 @@ x⋆≤x⋆⋆ : ∀ x → x ⋆ ≤ (x ⋆) ⋆
 x⋆≤x⋆⋆ = ⋆-mono ∘ x≤x⋆
 
 x⋆⋆≈x⋆ : ∀ x → (x ⋆) ⋆ ≈ x ⋆
-x⋆⋆≈x⋆ x = ≤-antisym (x⋆⋆≤x⋆ x) (x⋆≤x⋆⋆ x)
+x⋆⋆≈x⋆ x = x⋆⋆≤x⋆ x ⟨⟩ x⋆≤x⋆⋆ x
 
 -- distributive laws
 
@@ -317,9 +322,10 @@ yx≤zy⇒yx⋆≤z⋆y {y = y}{x = x} {z = z} yx≤zy = starDestructiveʳ _ _ _
     z ⋆ * y        ∎
 
 xy≈yz⇒x⋆y≈yz⋆ : x * y ≈ y * z → x ⋆ * y ≈ y * z ⋆
-xy≈yz⇒x⋆y≈yz⋆ {x = x} {y = y} {z = z} xy≈yz = ≤-antisym
-  (xy≤yz⇒x⋆y≤yz⋆ (≤-reflexive xy≈yz))
-  (yx≤zy⇒yx⋆≤z⋆y (≤-reflexive (sym xy≈yz)))
+xy≈yz⇒x⋆y≈yz⋆ {x = x} {y = y} {z = z} xy≈yz =
+  xy≤yz⇒x⋆y≤yz⋆ (begin x * y ≈⟨ xy≈yz ⟩ y * z ∎)
+  ⟨⟩
+  yx≤zy⇒yx⋆≤z⋆y (begin y * z ≈⟨ xy≈yz ⟨ x * y ∎)
 
 -- a useful absorption property
 

--- a/src/Algebra/Properties/KleeneAlgebra.agda
+++ b/src/Algebra/Properties/KleeneAlgebra.agda
@@ -252,6 +252,13 @@ x⋆≈1+x⋆x x = ≤-antisym (⋆-elimʳ (x≤x+y _ _) $ begin
   x ⋆ * x                ≤⟨ y≤x+y _ _ ⟩
   1# + x ⋆ * x           ∎) $ starExpansiveˡ _
 
+{- FAILS: parser falls over
+  begin-equality
+  x ⋆ ≈⟨ {!!} ⟨⟩ ? ⟩
+  {!!} ≈⟨ {!!} ⟩
+  1# + x ⋆ * x ∎
+-}
+
 -- special cases for 0# and 1#
 
 0⋆≤1 : 0# ⋆ ≤ 1#

--- a/src/Relation/Binary/Reasoning/PartialOrder.agda
+++ b/src/Relation/Binary/Reasoning/PartialOrder.agda
@@ -40,6 +40,7 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Relation.Binary.Bundles using (Poset)
+--open import Relation.Binary.Structures using (IsPartialOrder)
 
 module Relation.Binary.Reasoning.PartialOrder
   {p₁ p₂ p₃} (P : Poset p₁ p₂ p₃) where
@@ -48,6 +49,9 @@ open Poset P
 open import Relation.Binary.Construct.NonStrictToStrict _≈_ _≤_
   as Strict
   using (_<_)
+
+antisym-syntax = antisym
+syntax antisym-syntax x≤y y≤x = x≤y ⟨⟩ y≤x
 
 ------------------------------------------------------------------------
 -- Re-export contents of base module
@@ -61,12 +65,3 @@ open import Relation.Binary.Reasoning.Base.Triple
   (Strict.<-≤-trans Eq.sym trans antisym ≤-respʳ-≈)
   (Strict.≤-<-trans trans antisym ≤-respˡ-≈)
   public
-
-antisym-step-≈-⟩ : ∀ x {y z} → y IsRelatedTo z → y ≤ x → x ≤ y → x IsRelatedTo z
-antisym-step-≈-⟩ x yRz y≤x x≤y = step-≈-⟩ x yRz (antisym x≤y y≤x)
-
-antisym-step-≈-⟨ : ∀ x {y z} → y IsRelatedTo z → x ≤ y → y ≤ x → x IsRelatedTo z
-antisym-step-≈-⟨ x yRz x≤y y≤x = step-≈-⟩ x yRz (antisym x≤y y≤x)
-
-syntax antisym-step-≈-⟩ x yRz y≤x x≤y = x ≈⟨ y≤x ⟨⟩ x≤y ⟩ yRz
-syntax antisym-step-≈-⟨ x yRz y≤x x≤y = x ≈⟨ x≤y ⟩⟨ y≤x ⟩ yRz

--- a/src/Relation/Binary/Reasoning/PartialOrder.agda
+++ b/src/Relation/Binary/Reasoning/PartialOrder.agda
@@ -61,3 +61,12 @@ open import Relation.Binary.Reasoning.Base.Triple
   (Strict.<-≤-trans Eq.sym trans antisym ≤-respʳ-≈)
   (Strict.≤-<-trans trans antisym ≤-respˡ-≈)
   public
+
+antisym-step-≈-⟩ : ∀ x {y z} → y IsRelatedTo z → y ≤ x → x ≤ y → x IsRelatedTo z
+antisym-step-≈-⟩ x yRz y≤x x≤y = step-≈-⟩ x yRz (antisym x≤y y≤x)
+
+antisym-step-≈-⟨ : ∀ x {y z} → y IsRelatedTo z → x ≤ y → y ≤ x → x IsRelatedTo z
+antisym-step-≈-⟨ x yRz x≤y y≤x = step-≈-⟩ x yRz (antisym x≤y y≤x)
+
+syntax antisym-step-≈-⟩ x yRz y≤x x≤y = x ≈⟨ y≤x ⟨⟩ x≤y ⟩ yRz
+syntax antisym-step-≈-⟨ x yRz y≤x x≤y = x ≈⟨ x≤y ⟩⟨ y≤x ⟩ yRz

--- a/src/Relation/Binary/Reasoning/PartialOrder.agda
+++ b/src/Relation/Binary/Reasoning/PartialOrder.agda
@@ -40,7 +40,6 @@
 {-# OPTIONS --without-K --safe #-}
 
 open import Relation.Binary.Bundles using (Poset)
---open import Relation.Binary.Structures using (IsPartialOrder)
 
 module Relation.Binary.Reasoning.PartialOrder
   {p₁ p₂ p₃} (P : Poset p₁ p₂ p₃) where


### PR DESCRIPTION
Tackles the `PartialOrder`/`antisym` question in #3047 , with specimen usage illustrated in `Algebra.Properties.KleeneAlgebra` (which prompted the question in the first place).

The nice thing is that it was a (very) easy add-on, once I'd figured out what the parser was doing/failing to do. But maybe *too* easy, see the second point below.

TODO: currently
* the new syntax is the one that @JacquesCarette hates, so I'm open to some sort of debate around this, and offer a suggestion below
* the deployment isn't (yet) quite right, because its use in anger probably will entail *nested* reasoning, which for readability reasons, we tend to avoid, see the use of `lemma` in `KleeneAlgebra` for examples.
