### PR TITLE
[ style-guide ] no single-letter internal `module` names for export

### DIFF
--- a/doc/style-guide.md
+++ b/doc/style-guide.md
@@ -85,7 +85,10 @@ automate most of this.
 
 * As a rule of thumb, there should only be one named module per file. Anonymous
   modules are fine, but named internal modules should either be opened publicly
-  immediately or split out into a separate file.
+  immediately or split out into a separate file. There should be *no* internal
+  modules exported publicly with *single-letter* names; such modules are, of
+  course very useful (and much used) in `private`/`where` blocks to help with
+  local namespace management.
 
 * Module parameters should be put on a single line if they fit.
 


### PR DESCRIPTION
Fixes #2472 .
TODO: go through and find any remaining instances of the phenomenon (I didn't think that there were any left, ...)