### PR TITLE
[ refactor ] add `Data.Sum.Relation.Binary.Pointwise .elim`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,12 @@ Additions to existing modules
                     i / n + j / n ≡ (i ℤ.+ j) / n
   ```
 
+* In `Data.Sum.Relation.Binary.Pointwise`:
+  ```agda
+  elim : R =[ f ]⇒ T → S =[ g ]⇒ T →
+         Pointwise R S =[ Sum.[ f , g ]′ ]⇒ T
+  ```
+
 * In `Data.Vec.Properties`:
   ```agda
   lookup-head : (xs : Vec A (suc n)) → lookup xs zero ≡ head xs

--- a/src/Data/Sum/Relation/Binary/Pointwise.agda
+++ b/src/Data/Sum/Relation/Binary/Pointwise.agda
@@ -39,11 +39,16 @@ data Pointwise {A : Set a} {B : Set b} {C : Set c} {D : Set d}
 ----------------------------------------------------------------------
 -- Functions
 
+elim : ∀ {f : A → C} {g : B → C} →
+       R =[ f ]⇒ T → S =[ g ]⇒ T →
+       Pointwise R S =[ Sum.[ f , g ]′ ]⇒ T
+elim R⇒T S⇒T (inj₁ xRy) = R⇒T xRy
+elim R⇒T S⇒T (inj₂ xSy) = S⇒T xSy
+
 map : ∀ {f : A → C} {g : B → D} →
       R =[ f ]⇒ T → S =[ g ]⇒ U →
       Pointwise R S =[ Sum.map f g ]⇒ Pointwise T U
-map R⇒T _ (inj₁ x) = inj₁ (R⇒T x)
-map _ S⇒U (inj₂ x) = inj₂ (S⇒U x)
+map R⇒T S⇒U = elim {T = Pointwise _ _} (inj₁ ∘ R⇒T) (inj₂ ∘ S⇒U)
 
 ------------------------------------------------------------------------
 -- Relational properties


### PR DESCRIPTION
Grrrr... initiality `elim` *precedes* functoriality `map`, both conceptually and practically in type theory.

NB. With a proof of `[ id , id ] ≗ id`, more could / would be reducible to `elim`, but that can/could happen downstream. 