### PR TITLE
[ refactor ] remove custom syntax for `prep` and `swap` steps in `PermutationReasoning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,11 @@ Non-backwards compatible changes
   counterparts. Consider using `viaList` if you want a lawful lifting
   of `take` or `drop`.
 
+* [Issue #2319](https://github.com/agda/agda-stdlib/issues/2319)
+  The custom syntax for `swap` and `prep` steps in `PermutationReasoning`,
+  defined in `Data.List.Relation.Binary.Permutation.{Propositional|Setoid}`,
+  has been removed.
+
 Minor improvements
 ------------------
 

--- a/src/Data/List/Relation/Binary/Permutation/Propositional.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Propositional.agda
@@ -135,20 +135,3 @@ module PermutationReasoning where
     renaming (≈-go to ↭-go)
 
   open ↭-syntax _IsRelatedTo_ _IsRelatedTo_ ↭-go ↭-sym public
-
-  -- Some extra combinators that allow us to skip certain elements
-
-  infixr 2 step-swap step-prep
-
-  -- Skip reasoning on the first element
-  step-prep : ∀ x xs {ys zs : List A} → (x ∷ ys) IsRelatedTo zs →
-              xs ↭ ys → (x ∷ xs) IsRelatedTo zs
-  step-prep x xs rel xs↭ys = ↭-go (↭-prep x xs↭ys) rel
-
-  -- Skip reasoning about the first two elements
-  step-swap : ∀ x y xs {ys zs : List A} → (y ∷ x ∷ ys) IsRelatedTo zs →
-              xs ↭ ys → (x ∷ y ∷ xs) IsRelatedTo zs
-  step-swap x y xs rel xs↭ys = ↭-go (↭-swap x y xs↭ys) rel
-
-  syntax step-prep x xs y↭z x↭y = x ∷ xs <⟨ x↭y ⟩ y↭z
-  syntax step-swap x y xs y↭z x↭y = x ∷ y ∷ xs <<⟨ x↭y ⟩ y↭z

--- a/src/Data/List/Relation/Binary/Permutation/Setoid.agda
+++ b/src/Data/List/Relation/Binary/Permutation/Setoid.agda
@@ -135,20 +135,3 @@ module PermutationReasoning where
 
   open ↭-syntax _IsRelatedTo_ _IsRelatedTo_ ↭-go ↭-sym public
   open ≋-syntax _IsRelatedTo_ _IsRelatedTo_ (↭-go ∘′ ↭-reflexive-≋) ≋-sym public
-
-  -- Some extra combinators that allow us to skip certain elements
-
-  infixr 2 step-swap step-prep
-
-  -- Skip reasoning on the first element
-  step-prep : ∀ x xs {ys zs : List A} → (x ∷ ys) IsRelatedTo zs →
-              xs ↭ ys → (x ∷ xs) IsRelatedTo zs
-  step-prep x xs rel xs↭ys = ↭-go (↭-prep x xs↭ys) rel
-
-  -- Skip reasoning about the first two elements
-  step-swap : ∀ x y xs {ys zs : List A} → (y ∷ x ∷ ys) IsRelatedTo zs →
-              xs ↭ ys → (x ∷ y ∷ xs) IsRelatedTo zs
-  step-swap x y xs rel xs↭ys = ↭-go (↭-swap x y xs↭ys) rel
-
-  syntax step-prep x xs y↭z x↭y = x ∷ xs <⟨ x↭y ⟩ y↭z
-  syntax step-swap x y xs y↭z x↭y = x ∷ y ∷ xs <<⟨ x↭y ⟩ y↭z

--- a/src/Data/Nat/Primality/Factorisation.agda
+++ b/src/Data/Nat/Primality/Factorisation.agda
@@ -26,7 +26,7 @@ open import Data.List.Membership.Propositional.Properties using (∈-∃++)
 open import Data.List.Relation.Unary.All as All using (All; []; _∷_)
 open import Data.List.Relation.Unary.Any using (here; there)
 open import Data.List.Relation.Binary.Permutation.Propositional
-  using (_↭_; ↭-reflexive; ↭-refl; ↭-trans; module PermutationReasoning)
+  using (_↭_; ↭-reflexive; ↭-refl; ↭-trans; ↭-prep; module PermutationReasoning)
 open import Data.List.Relation.Binary.Permutation.Propositional.Properties
   using (All-resp-↭; shift)
 open import Data.Sum.Base using (inj₁; inj₂)
@@ -188,9 +188,12 @@ private
       prime[bs'] : All Prime bs′
       prime[bs'] = All.tail (All-resp-↭ bs↭a∷bs′ prime[bs])
 
+      as↭bs′ : as ↭ bs′
+      as↭bs′ = factorisationUnique′ as bs′ Πas≡Πbs′ prime[as] prime[bs']
+
       a∷as↭bs : a ∷ as ↭ bs
       a∷as↭bs = begin
-        a ∷ as  <⟨ factorisationUnique′ as bs′ Πas≡Πbs′ prime[as] prime[bs'] ⟩
+        a ∷ as  ↭⟨ ↭-prep _ as↭bs′ ⟩
         a ∷ bs′ ↭⟨ bs↭a∷bs′ ⟨
         bs      ∎
         where open PermutationReasoning


### PR DESCRIPTION
Fixes #2319 by removing the syntax, and its final use, as discussed on the issue.