### PR TITLE
[ fix ] universe levels in `Data.Product.Relation.Binary.Pointwise.Dependent.POINTWISE`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,10 @@ Non-backwards compatible changes
   defined in `Data.List.Relation.Binary.Permutation.{Propositional|Setoid}`,
   has been removed.
 
+* In `Data.Product.Relation.Binary.Pointwise.Dependent`, the universe level of
+  the `record POINTWISE` has been lowered to `ℓ₁ ⊔ ℓ₂` given the universe levels
+  `ℓ₁`, resp. `ℓ₂` of the argument relations `_R₁_`, resp. `_R₂_`.
+
 Minor improvements
 ------------------
 
@@ -166,7 +170,7 @@ Minor improvements
   subsequent imports by clients, as well as streamlined internals. Moreover,
   it now has the implicit parameters of its internal modules lifted out as
   global `variable`s.
-
+`
 * The definitions in `Function.Consequences.Propositional` of the form `strictlyX⇒X`
   have been streamlined via pattern-matching on `refl`, rather than defined by
   delegation to `Function.Consequences.Setoid` and the use of `cong`.

--- a/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
+++ b/src/Data/Product/Relation/Binary/Pointwise/Dependent.agda
@@ -30,7 +30,7 @@ record POINTWISE {a₁ a₂ b₁ b₂ ℓ₁ ℓ₂}
                  {A₂ : Set a₂} (B₂ : A₂ → Set b₂)
                  (_R₁_ : REL A₁ A₂ ℓ₁) (_R₂_ : IREL B₁ B₂ ℓ₂)
                  (xy₁ : Σ A₁ B₁) (xy₂ : Σ A₂ B₂)
-                 : Set (a₁ ⊔ a₂ ⊔ b₁ ⊔ b₂ ⊔ ℓ₁ ⊔ ℓ₂) where
+                 : Set (ℓ₁ ⊔ ℓ₂) where
   constructor _,_
   field
     proj₁ : (proj₁ xy₁) R₁ (proj₁ xy₂)


### PR DESCRIPTION
Salvaged from #3081 . Does this need a `CHANGELOG` entry?