### PR TITLE
Fix gh pages CI

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -352,7 +352,7 @@ jobs:
         with:
           name: ubuntu-html
           include-hidden-files: true
-          path: ${{ needs.init.outputs.AGDA_HTML_DIR }}
+          path: ./html/
 
   html-deploy:
     needs: [init, html-generate, test-stdlib-golden, test-stdlib]

--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -365,7 +365,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ubuntu-html
-          path: ${{ needs.init.outputs.AGDA_HTML_DIR }}
+          path: ./html/
 
       - name: Deploy HTML
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
#3049 broke the GitHub pages due to not properly uploading/downloading the html folder between `html-generate` and `html-deploy`. 

It used the `AGDA_HTML_DIR` variable by mistake as the upload/download folder, when it should be the entire `html/` folder.

The 2 most recent commits to [`gh-pages`](https://github.com/agda/agda-stdlib/tree/gh-pages) also need to be reverted for this fix to work. I apologise for the oversight.

#3076 should be merged first.