### PR TITLE
[ refactor ] `Data.Product.Relation.Binary.Pointwise.NonDependent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ Non-backwards compatible changes
   refactoring, lemmas in `Algebra.Properties.CancellativeCommutativeSemiring` no
   longer require a `Decidable _≈_` hypothesis.
 
+* [issue #2174](https://github.com/agda/agda-stdlib/issues/2174)
+  In `Data.Product.Relation.Binary.Pointwise.NonDependent`, the main definition
+  `Pointwise` has been made a `record` type to improve type inference. The former
+  definition of `Pointwise` has been retained as `Pointwise′`, with back-and-forth
+  conversion functions deifned between them.
+
 * [issue #2471](https://github.com/agda/agda-stdlib/issues/2471)
   In `Relation.Binary.Definitions`, the left/right order of the components of
   `_Respects₂_` have been swapped. Previously the position of the `_Respectsˡ_`
@@ -170,6 +176,9 @@ Minor improvements
 * The definitions in `Function.Consequences.Propositional` of the form `strictlyX⇒X`
   have been streamlined via pattern-matching on `refl`, rather than defined by
   delegation to `Function.Consequences.Setoid` and the use of `cong`.
+
+* The definition of `Data.Product.Relation.Binary.Pointwise.Dependent.POINTWISE`
+  now has the (correct) lower universe level, as with its `NonDependent` version.
 
 Deprecated modules
 ------------------
@@ -463,6 +472,14 @@ Additions to existing modules
   ```agda
   ∃!-≐ : P ≐ Q → ∃! _≈_ P → ∃! _≈_ Q
   ∃!-⇔ : P ≐ Q → ∃! _≈_ P ⇔ ∃! _≈_ Q
+  ```
+
+* In `Data.Product.Relation.Binary.Pointwise.NonDependent`:
+  ```agda
+  Pointwise′ : REL A B ℓ₁ → REL C D ℓ₂ → REL (A × C) (B × D) (ℓ₁ ⊔ ℓ₂)
+  pointwise⇒pointwise′ : Pointwise R S ⇒ Pointwise′ R S
+  pointwise′⇒pointwise : Pointwise′ R S ⇒ Pointwise R S
+  map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
   ```
 
 * In `Data.Rational.Properties`:

--- a/src/Data/Product/Function/NonDependent/Setoid.agda
+++ b/src/Data/Product/Function/NonDependent/Setoid.agda
@@ -5,12 +5,13 @@
 -- functions
 ------------------------------------------------------------------------
 
-{-# OPTIONS --without-K --safe #-}
+{-# OPTIONS --without-K --allow-unsolved-metas #-}
 
 module Data.Product.Function.NonDependent.Setoid where
 
 open import Data.Product.Base as Product
-open import Data.Product.Relation.Binary.Pointwise.NonDependent using (_×ₛ_)
+open import Data.Product.Relation.Binary.Pointwise.NonDependent
+  using (_,_; proj₁; proj₂; _×ₛ_)
 open import Level using (Level)
 open import Relation.Binary.Bundles using (Setoid)
 open import Function.Bundles
@@ -35,7 +36,7 @@ proj₂ₛ = record { to = proj₂ ; cong = proj₂ }
 <_,_>ₛ : Func A B → Func A C → Func A (B ×ₛ C)
 < f , g >ₛ = record
   { to   = < to   f , to   g >
-  ; cong = < cong f , cong g >
+  ; cong = {!< cong f , cong g >!}
   } where open Func
 
 swapₛ : Func (A ×ₛ B) (B ×ₛ A)
@@ -47,7 +48,7 @@ swapₛ = < proj₂ₛ , proj₁ₛ >ₛ
 _×-function_ : Func A B → Func C D → Func (A ×ₛ C) (B ×ₛ D)
 f ×-function g = record
   { to    = Product.map (to f) (to g)
-  ; cong  = Product.map (cong f) (cong g)
+  ; cong  = {!map (cong f) (cong g)!}
   } where open Func
 
 infixr 2 _×-equivalence_ _×-injection_ _×-left-inverse_
@@ -57,23 +58,23 @@ _×-equivalence_ : Equivalence A B → Equivalence C D →
 _×-equivalence_ f g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = Product.map (to-cong f) (to-cong g)
-  ; from-cong = Product.map (from-cong f) (from-cong g)
+  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
+  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
   } where open Equivalence
 
 _×-injection_ : Injection A B → Injection C D →
                 Injection (A ×ₛ C) (B ×ₛ D)
 f ×-injection g = record
   { to        = Product.map (to f) (to g)
-  ; cong      = Product.map (cong f) (cong g)
-  ; injective = Product.map (injective f) (injective g)
+  ; cong      = {!Product.map (cong f) (cong g)!}
+  ; injective = {!Product.map (injective f) (injective g)!}
   } where open Injection
 
 _×-surjection_ : Surjection A B → Surjection C D →
                  Surjection (A ×ₛ C) (B ×ₛ D)
 f ×-surjection g = record
   { to         = Product.map (to f) (to g)
-  ; cong       = Product.map (cong f) (cong g)
+  ; cong       = {!Product.map (cong f) (cong g)!}
   ; surjective = λ y → Product.zip _,_ (λ ff gg x₂ → (ff (proj₁ x₂)) , (gg (proj₂ x₂))) (surjective f (proj₁ y)) (surjective g (proj₂ y))
   } where open Surjection
 
@@ -81,8 +82,8 @@ _×-bijection_ : Bijection A B → Bijection C D →
                 Bijection (A ×ₛ C) (B ×ₛ D)
 f ×-bijection g = record
   { to         = Product.map (to f) (to g)
-  ; cong       = Product.map (cong f) (cong g)
-  ; bijective  = Product.map (injective f) (injective g) ,
+  ; cong       = {!Product.map (cong f) (cong g)!}
+  ; bijective  = {!Product.map (injective f) (injective g)!} ,
                  λ { (y₀ , y₁) → Product.zip _,_ (λ {ff gg (x₀ , x₁) → ff x₀ , gg x₁}) (surjective f y₀) (surjective g y₁)}
   } where open Bijection
 
@@ -91,8 +92,8 @@ _×-leftInverse_ : LeftInverse A B → LeftInverse C D →
 f ×-leftInverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = Product.map (to-cong f) (to-cong g)
-  ; from-cong = Product.map (from-cong f) (from-cong g)
+  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
+  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
   ; inverseˡ   = λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)
   } where open LeftInverse
 
@@ -101,8 +102,8 @@ _×-rightInverse_ : RightInverse A B → RightInverse C D →
 f ×-rightInverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = Product.map (to-cong f) (to-cong g)
-  ; from-cong = Product.map (from-cong f) (from-cong g)
+  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
+  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
   ; inverseʳ   = λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x)
   } where open RightInverse
 
@@ -113,8 +114,8 @@ _×-inverse_ : Inverse A B → Inverse C D →
 f ×-inverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = Product.map (to-cong f) (to-cong g)
-  ; from-cong = Product.map (from-cong f) (from-cong g)
+  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
+  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
   ; inverse   = (λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)) ,
                 (λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x))
   } where open Inverse

--- a/src/Data/Product/Function/NonDependent/Setoid.agda
+++ b/src/Data/Product/Function/NonDependent/Setoid.agda
@@ -5,13 +5,13 @@
 -- functions
 ------------------------------------------------------------------------
 
-{-# OPTIONS --without-K --allow-unsolved-metas #-}
+{-# OPTIONS --without-K --safe #-}
 
 module Data.Product.Function.NonDependent.Setoid where
 
 open import Data.Product.Base as Product
 open import Data.Product.Relation.Binary.Pointwise.NonDependent
-  using (_,_; proj₁; proj₂; _×ₛ_)
+  using (_,_; proj₁; proj₂; _×ₛ_; intro; intro′)
 open import Level using (Level)
 open import Relation.Binary.Bundles using (Setoid)
 open import Function.Bundles
@@ -24,6 +24,7 @@ private
     a ℓ : Level
     A B C D : Setoid a ℓ
 
+
 ------------------------------------------------------------------------
 -- Combinators for equality preserving functions
 
@@ -34,9 +35,9 @@ proj₂ₛ : Func (A ×ₛ B) B
 proj₂ₛ = record { to = proj₂ ; cong = proj₂ }
 
 <_,_>ₛ : Func A B → Func A C → Func A (B ×ₛ C)
-< f , g >ₛ = record
+<_,_>ₛ {A = A} f g = record
   { to   = < to   f , to   g >
-  ; cong = {!< cong f , cong g >!}
+  ; cong = intro′ (Setoid._≈_ A) (cong f) (cong g)
   } where open Func
 
 swapₛ : Func (A ×ₛ B) (B ×ₛ A)

--- a/src/Data/Product/Function/NonDependent/Setoid.agda
+++ b/src/Data/Product/Function/NonDependent/Setoid.agda
@@ -49,7 +49,7 @@ swapₛ = < proj₂ₛ , proj₁ₛ >ₛ
 _×-function_ : Func A B → Func C D → Func (A ×ₛ C) (B ×ₛ D)
 f ×-function g = record
   { to    = Product.map (to f) (to g)
-  ; cong  = {!map (cong f) (cong g)!}
+  ; cong  = λ (x , y) → cong f x , cong g y
   } where open Func
 
 infixr 2 _×-equivalence_ _×-injection_ _×-left-inverse_
@@ -59,23 +59,23 @@ _×-equivalence_ : Equivalence A B → Equivalence C D →
 _×-equivalence_ f g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
-  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
+  ; to-cong   = λ (x , y) → to-cong f x , to-cong g y
+  ; from-cong = λ (x , y) → from-cong f x , from-cong g y
   } where open Equivalence
 
 _×-injection_ : Injection A B → Injection C D →
                 Injection (A ×ₛ C) (B ×ₛ D)
 f ×-injection g = record
   { to        = Product.map (to f) (to g)
-  ; cong      = {!Product.map (cong f) (cong g)!}
-  ; injective = {!Product.map (injective f) (injective g)!}
+  ; cong      = λ (x , y) → cong f x , cong g y
+  ; injective = λ (x , y) → injective f x , injective g y
   } where open Injection
 
 _×-surjection_ : Surjection A B → Surjection C D →
                  Surjection (A ×ₛ C) (B ×ₛ D)
 f ×-surjection g = record
   { to         = Product.map (to f) (to g)
-  ; cong       = {!Product.map (cong f) (cong g)!}
+  ; cong       = λ (x , y) → cong f x , cong g y
   ; surjective = λ y → Product.zip _,_ (λ ff gg x₂ → (ff (proj₁ x₂)) , (gg (proj₂ x₂))) (surjective f (proj₁ y)) (surjective g (proj₂ y))
   } where open Surjection
 
@@ -83,8 +83,8 @@ _×-bijection_ : Bijection A B → Bijection C D →
                 Bijection (A ×ₛ C) (B ×ₛ D)
 f ×-bijection g = record
   { to         = Product.map (to f) (to g)
-  ; cong       = {!Product.map (cong f) (cong g)!}
-  ; bijective  = {!Product.map (injective f) (injective g)!} ,
+  ; cong       = λ (x , y) → cong f x , cong g y
+  ; bijective  = (λ (x , y) → injective f x , injective g y) ,
                  λ { (y₀ , y₁) → Product.zip _,_ (λ {ff gg (x₀ , x₁) → ff x₀ , gg x₁}) (surjective f y₀) (surjective g y₁)}
   } where open Bijection
 
@@ -93,9 +93,9 @@ _×-leftInverse_ : LeftInverse A B → LeftInverse C D →
 f ×-leftInverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
-  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
-  ; inverseˡ   = λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)
+  ; to-cong   = λ (x , y) → to-cong f x , to-cong g y
+  ; from-cong = λ (x , y) → from-cong f x , from-cong g y
+  ; inverseˡ  = λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)
   } where open LeftInverse
 
 _×-rightInverse_ : RightInverse A B → RightInverse C D →
@@ -103,9 +103,9 @@ _×-rightInverse_ : RightInverse A B → RightInverse C D →
 f ×-rightInverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
-  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
-  ; inverseʳ   = λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x)
+  ; to-cong   = λ (x , y) → to-cong f x , to-cong g y
+  ; from-cong = λ (x , y) → from-cong f x , from-cong g y
+  ; inverseʳ  = λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x)
   } where open RightInverse
 
 infixr 2 _×-surjection_ _×-inverse_
@@ -115,8 +115,8 @@ _×-inverse_ : Inverse A B → Inverse C D →
 f ×-inverse g = record
   { to        = Product.map (to f) (to g)
   ; from      = Product.map (from f) (from g)
-  ; to-cong   = {!Product.map (to-cong f) (to-cong g)!}
-  ; from-cong = {!Product.map (from-cong f) (from-cong g)!}
+  ; to-cong   = λ (x , y) → to-cong f x , to-cong g y
+  ; from-cong = λ (x , y) → from-cong f x , from-cong g y
   ; inverse   = (λ x → inverseˡ f (proj₁ x) , inverseˡ g (proj₂ x)) ,
                 (λ x → inverseʳ f (proj₁ x) , inverseʳ g (proj₂ x))
   } where open Inverse

--- a/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
@@ -30,7 +30,7 @@ record POINTWISE {a₁ a₂ b₁ b₂ ℓ₁ ℓ₂}
                  {A₂ : Set a₂} (B₂ : A₂ → Set b₂)
                  (_R₁_ : REL A₁ A₂ ℓ₁) (_R₂_ : IREL B₁ B₂ ℓ₂)
                  (xy₁ : Σ A₁ B₁) (xy₂ : Σ A₂ B₂)
-                 : Set (a₁ ⊔ a₂ ⊔ b₁ ⊔ b₂ ⊔ ℓ₁ ⊔ ℓ₂) where
+                 : Set (ℓ₁ ⊔ ℓ₂) where
   constructor _,_
   field
     proj₁ : (proj₁ xy₁) R₁ (proj₁ xy₂)

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -12,10 +12,10 @@ open import Data.Product.Base as Product
    using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Level using (Level; _⊔_; 0ℓ)
-open import Function.Base using (id)
+open import Function.Base using (id; _∘_)
 open import Function.Bundles using (Inverse)
 open import Relation.Nullary.Decidable.Core as Dec using (_×?_)
-open import Relation.Binary.Core using (REL; Rel; _⇒_)
+open import Relation.Binary.Core using (REL; Rel; _⇒_; _=[_]⇒_)
 open import Relation.Binary.Bundles
   using (Setoid; DecSetoid; Preorder; Poset; StrictPartialOrder)
 open import Relation.Binary.Definitions
@@ -27,7 +27,8 @@ private
   variable
     a b c d ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
     A B C D : Set a
-    R S ≈₁ ≈₂ : Rel A ℓ₁
+    R S T ≈₁ ≈₂ : Rel A ℓ₁
+    f g : A → B
 
 
 ------------------------------------------------------------------------
@@ -59,8 +60,12 @@ proj₂ (pointwise′⇒pointwise p) = proj₂ p
 ------------------------------------------------------------------------
 -- Helper functions as drop-ins for those from Product
 
+intro :  T =[ f ]⇒ R → T =[ g ]⇒ S → T =[ Product.< f , g > ]⇒ Pointwise R S
+intro T⇒R T⇒S p = T⇒R p , T⇒S p
+
 map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-map f g xR×Sy = f (proj₁ xR×Sy) , g  (proj₂ xR×Sy)
+map f g = intro (f ∘ proj₁) (g ∘ proj₂)
+--f (proj₁ xR×Sy) , g  (proj₂ xR×Sy)
 
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
@@ -80,7 +85,8 @@ map f g xR×Sy = f (proj₁ xR×Sy) , g  (proj₂ xR×Sy)
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric sym₁ sym₂ xR×Sy = map sym₁ sym₂ (proj₁ xR×Sy , proj₂ xR×Sy)
+×-symmetric sym₁ sym₂ = intro (sym₁ ∘ proj₁) (sym₂ ∘ proj₂)
+-- map sym₁ sym₂ (proj₁ xR×Sy , proj₂ xR×Sy)
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
 ×-transitive trans₁ trans₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₃ , y₂Sy₃) =

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -12,9 +12,9 @@ open import Data.Product.Base as Product
    using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Level using (Level; _⊔_; 0ℓ)
-open import Function.Base using (id; flip)
+open import Function.Base using (id)
 open import Function.Bundles using (Inverse)
-open import Relation.Nullary.Decidable using (_×?_)
+open import Relation.Nullary.Decidable.Core as Dec using (_×?_)
 open import Relation.Binary.Core using (REL; Rel; _⇒_)
 open import Relation.Binary.Bundles
   using (Setoid; DecSetoid; Preorder; Poset; StrictPartialOrder)
@@ -35,10 +35,9 @@ private
 
 infixr 4 _,_
 
-record Pointwise {A : Set a} {B : Set b} {C : Set c} {D : Set d}
-                 (R₁ : REL A B ℓ₁) (R₂ : REL C D ℓ₂)
+record Pointwise (R₁ : REL A B ℓ₁) (R₂ : REL C D ℓ₂)
                  (x : A × C) (y : B × D)
-                 : Set (a ⊔ b ⊔ c ⊔ d ⊔ ℓ₁ ⊔ ℓ₂) where
+                 : Set (ℓ₁ ⊔ ℓ₂) where
   constructor _,_
   field
     proj₁ : R₁ (proj₁ x) (proj₁ y)
@@ -62,10 +61,7 @@ proj₂ (pointwise′⇒pointwise p) = proj₂ p
 
 map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
 map f g (x , y) = f x , g y
-{-
-zip : Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-zip f g (x , y) = f x , g y
--}
+
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
 
@@ -84,14 +80,16 @@ zip f g (x , y) = f x , g y
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric {R = R} {S = S} sym₁ sym₂ = {!map sym₁ sym₂!}
+×-symmetric {R = R} {S = S} sym₁ sym₂ (x₁Rx₂ , y₁Sy₂) = sym₁ x₁Rx₂ , sym₂ y₁Sy₂
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
-×-transitive trans₁ trans₂ = {!Product.zip trans₁ trans₂!}
+×-transitive trans₁ trans₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₃ , y₂Sy₃) =
+  trans₁ x₁Rx₂ x₂Rx₃ , trans₂ y₁Sy₂ y₂Sy₃
 
 ×-antisymmetric : Antisymmetric ≈₁ R → Antisymmetric ≈₂ S →
                   Antisymmetric (Pointwise ≈₁ ≈₂) (Pointwise R S)
-×-antisymmetric antisym₁ antisym₂ = {!Product.zip antisym₁ antisym₂!}
+×-antisymmetric antisym₁ antisym₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₁ , y₂Sy₁) =
+  antisym₁ x₁Rx₂ x₂Rx₁ , antisym₂ y₁Sy₂ y₂Sy₁
 
 ×-asymmetric₁ : Asymmetric R → Asymmetric (Pointwise R S)
 ×-asymmetric₁ asym₁ x<y y<x = asym₁ (proj₁ x<y) (proj₁ y<x)
@@ -101,15 +99,19 @@ zip f g (x , y) = f x , g y
 
 ×-respectsʳ : R Respectsʳ ≈₁ → S Respectsʳ ≈₂ →
              (Pointwise R S) Respectsʳ (Pointwise ≈₁ ≈₂)
-×-respectsʳ resp₁ resp₂ = {!Product.zip resp₁ resp₂!}
+×-respectsʳ resp₁ resp₂ (x₁≈x₂ , y₁≈y₂) (x₁Rx₂ , y₁Sy₂) =
+  resp₁ x₁≈x₂ x₁Rx₂ , resp₂ y₁≈y₂ y₁Sy₂
 
 ×-respectsˡ : R Respectsˡ ≈₁ → S Respectsˡ ≈₂ →
              (Pointwise R S) Respectsˡ (Pointwise ≈₁ ≈₂)
-×-respectsˡ resp₁ resp₂ = {!Product.zip resp₁ resp₂!}
+×-respectsˡ resp₁ resp₂ (x₁Rx₂ , y₁Sy₂) (x₁≈x₂ , y₁≈y₂) =
+  resp₁ x₁Rx₂ x₁≈x₂ , resp₂ y₁Sy₂ y₁≈y₂
 
 ×-respects₂ : R Respects₂ ≈₁ → S Respects₂ ≈₂ →
               (Pointwise R S) Respects₂ (Pointwise ≈₁ ≈₂)
-×-respects₂ = {!Product.zip ×-respectsʳ ×-respectsˡ!}
+×-respects₂ resp₁ resp₂ =
+  ×-respectsˡ (proj₁ resp₁) (proj₁ resp₂) , ×-respectsʳ (proj₂ resp₁) (proj₂ resp₂)
+
 
 ×-total : Symmetric R → Total R → Total S → Total (Pointwise R S)
 ×-total sym₁ total₁ total₂ (x₁ , x₂) (y₁ , y₂)
@@ -120,7 +122,8 @@ zip f g (x , y) = f x , g y
 ... | inj₂ y₁∼x₁ | inj₁ x₂∼y₂ = inj₁ (sym₁ y₁∼x₁ , x₂∼y₂)
 
 ×-decidable : Decidable R → Decidable S → Decidable (Pointwise R S)
-×-decidable _≟₁_ _≟₂_ (x₁ , x₂) (y₁ , y₂) = {!(x₁ ≟₁ y₁) ×? (x₂ ≟₂ y₂)!}
+×-decidable _R?_ _S?_ (x₁ , x₂) (y₁ , y₂) =
+  Dec.map′ pointwise′⇒pointwise pointwise⇒pointwise′ ((x₁ R? y₁) ×? (x₂ S? y₂))
 
 ------------------------------------------------------------------------
 -- Structures can also be combined.
@@ -226,7 +229,7 @@ _×ₛ_ = ×-setoid
 ≡×≡⇒≡ (≡.refl , ≡.refl) = ≡.refl
 
 ≡⇒≡×≡ : _≡_ {A = A × B} ⇒ Pointwise _≡_ _≡_
-≡⇒≡×≡ ≡.refl = (≡.refl , ≡.refl)
+≡⇒≡×≡ ≡.refl = ≡.refl , ≡.refl
 
 Pointwise-≡↔≡ : Inverse (≡.setoid A ×ₛ ≡.setoid B) (≡.setoid (A × B))
 Pointwise-≡↔≡ = record

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -9,9 +9,10 @@
 module Data.Product.Relation.Binary.Pointwise.NonDependent where
 
 open import Data.Product.Base as Product
+   using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Level using (Level; _⊔_; 0ℓ)
-open import Function.Base using (id)
+open import Function.Base using (id; flip)
 open import Function.Bundles using (Inverse)
 open import Relation.Nullary.Decidable using (_×?_)
 open import Relation.Binary.Core using (REL; Rel; _⇒_)
@@ -24,21 +25,52 @@ import Relation.Binary.PropositionalEquality.Properties as ≡
 
 private
   variable
-    a b ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
+    a b c d ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
     A B C D : Set a
     R S ≈₁ ≈₂ : Rel A ℓ₁
+
 
 ------------------------------------------------------------------------
 -- Definition
 
-Pointwise : REL A B ℓ₁ → REL C D ℓ₂ → REL (A × C) (B × D) (ℓ₁ ⊔ ℓ₂)
-Pointwise R S (a , c) (b , d) = (R a b) × (S c d)
+infixr 4 _,_
 
+record Pointwise {A : Set a} {B : Set b} {C : Set c} {D : Set d}
+                 (R₁ : REL A B ℓ₁) (R₂ : REL C D ℓ₂)
+                 (x : A × C) (y : B × D)
+                 : Set (a ⊔ b ⊔ c ⊔ d ⊔ ℓ₁ ⊔ ℓ₂) where
+  constructor _,_
+  field
+    proj₁ : R₁ (proj₁ x) (proj₁ y)
+    proj₂ : R₂ (proj₂ x) (proj₂ y)
+
+open Pointwise public
+
+Pointwise′ : REL A B ℓ₁ → REL C D ℓ₂ → REL (A × C) (B × D) (ℓ₁ ⊔ ℓ₂)
+Pointwise′ R S (a , c) (b , d) = (R a b) × (S c d)
+
+pointwise⇒pointwise′ : Pointwise R S ⇒ Pointwise′ R S
+proj₁ (pointwise⇒pointwise′ p) = proj₁ p
+proj₂ (pointwise⇒pointwise′ p) = proj₂ p
+
+pointwise′⇒pointwise : Pointwise′ R S ⇒ Pointwise R S
+proj₁ (pointwise′⇒pointwise p) = proj₁ p
+proj₂ (pointwise′⇒pointwise p) = proj₂ p
+
+------------------------------------------------------------------------
+-- Helper functions as drop-ins for those from Product
+
+map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
+map f g (x , y) = f x , g y
+{-
+zip : Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
+zip f g (x , y) = f x , g y
+-}
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
 
 ×-reflexive : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-×-reflexive refl₁ refl₂ = Product.map refl₁ refl₂
+×-reflexive = map
 
 ×-refl : Reflexive R → Reflexive S → Reflexive (Pointwise R S)
 ×-refl refl₁ refl₂ = refl₁ , refl₂
@@ -52,14 +84,14 @@ Pointwise R S (a , c) (b , d) = (R a b) × (S c d)
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric sym₁ sym₂ = Product.map sym₁ sym₂
+×-symmetric {R = R} {S = S} sym₁ sym₂ = {!map sym₁ sym₂!}
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
-×-transitive trans₁ trans₂ = Product.zip trans₁ trans₂
+×-transitive trans₁ trans₂ = {!Product.zip trans₁ trans₂!}
 
 ×-antisymmetric : Antisymmetric ≈₁ R → Antisymmetric ≈₂ S →
                   Antisymmetric (Pointwise ≈₁ ≈₂) (Pointwise R S)
-×-antisymmetric antisym₁ antisym₂ = Product.zip antisym₁ antisym₂
+×-antisymmetric antisym₁ antisym₂ = {!Product.zip antisym₁ antisym₂!}
 
 ×-asymmetric₁ : Asymmetric R → Asymmetric (Pointwise R S)
 ×-asymmetric₁ asym₁ x<y y<x = asym₁ (proj₁ x<y) (proj₁ y<x)
@@ -69,15 +101,15 @@ Pointwise R S (a , c) (b , d) = (R a b) × (S c d)
 
 ×-respectsʳ : R Respectsʳ ≈₁ → S Respectsʳ ≈₂ →
              (Pointwise R S) Respectsʳ (Pointwise ≈₁ ≈₂)
-×-respectsʳ resp₁ resp₂ = Product.zip resp₁ resp₂
+×-respectsʳ resp₁ resp₂ = {!Product.zip resp₁ resp₂!}
 
 ×-respectsˡ : R Respectsˡ ≈₁ → S Respectsˡ ≈₂ →
              (Pointwise R S) Respectsˡ (Pointwise ≈₁ ≈₂)
-×-respectsˡ resp₁ resp₂ = Product.zip resp₁ resp₂
+×-respectsˡ resp₁ resp₂ = {!Product.zip resp₁ resp₂!}
 
 ×-respects₂ : R Respects₂ ≈₁ → S Respects₂ ≈₂ →
               (Pointwise R S) Respects₂ (Pointwise ≈₁ ≈₂)
-×-respects₂ = Product.zip ×-respectsʳ ×-respectsˡ
+×-respects₂ = {!Product.zip ×-respectsʳ ×-respectsˡ!}
 
 ×-total : Symmetric R → Total R → Total S → Total (Pointwise R S)
 ×-total sym₁ total₁ total₂ (x₁ , x₂) (y₁ , y₂)
@@ -88,7 +120,7 @@ Pointwise R S (a , c) (b , d) = (R a b) × (S c d)
 ... | inj₂ y₁∼x₁ | inj₁ x₂∼y₂ = inj₁ (sym₁ y₁∼x₁ , x₂∼y₂)
 
 ×-decidable : Decidable R → Decidable S → Decidable (Pointwise R S)
-×-decidable _≟₁_ _≟₂_ (x₁ , x₂) (y₁ , y₂) = (x₁ ≟₁ y₁) ×? (x₂ ≟₂ y₂)
+×-decidable _≟₁_ _≟₂_ (x₁ , x₂) (y₁ , y₂) = {!(x₁ ≟₁ y₁) ×? (x₂ ≟₂ y₂)!}
 
 ------------------------------------------------------------------------
 -- Structures can also be combined.
@@ -204,3 +236,4 @@ Pointwise-≡↔≡ = record
   ; from-cong  = ≡⇒≡×≡
   ; inverse    = ≡×≡⇒≡ , ≡⇒≡×≡
   }
+

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -60,7 +60,7 @@ proj₂ (pointwise′⇒pointwise p) = proj₂ p
 -- Helper functions as drop-ins for those from Product
 
 map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-map f g (x , y) = f x , g y
+map f g xR×Sy = f (proj₁ xR×Sy) , g  (proj₂ xR×Sy)
 
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
@@ -80,7 +80,7 @@ map f g (x , y) = f x , g y
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric {R = R} {S = S} sym₁ sym₂ (x₁Rx₂ , y₁Sy₂) = sym₁ x₁Rx₂ , sym₂ y₁Sy₂
+×-symmetric sym₁ sym₂ xR×Sy = map sym₁ sym₂ (proj₁ xR×Sy , proj₂ xR×Sy)
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
 ×-transitive trans₁ trans₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₃ , y₂Sy₃) =

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -94,8 +94,7 @@ map f g = intro′ (Pointwise _ _) (f ∘ proj₁) (g ∘ proj₂)
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric sym₁ sym₂ = intro (flip (Pointwise _ _)) (sym₁ ∘ proj₁) (sym₂ ∘ proj₂)
-  λ _ → ≡.refl
+×-symmetric sym₁ sym₂ = intro′ (flip (Pointwise _ _)) (sym₁ ∘ proj₁) (sym₂ ∘ proj₂)
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
 ×-transitive trans₁ trans₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₃ , y₂Sy₃) =

--- a/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/NonDependent.agda
@@ -12,7 +12,7 @@ open import Data.Product.Base as Product
    using (_×_; _,_; proj₁; proj₂)
 open import Data.Sum.Base using (inj₁; inj₂)
 open import Level using (Level; _⊔_; 0ℓ)
-open import Function.Base using (id; _∘_)
+open import Function.Base using (id; _∘_; _on_; flip)
 open import Function.Bundles using (Inverse)
 open import Relation.Nullary.Decidable.Core as Dec using (_×?_)
 open import Relation.Binary.Core using (REL; Rel; _⇒_; _=[_]⇒_)
@@ -20,12 +20,13 @@ open import Relation.Binary.Bundles
   using (Setoid; DecSetoid; Preorder; Poset; StrictPartialOrder)
 open import Relation.Binary.Definitions
 open import Relation.Binary.Structures
-open import Relation.Binary.PropositionalEquality.Core as ≡ using (_≡_)
+open import Relation.Binary.PropositionalEquality.Core as ≡
+  using (_≡_; _≗_)
 import Relation.Binary.PropositionalEquality.Properties as ≡
 
 private
   variable
-    a b c d ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
+    a b c d ℓ ℓ₁ ℓ₂ ℓ₃ ℓ₄ : Level
     A B C D : Set a
     R S T ≈₁ ≈₂ : Rel A ℓ₁
     f g : A → B
@@ -60,12 +61,20 @@ proj₂ (pointwise′⇒pointwise p) = proj₂ p
 ------------------------------------------------------------------------
 -- Helper functions as drop-ins for those from Product
 
-intro :  T =[ f ]⇒ R → T =[ g ]⇒ S → T =[ Product.< f , g > ]⇒ Pointwise R S
-intro T⇒R T⇒S p = T⇒R p , T⇒S p
+module _ {f : C → A} {g : C → B}
+         (T : Rel C ℓ) (T⇒R : T =[ f ]⇒ R) (T⇒S : T =[ g ]⇒ S)
+         where
+
+  intro :  ∀ {h} → Product.< f , g > ≗ h →
+           T =[ h ]⇒ Pointwise R S
+  intro H p =
+    ≡.subst₂ (R on proj₁) (H _) (H _) (T⇒R p) , ≡.subst₂ (S on proj₂) (H _) (H _) (T⇒S p)
+
+  intro′ :  T =[ Product.< f , g > ]⇒ Pointwise R S
+  intro′ = intro λ _ → ≡.refl
 
 map : ≈₁ ⇒ R → ≈₂ ⇒ S → Pointwise ≈₁ ≈₂ ⇒ Pointwise R S
-map f g = intro (f ∘ proj₁) (g ∘ proj₂)
---f (proj₁ xR×Sy) , g  (proj₂ xR×Sy)
+map f g = intro′ (Pointwise _ _) (f ∘ proj₁) (g ∘ proj₂)
 
 ------------------------------------------------------------------------
 -- Pointwise preserves many relational properties
@@ -85,8 +94,8 @@ map f g = intro (f ∘ proj₁) (g ∘ proj₂)
 ×-irreflexive₂ ir x≈y x<y = ir (proj₂ x≈y) (proj₂ x<y)
 
 ×-symmetric : Symmetric R → Symmetric S → Symmetric (Pointwise R S)
-×-symmetric sym₁ sym₂ = intro (sym₁ ∘ proj₁) (sym₂ ∘ proj₂)
--- map sym₁ sym₂ (proj₁ xR×Sy , proj₂ xR×Sy)
+×-symmetric sym₁ sym₂ = intro (flip (Pointwise _ _)) (sym₁ ∘ proj₁) (sym₂ ∘ proj₂)
+  λ _ → ≡.refl
 
 ×-transitive : Transitive R → Transitive S → Transitive (Pointwise R S)
 ×-transitive trans₁ trans₂ (x₁Rx₂ , y₁Sy₂) (x₂Rx₃ , y₂Sy₃) =

--- a/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
+++ b/src/Data/Vec/Functional/Relation/Binary/Pointwise/Properties.agda
@@ -13,7 +13,8 @@ open import Data.Fin.Properties using (all?; splitAt-↑ˡ; splitAt-↑ʳ)
 open import Data.Nat.Base using (ℕ; zero; suc)
 open import Data.Product.Base using (_×_; _,_; proj₁; proj₂)
 open import Data.Product.Relation.Binary.Pointwise.NonDependent
-  using () renaming (Pointwise to ×-Pointwise)
+  using (_,_; proj₁; proj₂)
+  renaming (Pointwise to ×-Pointwise)
 open import Data.Sum.Base using (_⊎_; inj₁; inj₂; [_,_])
 open import Data.Vec.Functional as VF hiding (map)
 open import Data.Vec.Functional.Relation.Binary.Pointwise


### PR DESCRIPTION
Fixes #2174 (or rather: will at some point).

Currently:
* provisional: first steps
* problem with defining  `zip` so that existing uses of `Product.zip` can be drop-in replaced
* also `map` doesn't work for eg `symmetric`

Advice welcome!

Alternative strategy: try to make this module a specialisation of `Data.Product.Relation.Binary.Pointwise.Dependent`? UPDATED no because the use of `IREL` there opens the door to unsolved metavariables when considering the *constant* `IREL` generated from a given `REL`...

NB. Universe levels for the definitions in `{Non}Dependent` have been corrected!

UPDATED: I'm abandoning this. The knock-on consequences are so/too painful to fix/figure out... anyone else is welcome to attempt this!