### PR TITLE
Adds the AVL tree's toList/Any properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,9 +353,9 @@ Additions to existing modules
 
 * In `Data.DifferenceList.Properties`:
   ```agda
-  fromList-++-homo : ∀ xs ys → fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
-  toList-++-homo : ListLike dxs → (dys : DiffList A) →
-                   toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+  fromList-++ : ∀ xs ys → fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
+  toList-++ : ListLike dxs → (dys : DiffList A) →
+              toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
   viaList⁺ : (f : List A → List B) → xs ∼ dxs → f xs ∼ viaList f dxs
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,8 +353,9 @@ Additions to existing modules
 
 * In `Data.DifferenceList.Properties`:
   ```agda
-  toList-++ : ListLike dxs → (dys : DiffList A) →
-              toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+  fromList-++-homo : ∀ xs ys → fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
+  toList-++-homo : ListLike dxs → (dys : DiffList A) →
+                   toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
   viaList⁺ : (f : List A → List B) → xs ∼ dxs → f xs ∼ viaList f dxs
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,9 @@ New modules
   Data.Tree.Rose.Show
   ```
 
+* `Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList` adds properties of
+  the AVL's operator `toList`: `toList⁺` and `toList⁻`.
+
 Additions to existing modules
 -----------------------------
 
@@ -350,6 +353,9 @@ Additions to existing modules
 
 * In `Data.DifferenceList.Properties`:
   ```agda
+  toList-refl : xs ∼ ys → toList ys ∼ ys
+  toList-++ : xs₁ ∼ ys₁ → (ys₂ : DiffList A) →
+              xs₁ List.++ toList ys₂ ≡ toList (ys₁ ++ ys₂)
   viaList⁺ : (f : List A → List B) → xs ∼ ys → f xs ∼ viaList f ys
   ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -353,10 +353,9 @@ Additions to existing modules
 
 * In `Data.DifferenceList.Properties`:
   ```agda
-  toList-refl : xs ∼ ys → toList ys ∼ ys
-  toList-++ : xs₁ ∼ ys₁ → (ys₂ : DiffList A) →
-              xs₁ List.++ toList ys₂ ≡ toList (ys₁ ++ ys₂)
-  viaList⁺ : (f : List A → List B) → xs ∼ ys → f xs ∼ viaList f ys
+  toList-++ : ListLike dxs → (dys : DiffList A) →
+              toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+  viaList⁺ : (f : List A → List B) → xs ∼ dxs → f xs ∼ viaList f dxs
   ```
 
 * In `Data.Integer.GCD`:

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -12,6 +12,7 @@ open import Data.DifferenceList.Base
   using (DiffList; fromList; toList; viaList; []; _∷_; [_]; _++_; _∷ʳ_; map)
 open import Data.List.Base as List using (List)
 open import Data.List.Properties using (++-assoc; ++-identityʳ)
+open import Data.Product using (Σ; _,_)
 open import Function.Base using (_∘′_; id; flip)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
@@ -24,8 +25,8 @@ private
     a b : Level
     A : Set a
     B : Set b
-    xs xs₁ xs₂ : List A
-    ys ys₁ ys₂ : DiffList A
+    xs ys : List A
+    dxs dys : DiffList A
 
 
 ------------------------------------------------------------------------
@@ -33,7 +34,10 @@ private
 
 infix 4 _∼_
 _∼_ : List A → DiffList A → Set _
-xs ∼ ys = fromList xs ≗ ys
+xs ∼ dxs = fromList xs ≗ dxs
+
+ListLike : DiffList A → Set _
+ListLike {A = A} dxs = Σ (List A) (_∼ dxs)
 
 ------------------------------------------------------------------------
 -- Properties of fromList and toList
@@ -44,30 +48,27 @@ xs ∼ ys = fromList xs ≗ ys
 toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
 toList∘fromList = ++-identityʳ
 
-toList⁺ : xs ∼ ys → xs ≡ toList ys
-toList⁺ {xs = xs} {ys} xs∼ys = begin
+toList⁺ : xs ∼ dxs → xs ≡ toList dxs
+toList⁺ {xs = xs} {dxs} x∼ = begin
   xs                  ≡⟨ ++-identityʳ xs ⟨
-  xs List.++ List.[]  ≡⟨ xs∼ys List.[] ⟩
-  ys List.[]          ≡⟨⟩
-  toList ys           ∎
+  xs List.++ List.[]  ≡⟨ x∼ List.[] ⟩
+  dxs List.[]         ≡⟨⟩
+  toList dxs          ∎
 
-toList-refl : xs ∼ ys → toList ys ∼ ys
-toList-refl {xs = xs} {ys} xs∼ys k =
-  subst (λ xs → fromList xs k ≡ ys k) (toList⁺ xs∼ys) (xs∼ys k)
+toList-++ : ListLike dxs → (dys : DiffList A) →
+            toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+toList-++ {dxs = dxs} (xs , x∼) dys = begin
+  toList dxs List.++ toList dys  ≡⟨ cong (List._++ toList dys) (toList⁺ x∼) ⟨
+  xs List.++ toList dys          ≡⟨⟩
+  fromList xs (toList dys)       ≡⟨ x∼ (toList dys) ⟩
+  dxs (toList dys)               ≡⟨⟩
+  toList (dxs ++ dys)            ∎
 
-toList-++ : xs₁ ∼ ys₁ → (ys₂ : DiffList A) →
-            xs₁ List.++ toList ys₂ ≡ toList (ys₁ ++ ys₂)
-toList-++ {xs₁ = xs₁} {ys₁} xs₁∼ys₁ ys₂ = begin
-  xs₁ List.++ toList ys₂     ≡⟨⟩
-  fromList xs₁ (toList ys₂)  ≡⟨ xs₁∼ys₁ (toList ys₂) ⟩
-  ys₁ (toList ys₂)           ≡⟨⟩
-  toList (ys₁ ++ ys₂)        ∎
-
-viaList⁺ : (f : List A → List B) → xs ∼ ys → f xs ∼ viaList f ys
-viaList⁺ {xs = xs} {ys = ys} f xs∼ys k = begin
-  fromList (f xs)          k ≡⟨ cong (flip fromList _ ∘′ f) (toList⁺ xs∼ys) ⟩
-  fromList (f (toList ys)) k ≡⟨⟩
-  viaList f ys             k ∎
+viaList⁺ : (f : List A → List B) → xs ∼ dxs → f xs ∼ viaList f dxs
+viaList⁺ {xs = xs} {dxs = dxs} f x∼ k = begin
+  fromList (f xs)           k  ≡⟨ cong (flip fromList _ ∘′ f) (toList⁺ x∼) ⟩
+  fromList (f (toList dxs)) k  ≡⟨⟩
+  viaList f dxs             k  ∎
 
 ------------------------------------------------------------------------
 -- Properties of operations that preserve _∼_
@@ -78,24 +79,19 @@ viaList⁺ {xs = xs} {ys = ys} f xs∼ys k = begin
 [_]⁺ : (x : A) → List.[ x ] ∼ [ x ]
 [_]⁺ _ _ = refl
 
-++⁺ : xs₁ ∼ ys₁ → xs₂ ∼ ys₂ → xs₁ List.++ xs₂ ∼ ys₁ ++ ys₂
-++⁺ {xs₁ = xs₁} {ys₁ = ys₁} {xs₂ = xs₂} {ys₂ = ys₂}
-    xs₁∼ys₁ xs₂∼ys₂ k = begin
-  (xs₁ List.++ xs₂) List.++ k  ≡⟨ ++-assoc xs₁ xs₂ k ⟩
-  xs₁ List.++ (xs₂ List.++ k)  ≡⟨ cong (xs₁ List.++_) (xs₂∼ys₂ k) ⟩
-  xs₁ List.++ ys₂ k            ≡⟨ xs₁∼ys₁ (ys₂ k) ⟩
-  ys₁ (ys₂ k)                  ≡⟨⟩
-  (ys₁ ++ ys₂) k               ∎
+++⁺ : xs ∼ dxs → ys ∼ dys → xs List.++ ys ∼ dxs ++ dys
+++⁺ {xs = xs} {dxs = dxs} {ys = ys} {dys = dys} x∼ y∼ k = begin
+  (xs List.++ ys) List.++ k  ≡⟨ ++-assoc xs ys k ⟩
+  xs List.++ (ys List.++ k)  ≡⟨ cong (xs List.++_) (y∼ k) ⟩
+  xs List.++ dys k           ≡⟨ x∼ (dys k) ⟩
+  dxs (dys k)                ≡⟨⟩
+  (dxs ++ dys) k             ∎
 
-∷⁺ : (x : A) → xs ∼ ys → x List.∷ xs ∼ x ∷ ys
-∷⁺ {xs = xs} {ys} x xs∼ys k = cong (x List.∷_) (xs∼ys k)
+∷⁺ : (x : A) → xs ∼ dxs → x List.∷ xs ∼ x ∷ dxs
+∷⁺ x x∼ k = cong (x List.∷_) (x∼ k)
 
-++-∷⁺ : (x : A) → xs₁ ∼ ys₁ → xs₂ ∼ ys₂ →
-        xs₁ List.++ x List.∷ xs₂ ∼ ys₁ ++ x ∷ ys₂
-++-∷⁺ x xs₁∼ys₁ xs₂∼ys₂ = ++⁺ xs₁∼ys₁ (∷⁺ x xs₂∼ys₂)
+∷ʳ⁺ : (x : A) → xs ∼ dxs → xs List.∷ʳ x ∼ dxs ∷ʳ x
+∷ʳ⁺ x x∼ k = ++⁺ x∼ [ x ]⁺ k
 
-∷ʳ⁺ : (x : A) → xs ∼ ys → xs List.∷ʳ x ∼ ys ∷ʳ x
-∷ʳ⁺ {xs = xs} {ys} x xs∼ys k = ++⁺ xs∼ys [ x ]⁺ k
-
-map⁺ : (f : A → B) → xs ∼ ys → List.map f xs ∼ map f ys
+map⁺ : (f : A → B) → xs ∼ dxs → List.map f xs ∼ map f dxs
 map⁺ f = viaList⁺ _

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -54,13 +54,13 @@ toList⁺ {xs = xs} {dxs} xs∼dxs = begin
   toList (fromList xs)  ≡⟨ xs∼dxs List.[] ⟩
   toList dxs            ∎
 
-fromList-++-homo : (xs ys : List A) →
+fromList-++ : (xs ys : List A) →
                    fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
-fromList-++-homo = ++-assoc
+fromList-++ = ++-assoc
 
-toList-++-homo : ListLike dxs → (dys : DiffList A) →
+toList-++ : ListLike dxs → (dys : DiffList A) →
                  toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
-toList-++-homo {dxs = dxs} (xs , xs∼dxs) dys = begin
+toList-++ {dxs = dxs} (xs , xs∼dxs) dys = begin
   toList dxs List.++ toList dys  ≡⟨ cong (List._++ toList dys) (toList⁺ xs∼dxs) ⟨
   xs List.++ toList dys          ≡⟨⟩
   fromList xs (toList dys)       ≡⟨ xs∼dxs (toList dys) ⟩
@@ -84,7 +84,7 @@ viaList⁺ {xs = xs} {dxs = dxs} f xs∼dxs k = begin
 
 ++⁺ : xs ∼ dxs → ys ∼ dys → xs List.++ ys ∼ dxs ++ dys
 ++⁺ {xs = xs} {dxs = dxs} {ys = ys} {dys = dys} xs∼dxs ys∼dys k = begin
-  fromList (xs List.++ ys) k      ≡⟨ fromList-++-homo xs ys k ⟩
+  fromList (xs List.++ ys) k      ≡⟨ fromList-++ xs ys k ⟩
   (fromList xs ++ fromList ys) k  ≡⟨⟩
   fromList xs (fromList ys k)     ≡⟨ cong (fromList xs) (ys∼dys k) ⟩
   fromList xs (dys k)             ≡⟨ xs∼dxs (dys k) ⟩

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -55,11 +55,11 @@ toList⁺ {xs = xs} {dxs} xs∼dxs = begin
   toList dxs            ∎
 
 fromList-++ : (xs ys : List A) →
-                   fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
+              fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
 fromList-++ = ++-assoc
 
 toList-++ : ListLike dxs → (dys : DiffList A) →
-                 toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+            toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
 toList-++ {dxs = dxs} (xs , xs∼dxs) dys = begin
   toList dxs List.++ toList dys  ≡⟨ cong (List._++ toList dys) (toList⁺ xs∼dxs) ⟨
   xs List.++ toList dys          ≡⟨⟩

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -12,7 +12,7 @@ open import Data.DifferenceList.Base
   using (DiffList; fromList; toList; viaList; []; _∷_; [_]; _++_; _∷ʳ_; map)
 open import Data.List.Base as List using (List)
 open import Data.List.Properties using (++-assoc; ++-identityʳ)
-open import Data.Product using (Σ; _,_)
+open import Data.Product.Base using (Σ; _,_)
 open import Function.Base using (_∘′_; id; flip)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -92,7 +92,7 @@ viaList⁺ {xs = xs} {dxs = dxs} f xs∼dxs k = begin
   (dxs ++ dys) k                  ∎
 
 ∷⁺ : (x : A) → xs ∼ dxs → x List.∷ xs ∼ x ∷ dxs
-∷⁺ x xs∼dxs k = cong (x List.∷_) (xs∼dxs k)
+∷⁺ x = ++⁺ [ x ]⁺
 
 ∷ʳ⁺ : (x : A) → xs ∼ dxs → xs List.∷ʳ x ∼ dxs ∷ʳ x
 ∷ʳ⁺ x xs∼dxs = ++⁺ xs∼dxs [ x ]⁺

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -49,24 +49,27 @@ toList∘fromList : (xs : List A) → toList (fromList xs) ≡ xs
 toList∘fromList = ++-identityʳ
 
 toList⁺ : xs ∼ dxs → xs ≡ toList dxs
-toList⁺ {xs = xs} {dxs} x∼ = begin
-  xs                  ≡⟨ ++-identityʳ xs ⟨
-  xs List.++ List.[]  ≡⟨ x∼ List.[] ⟩
-  dxs List.[]         ≡⟨⟩
-  toList dxs          ∎
+toList⁺ {xs = xs} {dxs} xs∼dxs = begin
+  xs                    ≡⟨ toList∘fromList xs ⟨
+  toList (fromList xs)  ≡⟨ xs∼dxs List.[] ⟩
+  toList dxs            ∎
 
-toList-++ : ListLike dxs → (dys : DiffList A) →
-            toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
-toList-++ {dxs = dxs} (xs , x∼) dys = begin
-  toList dxs List.++ toList dys  ≡⟨ cong (List._++ toList dys) (toList⁺ x∼) ⟨
+fromList-++-homo : (xs ys : List A) →
+                   fromList (xs List.++ ys) ≗ fromList xs ++ fromList ys
+fromList-++-homo = ++-assoc
+
+toList-++-homo : ListLike dxs → (dys : DiffList A) →
+                 toList dxs List.++ toList dys ≡ toList (dxs ++ dys)
+toList-++-homo {dxs = dxs} (xs , xs∼dxs) dys = begin
+  toList dxs List.++ toList dys  ≡⟨ cong (List._++ toList dys) (toList⁺ xs∼dxs) ⟨
   xs List.++ toList dys          ≡⟨⟩
-  fromList xs (toList dys)       ≡⟨ x∼ (toList dys) ⟩
+  fromList xs (toList dys)       ≡⟨ xs∼dxs (toList dys) ⟩
   dxs (toList dys)               ≡⟨⟩
   toList (dxs ++ dys)            ∎
 
 viaList⁺ : (f : List A → List B) → xs ∼ dxs → f xs ∼ viaList f dxs
-viaList⁺ {xs = xs} {dxs = dxs} f x∼ k = begin
-  fromList (f xs)           k  ≡⟨ cong (flip fromList _ ∘′ f) (toList⁺ x∼) ⟩
+viaList⁺ {xs = xs} {dxs = dxs} f xs∼dxs k = begin
+  fromList (f xs)           k  ≡⟨ cong (flip fromList _ ∘′ f) (toList⁺ xs∼dxs) ⟩
   fromList (f (toList dxs)) k  ≡⟨⟩
   viaList f dxs             k  ∎
 
@@ -80,18 +83,19 @@ viaList⁺ {xs = xs} {dxs = dxs} f x∼ k = begin
 [_]⁺ _ _ = refl
 
 ++⁺ : xs ∼ dxs → ys ∼ dys → xs List.++ ys ∼ dxs ++ dys
-++⁺ {xs = xs} {dxs = dxs} {ys = ys} {dys = dys} x∼ y∼ k = begin
-  (xs List.++ ys) List.++ k  ≡⟨ ++-assoc xs ys k ⟩
-  xs List.++ (ys List.++ k)  ≡⟨ cong (xs List.++_) (y∼ k) ⟩
-  xs List.++ dys k           ≡⟨ x∼ (dys k) ⟩
-  dxs (dys k)                ≡⟨⟩
-  (dxs ++ dys) k             ∎
+++⁺ {xs = xs} {dxs = dxs} {ys = ys} {dys = dys} xs∼dxs ys∼dys k = begin
+  fromList (xs List.++ ys) k      ≡⟨ fromList-++-homo xs ys k ⟩
+  (fromList xs ++ fromList ys) k  ≡⟨⟩
+  fromList xs (fromList ys k)     ≡⟨ cong (fromList xs) (ys∼dys k) ⟩
+  fromList xs (dys k)             ≡⟨ xs∼dxs (dys k) ⟩
+  dxs (dys k)                     ≡⟨⟩
+  (dxs ++ dys) k                  ∎
 
 ∷⁺ : (x : A) → xs ∼ dxs → x List.∷ xs ∼ x ∷ dxs
-∷⁺ x x∼ k = cong (x List.∷_) (x∼ k)
+∷⁺ x xs∼dxs k = cong (x List.∷_) (xs∼dxs k)
 
 ∷ʳ⁺ : (x : A) → xs ∼ dxs → xs List.∷ʳ x ∼ dxs ∷ʳ x
-∷ʳ⁺ x x∼ k = ++⁺ x∼ [ x ]⁺ k
+∷ʳ⁺ x xs∼dxs = ++⁺ xs∼dxs [ x ]⁺
 
 map⁺ : (f : A → B) → xs ∼ dxs → List.map f xs ∼ map f dxs
 map⁺ f = viaList⁺ _

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -16,7 +16,7 @@ open import Data.Product.Base using (Σ; _,_)
 open import Function.Base using (_∘′_; id; flip)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; subst; cong; _≗_; module ≡-Reasoning)
+  using (_≡_; refl; cong; _≗_; module ≡-Reasoning)
 
 open ≡-Reasoning
 

--- a/src/Data/DifferenceList/Properties.agda
+++ b/src/Data/DifferenceList/Properties.agda
@@ -10,12 +10,12 @@ module Data.DifferenceList.Properties where
 
 open import Data.DifferenceList.Base
   using (DiffList; fromList; toList; viaList; []; _∷_; [_]; _++_; _∷ʳ_; map)
-open import Data.List as List using (List)
+open import Data.List.Base as List using (List)
 open import Data.List.Properties using (++-assoc; ++-identityʳ)
-open import Function using (_∘′_; id; flip)
+open import Function.Base using (_∘′_; id; flip)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality
-  using (_≡_; refl; cong; _≗_; module ≡-Reasoning)
+  using (_≡_; refl; subst; cong; _≗_; module ≡-Reasoning)
 
 open ≡-Reasoning
 
@@ -51,6 +51,18 @@ toList⁺ {xs = xs} {ys} xs∼ys = begin
   ys List.[]          ≡⟨⟩
   toList ys           ∎
 
+toList-refl : xs ∼ ys → toList ys ∼ ys
+toList-refl {xs = xs} {ys} xs∼ys k =
+  subst (λ xs → fromList xs k ≡ ys k) (toList⁺ xs∼ys) (xs∼ys k)
+
+toList-++ : xs₁ ∼ ys₁ → (ys₂ : DiffList A) →
+            xs₁ List.++ toList ys₂ ≡ toList (ys₁ ++ ys₂)
+toList-++ {xs₁ = xs₁} {ys₁} xs₁∼ys₁ ys₂ = begin
+  xs₁ List.++ toList ys₂     ≡⟨⟩
+  fromList xs₁ (toList ys₂)  ≡⟨ xs₁∼ys₁ (toList ys₂) ⟩
+  ys₁ (toList ys₂)           ≡⟨⟩
+  toList (ys₁ ++ ys₂)        ∎
+
 viaList⁺ : (f : List A → List B) → xs ∼ ys → f xs ∼ viaList f ys
 viaList⁺ {xs = xs} {ys = ys} f xs∼ys k = begin
   fromList (f xs)          k ≡⟨ cong (flip fromList _ ∘′ f) (toList⁺ xs∼ys) ⟩
@@ -76,7 +88,7 @@ viaList⁺ {xs = xs} {ys = ys} f xs∼ys k = begin
   (ys₁ ++ ys₂) k               ∎
 
 ∷⁺ : (x : A) → xs ∼ ys → x List.∷ xs ∼ x ∷ ys
-∷⁺ {xs = xs} {ys} x xs~ys k = cong (x List.∷_) (xs~ys k)
+∷⁺ {xs = xs} {ys} x xs∼ys k = cong (x List.∷_) (xs∼ys k)
 
 ++-∷⁺ : (x : A) → xs₁ ∼ ys₁ → xs₂ ∼ ys₂ →
         xs₁ List.++ x List.∷ xs₂ ∼ ys₁ ++ x ∷ ys₂

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties.agda
@@ -20,3 +20,4 @@ open import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.JoinLemmas sto p
 open import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.Join sto public
 open import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.Lookup sto public
 open import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.Singleton sto public
+open import Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList sto public

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
@@ -1,0 +1,74 @@
+------------------------------------------------------------------------
+-- The Agda standard library
+--
+-- Properties of toList related to Any
+------------------------------------------------------------------------
+
+{-# OPTIONS --without-K --safe #-}
+
+open import Relation.Binary.Bundles using (StrictTotalOrder)
+
+module Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList
+  {a ℓ₁ ℓ₂} (sto : StrictTotalOrder a ℓ₁ ℓ₂)
+  where
+
+open import Data.DifferenceList.Base using (_∷_)
+open import Data.DifferenceList.Properties
+  using (_∼_; []⁺; ++-∷⁺; toList-refl; toList-++)
+import Data.List.Base as List
+import Data.List.Relation.Unary.Any as List
+import Data.List.Relation.Unary.Any.Properties as List
+open import Data.Nat.Base using (ℕ)
+open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
+open import Level using (Level)
+open import Relation.Binary.PropositionalEquality.Core
+  using (_≡_; subst; sym)
+open import Relation.Unary using (Pred)
+
+open import Data.Tree.AVL.Indexed sto
+open import Data.Tree.AVL.Indexed.Relation.Unary.Any sto
+  using (Any; here; left; right)
+
+private
+  variable
+    v : Level
+    V : Value v
+    p : Level
+    P : Pred (K& V) p
+    l u : Key⁺
+    h : ℕ
+    t : Tree V l u h
+
+
+toList∼toDiffList : (t : Tree V l u h) →
+                    toList t ∼ toDiffList t
+toList∼toDiffList (leaf l<u) = []⁺
+toList∼toDiffList (node k l r bal) =
+  toList-refl (++-∷⁺ k (toList∼toDiffList l) (toList∼toDiffList r))
+
+toList⁺ : Any P t → List.Any P (toList t)
+toList⁺ {P = P} {t = node k l r bal} p =
+  subst (List.Any P) toList-node (path-++-∷ p)
+  where
+  path-++-∷ : Any P (node k l r bal) →
+              List.Any P (toList l List.++ k List.∷ toList r)
+  path-++-∷ (here p) = List.++⁺ʳ (toList l) (List.here p)
+  path-++-∷ (left p) = List.++⁺ˡ (toList⁺ p)
+  path-++-∷ (right p) = List.++⁺ʳ (toList l) (List.there (toList⁺ p))
+  toList-node : toList l List.++ k List.∷ toList r ≡
+                toList (node k l r bal)
+  toList-node = toList-++ (toList∼toDiffList l) (k ∷ toDiffList r)
+
+toList⁻ : List.Any P (toList t) → Any P t
+toList⁻ {P = P} {t = node k l r bal} p =
+  path-++-∷ (List.++⁻ (toList l)
+                      (subst (List.Any P) (sym toList-node) p))
+  where
+  path-++-∷ : List.Any P (toList l) ⊎ List.Any P (k List.∷ toList r) →
+              Any P (node k l r bal)
+  path-++-∷ (inj₁ p) = left (toList⁻ p)
+  path-++-∷ (inj₂ (List.here p)) = here p
+  path-++-∷ (inj₂ (List.there p)) = right (toList⁻ p)
+  toList-node : toList l List.++ k List.∷ toList r ≡
+                toList (node k l r bal)
+  toList-node = toList-++ (toList∼toDiffList l) (k ∷ toDiffList r)

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
@@ -12,13 +12,15 @@ module Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList
   {a ℓ₁ ℓ₂} (sto : StrictTotalOrder a ℓ₁ ℓ₂)
   where
 
+open import Data.DifferenceList.Properties using ()
 open import Data.DifferenceList.Base using (_∷_)
 open import Data.DifferenceList.Properties
-  using (_∼_; []⁺; ++-∷⁺; toList-refl; toList-++)
+  using (ListLike; []⁺; ∷⁺; ++⁺; toList-++)
 import Data.List.Base as List
 import Data.List.Relation.Unary.Any as List
 import Data.List.Relation.Unary.Any.Properties as List
 open import Data.Nat.Base using (ℕ)
+open import Data.Product using (_,_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality.Core
@@ -39,12 +41,13 @@ private
     h : ℕ
     t : Tree V l u h
 
-
-toList∼toDiffList : (t : Tree V l u h) →
-                    toList t ∼ toDiffList t
-toList∼toDiffList (leaf l<u) = []⁺
-toList∼toDiffList (node k l r bal) =
-  toList-refl (++-∷⁺ k (toList∼toDiffList l) (toList∼toDiffList r))
+listLike : (t : Tree V l u h) → ListLike (toDiffList t)
+listLike (leaf l<u) = List.[] , []⁺
+listLike (node k l r bal) =
+  let (ls , l∼) = listLike l
+      (rs , r∼) = listLike r
+  in ls List.++ k List.∷ rs ,
+     (++⁺ l∼ (∷⁺ k r∼))
 
 toList⁺ : Any P t → List.Any P (toList t)
 toList⁺ {P = P} {t = node k l r bal} p =
@@ -57,7 +60,7 @@ toList⁺ {P = P} {t = node k l r bal} p =
   path-++-∷ (right p) = List.++⁺ʳ (toList l) (List.there (toList⁺ p))
   toList-node : toList l List.++ k List.∷ toList r ≡
                 toList (node k l r bal)
-  toList-node = toList-++ (toList∼toDiffList l) (k ∷ toDiffList r)
+  toList-node = toList-++ (listLike l) (k ∷ toDiffList r)
 
 toList⁻ : List.Any P (toList t) → Any P t
 toList⁻ {P = P} {t = node k l r bal} p =
@@ -71,4 +74,4 @@ toList⁻ {P = P} {t = node k l r bal} p =
   path-++-∷ (inj₂ (List.there p)) = right (toList⁻ p)
   toList-node : toList l List.++ k List.∷ toList r ≡
                 toList (node k l r bal)
-  toList-node = toList-++ (toList∼toDiffList l) (k ∷ toDiffList r)
+  toList-node = toList-++ (listLike l) (k ∷ toDiffList r)

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
@@ -14,7 +14,7 @@ module Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList
 
 open import Data.DifferenceList.Base using (_∷_)
 open import Data.DifferenceList.Properties
-  using (ListLike; []⁺; ∷⁺; ++⁺; toList-++-homo)
+  using (ListLike; []⁺; ∷⁺; ++⁺; toList-++)
 import Data.List.Base as List
 import Data.List.Relation.Unary.Any as List
 import Data.List.Relation.Unary.Any.Properties as List
@@ -42,11 +42,10 @@ private
 
 listLike : (t : Tree V l u h) → ListLike (toDiffList t)
 listLike (leaf l<u) = List.[] , []⁺
-listLike (node k l r bal) =
-  let (ls , ls∼dls) = listLike l
-      (rs , rs∼drs) = listLike r
-  in ls List.++ k List.∷ rs ,
-     (++⁺ ls∼dls (∷⁺ k rs∼drs))
+listLike (node k l r bal)
+  with (ls , ls∼dls) ← listLike l
+  with (rs , rs∼drs) ← listLike r
+  = ls List.++ k List.∷ rs , (++⁺ ls∼dls (∷⁺ k rs∼drs))
 
 ++≡node : (kv : K& V) →
           (lk : Tree V l [ kv .key ] hˡ) →
@@ -55,7 +54,7 @@ listLike (node k l r bal) =
           toList lk List.++ kv List.∷ toList ku ≡
             toList (node kv lk ku bal)
 ++≡node kv lk ku _ =
-  toList-++-homo (listLike lk) (kv ∷ toDiffList ku)
+  toList-++ (listLike lk) (kv ∷ toDiffList ku)
 
 toList⁺ : Any P t → List.Any P (toList t)
 toList⁺-node : {kv : K& V} →

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
@@ -19,7 +19,7 @@ import Data.List.Base as List
 import Data.List.Relation.Unary.Any as List
 import Data.List.Relation.Unary.Any.Properties as List
 open import Data.Nat.Base using (ℕ)
-open import Data.Product using (_,_)
+open import Data.Product.Base using (_,_)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂)
 open import Level using (Level)
 open import Relation.Binary.PropositionalEquality.Core
@@ -32,13 +32,13 @@ open import Data.Tree.AVL.Indexed.Relation.Unary.Any sto
 
 private
   variable
-    v : Level
+    v p : Level
     V : Value v
-    p : Level
     P : Pred (K& V) p
     l u : Key⁺
     hˡ hʳ h : ℕ
     t : Tree V l u h
+
 
 listLike : (t : Tree V l u h) → ListLike (toDiffList t)
 listLike (leaf l<u) = List.[] , []⁺

--- a/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
+++ b/src/Data/Tree/AVL/Indexed/Relation/Unary/Any/Properties/ToList.agda
@@ -12,10 +12,9 @@ module Data.Tree.AVL.Indexed.Relation.Unary.Any.Properties.ToList
   {a ℓ₁ ℓ₂} (sto : StrictTotalOrder a ℓ₁ ℓ₂)
   where
 
-open import Data.DifferenceList.Properties using ()
 open import Data.DifferenceList.Base using (_∷_)
 open import Data.DifferenceList.Properties
-  using (ListLike; []⁺; ∷⁺; ++⁺; toList-++)
+  using (ListLike; []⁺; ∷⁺; ++⁺; toList-++-homo)
 import Data.List.Base as List
 import Data.List.Relation.Unary.Any as List
 import Data.List.Relation.Unary.Any.Properties as List
@@ -38,40 +37,53 @@ private
     p : Level
     P : Pred (K& V) p
     l u : Key⁺
-    h : ℕ
+    hˡ hʳ h : ℕ
     t : Tree V l u h
 
 listLike : (t : Tree V l u h) → ListLike (toDiffList t)
 listLike (leaf l<u) = List.[] , []⁺
 listLike (node k l r bal) =
-  let (ls , l∼) = listLike l
-      (rs , r∼) = listLike r
+  let (ls , ls∼dls) = listLike l
+      (rs , rs∼drs) = listLike r
   in ls List.++ k List.∷ rs ,
-     (++⁺ l∼ (∷⁺ k r∼))
+     (++⁺ ls∼dls (∷⁺ k rs∼drs))
+
+++≡node : (kv : K& V) →
+          (lk : Tree V l [ kv .key ] hˡ) →
+          (ku : Tree V [ kv .key ] u hʳ) →
+          (bal : hˡ ∼ hʳ ⊔ h) →
+          toList lk List.++ kv List.∷ toList ku ≡
+            toList (node kv lk ku bal)
+++≡node kv lk ku _ =
+  toList-++-homo (listLike lk) (kv ∷ toDiffList ku)
 
 toList⁺ : Any P t → List.Any P (toList t)
-toList⁺ {P = P} {t = node k l r bal} p =
-  subst (List.Any P) toList-node (path-++-∷ p)
-  where
-  path-++-∷ : Any P (node k l r bal) →
-              List.Any P (toList l List.++ k List.∷ toList r)
-  path-++-∷ (here p) = List.++⁺ʳ (toList l) (List.here p)
-  path-++-∷ (left p) = List.++⁺ˡ (toList⁺ p)
-  path-++-∷ (right p) = List.++⁺ʳ (toList l) (List.there (toList⁺ p))
-  toList-node : toList l List.++ k List.∷ toList r ≡
-                toList (node k l r bal)
-  toList-node = toList-++ (listLike l) (k ∷ toDiffList r)
+toList⁺-node : {kv : K& V} →
+               {lk : Tree V l [ kv .key ] hˡ} →
+               {ku : Tree V [ kv .key ] u hʳ} →
+               {bal : hˡ ∼ hʳ ⊔ h} →
+               Any P (node kv lk ku bal) →
+               List.Any P (toList lk List.++ kv List.∷ toList ku)
+toList⁺ {P = P} {t = node kv lk ku bal} p =
+  subst (List.Any P) (++≡node kv lk ku bal) (toList⁺-node p)
+toList⁺-node {lk = lk} (here p) =
+  List.++⁺ʳ (toList lk) (List.here p)
+toList⁺-node (left p) =
+  List.++⁺ˡ (toList⁺ p)
+toList⁺-node {lk = lk} (right p) =
+  List.++⁺ʳ (toList lk) (List.there (toList⁺ p))
 
 toList⁻ : List.Any P (toList t) → Any P t
-toList⁻ {P = P} {t = node k l r bal} p =
-  path-++-∷ (List.++⁻ (toList l)
-                      (subst (List.Any P) (sym toList-node) p))
-  where
-  path-++-∷ : List.Any P (toList l) ⊎ List.Any P (k List.∷ toList r) →
-              Any P (node k l r bal)
-  path-++-∷ (inj₁ p) = left (toList⁻ p)
-  path-++-∷ (inj₂ (List.here p)) = here p
-  path-++-∷ (inj₂ (List.there p)) = right (toList⁻ p)
-  toList-node : toList l List.++ k List.∷ toList r ≡
-                toList (node k l r bal)
-  toList-node = toList-++ (listLike l) (k ∷ toDiffList r)
+toList⁻-node : {kv : K& V} →
+               {lk : Tree V l [ kv .key ] hˡ} →
+               {ku : Tree V [ kv .key ] u hʳ} →
+               {bal : hˡ ∼ hʳ ⊔ h} →
+               List.Any P (toList lk) ⊎ List.Any P (kv List.∷ toList ku) →
+               Any P (node kv lk ku bal)
+toList⁻ {P = P} {t = node kv lk ku bal} p =
+  toList⁻-node
+    (List.++⁻ (toList lk)
+      (subst (List.Any P) (sym (++≡node kv lk ku bal)) p))
+toList⁻-node (inj₁ p) = left (toList⁻ p)
+toList⁻-node (inj₂ (List.here p)) = here p
+toList⁻-node (inj₂ (List.there p)) = right (toList⁻ p)

--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -1,2 +1,3 @@
 name: standard-library-3.0
 include: src
+flags: -WnoUnguardedEtaRecord -WnoUselessPatternDeclarationForRecord

--- a/standard-library.agda-lib
+++ b/standard-library.agda-lib
@@ -1,3 +1,2 @@
 name: standard-library-3.0
 include: src
-flags: -WnoUnguardedEtaRecord -WnoUselessPatternDeclarationForRecord


### PR DESCRIPTION
This adds
```
toList⁺ : Any P t → List.Any P (toList t)
toList⁻ : List.Any P (toList t) → Any P t
```
These use a relation that states that the AVL's `toList` and `toDiffList` are equivalent:
```
toList∼toDiffList : ∀ t → toList t ∼ toDiffList t
```

I also added lemmas to `Data.DifferenceList.Properties`:
```
toList-refl : xs ∼ ys → toList ys ∼ ys
toList-++ : xs₁ ∼ ys₁ → (ys₂ : DiffList A) → xs₁ List.++ toList ys₂ ≡ toList (ys₁ ++ ys₂)
```
These let the `DiffList` user reason about the correspond between List and DiffList. Lower-level reasoning that uses the definition of `DiffList` as a function, or the definitions of `toList` and `fromList` as appends is hidden in `toList-refl` and `toList-++`. It seemed helpful to hide this reasoning at the risk of adding lemmas that seem ad-hoc.
