### PR TITLE
[ testing ] express `tests.text.pretty.Main.pretty` as a `Data.Tree.Rose.foldr`

### DIFF
--- a/tests/text/pretty/Main.agda
+++ b/tests/text/pretty/Main.agda
@@ -2,16 +2,17 @@
 
 module Main where
 
-open import Data.List.Base
-open import Data.Maybe.Base using (Maybe; just; nothing)
+open import Data.Bool.Base using (if_then_else_)
+open import Data.List.Base using (List; []; _∷_; null)
+open import Data.Maybe.Base using (Maybe; just; nothing; maybe′)
 open import Data.Nat.Base using (ℕ)
 open import Data.String.Base using (String)
-open import Data.Tree.Rose using (Rose; node)
+open import Data.Tree.Rose using (Rose; node; leaf; foldr)
 
 open import IO.Base
 open import IO.Finite
 
-open import Function.Base using (_$_)
+open import Function.Base using (_∘_; _$_)
 
 open import Text.Pretty using (Doc; render)
 open module Pretty {w} = Text.Pretty w hiding (Doc; render)
@@ -22,19 +23,15 @@ private
 
 
 pretty : Rose (Maybe String) → Doc w
-mapPretty : List (Rose (Maybe String)) → List (Doc w)
-
-pretty (node nothing  ts) = vcat (mapPretty ts)
-pretty (node (just a) []) = text a
-pretty (node (just a) ts) = parens $ text a <+> sep (mapPretty ts)
-
-mapPretty [] = []
-mapPretty (t ∷ ts) = pretty t ∷ mapPretty ts
+pretty = foldr $ maybe′
+                   (λ s → let d = text s in
+                      λ ds → if null ds then d else (parens $ d <+> sep ds))
+                   vcat
 
 SEXP = Rose (Maybe String)
 
 atom : String → SEXP
-atom a = node (just a) []
+atom = leaf ∘ just
 
 list : List SEXP → SEXP
 list = node nothing
@@ -47,7 +44,7 @@ showTrailing = node (just "setq-default")
              $ atom "show-trailing-whitespace" ∷ atom "t" ∷ []
 
 deleteTrailing : SEXP
-deleteTrailing =  node (just "add-hook")
+deleteTrailing = node (just "add-hook")
                $ atom "'write-file-hooks"
                ∷ atom "'delete-trailing-whitespace"
                ∷ []


### PR DESCRIPTION
Since #3025 it's been driving me mad not to have been able to (re)express the main `pretty` printing function in the testsuite as an instance of `Data.Tree.Rose.foldr`.

This PR hopefully, finally, successfully scratches that itch. Consequently, need not be merged. 

Question (for @gallais specifically): does this refactoring earn its place? does it make things 'clearer'? 

Pro: 
* it clearly makes things 'obviously' terminating
* avoids having to write the `mapPretty` helper 

Con:
* the reader (who that?) has to mentally unfold (sic) the `foldr`, never mind the `maybe′`, ... 
* ... to know that `pretty` even does what we want!?